### PR TITLE
Fix dark fullscreen button on editor page

### DIFF
--- a/addons/editor-dark-mode/styles.css
+++ b/addons/editor-dark-mode/styles.css
@@ -193,7 +193,8 @@ div.s3devDDOut.vis {
   text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
-[class^=gui_stage-and-target-wrapper] [class^="button_outlined-button"]:not([class*="menu-bar"]):not([class*="modal"]):not([class*="tag-button_active"]) {
+[class^="gui_stage-and-target-wrapper"]
+  [class^="button_outlined-button"]:not([class*="menu-bar"]):not([class*="modal"]):not([class*="tag-button_active"]) {
   background: #444 !important;
 }
 

--- a/addons/editor-dark-mode/styles.css
+++ b/addons/editor-dark-mode/styles.css
@@ -193,7 +193,7 @@ div.s3devDDOut.vis {
   text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
 }
 
-[class^="button_outlined-button"]:not([class*="menu-bar"]):not([class*="modal"]):not([class*="tag-button_active"]) {
+[class^=gui_stage-and-target-wrapper] [class^="button_outlined-button"]:not([class*="menu-bar"]):not([class*="modal"]):not([class*="tag-button_active"]) {
   background: #444 !important;
 }
 


### PR DESCRIPTION
**Resolves**

(Doesn't look like there's an issue for this but I was told about it by @WorldLanguages!)

**Changes**

Fixes the fullscreen button getting styled dark while on the editor page (when the dark editor addon is enabled).

**Reason for changes**

It looks better! This was a bug in the dark editor addon. (I'm the original author of the CSS used in it.) In my userstyle I dealt with this by only applying the styles to `*/editor` and `*/fullscreen` pages, which is arguably more robust than this is, but this gets the bug fixed with only a single CSS change.

**Tests**

Tested manually.
