### PR TITLE
Update "True YouTube links" addon (05/09/2020)

### DIFF
--- a/addons/true-youtube-links/userscript.js
+++ b/addons/true-youtube-links/userscript.js
@@ -1,13 +1,14 @@
 ﻿export default async function ({ addon, console }) {
-
   addon.settings.addEventListener("change", () => console.log("changed!"));
 
   while (true) {
     await addon.tab.waitForElement("a[href^=https://scratch.mit.edu/discuss/youtube/");
     var elements = document.querySelectorAll("a[href^=https://scratch.mit.edu/discuss/youtube/]");
-    elements.forEach(element => {
-      element.href = element.href.replace("https://scratch.mit.edu/discuss/youtube/", "https://www.youtube.com/watch?v=");
-    })
+    elements.forEach((element) => {
+      element.href = element.href.replace(
+        "https://scratch.mit.edu/discuss/youtube/",
+        "https://www.youtube.com/watch?v="
+      );
+    });
   }
-
 }

--- a/addons/true-youtube-links/userscript.js
+++ b/addons/true-youtube-links/userscript.js
@@ -1,11 +1,13 @@
-﻿export default async function ({ addon, global, console }) {
+﻿export default async function ({ addon, console }) {
+
   addon.settings.addEventListener("change", () => console.log("changed!"));
+
   while (true) {
-    await addon.tab.waitForElement("a:not(.trueYTLinksViewed)");
-    var element = document.querySelector("a:not(.trueYTLinksViewed)");
-    if (element.href.indexOf("https://scratch.mit.edu/discuss/youtube/") == 0) {
-      element.href = element.href.replace("https://scratch.mit.edu/discuss/youtube/", "https://youtu.be/");
-    }
-    element.classList.add("trueYTLinksViewed");
+    await addon.tab.waitForElement("a[href^=https://scratch.mit.edu/discuss/youtube/");
+    var elements = document.querySelectorAll("a[href^=https://scratch.mit.edu/discuss/youtube/]");
+    elements.forEach(element => {
+      element.href = element.href.replace("https://scratch.mit.edu/discuss/youtube/", "https://www.youtube.com/watch?v=");
+    })
   }
+
 }

--- a/addons/true-youtube-links/userscript.js
+++ b/addons/true-youtube-links/userscript.js
@@ -2,8 +2,8 @@
   addon.settings.addEventListener("change", () => console.log("changed!"));
 
   while (true) {
-    await addon.tab.waitForElement("a[href^=https://scratch.mit.edu/discuss/youtube/");
-    var elements = document.querySelectorAll("a[href^=https://scratch.mit.edu/discuss/youtube/]");
+    await addon.tab.waitForElement('a[href^="https://scratch.mit.edu/discuss/youtube/"]');
+    var elements = document.querySelectorAll('a[href^="https://scratch.mit.edu/discuss/youtube/"]');
     elements.forEach((element) => {
       element.href = element.href.replace(
         "https://scratch.mit.edu/discuss/youtube/",

--- a/addons/true-youtube-links/userscript.js
+++ b/addons/true-youtube-links/userscript.js
@@ -2,8 +2,8 @@
   addon.settings.addEventListener("change", () => console.log("changed!"));
 
   while (true) {
-    await addon.tab.waitForElement('a[href^="https://scratch.mit.edu/discuss/youtube/"]');
-    var elements = document.querySelectorAll('a[href^="https://scratch.mit.edu/discuss/youtube/"]');
+    await addon.tab.waitForElement('a[href^="https://scratch.mit.edu/discuss/youtube/"], a[href^="/discuss/youtube/"]');
+    var elements = document.querySelectorAll('a[href^="https://scratch.mit.edu/discuss/youtube/"], a[href^="/discuss/youtube/"]');
     elements.forEach((element) => {
       element.href = element.href.replace(
         "https://scratch.mit.edu/discuss/youtube/",
@@ -11,4 +11,5 @@
       );
     });
   }
+
 }


### PR DESCRIPTION
**Changes**

This pull request introduces this request.

- Change CSS selector so tagging with class is not needed
- Use the direct YouTube link (https://www.youtube.com/watch?v=) instead of the shortened format (https://youtu.be/)

**Reason for changes**

Why not? Is that acceptable?

**Tests**

In theory, it should have worked. I'm not sure how to test it because I don't know any page that has a YouTube link, so please help with testing it.