### PR TITLE
Do not load traps unless addons that use them are enabled (performance concerns)

### DIFF
--- a/addon-api/content-script/Addon.js
+++ b/addon-api/content-script/Addon.js
@@ -15,7 +15,7 @@ export default class Addon {
     this.auth = new Auth(this);
     this.account = new Account();
     this.fetch = fetch;
-    this.tab = new Tab();
+    this.tab = new Tab(info);
     this.settings = new Settings(this);
   }
 }

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -5,28 +5,29 @@ import dataURLToBlob from "../../libraries/data-url-to-blob.js";
 const DATA_PNG = "data:image/png;base64,";
 const template = document.getElementById("scratch-addons");
 
-export default class Tab extends EventTarget {
-  constructor() {
-    super();
-    if (scratchAddons.eventTargets) scratchAddons.eventTargets.tab.push(this);
+export default class Tab {
+  constructor(info) {
+    scratchAddons.eventTargets.tab.push(this);
     this.clientVersion =
       document.querySelector("#app #navigation") || this.editorMode !== null
         ? "scratch-www"
         : window.Scratch
         ? "scratchr2"
         : null;
-    this.traps = new Trap();
-    __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
-      const newEvent = new CustomEvent("fakestatechanged", {
-        detail: {
-          reducerOrigin: detail.reducerOrigin,
-          path: detail.path,
-          prev: detail.prev,
-          next: detail.next,
-        },
+    if(info.traps) {
+      this.traps = new Trap();
+      __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
+        const newEvent = new CustomEvent("fakestatechanged", {
+          detail: {
+            reducerOrigin: detail.reducerOrigin,
+            path: detail.path,
+            prev: detail.prev,
+            next: detail.next,
+          },
+        });
+        this.traps.dispatchEvent(newEvent);
       });
-      this.dispatchEvent(newEvent);
-    });
+    }
     this.redux = new ReduxHandler();
   }
   loadScript(url) {

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -14,7 +14,7 @@ export default class Tab {
         : window.Scratch
         ? "scratchr2"
         : null;
-    if(info.traps) {
+    if (info.traps) {
       this.traps = new Trap();
       __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
         const newEvent = new CustomEvent("fakestatechanged", {

--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -1,4 +1,7 @@
-export default class Trap {
+export default class Trap extends EventTarget {
+  constructor() {
+    super();
+  }
   /**
    * @type {object.<string, *>} mapping for the Once objects trapped.
    */

--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -12,6 +12,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
+  "traps": true,
   "tags": ["editor"],
   "enabled_by_default": false
 }

--- a/addons/data-category-tweaks/addon.json
+++ b/addons/data-category-tweaks/addon.json
@@ -21,6 +21,7 @@
       "default": false
     }
   ],
+  "traps": true,
   "tags": ["editor"],
   "enabled_by_default": false
 }

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -7,6 +7,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
+  "traps": true,
   "tags": ["editor"],
   "enabled_by_default": false
 }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, global, console }) {
-  const virtualMachine = await addon.tab.getScratchVM();
+  const virtualMachine = addon.tab.traps.onceValues.vm;
   const removeHighlight = () =>
     Array.prototype.forEach.call(document.querySelectorAll("path[style*='outline' i]"), (e) =>
       e.removeAttribute("style")

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -7,6 +7,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
+  "traps": true,
   "tags": ["editor"],
   "enabled_by_default": false
 }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -7,6 +7,7 @@ async function getUserscripts() {
     if (manifest.userscripts || manifest.userstyles) {
       addonsWithScriptsOrStyles.push({
         addonId,
+        traps: manifest.traps || null,
         scripts: manifest.userscripts || [],
         styles: manifest.userstyles || [],
       });
@@ -38,7 +39,7 @@ async function sendUserscriptsAndUserstyles(url, tabId) {
     for (const style of addon.styles) {
       if (userscriptMatches({ url }, style, addon.addonId)) styleUrls.push(style.url);
     }
-    if (scripts.length || styleUrls.length) data.push({ addonId: addon.addonId, scripts, styleUrls, styles: [] });
+    if (scripts.length || styleUrls.length) data.push({ addonId: addon.addonId, scripts, traps: addon.traps, styleUrls, styles: [] });
   }
 
   const promises = [];

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -39,7 +39,8 @@ async function sendUserscriptsAndUserstyles(url, tabId) {
     for (const style of addon.styles) {
       if (userscriptMatches({ url }, style, addon.addonId)) styleUrls.push(style.url);
     }
-    if (scripts.length || styleUrls.length) data.push({ addonId: addon.addonId, scripts, traps: addon.traps, styleUrls, styles: [] });
+    if (scripts.length || styleUrls.length)
+      data.push({ addonId: addon.addonId, scripts, traps: addon.traps, styleUrls, styles: [] });
   }
 
   const promises = [];

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -1,5 +1,29 @@
 import runPersistentScripts from "./imports/run-persistent-scripts.js";
 
+function setLocalStorage(arr) {
+  const iframe = document.createElement("iframe");
+  iframe.src = "https://scratch.mit.edu/projects/0111001101100001/embed";
+  document.body.appendChild(iframe);
+  window.addEventListener("message", (event) => {
+    if (event.origin === "https://scratch.mit.edu" && event.data === "ready") {
+      iframe.contentWindow.postMessage(arr, "*");
+      window.addEventListener("message", (event) => {
+        if (event.origin === "https://scratch.mit.edu" && event.data === "OK") {
+          iframe.remove();
+        }
+      }, {once: true});
+    }
+  }, {once: true});
+}
+
+function setTrapsLocalStorageValue() {
+  const enabled = scratchAddons.manifests.filter((obj) => scratchAddons.localState.addonsEnabled[obj.addonId]).some((obj) => obj.manifest.traps);
+  setLocalStorage([{key: "sa-trapsEnabled", value: enabled}]);
+}
+
+if (scratchAddons.localState.allReady) setTrapsLocalStorageValue();
+else scratchAddons.localEvents.addEventListener("ready", setTrapsLocalStorageValue);
+
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "getSettingsInfo") {
     sendResponse({
@@ -24,6 +48,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 
     if (scratchAddons.manifests.find((obj) => obj.addonId === addonId).manifest.tags.includes("theme"))
       scratchAddons.localEvents.dispatchEvent(new CustomEvent("themesUpdated"));
+    setTrapsLocalStorageValue();
   } else if (request.changeAddonSettings) {
     const { addonId, newSettings } = request.changeAddonSettings;
     scratchAddons.globalState.addonSettings[addonId] = newSettings;

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -4,21 +4,31 @@ function setLocalStorage(arr) {
   const iframe = document.createElement("iframe");
   iframe.src = "https://scratch.mit.edu/projects/0111001101100001/embed";
   document.body.appendChild(iframe);
-  window.addEventListener("message", (event) => {
-    if (event.origin === "https://scratch.mit.edu" && event.data === "ready") {
-      iframe.contentWindow.postMessage(arr, "*");
-      window.addEventListener("message", (event) => {
-        if (event.origin === "https://scratch.mit.edu" && event.data === "OK") {
-          iframe.remove();
-        }
-      }, {once: true});
-    }
-  }, {once: true});
+  window.addEventListener(
+    "message",
+    (event) => {
+      if (event.origin === "https://scratch.mit.edu" && event.data === "ready") {
+        iframe.contentWindow.postMessage(arr, "*");
+        window.addEventListener(
+          "message",
+          (event) => {
+            if (event.origin === "https://scratch.mit.edu" && event.data === "OK") {
+              iframe.remove();
+            }
+          },
+          { once: true }
+        );
+      }
+    },
+    { once: true }
+  );
 }
 
 function setTrapsLocalStorageValue() {
-  const enabled = scratchAddons.manifests.filter((obj) => scratchAddons.localState.addonsEnabled[obj.addonId]).some((obj) => obj.manifest.traps);
-  setLocalStorage([{key: "sa-trapsEnabled", value: enabled}]);
+  const enabled = scratchAddons.manifests
+    .filter((obj) => scratchAddons.localState.addonsEnabled[obj.addonId])
+    .some((obj) => obj.manifest.traps);
+  setLocalStorage([{ key: "sa-trapsEnabled", value: enabled }]);
 }
 
 if (scratchAddons.localState.allReady) setTrapsLocalStorageValue();

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -1,4 +1,4 @@
-import runUserscript from "./run-userscript.js";
+import runAddonUserscripts from "./run-userscript.js";
 
 const template = document.getElementById("scratch-addons");
 const getGlobalState = () => {
@@ -25,24 +25,6 @@ scratchAddons.methods.getMsgCount = () => {
   const promise = new Promise((resolve) => (promiseResolver = resolve));
   pendingPromises.msgCount.push(promiseResolver);
   return promise;
-};
-scratchAddons.methods.getScratchVM = () => {
-  if (__scratchAddonsTraps._onceMap) {
-    for (const vmAttr of ["vm", "vm.propsVMBind", "vm.propsVMAssign"]) {
-      const maybeVM = __scratchAddonsTraps._onceMap[vmAttr];
-      if (maybeVM) return Promise.resolve(maybeVM);
-    }
-  }
-  if (window._scratchAddonsScratchVM) return Promise.resolve(window._scratchAddonsScratchVM);
-  else
-    return new Promise((resolve) => {
-      const handler = (e) => {
-        if (!e.trapName.startsWith("vm")) return;
-        resolve(e.value);
-        __scratchAddonsTraps._targetOnce.removeEventListener("trapready", handler);
-      };
-      __scratchAddonsTraps._targetOnce.addEventListener("trapready", handler);
-    });
 };
 
 const observer = new MutationObserver((mutationsList) => {
@@ -80,5 +62,5 @@ const observer = new MutationObserver((mutationsList) => {
 observer.observe(template, { attributes: true });
 
 for (const addon of JSON.parse(template.getAttribute("data-addons"))) {
-  if (addon.scripts.length) runUserscript(addon);
+  if (addon.scripts.length) runAddonUserscripts(addon);
 }

--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -1,7 +1,7 @@
 import Addon from "../../addon-api/content-script/Addon.js";
 
-export default async function runAddonUserscripts({ addonId, scripts }) {
-  const addonObj = new Addon({ id: addonId });
+export default async function runAddonUserscripts({ addonId, scripts, traps }) {
+  const addonObj = new Addon({ id: addonId, traps });
   const globalObj = Object.create(null);
   for (const scriptInfo of scripts) {
     const { url: scriptPath, runAtComplete } = scriptInfo;

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -341,7 +341,7 @@ function injectPrototype() {
   });
 }
 
-if(localStorage.getItem("sa-trapsEnabled") === "true") {
+if (localStorage.getItem("sa-trapsEnabled") === "true") {
   const injectPrototypeScript = document.createElement("script");
   injectPrototypeScript.append(document.createTextNode("(" + injectPrototype + ")()"));
   (document.head || document.documentElement).appendChild(injectPrototypeScript);

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -340,6 +340,9 @@ function injectPrototype() {
     }
   });
 }
-const injectPrototypeScript = document.createElement("script");
-injectPrototypeScript.append(document.createTextNode("(" + injectPrototype + ")()"));
-(document.head || document.documentElement).appendChild(injectPrototypeScript);
+
+if(localStorage.getItem("sa-trapsEnabled") === "true") {
+  const injectPrototypeScript = document.createElement("script");
+  injectPrototypeScript.append(document.createTextNode("(" + injectPrototype + ")()"));
+  (document.head || document.documentElement).appendChild(injectPrototypeScript);
+} else console.log("Scratch Addons: traps disabled");

--- a/content-scripts/sa-embed.js
+++ b/content-scripts/sa-embed.js
@@ -1,0 +1,8 @@
+if (window.parent !== window) window.parent.postMessage("ready", "*");
+
+window.addEventListener("message", (event) => {
+  if (event.origin === chrome.runtime.getURL("").slice(0, -1)) {
+    event.data.forEach((obj => localStorage.setItem(obj.key, obj.value)));
+    event.source.postMessage("OK", "*");
+  }
+});

--- a/content-scripts/sa-embed.js
+++ b/content-scripts/sa-embed.js
@@ -2,7 +2,7 @@ if (window.parent !== window) window.parent.postMessage("ready", "*");
 
 window.addEventListener("message", (event) => {
   if (event.origin === chrome.runtime.getURL("").slice(0, -1)) {
-    event.data.forEach((obj => localStorage.setItem(obj.key, obj.value)));
+    event.data.forEach((obj) => localStorage.setItem(obj.key, obj.value));
     event.source.postMessage("OK", "*");
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,12 @@
       "matches": ["https://scratch.mit.edu/*"],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js"]
+    },
+    {
+      "matches": ["https://scratch.mit.edu/projects/0111001101100001/embed"],
+      "run_at": "document_start",
+      "js": ["content-scripts/sa-embed.js"],
+      "all_frames": true
     }
   ],
   "options_ui": {


### PR DESCRIPTION
Resolves #345

With this change, if you have none of these addons enabled, Scratch projects performance goes back to normal:
- 60fps
- Data category tweaks
- Editor stepping
- Remove sprite confirm

This introduces a `traps` property in the manifest, with the default value of `false`. If truthy, addon.tab.traps is available to that addon. In the future, we expect to make this an object that specifies which objects it wants to trap, instead of doing that at runtime.

This removes `addon.tabs.getScratchVM()` - please use the `addon.tab.traps` API for consistency.