### PR TITLE
Bug fixes

### DIFF
--- a/background/handle-messages.js
+++ b/background/handle-messages.js
@@ -1,18 +1,18 @@
 const COUNT_CHECK_INTERVAL = 30000;
 const MSGS_CHECK_INTERVAL = 120000; // Ignored if message count change has been seen
 
-let lastCheckUsername = null;
-
 // For getMsgCount
 let lastCountCheck = null;
 let lastMsgCount = null;
 let currentlyCheckingCount = false;
+let lastCheckUsernameCount = null;
 const msgCountPromises = [];
 
 // For getMessages. These only apply for offset 0.
 let lastMessagesCheck = null;
 let lastMsgsArray = null;
 let currentlyCheckingMessages = false;
+let lastCheckUsernameMessages = null;
 const msgsArrayPromises = [];
 
 scratchAddons.methods.getMsgCount = function () {
@@ -30,17 +30,17 @@ async function updateMsgCount() {
   const username = scratchAddons.globalState.auth.username;
   if (!username) {
     lastMsgCount = null;
-    lastCheckUsername = null;
+    lastCheckUsernameCount = null;
     return null;
   }
   try {
-    if (Date.now() - lastCountCheck > COUNT_CHECK_INTERVAL || username !== lastCheckUsername) {
+    if (Date.now() - lastCountCheck > COUNT_CHECK_INTERVAL || username !== lastCheckUsernameCount) {
       const res = await fetch(`https://api.scratch.mit.edu/users/${username}/messages/count?timestamp=${Date.now()}`);
       if (!res.ok) return null;
       const json = await res.json();
       if (json.count !== lastMsgCount) lastMessagesCheck = null;
       lastCountCheck = Date.now();
-      lastCheckUsername = username;
+      lastCheckUsernameCount = username;
       lastMsgCount = json.count;
       return json.count;
     } else {
@@ -82,14 +82,14 @@ async function checkMessages(options) {
   const username = scratchAddons.globalState.auth.username;
   if (!username) {
     lastMsgsArray = null;
-    lastCheckUsername = null;
+    lastCheckUsernameMessages = null;
     return null;
   }
   try {
-    if (Date.now() - lastMessagesCheck > MSGS_CHECK_INTERVAL || username !== lastCheckUsername) {
+    if (Date.now() - lastMessagesCheck > MSGS_CHECK_INTERVAL || username !== lastCheckUsernameMessages) {
       const json = await requestMessages(options);
       lastMessagesCheck = Date.now();
-      lastCheckUsername = username;
+      lastCheckUsernameMessages = username;
       lastMsgsArray = json;
       return json;
     } else {

--- a/background/imports/global-state.js
+++ b/background/imports/global-state.js
@@ -63,20 +63,20 @@ function stateChange(parentObjectPath, key, value) {
     objectPathArr[0] === "auth" ? "[redacted]" : value,
     `\nChanged by: ${setterUrl}`
   );
-  if (objectPath[0] === "auth" && key !== "scratchLang") {
+  if (objectPathArr[0] === "auth" && key !== "scratchLang") {
     scratchAddons.eventTargets.auth.forEach((eventTarget) => eventTarget.dispatchEvent(new CustomEvent("change")));
     messageForAllTabs({ fireEvent: { target: "auth", name: "change" } });
-  } else if (objectPath[0] === "addonSettings") {
+  } else if (objectPathArr[0] === "addonSettings") {
     // Send event to persistent script and userscripts, if they exist.
     const settingsEventTarget = scratchAddons.eventTargets.settings.find(
-      (eventTarget) => eventTarget._addonId === objectPath[1]
+      (eventTarget) => eventTarget._addonId === objectPathArr[1]
     );
     if (settingsEventTarget) settingsEventTarget.dispatchEvent(new CustomEvent("change"));
     messageForAllTabs({
       fireEvent: {
         target: "settings",
         name: "change",
-        addonId: objectPath[1],
+        addonId: objectPathArr[1],
       },
     });
   }


### PR DESCRIPTION
- Auth change and settings change events weren't firing bc of weird variable name changes I made :S 
- To avoid any sync issues, now the last checked username for message count checks and message array checks are stored separately. Previously, a message count check could result on a cached version of the message array from the previous username to be returned, if message counts matched between accounts.