### PR TITLE
Editor Only Dark Mode

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -12,7 +12,7 @@
   "userstyles": [
     {
       "url": "dark-editor.css",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["https://scratch.mit.edu/projects/*/editor"],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "Dark editor"
@@ -20,7 +20,7 @@
     },
     {
       "url": "3dark.css",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["https://scratch.mit.edu/projects/*/editor"],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "3.Dark"
@@ -28,7 +28,7 @@
     },
     {
       "url": "3darker.css",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["https://scratch.mit.edu/projects/*/editor"],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "3.Darker"
@@ -36,7 +36,7 @@
     },
     {
       "url": "global.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["https://scratch.mit.edu/projects/*/editor"]
     }
   ],
   "options": [


### PR DESCRIPTION


**Changes**

Adds /editor to all of the links. Before, it was showing some dark elements on the remixtree page.
**Reason for changes**
Before, it was showing some dark elements on the remixtree page.
<!-- Why should these changes be made? -->

**Tests**

Changing in local extension files.