### PR TITLE
Add schema validation workflow

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -42,4 +42,3 @@ jobs:
         with:
           schema: https://github.com/Hans5958/ScratchAddons-Schemas/raw/master/addon/1.0.json
           jsons: changes.txt
-      

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,45 @@
+name: Schema validation
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - addons/*/addon.json
+  pull_request:
+    branches:
+      - master
+    paths:
+      - addons/*/addon.json
+
+jobs:
+  sv:
+    name: Validation
+    runs-on: ubuntu-latest
+    if: github.repository_owner == "ScratchAddons"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Find changed files
+        id: changed
+        uses: Hans5958/changed-files@master
+        with:
+          pattern: '^addons\/.*\/addon.json$'
+          repo-token: ${{ github.token }}
+
+      - name: Write changed files
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: changes.txt
+          contents: |
+            ${{ steps.changed.outputs.files_created }}
+            ${{ steps.changed.outputs.files_updated }}
+
+      - name: Validate .json with schema
+        uses: Hans5958/validate-json-action@master
+        with:
+          schema: https://github.com/Hans5958/ScratchAddons-Schemas/raw/master/addon/1.0.json
+          jsons: changes.txt
+      


### PR DESCRIPTION
This PR adds a schema validation workflow for addon manifests, based on the schema that I made on [Hans5958/ScratchAddons-Schema](https://github.com/Hans5958/ScratchAddons-Schemas/blob/master/addon/1.0.json), with some actions that I have modified so it works properly.

The workflow have been tested rigorously by myself and it seems that it is working properly.

This pull request partially resolves #229 as there will be future PRs for updating all addon manifest for the schema, which will be done after this PR. 

Some notes:
- There is still a need to get the descriptions done on [the schema](https://github.com/Hans5958/ScratchAddons-Schemas/blob/master/addon/1.0.json). I have filled some of the description based on the wiki, but there still some field missing, indicated by the TODO comments.
- Tell me if you need to move the repositories from mine to this organization.
- I made this so it only works on the master branch of this repo only. Should I make it work on all forks and branches also? It's quite easy, don't worry.