### PR TITLE
Throw if setting ID doesn't exist (addon.settings.get)

### DIFF
--- a/addon-api/common/Settings.js
+++ b/addon-api/common/Settings.js
@@ -5,9 +5,11 @@ export default class Settings extends EventTarget {
     scratchAddons.eventTargets.settings.push(this);
   }
   get(optionName) {
-    const settingsObj = scratchAddons.globalState.addonSettings[this._addonId] || {};
+    const settingsObj =
+      scratchAddons.globalState.addonSettings[this._addonId] || {};
     const value = settingsObj[optionName];
-    if (value === undefined) throw "ScratchAddons exception: invalid setting ID";
+    if (value === undefined)
+      throw "ScratchAddons exception: invalid setting ID";
     else return value;
   }
   _removeEventListeners() {

--- a/addon-api/common/Settings.js
+++ b/addon-api/common/Settings.js
@@ -5,7 +5,10 @@ export default class Settings extends EventTarget {
     scratchAddons.eventTargets.settings.push(this);
   }
   get(optionName) {
-    return scratchAddons.globalState.addonSettings[this._addonId][optionName];
+    const settingsObj = scratchAddons.globalState.addonSettings[this._addonId] || {};
+    const value = settingsObj[optionName];
+    if (value === undefined) throw "ScratchAddons exception: invalid setting ID";
+    else return value;
   }
   _removeEventListeners() {
     scratchAddons.eventTargets.settings.splice(


### PR DESCRIPTION
**Resolves**

Resolves #63

**Changes**

Now throws instead of returning `undefined`.
It also throws this error if the addon has no options object in the manifest.