### PR TITLE
Small bug fix: avoid HTML attribute memory leak and console errors

### DIFF
--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -68,7 +68,7 @@ const observer = new MutationObserver((mutationsList) => {
         const settingsEventTarget = scratchAddons.eventTargets.settings.find(
           (eventTarget) => eventTarget._addonId === attrVal.addonId
         );
-        if(settingsEventTarget) settingsEventTarget.dispatchEvent(new CustomEvent("change"));
+        if (settingsEventTarget) settingsEventTarget.dispatchEvent(new CustomEvent("change"));
       } else
         scratchAddons.eventTargets[attrVal.target].forEach((eventTarget) =>
           eventTarget.dispatchEvent(new CustomEvent(attrVal.name))

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -68,11 +68,12 @@ const observer = new MutationObserver((mutationsList) => {
         const settingsEventTarget = scratchAddons.eventTargets.settings.find(
           (eventTarget) => eventTarget._addonId === attrVal.addonId
         );
-        settingsEventTarget.dispatchEvent(new CustomEvent("change"));
+        if(settingsEventTarget) settingsEventTarget.dispatchEvent(new CustomEvent("change"));
       } else
         scratchAddons.eventTargets[attrVal.target].forEach((eventTarget) =>
           eventTarget.dispatchEvent(new CustomEvent(attrVal.name))
         );
+      removeAttr();
     }
   }
 });


### PR DESCRIPTION
- Avoids `dispatchEvent` from being called on non-existent `addon.settings` event targets.
- Removes the `data-fire-event` from the DOM after being read by the injected script.