### PR TITLE
Fix For Full Signature Addon

### DIFF
--- a/addons/full-signature/addon.json
+++ b/addons/full-signature/addon.json
@@ -28,9 +28,7 @@
         "setting_id": "signature",
         "setting_value": true
       }
-    }
-  ],
-  "userstyles": [
+    },
     {
       "url": "style2.css",
       "matches": ["https://scratch.mit.edu/users/*"],


### PR DESCRIPTION
(－‸ლ)
(－‸ლ)
I used two userstyle keys. Wow, I'm stupid. Well, it's fixed now.