### PR TITLE
Scratch Messaging little fixes

### DIFF
--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -93,13 +93,14 @@ export default async function ({ addon, global, console, setTimeout, setInterval
         // Remove extra messages
         data.messages.length = 40;
       }
+      if (data.messages.length > 1000) {
+        data.messages.length = 1000;
+      }
     }
     lastDateTime = new Date(checkedMessages[0].datetime_created).getTime();
     data.ready = true;
   }
 
-  // NOTE: addons aren't supposed to use chrome APIs
-  // Until addons have a way to communicate with popups, this is the only way
   chrome.runtime.onMessage.addListener(function thisFunction(request, sender, sendResponse) {
     // If this addon has been killed, addon.self will throw
     try {


### PR DESCRIPTION
Limit the amount of saved messages over time to 1000 (not just for the first check).
Remove comment that could be misinterpreted.