### PR TITLE
Add addon.tab.waitForElement

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -9,4 +9,20 @@ export default class Tab {
   getScratchVM() {
     return scratchAddons.methods.getScratchVM();
   }
+  waitForElement(selector) {
+    if (!document.querySelector(selector)) {
+        return new Promise((resolve) => new MutationObserver(function(mutationsList, observer) {
+            if (document.querySelector(selector)) {
+                observer.disconnect();
+                resolve();
+            }
+        }).observe(document.body, {
+            attributes: true,
+            childList: true,
+            subtree: true
+        }))
+    } else {
+        return Promise.resolve()
+    }
+  }
 }


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #96

**Changes**

<!-- Please describe the changes you've made. -->
Adds addon.tab.waitForElement

**Reason for changes**

<!-- Why should these changes be made? -->
This function allows addons to wait for elements to appear in the DOM. For example, `await addon.tab.waitForElement("#navigation span.message-count")` will wait for the message-count element to load. If the element already exists, it will resolve instantly.

**Tests**

<!-- Have you tested this pull request? If so, how? -->
I haven't tested it with the rest of the extention, but it works on it's own.
