### PR TITLE
Fix url matches

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -40,7 +40,7 @@ function userscriptMatches(data, matches) {
 }
 
 function urlMatchesPattern(pattern, url) {
-  if(url[url.length-1] !== "/") url += "/";
+  if (url[url.length - 1] !== "/") url += "/";
   const patternURL = new URL(pattern);
   const urlURL = new URL(url);
   if (patternURL.origin !== urlURL.origin) return false;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -42,7 +42,7 @@ function userscriptMatches(data, matches) {
 function urlMatchesPattern(pattern, url) {
   const patternURL = new URL(pattern);
   const urlURL = new URL(url);
-  if(patternURL.origin !== urlURL.origin) return false;
+  if (patternURL.origin !== urlURL.origin) return false;
   const patternPath = patternURL.pathname.split("/");
   const urlPath = urlURL.pathname.split("/");
   while (patternPath.length) {

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -40,7 +40,6 @@ function userscriptMatches(data, matches) {
 }
 
 function urlMatchesPattern(pattern, url) {
-  if (url[url.length - 1] !== "/") url += "/";
   const patternURL = new URL(pattern);
   const urlURL = new URL(url);
   if (patternURL.origin !== urlURL.origin) return false;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -39,14 +39,16 @@ function userscriptMatches(data, matches) {
   return false;
 }
 
-function urlMatchesPattern(_pattern, _url) {
-  const pattern = _pattern.split("/");
-  const url = _url.split("/");
-  while (pattern.length) {
-    const p = pattern.shift();
-    const q = url.shift();
+function urlMatchesPattern(pattern, url) {
+  const patternURL = new URL(pattern);
+  const urlURL = new URL(url);
+  if(patternURL.origin !== urlURL.origin) return false;
+  const patternPath = patternURL.pathname.split("/");
+  const urlPath = urlURL.pathname.split("/");
+  while (patternPath.length) {
+    const p = patternPath.shift();
+    const q = urlPath.shift();
     if (p !== q && p !== "*") return false;
   }
   return true;
 }
-window.urlMatchesPattern = urlMatchesPattern;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -40,6 +40,7 @@ function userscriptMatches(data, matches) {
 }
 
 function urlMatchesPattern(pattern, url) {
+  if(url[url.length-1] !== "/") url += "/";
   const patternURL = new URL(pattern);
   const urlURL = new URL(url);
   if (patternURL.origin !== urlURL.origin) return false;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -45,6 +45,7 @@ function urlMatchesPattern(pattern, url) {
   if (patternURL.origin !== urlURL.origin) return false;
   const patternPath = patternURL.pathname.split("/");
   const urlPath = urlURL.pathname.split("/");
+  if (urlPath[urlPath.length - 1] !== "") urlPath.push("");
   while (patternPath.length) {
     const p = patternPath.shift();
     const q = urlPath.shift();


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #24

**Changes**

<!-- Please describe the changes you've made. -->

Adds an implicit hash to the URL path, so that, for example, `https://scratch.mit.edu/users/kaj` matches `https://scratch.mit.edu/users/*/`.
Now, only the URL origin and paths are checked. We don't allow matches for other parts of the URL.

**Tests**

<!-- Have you tested this pull request? If so, how? -->
Latest Chromium