### PR TITLE
Add options page to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
       "js": ["content-scripts/cs.js"]
     }
   ],
+  "options_page": "webpages/settings/index.html",
   "permissions": [
     "https://*.scratch.mit.edu/*",
     "cookies",


### PR DESCRIPTION
**Changes**

<!-- Please describe the changes you've made. -->

The options page can now be accessed by right clicking the extension icon and clicking "options".

**Tests**

Latest Chromium