### PR TITLE
Standardize naming, add some credits, recommended tags, settings page bug fixes

### DIFF
--- a/addons/bitmap-copy/addon.json
+++ b/addons/bitmap-copy/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Bitmap Copying",
-  "description": "Allows you to actually copy a bitmap image from the paint editor.",
+  "name": "Bitmap images copying",
+  "description": "Allows you to actually copy a bitmap image from the paint editor, so that you can paste it in other websites or software.",
   "userscripts": [
     {
       "url": "userscript.js",
@@ -8,7 +8,7 @@
     }
   ],
   "options": [],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "permissions": ["clipboardWrite"],
   "enabled_by_default": false
 }

--- a/addons/data-category-tweaks/addon.json
+++ b/addons/data-category-tweaks/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Data Category Tweaks",
+  "name": "Data category tweaks",
   "description": "Provides tweaks for the Data (\"Variables\") category in the editor.",
   "userscripts": [
     {

--- a/addons/deleted-comments/addon.json
+++ b/addons/deleted-comments/addon.json
@@ -1,6 +1,11 @@
 {
   "name": "See deleted comments",
-  "description": "Allows you to see the author and post date of deleted comments in profiles and studios. By Jeffalo.",
+  "description": "Allows you to see the author and post date of deleted comments in profiles and studios.",
+  "credits": [
+    {
+      "name": "Jeffalo"
+    }
+  ],
   "userstyles": [
     {
       "url": "style.css",

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,6 +1,9 @@
 {
-  "name": "Colored Context Menus",
+  "name": "Colored context menus",
   "description": "Makes the editor context menus colorful when right-clicking a block.",
+  "credits": [{
+    "name": "GarboMuffin"
+  }],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,9 +1,11 @@
 {
   "name": "Colored context menus",
   "description": "Makes the editor context menus colorful when right-clicking a block.",
-  "credits": [{
-    "name": "GarboMuffin"
-  }],
+  "credits": [
+    {
+      "name": "GarboMuffin"
+    }
+  ],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/editor-devtools/addon.json
+++ b/addons/editor-devtools/addon.json
@@ -18,6 +18,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabled_by_default": false
 }

--- a/addons/editor-searchable-dropdowns/addon.json
+++ b/addons/editor-searchable-dropdowns/addon.json
@@ -1,9 +1,11 @@
 {
   "name": "Searchable dropdowns",
   "description": "Allows you to search dropdowns in the Scratch editor.",
-  "credits": [{
-    "name": "GarboMuffin"
-  }],
+  "credits": [
+    {
+      "name": "GarboMuffin"
+    }
+  ],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/editor-searchable-dropdowns/addon.json
+++ b/addons/editor-searchable-dropdowns/addon.json
@@ -1,6 +1,9 @@
 {
-  "name": "Searchable Dropdowns",
+  "name": "Searchable dropdowns",
   "description": "Allows you to search dropdowns in the Scratch editor.",
+  "credits": [{
+    "name": "GarboMuffin"
+  }],
   "userscripts": [
     {
       "url": "userscript.js",
@@ -13,6 +16,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabled_by_default": false
 }

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "View stepping",
-  "description": "Allows you to see which block currently executes.",
+  "name": "Highlight currently executing blocks",
+  "description": "Adds a blue border to the blocks that are currently running in a project.",
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/fix-buttons/addon.json
+++ b/addons/fix-buttons/addon.json
@@ -1,9 +1,11 @@
 {
   "name": "\"Load more\" scrolling fix",
   "description": "Fixes the scrolling when pressing the load more button on Scratch.",
-  "credits": [{
-    "name": "Maximouse"
-  }],
+  "credits": [
+    {
+      "name": "Maximouse"
+    }
+  ],
   "userstyles": [
     {
       "url": "style.css",

--- a/addons/fix-buttons/addon.json
+++ b/addons/fix-buttons/addon.json
@@ -1,12 +1,15 @@
 {
-  "name": "Load More Scrolling Fix",
-  "description": "Fixes the scrolling when pressing the load more button on Scratch. By Maximouse.",
+  "name": "\"Load more\" scrolling fix",
+  "description": "Fixes the scrolling when pressing the load more button on Scratch.",
+  "credits": [{
+    "name": "Maximouse"
+  }],
   "userstyles": [
     {
       "url": "style.css",
       "matches": ["https://scratch.mit.edu/*"]
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "recommended"],
   "enabled_by_default": true
 }

--- a/addons/forum-time-zones/addon.json
+++ b/addons/forum-time-zones/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Forum time zones",
+  "name": "Forums time zone",
   "description": "Converts the post times to the client's time zone.",
   "userscripts": [
     {

--- a/addons/image-uploader/addon.json
+++ b/addons/image-uploader/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Image Uploader",
+  "name": "Forums image uploader",
   "description": "Integrates image uploading into the forums.",
   "userscripts": [
     {

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -3,6 +3,6 @@
   "description": "Adds the current message count in the Scratch Addons icon.",
   "persistent_scripts": ["background.js"],
   "permissions": ["badge"],
-  "tags": ["community"],
+  "tags": ["community", "recommended"],
   "enabled_by_default": true
 }

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Progress Bar",
+  "name": "Project progress bar",
   "description": "Adds a progress bar for loading and saving projects.",
   "credits": [
     {
@@ -33,6 +33,6 @@
       "default": 5
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabled_by_default": false
 }

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Remove Sprite Confirm",
-  "description": "Show confirm screen when deleting sprite.",
+  "name": "Confirm sprite deletion",
+  "description": "Asks if you're sure when deleting a sprite inside a project.",
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/scratch-messaging/addon.json
+++ b/addons/scratch-messaging/addon.json
@@ -1,7 +1,15 @@
 {
   "name": "Scratch Messaging",
   "description": "Available when clicking the Scratch Addons icon. Provides easy reading and replying to your Scratch messages: groups messages by project, shows full comment text and context, allows direct comment replying.",
+  "credits": [
+    {
+    "name": "World_Languages"
+    },
+    {
+      "name": "griffpatch"
+    }
+  ],
   "persistent_scripts": ["background.js"],
-  "tags": ["community"],
+  "tags": ["community", "recommended"],
   "enabled_by_default": true
 }

--- a/addons/scratch-messaging/addon.json
+++ b/addons/scratch-messaging/addon.json
@@ -3,7 +3,7 @@
   "description": "Available when clicking the Scratch Addons icon. Provides easy reading and replying to your Scratch messages: groups messages by project, shows full comment text and context, allows direct comment replying.",
   "credits": [
     {
-    "name": "World_Languages"
+      "name": "World_Languages"
     },
     {
       "name": "griffpatch"

--- a/addons/scratch-notifier/addon.json
+++ b/addons/scratch-notifier/addon.json
@@ -70,6 +70,6 @@
       "default": true
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "recommended"],
   "enabled_by_default": false
 }

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "True YouTube links",
-  "description": "Replaces links to the embedded site with true YT links",
+  "name": "True forums YouTube links",
+  "description": "Replaces links to the embedded site with real YouTube links.",
   "credits": [
     {
       "name": "HTML-Fan/NT"

--- a/addons/youtube-fullscreen/addon.json
+++ b/addons/youtube-fullscreen/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "YouTube full screen",
-  "description": "Enables the full screen button in Scratch's YouTube video player",
+  "description": "Enables the full screen button in Scratch's YouTube video player.",
   "credits": [
     {
       "name": "Maximouse",
@@ -15,6 +15,6 @@
     }
   ],
   "options": [],
-  "tags": ["community", "forums"],
+  "tags": ["community", "forums", "recommended"],
   "enabled_by_default": false
 }

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -93,7 +93,9 @@
                 </div>
               </div>
               <div class="badge blue" v-if="addon._tags.recommended">Recommended</div>
+              <div class="badge blue" v-if="selectedTab === 'theme' && addon._tags.forEditor">For editor</div>
               <div class="badge red" v-if="addon._tags.beta">Beta</div>
+              <div class="badge red" v-if="selectedTab === 'theme' && addon._tags.forWebsite">For website</div>
               <div class="badge green" v-if="addon._tags.forums">Forums</div>
               <div class="addon-description" v-show="!addon._expanded">{{ addon.description }}</div>
               <div class="addon-check">

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -79,7 +79,10 @@ const vue = new Vue({
         this.searchInput === "" ||
         addonManifest.name.toLowerCase().includes(this.searchInput.toLowerCase()) ||
         addonManifest.description.toLowerCase().includes(this.searchInput.toLowerCase()) ||
-        addonManifest.credits && addonManifest.credits.map(obj => obj.name.toLowerCase()).some(author => author.includes(this.searchInput.toLowerCase()));
+        (addonManifest.credits &&
+          addonManifest.credits
+            .map((obj) => obj.name.toLowerCase())
+            .some((author) => author.includes(this.searchInput.toLowerCase())));
       return matchesTag && matchesSearch;
     },
     stopPropagation(e) {
@@ -143,18 +146,18 @@ chrome.runtime.sendMessage("getSettingsInfo", ({ manifests, addonsEnabled, addon
   }
   // Sort: enabled first, then recommended disabled, then other disabled addons. All alphabetically.
   manifests.sort((a, b) => {
-    if (a.manifest._enabled === true && b.manifest._enabled === true) return a.manifest.name.localeCompare(b.manifest.name);
+    if (a.manifest._enabled === true && b.manifest._enabled === true)
+      return a.manifest.name.localeCompare(b.manifest.name);
     else if (a.manifest._enabled === true && b.manifest._enabled === false) return -1;
     else if (a.manifest._enabled === false && b.manifest._enabled === false) {
       if (a.manifest._tags.recommended === true && b.manifest._tags.recommended === false) return -1;
       else if (a.manifest._tags.recommended === false && b.manifest._tags.recommended === true) return 1;
       else return a.manifest.name.localeCompare(b.manifest.name);
-    } 
-    else return 1;
+    } else return 1;
   });
   // Messaging related addons should always go first no matter what
-  manifests.sort((a,b) => a.addonId === "msg-count-badge" ? -1 : b.addonId === "msg-count-badge" ? 1 : 0);
-  manifests.sort((a,b) => a.addonId === "scratch-messaging" ? -1 : b.addonId === "scratch-messaging" ? 1 : 0);
+  manifests.sort((a, b) => (a.addonId === "msg-count-badge" ? -1 : b.addonId === "msg-count-badge" ? 1 : 0));
+  manifests.sort((a, b) => (a.addonId === "scratch-messaging" ? -1 : b.addonId === "scratch-messaging" ? 1 : 0));
   vue.manifests = manifests.map(({ manifest }) => manifest);
 });
 

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -143,7 +143,7 @@ h1 {
   height: 16px;
   vertical-align: middle;
   filter: brightness(10);
-  margin-right: 5px;
+  margin-right: 8px;
 }
 
 .badge {


### PR DESCRIPTION
- Resolves #180 (standardize naming - most addons shouldn't have Names Like This)
- Changed the name of some addons to make it more clear what their job is.
- Add credits to some addons when the author did credit themselves in other addons.
- Added `recommended` tags to some addons I believed deserved the tag. My main judging point was that these addons were either related to messaging, or added functionality without removing/replacing any original Scratch functionality. Please tell me if you disagree with any tag choice I made!
- Fixed ordering in the settings page. Messaging addons go first, then enabled addons alphabetically , then recommended disabled addons alphabetically, then other addons alphabetically.
- Allow searching by author in the settings page. Already supported were name and description.
- Add "for editor", "for website" tags to themes.