### PR TITLE
Fix colored context menus styles breaking

### DIFF
--- a/addons/editor-colored-context-menus/userscript.css
+++ b/addons/editor-colored-context-menus/userscript.css
@@ -1,6 +1,6 @@
 .u-contextmenu-colored .blocklyContextMenu {
-  background-color: var(--u-contextmenu-bg);
-  border-color: var(--u-contextmenu-border);
+  background-color: var(--u-contextmenu-bg) !important;
+  border-color: var(--u-contextmenu-border) !important;
 }
 .u-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {
   color: white;


### PR DESCRIPTION
**Resolves**

Found a bug while trying to recreate #388 (which I was never able to do) where context menu styles can break and always be displayed as [white text on a white background](https://user-images.githubusercontent.com/33787854/95021617-abc95b00-0637-11eb-80f2-0dce0d25670c.png) because of inconsistent stylesheet order

**Changes**

!important to override CSS specificity

**Reason for changes**

bugs = bad

**Tests**

<!-- Have you tested this pull request? If so, how? -->
it still works
