### PR TITLE
Fix #322: bug in URL/pattern matcher 

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -49,17 +49,22 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
 }
 
 function urlMatchesPattern(pattern, url) {
-  const patternURL = new URL(pattern);
-  const urlURL = new URL(url);
-  if (patternURL.origin !== urlURL.origin) return false;
-  const patternPath = patternURL.pathname.split("/");
-  const urlPath = urlURL.pathname.split("/");
-  if (patternPath[patternPath.length - 1] !== "") patternPath.push("");
+  const patternUrl = new URL(pattern);
+  const urlUrl = new URL(url);
+  // We assume both URLs start with https://scratch.mit.edu
+
+  const patternPath = patternUrl.pathname.split("/");
+  const urlPath = urlUrl.pathname.split("/");
+  // Implicit slash at the end of the URL path, if it's not there
   if (urlPath[urlPath.length - 1] !== "") urlPath.push("");
+  // Implicit slash at the end of the pattern, unless it's a wildcard
+  if (patternPath[patternPath.length - 1] !== "" && patternPath[patternPath.length - 1] !== "*") patternPath.push("");
+
   while (patternPath.length) {
-    const p = patternPath.shift();
-    const q = urlPath.shift();
-    if (p !== q && p !== "*") return false;
+    // shift() removes the first item of an array, and returns it
+    const patternItem = patternPath.shift();
+    const urlItem = urlPath.shift();
+    if (patternItem !== urlItem && patternItem !== "*") return false;
   }
   return true;
 }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -54,6 +54,7 @@ function urlMatchesPattern(pattern, url) {
   if (patternURL.origin !== urlURL.origin) return false;
   const patternPath = patternURL.pathname.split("/");
   const urlPath = urlURL.pathname.split("/");
+  if (patternPath[patternPath.length - 1] !== "") patternPath.push("");
   if (urlPath[urlPath.length - 1] !== "") urlPath.push("");
   while (patternPath.length) {
     const p = patternPath.shift();


### PR DESCRIPTION
Resolves #332 

Adds an implicit "/" at the end of the pattern. This was already done with the URL, but not with the pattern.
This implicit slash is only added if the last character of the pattern isn't a wildcard - `https://scratch.mit.edu/discuss/*` would match any URL inside discuss, but `https://scratch.mit.edu/discuss/*/` would only match those that have a single "sub-folder" after "discuss".