### PR TITLE
Fix addon.auth.scratchLang being null while logged out #134

### DIFF
--- a/background/declare-scratchaddons-object.js
+++ b/background/declare-scratchaddons-object.js
@@ -35,7 +35,7 @@ class GlobalStateProxyHandler {
         "Global state changed!\n" + objectPath.join(".") + " is now:",
         objectPath[0] === "auth" ? "[redacted]" : value
       );
-      if (objectPath[0] === "auth") {
+      if (objectPath[0] === "auth" && objectPath[1] !== "scratchLang") {
         scratchAddons.eventTargets.auth.forEach((eventTarget) => eventTarget.dispatchEvent(new CustomEvent("change")));
         messageForAllTabs({ fireEvent: { target: "auth", name: "change" } });
       }


### PR DESCRIPTION
Resolves #134 

- Cleaned up `handle-auth.js`
- Fixes bug
- Now, a change in `scratchLang` won't trigger a `"change"` event on `addon.auth`.