### PR TITLE
Add API for low-level prototype trap interaction

### DIFF
--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -61,4 +61,24 @@ export default class Trap {
     if (!__scratchAddonsTraps._targetMany) throw new Error("Event target not initialized");
     __scratchAddonsTraps._targetMany.removeEventListener(eventName, fn);
   }
+
+  /**
+   * Adds listener for prototype functions trapped.
+   * @param {string} trapName Trap name to listen to. Can be '*' for any.
+   * @param {function} fn callback passed to addEventListener.
+   */
+  addPrototypeListener(trapName, fn) {
+    const eventName = trapName === "*" ? "prototypecalled" : `prototype.${trapName}`;
+    __scratchAddonsTraps.addEventListener(eventName, fn);
+  }
+
+  /**
+   * Removes listener for prototype functions trapped.
+   * @param {string} trapName Trap name to listen to. Can be '*' for any.
+   * @param {function} fn callback passed to removeEventListener.
+   */
+  removePrototypeListener(trapName, fn) {
+    const eventName = trapName === "*" ? "prototypecalled" : `prototype.${trapName}`;
+    __scratchAddonsTraps.removeEventListener(eventName, fn);
+  }
 }

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -167,24 +167,24 @@ function injectPrototype() {
   };
 
   const override = (overrideId) => {
-    return function(...args) {
+    return function (...args) {
       // Dispatch override events first, so handlers have a chance to mutate the args array before it's passed on to
       // extra handlers defined in this file. (This allows addons to work with low-level overrides themselves.)
       const overrideEvent = new CustomEvent("prototypecalled", {
         detail: {
           trapName: overrideId,
           args,
-        }
+        },
       });
       __scratchAddonsTraps.dispatchEvent(overrideEvent);
       const specificEvent = new CustomEvent(`prototype.${overrideId}`, {
         detail: {
           args,
-        }
+        },
       });
       __scratchAddonsTraps.dispatchEvent(specificEvent);
 
-      extraHandlers[overrideId].forEach(fn => fn(args));
+      extraHandlers[overrideId].forEach((fn) => fn(args));
       return oldPrototypes[overrideId].apply(this, args);
     };
   };


### PR DESCRIPTION
**Resolves**

Resolves #243.

**Changes**

Implements two new API functions for low-level interaction with prototype traps/overrides, as outlined in #243:

* `addon.tab.traps.addPrototypeListener`: Adds an event listener for when overridden prototype functions (e.g. on `Function`, `Array`, `Object`) are called. This follows the same details as other `add...Listeners` functions in the `addon.tab.traps` API; the event details are `args` and (optionally) `trapName`. The value of `args` is an array which contains the arguments passed to that function, and this array can be mutated to change the values which will be passed to the trapped prototype function once all listeners have been called.
* `addon.tab.traps.removePrototypeListener`: Corresponding interface for removing an existing event listener.

If multiple listeners exist and mutate the `args` array, the order they are called is not explicitly defined but will be determined the same way as for other event dispatches. Since all listeners share the same `args` array (per dispatch), later listeners may be provided data already mutated by previous listeners. This allows for straightforward chaining of listeners, be they within the same addon or across multiple addons.

**Reason for changes**

See discussion in #243.

**Tests**

The APIs implemented in this pull request have been tested manually within a separate addon I've created and will share a pull request for soon; in that code (which I share below), I mutate the value passed to `Object.assign` as called by a reducer defined in scratch-gui.

```js
addon.tab.traps.addPrototypeListener("objectAssign", (event) => {
  const { args } = event.detail;
  if (args[2] && args[2].toolboxXML) {
    args[2].toolboxXML = overrideToolboxXML(args[2].toolboxXML);
    // (overrideToolboxXML is defined elsewhere in the addon code.)
  }
});
```