### PR TITLE
Add colored context menus addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -1,1 +1,1 @@
-["msg-count-badge", "scratch-notifier", "discuss-button", "editor-devtools", "editor-stepping", "image-uploader"]
+["msg-count-badge", "scratch-notifier", "discuss-button", "editor-devtools", "editor-stepping", "image-uploader", "editor-colored-context-menus"]

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -1,1 +1,9 @@
-["msg-count-badge", "scratch-notifier", "discuss-button", "editor-devtools", "editor-stepping", "image-uploader", "editor-colored-context-menus"]
+[
+  "msg-count-badge",
+  "scratch-notifier",
+  "discuss-button",
+  "editor-devtools",
+  "editor-stepping",
+  "image-uploader",
+  "editor-colored-context-menus"
+]

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -7,7 +7,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "userstyles": [    
+  "userstyles": [
     {
       "url": "userscript.css",
       "matches": ["https://scratch.mit.edu/projects/*"]

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Colored Context Menus",
+  "description": "Makes the editor context menus colorful.",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "userstyles": [    
+    {
+      "url": "userscript.css",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["editor"],
+  "enabled_by_default": false
+}

--- a/addons/editor-colored-context-menus/userscript.css
+++ b/addons/editor-colored-context-menus/userscript.css
@@ -1,0 +1,13 @@
+.u-contextmenu-colored .blocklyContextMenu {
+  background-color: var(--u-contextmenu-bg);
+  border-color: var(--u-contextmenu-border);
+}
+.u-contextmenu-colored .blocklyContextMenu .goog-menuitem {
+  color: white;
+}
+.u-contextmenu-colored .blocklyContextMenu .goog-menuitem:hover.goog-menuitem-highlight {
+  border-color: transparent;
+}
+.u-contextmenu-colored .blocklyContextMenu .goog-menuitem:hover {
+  background-color: rgba(0, 0, 0, 0.2);
+}

--- a/addons/editor-colored-context-menus/userscript.js
+++ b/addons/editor-colored-context-menus/userscript.js
@@ -1,5 +1,5 @@
-export default async function({ addon, global, console }) {
-  document.body.addEventListener('mousedown', handleClick, true);
+export default async function ({ addon, global, console }) {
+  document.body.addEventListener("mousedown", handleClick, true);
 }
 
 function handleClick(e) {
@@ -7,27 +7,27 @@ function handleClick(e) {
     return;
   }
 
-  const widgetDiv = document.querySelector('.blocklyWidgetDiv');
+  const widgetDiv = document.querySelector(".blocklyWidgetDiv");
   if (!widgetDiv) {
     return;
   }
 
-  if (e.target.closest('.blocklyMainBackground') || e.target.closest('.blocklyBubbleCanvas')) {
-    widgetDiv.classList.remove('u-contextmenu-colored');
+  if (e.target.closest(".blocklyMainBackground") || e.target.closest(".blocklyBubbleCanvas")) {
+    widgetDiv.classList.remove("u-contextmenu-colored");
     return;
   }
 
-  const block = e.target.closest('.blocklyDraggable');
+  const block = e.target.closest(".blocklyDraggable");
   if (!block) {
     return;
   }
 
-  const background = block.querySelector('.blocklyBlockBackground');
+  const background = block.querySelector(".blocklyBlockBackground");
   if (!background) {
     return;
   }
 
-  const fill = background.getAttribute('fill');
+  const fill = background.getAttribute("fill");
   if (!fill) {
     return;
   }
@@ -36,16 +36,16 @@ function handleClick(e) {
   const rgb = parseInt(fillHex, 16);
   const hsl = rgb2hsl(rgb);
   hsl[2] = Math.max(hsl[2] - 15, 0);
-  const border = 'hsl(' + hsl[0] + ', ' + hsl[1] + '%, ' + hsl[2] + '%)';
+  const border = "hsl(" + hsl[0] + ", " + hsl[1] + "%, " + hsl[2] + "%)";
 
-  widgetDiv.classList.add('u-contextmenu-colored');
-  widgetDiv.style.setProperty('--u-contextmenu-bg', fill);
-  widgetDiv.style.setProperty('--u-contextmenu-border', border);
+  widgetDiv.classList.add("u-contextmenu-colored");
+  widgetDiv.style.setProperty("--u-contextmenu-bg", fill);
+  widgetDiv.style.setProperty("--u-contextmenu-border", border);
 }
 
 function rgb2hsl(rgb) {
-  const r = (rgb >> 16 & 0xff) / 0xff;
-  const g = (rgb >> 8 & 0xff) / 0xff;
+  const r = ((rgb >> 16) & 0xff) / 0xff;
+  const g = ((rgb >> 8) & 0xff) / 0xff;
   const b = (rgb & 0xff) / 0xff;
 
   const min = Math.min(r, g, b);
@@ -61,9 +61,15 @@ function rgb2hsl(rgb) {
 
   var h;
   switch (max) {
-    case r: h = ((g - b) / c + 6) % 6; break;
-    case g: h = (b - r) / c + 2; break;
-    case b: h = (r - g) / c + 4; break;
+    case r:
+      h = ((g - b) / c + 6) % 6;
+      break;
+    case g:
+      h = (b - r) / c + 2;
+      break;
+    case b:
+      h = (r - g) / c + 4;
+      break;
   }
   h *= 60;
 

--- a/addons/editor-colored-context-menus/userscript.js
+++ b/addons/editor-colored-context-menus/userscript.js
@@ -1,0 +1,71 @@
+export default async function({ addon, global, console }) {
+  document.body.addEventListener('mousedown', handleClick, true);
+}
+
+function handleClick(e) {
+  if (e.button !== 2) {
+    return;
+  }
+
+  const widgetDiv = document.querySelector('.blocklyWidgetDiv');
+  if (!widgetDiv) {
+    return;
+  }
+
+  if (e.target.closest('.blocklyMainBackground') || e.target.closest('.blocklyBubbleCanvas')) {
+    widgetDiv.classList.remove('u-contextmenu-colored');
+    return;
+  }
+
+  const block = e.target.closest('.blocklyDraggable');
+  if (!block) {
+    return;
+  }
+
+  const background = block.querySelector('.blocklyBlockBackground');
+  if (!background) {
+    return;
+  }
+
+  const fill = background.getAttribute('fill');
+  if (!fill) {
+    return;
+  }
+
+  const fillHex = fill.substr(1);
+  const rgb = parseInt(fillHex, 16);
+  const hsl = rgb2hsl(rgb);
+  hsl[2] = Math.max(hsl[2] - 15, 0);
+  const border = 'hsl(' + hsl[0] + ', ' + hsl[1] + '%, ' + hsl[2] + '%)';
+
+  widgetDiv.classList.add('u-contextmenu-colored');
+  widgetDiv.style.setProperty('--u-contextmenu-bg', fill);
+  widgetDiv.style.setProperty('--u-contextmenu-border', border);
+}
+
+function rgb2hsl(rgb) {
+  const r = (rgb >> 16 & 0xff) / 0xff;
+  const g = (rgb >> 8 & 0xff) / 0xff;
+  const b = (rgb & 0xff) / 0xff;
+
+  const min = Math.min(r, g, b);
+  const max = Math.max(r, g, b);
+
+  if (min === max) {
+    return [0, 0, r * 100];
+  }
+
+  const c = max - min;
+  const l = (min + max) / 2;
+  const s = c / (1 - Math.abs(2 * l - 1));
+
+  var h;
+  switch (max) {
+    case r: h = ((g - b) / c + 6) % 6; break;
+    case g: h = (b - r) / c + 2; break;
+    case b: h = (r - g) / c + 4; break;
+  }
+  h *= 60;
+
+  return [h, s * 100, l * 100];
+}


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Part of #70

**Changes**

<!-- Please describe the changes you've made. -->

Adds an addon that makes the color of context menus in the editor match the block that was clicked:

![image](https://user-images.githubusercontent.com/33787854/91504273-4644ba80-e892-11ea-9faf-052b6fddebda.png)

**Reason for changes**

It looks cool and Scratch 2 did it. That's about the only reason.

**Tests**

It works in Chrome and Firefox.

It might break if the addon runs before the body is setup but I'm not sure if that's possible in this extension.
