### PR TITLE
Separate List Category addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ If you found a bug, or want to suggest new features, please use the [issues tab]
 ## License
 
 Scratch Addons is licensed under the terms of the [GNU General Public License v3.0](https://github.com/ScratchAddons/ScratchAddons/blob/master/LICENSE).
+
+## Learn more
+If you would like to know mroe about ScratchAddons, what it does, and who helped feel free to check out the [ScratchAddons official website](scratchaddons.github.io) for more!

--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -61,4 +61,24 @@ export default class Trap {
     if (!__scratchAddonsTraps._targetMany) throw new Error("Event target not initialized");
     __scratchAddonsTraps._targetMany.removeEventListener(eventName, fn);
   }
+
+  /**
+   * Adds listener for prototype functions trapped.
+   * @param {string} trapName Trap name to listen to. Can be '*' for any.
+   * @param {function} fn callback passed to addEventListener.
+   */
+  addPrototypeListener(trapName, fn) {
+    const eventName = trapName === "*" ? "prototypecalled" : `prototype.${trapName}`;
+    __scratchAddonsTraps.addEventListener(eventName, fn);
+  }
+
+  /**
+   * Removes listener for prototype functions trapped.
+   * @param {string} trapName Trap name to listen to. Can be '*' for any.
+   * @param {function} fn callback passed to removeEventListener.
+   */
+  removePrototypeListener(trapName, fn) {
+    const eventName = trapName === "*" ? "prototypecalled" : `prototype.${trapName}`;
+    __scratchAddonsTraps.removeEventListener(eventName, fn);
+  }
 }

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -24,5 +24,6 @@
   "progress-bar",
   "bitmap-copy",
   "more-links",
-  "youtube-fullscreen"
+  "youtube-fullscreen",
+  "list-category"
 ]

--- a/addons/list-category/addon.json
+++ b/addons/list-category/addon.json
@@ -1,0 +1,14 @@
+{
+  "name": "Separate List Category",
+  "description": "Displays a separate category button for List blocks.",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "options": [],
+  "tags": ["editor"],
+  "permissions": [],
+  "enabled_by_default": false
+}

--- a/addons/list-category/userscript.js
+++ b/addons/list-category/userscript.js
@@ -1,0 +1,112 @@
+export default async ({ addon, console }) => {
+  // The first step of this extension is to provide two new categories from Blockly (i.e. ScratchBlocks).
+  //
+  // This code is essentially a transcription of the changes to blocks_vertical/default_toolbox.js in the pull
+  // request LLK/scratch-blocks#2099, but with somewhat fewer changes because we opt to reuse existing functions on
+  // DataCategory instead of changing them to be defined on the new VariableCategory and ListCategory prototypes.
+
+  const {
+    ScratchBlocks: Blockly,
+    workspace
+  } = addon.tab.traps.onceValues;
+
+  Blockly.LIST_CATEGORY_NAME = "LIST";
+  Blockly.Msg.CATEGORY_LISTS = "Lists";
+
+  Blockly.VariableCategory = function(workspace) {
+    const variableModelList = workspace.getVariablesOfType("");
+    variableModelList.sort(Blockly.VariableModel.compareByName);
+    const xmlList = [];
+
+    Blockly.DataCategory.addCreateButton(xmlList, workspace, "VARIABLE");
+
+    for (const variableModel of variableModelList) {
+      Blockly.DataCategory.addDataVariable(xmlList, variableModel);
+    }
+
+    if (variableModelList.length > 0) {
+      xmlList[xmlList.length - 1].setAttribute("gap", 24);
+      const firstVariable = variableModelList[0];
+
+      Blockly.DataCategory.addSetVariableTo(xmlList, firstVariable);
+      Blockly.DataCategory.addChangeVariableBy(xmlList, firstVariable);
+      Blockly.DataCategory.addShowVariable(xmlList, firstVariable);
+      Blockly.DataCategory.addHideVariable(xmlList, firstVariable);
+    }
+    Blockly.DataCategory.addSep(xmlList);
+
+    return xmlList;
+  };
+
+  Blockly.ListCategory = function(workspace) {
+    const variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
+    variableModelList.sort(Blockly.VariableModel.compareByName);
+    const xmlList = [];
+
+    Blockly.DataCategory.addCreateButton(xmlList, workspace, "LIST");
+
+    for (const variableModel of variableModelList) {
+      Blockly.DataCategory.addDataList(xmlList, variableModel);
+    }
+
+    if (variableModelList.length > 0) {
+      xmlList[xmlList.length - 1].setAttribute("gap", 24);
+      const firstVariable = variableModelList[0];
+
+      Blockly.DataCategory.addAddToList(xmlList, firstVariable);
+      Blockly.DataCategory.addSep(xmlList);
+      Blockly.DataCategory.addDeleteOfList(xmlList, firstVariable);
+      Blockly.DataCategory.addDeleteAllOfList(xmlList, firstVariable);
+      Blockly.DataCategory.addInsertAtList(xmlList, firstVariable);
+      Blockly.DataCategory.addReplaceItemOfList(xmlList, firstVariable);
+      Blockly.DataCategory.addSep(xmlList);
+      Blockly.DataCategory.addItemOfList(xmlList, firstVariable);
+      Blockly.DataCategory.addItemNumberOfList(xmlList, firstVariable);
+      Blockly.DataCategory.addLengthOfList(xmlList, firstVariable);
+      Blockly.DataCategory.addListContainsItem(xmlList, firstVariable);
+      Blockly.DataCategory.addSep(xmlList);
+      Blockly.DataCategory.addShowList(xmlList, firstVariable);
+      Blockly.DataCategory.addHideList(xmlList, firstVariable);
+    }
+    Blockly.DataCategory.addSep(xmlList);
+
+    return xmlList;
+  };
+
+  workspace.registerToolboxCategoryCallback(Blockly.VARIABLE_CATEGORY_NAME,
+    Blockly.VariableCategory);
+  workspace.registerToolboxCategoryCallback(Blockly.LIST_CATEGORY_NAME,
+    Blockly.ListCategory);
+
+  // The second step is to change the categories which scratch-gui displays in the category list.
+  //
+  // Category data (which categories are displayed and in what order) is controlled by lib/make-toolbox-xml.js, but
+  // we can't override this function because it isn't actually defined on an object anywhere. Instead, we'll find
+  // better luck looking at the Redux reducer encapsulating toolbox XML state. We can't directly override the behavior
+  // defined in reducers/toolbox.js, but we can use an objectAssign prototype listener to change what state gets
+  // applied during updates.
+
+  addon.tab.traps.addPrototypeListener("objectAssign", (event) => {
+    const { args } = event.detail;
+    if (args[2] && args[2].toolboxXML) {
+      args[2].toolboxXML = overrideToolboxXML(args[2].toolboxXML);
+    }
+  });
+
+  function overrideToolboxXML(toolboxXML) {
+    if (toolboxXML.includes("custom=\"LIST\"")) {
+      return toolboxXML;
+    }
+
+    return toolboxXML.replace(/<category\s*name="%{BKY_CATEGORY_VARIABLES}"[\s\S]*?<\/category>/m, `
+      $&
+      <category
+        name="%{BKY_CATEGORY_LISTS}"
+        id="lists"
+        colour="#FF661A"
+        secondaryColour="#FF5500"
+        custom="LIST">
+      </category>
+    `);
+  }
+};

--- a/addons/list-category/userscript.js
+++ b/addons/list-category/userscript.js
@@ -5,15 +5,12 @@ export default async ({ addon, console }) => {
   // request LLK/scratch-blocks#2099, but with somewhat fewer changes because we opt to reuse existing functions on
   // DataCategory instead of changing them to be defined on the new VariableCategory and ListCategory prototypes.
 
-  const {
-    ScratchBlocks: Blockly,
-    workspace
-  } = addon.tab.traps.onceValues;
+  const { ScratchBlocks: Blockly, workspace } = addon.tab.traps.onceValues;
 
   Blockly.LIST_CATEGORY_NAME = "LIST";
   Blockly.Msg.CATEGORY_LISTS = "Lists";
 
-  Blockly.VariableCategory = function(workspace) {
+  Blockly.VariableCategory = function (workspace) {
     const variableModelList = workspace.getVariablesOfType("");
     variableModelList.sort(Blockly.VariableModel.compareByName);
     const xmlList = [];
@@ -38,7 +35,7 @@ export default async ({ addon, console }) => {
     return xmlList;
   };
 
-  Blockly.ListCategory = function(workspace) {
+  Blockly.ListCategory = function (workspace) {
     const variableModelList = workspace.getVariablesOfType(Blockly.LIST_VARIABLE_TYPE);
     variableModelList.sort(Blockly.VariableModel.compareByName);
     const xmlList = [];
@@ -73,10 +70,8 @@ export default async ({ addon, console }) => {
     return xmlList;
   };
 
-  workspace.registerToolboxCategoryCallback(Blockly.VARIABLE_CATEGORY_NAME,
-    Blockly.VariableCategory);
-  workspace.registerToolboxCategoryCallback(Blockly.LIST_CATEGORY_NAME,
-    Blockly.ListCategory);
+  workspace.registerToolboxCategoryCallback(Blockly.VARIABLE_CATEGORY_NAME, Blockly.VariableCategory);
+  workspace.registerToolboxCategoryCallback(Blockly.LIST_CATEGORY_NAME, Blockly.ListCategory);
 
   // The second step is to change the categories which scratch-gui displays in the category list.
   //
@@ -94,11 +89,13 @@ export default async ({ addon, console }) => {
   });
 
   function overrideToolboxXML(toolboxXML) {
-    if (toolboxXML.includes("custom=\"LIST\"")) {
+    if (toolboxXML.includes('custom="LIST"')) {
       return toolboxXML;
     }
 
-    return toolboxXML.replace(/<category\s*name="%{BKY_CATEGORY_VARIABLES}"[\s\S]*?<\/category>/m, `
+    return toolboxXML.replace(
+      /<category\s*name="%{BKY_CATEGORY_VARIABLES}"[\s\S]*?<\/category>/m,
+      `
       $&
       <category
         name="%{BKY_CATEGORY_LISTS}"
@@ -107,6 +104,7 @@ export default async ({ addon, console }) => {
         secondaryColour="#FF5500"
         custom="LIST">
       </category>
-    `);
+      `
+    );
   }
 };


### PR DESCRIPTION
**Resolves**

Resolves #245. **Depends on #244**, so that should be merged before this. (This is a fork of that PR - commit f06b636d4d07cbf44d3d155a1d3e9e6608039212 contains the addon code.)

**Changes**

Implements a "Separate List Category" addon, which does what it says: it breaks the "Variables" category into two, one for (scalar/ordinary) variable blocks and one for list blocks.

![The block palette scrolled to the "Lists" category.](https://user-images.githubusercontent.com/9948030/92638760-29a47b80-f2b1-11ea-85f7-2f157d9b874a.png)

**Reason for changes**

Implementing a (self- :P) requested addon; rationale for the request is in LLK/scratch-blocks#1874.

**Tests**

Tested manually by enabling the extension and running it!
