### PR TITLE
Functional settings page

### DIFF
--- a/background/declare-scratchaddons-object.js
+++ b/background/declare-scratchaddons-object.js
@@ -16,13 +16,10 @@ _globalState.auth = {
 class GlobalStateProxyHandler {
   constructor(name, target) {
     if (name) this.name = `${name}.`;
-    else {
-      this.name = "";
-      this._target = target;
-    }
+    else this._target = target;
   }
   get(target, key) {
-    if (this.name === "" && key === "_target") return this._target;
+    if (key === "_target") return target;
     if (typeof target[key] === "object" && target[key] !== null) {
       return new Proxy(target[key], new GlobalStateProxyHandler(`${this.name}${key}`));
     } else {

--- a/background/get-background-scripts.js
+++ b/background/get-background-scripts.js
@@ -6,8 +6,7 @@ if (scratchAddons.localState.allReady) getBgScripts();
 else window.addEventListener("scratchaddonsready", getBgScripts);
 
 async function getBgScripts() {
-  for (const addonId in scratchAddons.manifests) {
-    const manifest = scratchAddons.manifests[addonId];
+  for (const {manifest, addonId} of scratchAddons.manifests) {
     if (manifest.persistent_scripts) {
       let permissions;
       if (manifest.permissions) permissions = manifest.permissions;

--- a/background/get-background-scripts.js
+++ b/background/get-background-scripts.js
@@ -6,7 +6,7 @@ if (scratchAddons.localState.allReady) getBgScripts();
 else window.addEventListener("scratchaddonsready", getBgScripts);
 
 async function getBgScripts() {
-  for (const {manifest, addonId} of scratchAddons.manifests) {
+  for (const { manifest, addonId } of scratchAddons.manifests) {
     if (manifest.persistent_scripts) {
       let permissions;
       if (manifest.permissions) permissions = manifest.permissions;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -3,8 +3,7 @@ else window.addEventListener("scratchaddonsready", getUsercripts);
 
 const addonsWithUserscripts = [];
 async function getUsercripts() {
-  for (const addonId in scratchAddons.manifests) {
-    const manifest = scratchAddons.manifests[addonId];
+  for (const {manifest, addonId} of scratchAddons.manifests) {
     if (manifest.userscripts || manifest.userstyles) {
       addonsWithUserscripts.push({ addonId, scripts: manifest.userscripts || [], styles: manifest.userstyles || [] });
     }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -3,7 +3,7 @@ else window.addEventListener("scratchaddonsready", getUsercripts);
 
 const addonsWithUserscripts = [];
 async function getUsercripts() {
-  for (const {manifest, addonId} of scratchAddons.manifests) {
+  for (const { manifest, addonId } of scratchAddons.manifests) {
     if (manifest.userscripts || manifest.userstyles) {
       addonsWithUserscripts.push({ addonId, scripts: manifest.userscripts || [], styles: manifest.userstyles || [] });
     }

--- a/background/handle-addon-settings.js
+++ b/background/handle-addon-settings.js
@@ -1,6 +1,6 @@
 chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {}, addonsEnabled = {} }) => {
   const func = () => {
-    for (const {manifest, addonId} of scratchAddons.manifests) {
+    for (const { manifest, addonId } of scratchAddons.manifests) {
       const settings = addonSettings[addonId] || {};
       let madeChanges = false;
       if (manifest.options) {

--- a/background/handle-addon-settings.js
+++ b/background/handle-addon-settings.js
@@ -1,7 +1,6 @@
 chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {}, addonsEnabled = {} }) => {
   const func = () => {
-    for (const addonId in scratchAddons.manifests) {
-      const manifest = scratchAddons.manifests[addonId];
+    for (const {manifest, addonId} of scratchAddons.manifests) {
       const settings = addonSettings[addonId] || {};
       let madeChanges = false;
       if (manifest.options) {
@@ -27,23 +26,3 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
   window.addEventListener("manifestsready", func);
   if (scratchAddons.localState.ready.manifests) func();
 });
-
-// TODO: allow these to be called from the settings page. These are for testing.
-window.updateAddonSettings = function updateAddonSettings(addonId, newSettings) {
-  scratchAddons.globalState.addonSettings[addonId] = newSettings;
-  chrome.storage.sync.set({
-    addonSettings: scratchAddons.globalState.addonSettings,
-  });
-};
-window.changeEnabledState = function changeEnabledState(addonId, newState) {
-  scratchAddons.localState.addonsEnabled[addonId] = newState;
-  chrome.storage.sync.set({
-    addonsEnabled: scratchAddons.localState.addonsEnabled,
-  });
-  if (newState === false) {
-    const addonObj = scratchAddons.addons.find((addonObj) => addonObj.self.id === addonId);
-    if (addonObj) addonObj._kill();
-  } else {
-    scratchAddons.runBgScriptsById(addonId);
-  }
-};

--- a/background/handle-local-state.js
+++ b/background/handle-local-state.js
@@ -16,6 +16,7 @@ class LocalStateProxyHandler {
     else this.name = "";
   }
   get(target, key) {
+    if (key === "_target") return target;
     if (typeof target[key] === "object" && target[key] !== null) {
       return new Proxy(target[key], new LocalStateProxyHandler(`${this.name}${key}`));
     } else {

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -1,7 +1,31 @@
-chrome.runtime.onMessage.addListener(async function (request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "getSettingsInfo") {
     sendResponse({
       manifests: scratchAddons.manifests,
+      // Firefox breaks if we send proxies
+      addonsEnabled: scratchAddons.localState._target.addonsEnabled,
+      addonSettings: scratchAddons.globalState._target.addonSettings
+    });
+  }
+  else if(request.changeEnabledState) {
+    const { addonId, newState } = request.changeEnabledState;
+    scratchAddons.localState.addonsEnabled[addonId] = newState;
+    chrome.storage.sync.set({
+      addonsEnabled: scratchAddons.localState.addonsEnabled,
+    });
+    if (newState === false) {
+      const addonObjs = scratchAddons.addons.filter((addonObj) => addonObj.self.id === addonId);
+      if (addonObjs) addonObjs.forEach(addonObj => addonObj._kill());
+    } else {
+      scratchAddons.runBgScriptsById(addonId);
+    }
+  }
+  else if(request.changeAddonSettings) {
+    console.log(request.changeAddonSettings);
+    const { addonId, newSettings } = request.changeAddonSettings;
+    scratchAddons.globalState.addonSettings[addonId] = newSettings;
+    chrome.storage.sync.set({
+      addonSettings: scratchAddons.globalState.addonSettings,
     });
   }
 });

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -4,10 +4,9 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       manifests: scratchAddons.manifests,
       // Firefox breaks if we send proxies
       addonsEnabled: scratchAddons.localState._target.addonsEnabled,
-      addonSettings: scratchAddons.globalState._target.addonSettings
+      addonSettings: scratchAddons.globalState._target.addonSettings,
     });
-  }
-  else if(request.changeEnabledState) {
+  } else if (request.changeEnabledState) {
     const { addonId, newState } = request.changeEnabledState;
     scratchAddons.localState.addonsEnabled[addonId] = newState;
     chrome.storage.sync.set({
@@ -15,12 +14,11 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     });
     if (newState === false) {
       const addonObjs = scratchAddons.addons.filter((addonObj) => addonObj.self.id === addonId);
-      if (addonObjs) addonObjs.forEach(addonObj => addonObj._kill());
+      if (addonObjs) addonObjs.forEach((addonObj) => addonObj._kill());
     } else {
       scratchAddons.runBgScriptsById(addonId);
     }
-  }
-  else if(request.changeAddonSettings) {
+  } else if (request.changeAddonSettings) {
     console.log(request.changeAddonSettings);
     const { addonId, newSettings } = request.changeAddonSettings;
     scratchAddons.globalState.addonSettings[addonId] = newSettings;

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -1,10 +1,10 @@
-scratchAddons.manifests = {};
+scratchAddons.manifests = [];
 
 (async function () {
   const folderNames = await (await fetch("/addons/addons.json")).json();
   for (const folderName of folderNames) {
     const manifest = await (await fetch(`/addons/${folderName}/addon.json`)).json();
-    scratchAddons.manifests[folderName] = manifest;
+    scratchAddons.manifests.push({addonId: folderName, manifest});
   }
   scratchAddons.localState.ready.manifests = true;
   window.dispatchEvent(new CustomEvent("manifestsready"));

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -4,7 +4,7 @@ scratchAddons.manifests = [];
   const folderNames = await (await fetch("/addons/addons.json")).json();
   for (const folderName of folderNames) {
     const manifest = await (await fetch(`/addons/${folderName}/addon.json`)).json();
-    scratchAddons.manifests.push({addonId: folderName, manifest});
+    scratchAddons.manifests.push({ addonId: folderName, manifest });
   }
   scratchAddons.localState.ready.manifests = true;
   window.dispatchEvent(new CustomEvent("manifestsready"));

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ScratchAddons</title>
+    <title>Scratch Addons - Settings</title>
     <link rel="stylesheet" href="style.css" />
     <link href="../../libraries/Sora.css" rel="stylesheet" />
   </head>
@@ -13,79 +13,108 @@
       <h1>Settings</h1>
     </div>
     <div class="main">
-      <!-- This is a side menu, from which you select different categories-->
       <div class="categories-block">
-        <div class="category">
-          <img src="./puzzle.svg" />
-          <span>All Categories</span>
+        <div class="category" :class="{sel: selectedTab === 'all'}" @click="selectedTab = 'all'">
+          <img src="./list.svg" />
+          <span>All</span>
         </div>
-        <div class="category">
+        <div class="category" :class="{sel: selectedTab === 'editor'}" @click="selectedTab = 'editor'">
+          <img src="./puzzle.svg" />
+          <span>Scratch Editor Features</span>
+        </div>
+        <div class="category" :class="{sel: selectedTab === 'community'}" @click="selectedTab = 'community'">
+          <img src="./web.svg" />
+          <span>Scratch Website Features</span>
+        </div>
+        <div class="category" :class="{sel: selectedTab === 'themes'}" @click="selectedTab = 'themes'">
           <img src="./brush.svg" />
           <span>Themes</span>
         </div>
-        <div class="category sel">
-          <img src="./feature.svg" />
-          <span>Features</span>
-        </div>
-        <div class="category">
-          <img src="./newuser.svg" />
-          <span>User Experience</span>
-        </div>
-        <div class="category">
+        <!--<div class="category">
           <img src="./wrench.svg" />
-          <span>Griffpatch is Fat</span>
-        </div>
-        <div class="category">
-          <img src="./web.svg" />
-          <span>Scratch Website</span>
-        </div>
+          <span>More settings</span>
+        </div>-->
       </div>
 
       <!-- This is a the main menu, where the searchbar and the addon items are located -->
       <div class="addons-block">
         <div class="search-box">
-          <input type="text" id="searchBox" placeholder="Search" />
-          <button id="searchBtn"></button>
-
+          <input type="text" id="searchBox" placeholder="Search" :autofocus="true" v-model="searchInput"/>
+          <button v-show="searchInput === ''" style="background-image: url('https://api.iconify.design/uil:search.svg?color=grey')"></button>
+          <button v-else style="background-image: url('https://api.iconify.design/bi:x.svg?color=grey')" @click="clearSearch()"></button>
           <div class="filter-selector">
-            <span>State: </span>
+            <span class="filter-text">Filter: </span>
             <div class="filter-options">
-              <div class="filter-option sel">All</div>
-              <div class="filter-option">Enabled</div>
-              <div class="filter-option">Disabled</div>
-            </div>
-          </div>
-          <div class="filter-selector">
-            <span>Type: </span>
-            <div class="filter-options">
-              <div class="filter-option sel">Theme</div>
-              <div class="filter-option">Script</div>
-            </div>
-          </div>
-          <div class="filter-selector">
-            <span>More: </span>
-            <div class="filter-options">
-              <div class="filter-option">Other Filters</div>
+              <div 
+              class="filter-option"
+              :class="{'sel': selectedTag === null}"
+              @click="selectedTag = null">
+              All</div>
+              <div 
+              v-for="tag of tags"
+              v-show="tag.tabShow[selectedTab]"
+              class="filter-option"
+              class="badge" :class="{
+                'sel': selectedTag === tag.matchName,
+                'blue': tag.color === 'blue',
+                'yellow': tag.color === 'yellow',
+                'red': tag.color === 'red',
+                'green': tag.color === 'green'}"
+              @click="selectedTag === tag.matchName ? (selectedTag = null) : (selectedTag = tag.matchName)">
+              {{ tag.name }}
+              </div>
             </div>
           </div>
         </div>
 
         <div class="addons-container">
-          <!-- This is an individual addon item. It has a top bar where all the info is displayed and 
-                settings, which appear when you expand it -->
-          <div class="addon-body" v-for="addon of addons">
+          <div class="addon-body" 
+          v-for="addon of manifests" 
+          v-show="addonMatchesFilters(addon) && (selectedTab === 'all' || addon._category === selectedTab)">
             <div class="addon-topbar">
-              <div class="btn-dropdown" id="testDropdown"><img src="./expand.svg" alt="v" /></div>
-              <div class="addon-name">{{ addon.name }}</div>
-              <div class="badge blue">Recommended</div>
-              <div class="badge red">Beta</div>
+              <div class="clickeable-area" @click="addon._expanded = !addon._expanded">
+                <div class="btn-dropdown"><img src="./expand.svg" alt="v" :class="{'reverted': addon._expanded}" /></div>
+                <div class="addon-name">
+                  <img v-if="addon._category === 'editor'" src="./puzzle.svg" class="icon-type">
+                  <img v-if="addon._category === 'community'" src="./web.svg" class="icon-type">
+                  <img v-if="addon._category === 'theme'" src="./brush.svg" class="icon-type">
+                  {{ addon.name }}
+                </div>
+              </div>
+              <div class="badge blue" v-if="addon._tags.recommended">Recommended</div>
+              <div class="badge red" v-if="addon._tags.beta">Beta</div>
+              <div class="badge green" v-if="addon._tags.forums">Forums</div>
+              <div class="addon-description" v-show="!addon._expanded">{{ addon.description }}</div>
               <div class="addon-check">
-                <switch state="off" id="testSwitch" />
+                <switch :state="addon._enabled ? 'on' : 'off'" @click="toggleAddon(addon)"/>
               </div>
             </div>
-            <div class="addon-settings">
+            <div class="addon-settings" v-show="addon._expanded">
+              <div class="addon-description-full" v-show="addon._expanded">{{ addon.description }}</div>
               <div class="settings-column">
-                <div class="addon-setting">
+                <div v-for="setting of addon.options">
+                  <div class="addon-setting" v-if="setting.type === 'boolean'">
+                    <div class="setting-label">{{ setting.name }}</div>
+                    <input type="checkbox" 
+                    class="setting-input check"
+                    v-model="addonSettings[addon._addonId][setting.id]"
+                    @change="updateSettings(addon);"
+                    :disabled="!addon._enabled"
+                    />
+                  </div>
+                    <div class="addon-setting" v-if="setting.type === 'positive_integer'">
+                      <div class="setting-label">{{ setting.name }}</div>
+                      <input type="number" 
+                      class="setting-input number"
+                      v-model="addonSettings[addon._addonId][setting.id]"
+                      @change="updateSettings(addon)"
+                      :disabled="!addon._enabled"
+                      />
+                  </div>
+                </div>
+                </div>
+                <!--
+                <div class="addon-setting" v-for="setting of addon.options">
                   <div class="setting-label">Your Mood</div>
                   <input type="text" class="setting-input string" placeholder="How are you?" />
                 </div>
@@ -94,7 +123,6 @@
                   <input type="number" class="setting-input number" placeholder="Aeg" />
                 </div>
               </div>
-              <div class="settings-column">
                 <div class="addon-setting">
                   <div class="setting-label">Show Ads pls</div>
                   <input type="checkbox" class="setting-input check" min="0" max="10" />
@@ -106,34 +134,14 @@
                     <div class="filter-option">Stinky</div>
                     <div class="filter-option">Poop</div>
                   </div>
-                </div>
-              </div>
+                </div> -->
             </div>
           </div>
         </div>
       </div>
     </div>
-
-    <script>
-      //this is just a test code to see how stuff works.
-
-      document.querySelector("#testSwitch").onclick = () => {
-        //this statement is true if the switch is on, and false if it's off
-        let state = document.querySelector("#testSwitch").getAttribute("state") == "on";
-
-        //is the statement above is true, turn the switch off. If it's false, turn it on.
-        if (state) document.querySelector("#testSwitch").setAttribute("state", "off");
-        else document.querySelector("#testSwitch").setAttribute("state", "on");
-      };
-
-      document.querySelector("#testDropdown").onclick = () => {
-        //this statement is true if the switch is on, and false if it's off
-        let p = document.querySelector("#testDropdown").parentElement.parentElement;
-        p.classList.toggle("sh");
-      };
-    </script>
     <script src="../../libraries/iconify.min.js"></script>
     <script src="../../libraries/vue.js"></script>
-    <!-- <script src="index.js"></script> -->
+    <script src="index.js"></script>
   </body>
 </html>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -39,45 +39,54 @@
       <!-- This is a the main menu, where the searchbar and the addon items are located -->
       <div class="addons-block">
         <div class="search-box">
-          <input type="text" id="searchBox" placeholder="Search" :autofocus="true" v-model="searchInput"/>
-          <button v-show="searchInput === ''" style="background-image: url('https://api.iconify.design/uil:search.svg?color=grey')"></button>
-          <button v-else style="background-image: url('https://api.iconify.design/bi:x.svg?color=grey')" @click="clearSearch()"></button>
+          <input type="text" id="searchBox" placeholder="Search" :autofocus="true" v-model="searchInput" />
+          <button
+            v-show="searchInput === ''"
+            style="background-image: url('https://api.iconify.design/uil:search.svg?color=grey')"
+          ></button>
+          <button
+            v-else
+            style="background-image: url('https://api.iconify.design/bi:x.svg?color=grey')"
+            @click="clearSearch()"
+          ></button>
           <div class="filter-selector">
             <span class="filter-text">Filter: </span>
             <div class="filter-options">
-              <div 
-              class="filter-option"
-              :class="{'sel': selectedTag === null}"
-              @click="selectedTag = null">
-              All</div>
-              <div 
-              v-for="tag of tags"
-              v-show="tag.tabShow[selectedTab]"
-              class="filter-option"
-              class="badge" :class="{
+              <div class="filter-option" :class="{'sel': selectedTag === null}" @click="selectedTag = null">All</div>
+              <div
+                v-for="tag of tags"
+                v-show="tag.tabShow[selectedTab]"
+                class="filter-option"
+                class="badge"
+                :class="{
                 'sel': selectedTag === tag.matchName,
                 'blue': tag.color === 'blue',
                 'yellow': tag.color === 'yellow',
                 'red': tag.color === 'red',
                 'green': tag.color === 'green'}"
-              @click="selectedTag === tag.matchName ? (selectedTag = null) : (selectedTag = tag.matchName)">
-              {{ tag.name }}
+                @click="selectedTag === tag.matchName ? (selectedTag = null) : (selectedTag = tag.matchName)"
+              >
+                {{ tag.name }}
               </div>
             </div>
           </div>
         </div>
 
         <div class="addons-container">
-          <div class="addon-body" 
-          v-for="addon of manifests" 
-          v-show="addonMatchesFilters(addon) && (selectedTab === 'all' || addon._category === selectedTab)">
+          <div
+            class="addon-body"
+            v-for="addon of manifests"
+            v-show="addonMatchesFilters(addon) && (selectedTab === 'all' || addon._category === selectedTab)"
+          >
             <div class="addon-topbar">
               <div class="clickeable-area" @click="addon._expanded = !addon._expanded">
-                <div class="btn-dropdown"><img src="./expand.svg" alt="v" :class="{'reverted': addon._expanded}" /></div>
+                <div class="btn-dropdown">
+                  <img src="./expand.svg" alt="v" :class="{'reverted': addon._expanded}" />
+                </div>
                 <div class="addon-name">
-                  <img v-if="addon._category === 'editor'" src="./puzzle.svg" class="icon-type">
-                  <img v-if="addon._category === 'community'" src="./web.svg" class="icon-type">
-                  <img v-if="addon._category === 'theme'" src="./brush.svg" class="icon-type">
+                  <img v-if="addon._category === 'editor'" src="./puzzle.svg" class="icon-type" />
+                  <img v-if="addon._category === 'community'" src="./web.svg" class="icon-type" />
+                  <img v-if="addon._category === 'theme'" src="./brush.svg" class="icon-type" />
                   {{ addon.name }}
                 </div>
               </div>
@@ -86,7 +95,7 @@
               <div class="badge green" v-if="addon._tags.forums">Forums</div>
               <div class="addon-description" v-show="!addon._expanded">{{ addon.description }}</div>
               <div class="addon-check">
-                <switch :state="addon._enabled ? 'on' : 'off'" @click="toggleAddon(addon)"/>
+                <switch :state="addon._enabled ? 'on' : 'off'" @click="toggleAddon(addon)" />
               </div>
             </div>
             <div class="addon-settings" v-show="addon._expanded">
@@ -95,25 +104,27 @@
                 <div v-for="setting of addon.options">
                   <div class="addon-setting" v-if="setting.type === 'boolean'">
                     <div class="setting-label">{{ setting.name }}</div>
-                    <input type="checkbox" 
-                    class="setting-input check"
-                    v-model="addonSettings[addon._addonId][setting.id]"
-                    @change="updateSettings(addon);"
-                    :disabled="!addon._enabled"
+                    <input
+                      type="checkbox"
+                      class="setting-input check"
+                      v-model="addonSettings[addon._addonId][setting.id]"
+                      @change="updateSettings(addon);"
+                      :disabled="!addon._enabled"
                     />
                   </div>
-                    <div class="addon-setting" v-if="setting.type === 'positive_integer'">
-                      <div class="setting-label">{{ setting.name }}</div>
-                      <input type="number" 
+                  <div class="addon-setting" v-if="setting.type === 'positive_integer'">
+                    <div class="setting-label">{{ setting.name }}</div>
+                    <input
+                      type="number"
                       class="setting-input number"
                       v-model="addonSettings[addon._addonId][setting.id]"
                       @change="updateSettings(addon)"
                       :disabled="!addon._enabled"
-                      />
+                    />
                   </div>
                 </div>
-                </div>
-                <!--
+              </div>
+              <!--
                 <div class="addon-setting" v-for="setting of addon.options">
                   <div class="setting-label">Your Mood</div>
                   <input type="text" class="setting-input string" placeholder="How are you?" />

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -1,11 +1,105 @@
 const vue = new Vue({
-  el: ".main",
+  el: "body",
   data: {
-    addons: [],
+    manifests: [],
+    selectedTab: "all",
+    selectedTag: null,
+    searchInput: "",
+    addonSettings: {},
+    tags: [
+      {
+        name: "Recommended",
+        matchType: "tag",
+        matchName: "recommended",
+        color: "blue",
+        tabShow: {
+          "all": true,
+          "editor": true,
+          "community": true,
+          "themes": false
+        }
+      },
+      {
+        name: "Beta",
+        matchType: "tag",
+        matchName: "beta",
+        color: "red",
+        tabShow: {
+          "all": true,
+          "editor": true,
+          "community": true,
+          "themes": true
+        }
+      },
+      {
+        name: "Forums",
+        matchType: "tag",
+        matchName: "forums",
+        color: "green",
+        tabShow: {
+          "all": true,
+          "editor": false,
+          "community": true,
+          "themes": false
+        }
+      }
+    ]
   },
+  methods: {
+    clearSearch() {
+      this.searchInput = "";
+    },
+    addonMatchesFilters(addonManifest) {
+      const matchesTag = this.selectedTag === null || addonManifest.tags.includes(this.selectedTag);
+      const matchesSearch = this.searchInput === ""
+        || addonManifest.name.toLowerCase().includes(this.searchInput.toLowerCase())
+        || addonManifest.description.toLowerCase().includes(this.searchInput.toLowerCase());
+      return matchesTag && matchesSearch;
+    },
+    stopPropagation(e) {
+      e.stopPropagation();
+    },
+    toggleAddon(addon) {
+      const newState = !addon._enabled;
+      addon._enabled = newState;
+      addon._expanded = newState;
+      chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } })
+    },
+    updateSettings(addon) {
+      chrome.runtime.sendMessage({ changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] } });
+      console.log("Updated", this.addonSettings[addon._addonId]);
+    }
+  }
 });
 
-chrome.runtime.sendMessage("getSettingsInfo", ({ manifests }) => {
-  vue.addons = manifests;
-  console.log(manifests);
+chrome.runtime.sendMessage("getSettingsInfo", ({ manifests, addonsEnabled, addonSettings }) => {
+  console.log(manifests, addonsEnabled, addonSettings);
+  vue.addonSettings = addonSettings;
+  for(const {manifest, addonId} of manifests) {
+    manifest._category = manifest.tags.includes("theme") ? "theme" : manifest.tags.includes("community") ? "community" : "editor";
+    manifest._enabled = addonsEnabled[addonId];
+    manifest._addonId = addonId;
+    manifest._expanded = manifest._enabled;
+    manifest._tags = {};
+    manifest._tags.recommended = manifest.tags.includes("recommended");
+    manifest._tags.beta = manifest.tags.includes("beta");
+    manifest._tags.forums = manifest.tags.includes("forums");
+  }
+  // Sort: enabled first, then recommended disabled, then other disabled addons. All alphabetically.
+  manifests.sort((a,b) => {
+    if (a.manifest._enabled === true && b.manifest._enabled === false) return -1;
+    else if(a.manifest._enabled === b.manifest._enabled) {
+      if(a.manifest.name.localeCompare(b.manifest.name) === 1) {
+        if(a.manifest._tags.recommended === true && b.manifest._tags.recommended === false) return -1;
+        else return 1;
+      }
+      else return -1;
+    }
+    else return 1;
+  });
+  vue.manifests = manifests.map(({manifest}) => manifest);
+});
+
+vue.$watch("selectedTab", function (newSelectedTab) {
+  this.selectedTag = null;
 });

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -13,11 +13,11 @@ const vue = new Vue({
         matchName: "recommended",
         color: "blue",
         tabShow: {
-          "all": true,
-          "editor": true,
-          "community": true,
-          "themes": false
-        }
+          all: true,
+          editor: true,
+          community: true,
+          themes: false,
+        },
       },
       {
         name: "Beta",
@@ -25,11 +25,11 @@ const vue = new Vue({
         matchName: "beta",
         color: "red",
         tabShow: {
-          "all": true,
-          "editor": true,
-          "community": true,
-          "themes": true
-        }
+          all: true,
+          editor: true,
+          community: true,
+          themes: true,
+        },
       },
       {
         name: "Forums",
@@ -37,13 +37,13 @@ const vue = new Vue({
         matchName: "forums",
         color: "green",
         tabShow: {
-          "all": true,
-          "editor": false,
-          "community": true,
-          "themes": false
-        }
-      }
-    ]
+          all: true,
+          editor: false,
+          community: true,
+          themes: false,
+        },
+      },
+    ],
   },
   methods: {
     clearSearch() {
@@ -51,9 +51,10 @@ const vue = new Vue({
     },
     addonMatchesFilters(addonManifest) {
       const matchesTag = this.selectedTag === null || addonManifest.tags.includes(this.selectedTag);
-      const matchesSearch = this.searchInput === ""
-        || addonManifest.name.toLowerCase().includes(this.searchInput.toLowerCase())
-        || addonManifest.description.toLowerCase().includes(this.searchInput.toLowerCase());
+      const matchesSearch =
+        this.searchInput === "" ||
+        addonManifest.name.toLowerCase().includes(this.searchInput.toLowerCase()) ||
+        addonManifest.description.toLowerCase().includes(this.searchInput.toLowerCase());
       return matchesTag && matchesSearch;
     },
     stopPropagation(e) {
@@ -63,20 +64,26 @@ const vue = new Vue({
       const newState = !addon._enabled;
       addon._enabled = newState;
       addon._expanded = newState;
-      chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } })
+      chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } });
     },
     updateSettings(addon) {
-      chrome.runtime.sendMessage({ changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] } });
+      chrome.runtime.sendMessage({
+        changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] },
+      });
       console.log("Updated", this.addonSettings[addon._addonId]);
-    }
-  }
+    },
+  },
 });
 
 chrome.runtime.sendMessage("getSettingsInfo", ({ manifests, addonsEnabled, addonSettings }) => {
   console.log(manifests, addonsEnabled, addonSettings);
   vue.addonSettings = addonSettings;
-  for(const {manifest, addonId} of manifests) {
-    manifest._category = manifest.tags.includes("theme") ? "theme" : manifest.tags.includes("community") ? "community" : "editor";
+  for (const { manifest, addonId } of manifests) {
+    manifest._category = manifest.tags.includes("theme")
+      ? "theme"
+      : manifest.tags.includes("community")
+      ? "community"
+      : "editor";
     manifest._enabled = addonsEnabled[addonId];
     manifest._addonId = addonId;
     manifest._expanded = manifest._enabled;
@@ -86,18 +93,16 @@ chrome.runtime.sendMessage("getSettingsInfo", ({ manifests, addonsEnabled, addon
     manifest._tags.forums = manifest.tags.includes("forums");
   }
   // Sort: enabled first, then recommended disabled, then other disabled addons. All alphabetically.
-  manifests.sort((a,b) => {
+  manifests.sort((a, b) => {
     if (a.manifest._enabled === true && b.manifest._enabled === false) return -1;
-    else if(a.manifest._enabled === b.manifest._enabled) {
-      if(a.manifest.name.localeCompare(b.manifest.name) === 1) {
-        if(a.manifest._tags.recommended === true && b.manifest._tags.recommended === false) return -1;
+    else if (a.manifest._enabled === b.manifest._enabled) {
+      if (a.manifest.name.localeCompare(b.manifest.name) === 1) {
+        if (a.manifest._tags.recommended === true && b.manifest._tags.recommended === false) return -1;
         else return 1;
-      }
-      else return -1;
-    }
-    else return 1;
+      } else return -1;
+    } else return 1;
   });
-  vue.manifests = manifests.map(({manifest}) => manifest);
+  vue.manifests = manifests.map(({ manifest }) => manifest);
 });
 
 vue.$watch("selectedTab", function (newSelectedTab) {

--- a/webpages/settings/list.svg
+++ b/webpages/settings/list.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="list.svg"
+   id="svg6"
+   version="1.1"
+   style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);"
+   viewBox="0 0 1024 1024"
+   preserveAspectRatio="xMidYMid meet"
+   height="1024"
+   width="1024">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg6"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:cy="512"
+     inkscape:cx="512"
+     inkscape:zoom="0.57314319"
+     showgrid="false"
+     id="namedview8"
+     inkscape:window-height="1001"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ff7b26;fill-opacity:1"
+     id="path2"
+     fill="black"
+     d="M912 192H328c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h584c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zm0 284H328c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h584c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zm0 284H328c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h584c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM104 228a56 56 0 1 0 112 0a56 56 0 1 0-112 0zm0 284a56 56 0 1 0 112 0a56 56 0 1 0-112 0zm0 284a56 56 0 1 0 112 0a56 56 0 1 0-112 0z" />
+</svg>

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -167,7 +167,7 @@ h1 {
   width: 100%;
   margin-bottom: 10px;
   white-space: normal;
-  color: #DDDDDD;
+  color: #dddddd;
 }
 
 .badge.blue {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -110,7 +110,6 @@ h1 {
 .btn-dropdown {
   display: flex;
   align-items: center;
-  cursor: pointer;
   padding: 5px;
   border-radius: 4px;
 }
@@ -126,19 +125,49 @@ h1 {
   height: 23px;
 }
 
+.clickeable-area {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
 .addon-name {
-  margin: 10px;
+  margin-left: 15px;
   font-weight: 300;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+.icon-type {
+  height: 16px;
+  vertical-align: middle;
+  filter: brightness(10);
+  margin-right: 5px;
 }
 
 .badge {
-  background: #000;
+  background: gray;
   color: #fff;
   border-radius: 4px;
   padding: 2px 5px;
   font-size: 12px;
   margin-left: 10px;
   border-bottom: 2px solid #111;
+}
+
+.addon-description {
+  margin-left: 10px;
+  color: gray;
+  width: 35vw;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.addon-description-full {
+  width: 100%;
+  margin-bottom: 10px;
+  white-space: normal;
+  color: #DDDDDD;
 }
 
 .badge.blue {
@@ -159,6 +188,20 @@ h1 {
   background: #fd662b;
   border-color: #d84a12;
 }
+.filter-option.sel.blue {
+  background: #175ef8;
+}
+.filter-option.sel.green {
+  background: #78fd2b;
+  color: #333333;
+}
+.filter-option.sel.yellow {
+  background: #fddd2b;
+  color: #333333;
+}
+.filter-option.sel.red {
+  background: #d84a12;
+}
 
 .rating {
   margin-left: 20px;
@@ -173,9 +216,7 @@ h1 {
   display: flex;
 }
 .addon-settings {
-  display: none;
   padding: 0 20px;
-  display: none;
 }
 
 .settings-column {
@@ -185,7 +226,7 @@ h1 {
 
 .addon-setting {
   margin: 10px;
-  height: 35px;
+  min-height: 35px;
   display: flex;
   align-items: center;
 }
@@ -254,17 +295,24 @@ h1 {
 
 .search-box button {
   background: #111;
-  background-image: url("https://api.iconify.design/uil:search.svg?color=grey");
+  /* Background URL set by Vue */
   background-repeat: no-repeat;
   background-position: center;
-  height: 35px;
+  height: 36px;
   width: 45px;
   border: none;
   border-radius: 0 4px 4px 0;
-}
-.search-box button:hover {
-  background-image: url("https://api.iconify.design/uil:search.svg?color=white");
+  outline: none;
   cursor: pointer;
+}
+
+.search-box .badge {
+  cursor: pointer;
+  border-bottom: none;
+}
+.search-box .badge .selected-badge {
+  cursor: pointer;
+  border-bottom: none;
 }
 
 switch {
@@ -305,7 +353,7 @@ switch[state="on"]::before {
   align-items: center;
 }
 
-.filter-selector span {
+.filter-text {
   font-weight: 600;
   margin-right: 20px;
 }
@@ -333,4 +381,8 @@ switch[state="on"]::before {
 }
 .filter-option.sel {
   background: #ff7b26;
+}
+
+.reverted {
+  transform: rotate(180deg);
 }


### PR DESCRIPTION
You can now:
- Enable and disable addons
- Change addon settings (for now, only boolean and positive_integer)
- Filter addons by category and tags
- Search addons by typing keywords found in title/description

Other changes:
- Standardized the way `_target` works between global state and local state.
- Changed `scratchAddons.manifest` to be an array of objects, with keys `"id"` and  `"manifest"`.