### PR TITLE
New option types: select & string

### DIFF
--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -22,6 +22,12 @@
       "id": "removeIdeasBtn",
       "type": "boolean",
       "default": false
+    },
+    {
+      "name": "Discuss button name",
+      "id": "buttonName",
+      "type": "string",
+      "default": "Discuss"
     }
   ],
   "tags": ["community", "forums"],

--- a/addons/discuss-button/userscript.js
+++ b/addons/discuss-button/userscript.js
@@ -2,8 +2,11 @@ export default async function ({ addon, global, console }) {
   if (!addon.tab.clientVersion) return;
 
   const link = document.createElement("li");
-  link.innerHTML = '<a href="/discuss">Discuss</a>';
   link.className = "link discuss";
+  const a = document.createElement("a");
+  a.href = "/discuss";
+  a.textContent = addon.settings.get("buttonName");
+  link.appendChild(a);
 
   function scratchWww(el) {
     if (addon.settings.get("removeIdeasBtn")) el.getElementsByTagName("li")[3].remove();

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -135,22 +135,25 @@
                     min="0"
                   />
                   <input
-                  type="text"
-                  class="setting-input string"
-                  v-model="addonSettings[addon._addonId][setting.id]"
-                  @input="updateSettings(addon)"
-                  :disabled="!addon._enabled"
-                  v-if="setting.type === 'string'"
-                  :placeholder="setting.default"
-                  maxlength="100"
-                />
-                <div class="filter-options" v-if="setting.type === 'select'">
-                  <div class="filter-option" 
-                  v-for="option of setting.potential_values"
-                  :class="{'sel' : addonSettings[addon._addonId][setting.id] === option}"
-                  @click="updateSelect(setting.id, option, addon);"
-                  >{{ option }}</div>
-                </div>
+                    type="text"
+                    class="setting-input string"
+                    v-model="addonSettings[addon._addonId][setting.id]"
+                    @input="updateSettings(addon)"
+                    :disabled="!addon._enabled"
+                    v-if="setting.type === 'string'"
+                    :placeholder="setting.default"
+                    maxlength="100"
+                  />
+                  <div class="filter-options" v-if="setting.type === 'select'">
+                    <div
+                      class="filter-option"
+                      v-for="option of setting.potential_values"
+                      :class="{'sel' : addonSettings[addon._addonId][setting.id] === option}"
+                      @click="updateSelect(setting.id, option, addon);"
+                    >
+                      {{ option }}
+                    </div>
+                  </div>
                 </div>
               </div>
               <!--

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -132,7 +132,25 @@
                     @change="updateSettings(addon)"
                     :disabled="!addon._enabled"
                     v-if="setting.type === 'positive_integer'"
+                    min="0"
                   />
+                  <input
+                  type="text"
+                  class="setting-input string"
+                  v-model="addonSettings[addon._addonId][setting.id]"
+                  @input="updateSettings(addon)"
+                  :disabled="!addon._enabled"
+                  v-if="setting.type === 'string'"
+                  :placeholder="setting.default"
+                  maxlength="100"
+                />
+                <div class="filter-options" v-if="setting.type === 'select'">
+                  <div class="filter-option" 
+                  v-for="option of setting.potential_values"
+                  :class="{'sel' : addonSettings[addon._addonId][setting.id] === option}"
+                  @click="updateSelect(setting.id, option, addon);"
+                  >{{ option }}</div>
+                </div>
                 </div>
               </div>
               <!--

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -108,6 +108,10 @@ const vue = new Vue({
         );
       } else toggle();
     },
+    updateSelect(settingId, newValue, addon) {
+      this.addonSettings[addon._addonId][settingId] = newValue;
+      this.updateSettings(addon);
+    },
     updateSettings(addon) {
       chrome.runtime.sendMessage({
         changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] },


### PR DESCRIPTION
String: works exactly like `positive_integer` but for strings.
Select: requires a `potential_values` array of strings (and a default value as well, that should exactly match one of those values).

Bonus: with this addition, now the discuss button addon lets the user rename the button. This is useful for internationalization.