### PR TITLE
Add extension ID for Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,10 @@
     "content-scripts/inject/*",
     "addon-api/*",
     "addons/*"
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "firefox@scratchaddons"
+    }
+  }
 }


### PR DESCRIPTION
**Resolves**

`chrome.storage.sync` did not fully work because there was no specified ID.

**Changes**

Specify ID `firefox@scratchaddons` in the manifest.