### PR TITLE
True YouTube links

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -13,5 +13,6 @@
   "move-your-cat",
   "external-player-button",
   "remove-sprite-confirm",
-  "editor-searchable-dropdowns"
+  "editor-searchable-dropdowns",
+  "true-youtube-links"
 ]

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -14,6 +14,6 @@
     }
   ],
   "options": [],
-  "tags": ["community"],
-  "enabled_by_default": true
+  "tags": ["community", "forums"],
+  "enabled_by_default": false
 }

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "True YT links",
+  "name": "True YouTube links",
   "description": "Replaces links to the embedded site with true YT links",
   "credits": [
     {

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "True YT links",
+  "description": "Replaces links to the embedded site with true YT links",
+  "credits": [
+    {
+      "name": "HTML-Fan/NT"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/*"],
+      "runAtComplete": false
+    }
+  ],
+  "options": [
+  ],
+  "tags": ["community"],
+  "enabled_by_default": true
+}

--- a/addons/true-youtube-links/userscript.js
+++ b/addons/true-youtube-links/userscript.js
@@ -1,0 +1,11 @@
+﻿export default async function ({ addon, global, console }) {
+  addon.settings.addEventListener("change", () => console.log("changed!"));
+  while(true){
+    await addon.tab.waitForElement("a:not(.trueYTLinksViewed)");
+    var element = document.querySelector("a:not(.trueYTLinksViewed)");
+    if(element.href.indexOf("https://scratch.mit.edu/discuss/youtube/") == 0){
+      element.href = element.href.replace("https://scratch.mit.edu/discuss/youtube/", "https://youtu.be/");
+    }
+    element.classList.add("trueYTLinksViewed");
+  }
+}


### PR DESCRIPTION
The extension replaces every https://scratch.mit.edu/discuss/youtube/ link with a youtu.be link.
I think that it's okay that it's enabled by default since it is more or less a fix.
I guess seeing Rick's face in a YT tab is nicer then doing it in a Scratch tab. 

I can remove the default tag but I see no reason why.
Also, should I add the tag "forum"?