### PR TITLE
Replacing the stage automatically when it's recommended

### DIFF
--- a/addons/external-player-button/addon.json
+++ b/addons/external-player-button/addon.json
@@ -45,7 +45,7 @@
       "default": false
     },
     {
-      "name": "Replace the stage automatically when a recommendation in the instructions or notes is found (requires \"Replace stage\" to be turned on due to laziness)",
+      "name": "Replace the stage automatically when a recommendation in the instructions or notes is found (only works when \"Replace stage\" is turned on)",
       "id": "autoreplace",
       "type": "boolean",
       "default": true

--- a/addons/external-player-button/addon.json
+++ b/addons/external-player-button/addon.json
@@ -51,6 +51,6 @@
       "default": true
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "beta"],
   "enabled_by_default": false
 }

--- a/addons/image-uploader/userscript.js
+++ b/addons/image-uploader/userscript.js
@@ -1,4 +1,4 @@
-﻿import textFieldEdit from "../../libraries/text-field-edit.js"; //used for editing the forum text box without messing with the edit history
+import textFieldEdit from "../../libraries/text-field-edit.js"; //used for editing the forum text box without messing with the edit history
 import md5 from "../../libraries/md5.js";
 
 export default async function ({ addon, global, console }) {

--- a/addons/image-uploader/userscript.js
+++ b/addons/image-uploader/userscript.js
@@ -81,10 +81,6 @@ export default async function ({ addon, global, console }) {
       textBox.style.backgroundColor = "lightgrey";
     });
 
-    textBox.addEventListener("dragover", (e) => {
-      e.preventDefault();
-    });
-
     textBox.addEventListener("dragleave", () => {
       textBox.readonly = false;
       textBox.style.backgroundColor = "white";

--- a/addons/image-uploader/userscript.js
+++ b/addons/image-uploader/userscript.js
@@ -1,4 +1,4 @@
-import textFieldEdit from "../../libraries/text-field-edit.js"; //used for editing the forum text box without messing with the edit history
+﻿import textFieldEdit from "../../libraries/text-field-edit.js"; //used for editing the forum text box without messing with the edit history
 import md5 from "../../libraries/md5.js";
 
 export default async function ({ addon, global, console }) {
@@ -79,6 +79,10 @@ export default async function ({ addon, global, console }) {
     textBox.addEventListener("dragenter", () => {
       textBox.readonly = true;
       textBox.style.backgroundColor = "lightgrey";
+    });
+
+    textBox.addEventListener("dragover", (e) => {
+      e.preventDefault();
     });
 
     textBox.addEventListener("dragleave", () => {


### PR DESCRIPTION
**Resolves**

It automatically switches the stage from Scratch to forkphorus or turbowarp when it's recommended. That's neat I think.

Resolves #191 

**Changes**

I added code for searching in the instructions and notes for links to fork and warp. 
I also added some code that adds a button that adds ?ignoreplayerlinks=true to the URL that adds the possibility to view projects with Scratch in case you want to that adds 5 points to the awesomeness of this addon.

**Reason for changes**

Because

> it's never bad to have features

**Tests**

Well, it works. I tested it and didn't run into problems.

**Other stuff I want to talk about**

It would be nice to have #190 so the last two options are only there when you have enabled "replace stage".