### PR TITLE
Fix addon.fetch issues

### DIFF
--- a/background/handle-fetch.js
+++ b/background/handle-fetch.js
@@ -12,18 +12,17 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
     if (details.originUrl) {
       // Firefox
       const origin = new URL(details.originUrl).origin;
-      if(origin !== chrome.runtime.getURL("").slice(0, -1) &&
-      origin !== "https://scratch.mit.edu") return;
-    }
-    else if(
+      if (origin !== chrome.runtime.getURL("").slice(0, -1) && origin !== "https://scratch.mit.edu") return;
+    } else if (
       // Chrome
       details.initiator !== chrome.runtime.getURL("").slice(0, -1) &&
       details.initiator !== "https://scratch.mit.edu"
-    ) return;
+    )
+      return;
 
     let useFetchHeaderIndex = null;
     let interceptRequest = false || optionRequestIds.includes(details.requestId);
-    if(!interceptRequest) {
+    if (!interceptRequest) {
       for (const i in details.requestHeaders) {
         const headerName = details.requestHeaders[i].name;
         if (headerName === "X-ScratchAddons-Uses-Fetch") {
@@ -63,21 +62,21 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 
 chrome.webRequest.onHeadersReceived.addListener(
   function (details) {
-    if(details.method === "OPTIONS") {
+    if (details.method === "OPTIONS") {
       for (const i in details.responseHeaders) {
         const headerName = details.responseHeaders[i].name;
         if (headerName === "access-control-allow-headers") {
           details.responseHeaders[i].value += ", x-scratchaddons-uses-fetch";
           return {
-            responseHeaders: details.responseHeaders
-          }
+            responseHeaders: details.responseHeaders,
+          };
         }
       }
     }
-  }
-  ,{
+  },
+  {
     urls: ["https://*.scratch.mit.edu/*"],
     types: ["xmlhttprequest"],
   },
   extraInfoSpec2
-  );
+);


### PR DESCRIPTION
- `addon.fetch` can now be used with requests that require preflight
- Removed unnecessary removal of the Origin header, that sometimes broke stuff. I'm not 100% sure, but I don't think any Scratch API cares about the Origin header. If they do, we might have to readd this.
- Corrected a weird fix by me to fix the fact `details.originUrl` might be `null` so that the check correctly works in Chrome. We don't want third parties playing with the `X-ScratchAddons-Uses-Fetch` header.