### PR TITLE
Make sure the head loaded before injecting userstyles

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -10,18 +10,32 @@ let userscriptsAndUserstyles;
 let firstRun = true;
 let domLoaded = false;
 
+function injectUserstyles(object) {
+  for (const addon of object) {
+    for (const css of addon.styles) {
+      const style = document.createElement("style");
+      style.classList.add("scratch-addons-css");
+      style.textContent = css;
+      document.documentElement.appendChild(style);
+    }
+  }
+}
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log("[Message from background]", request);
   if (request.userscriptsAndUserstyles) {
     sendResponse("OK");
     document.querySelectorAll(".scratch-addons-css").forEach((style) => style.remove());
-    for (const addon of request.userscriptsAndUserstyles) {
-      for (const css of addon.styles) {
-        const style = document.createElement("style");
-        style.classList.add("scratch-addons-css");
-        style.textContent = css;
-        document.documentElement.appendChild(style);
-      }
+    
+    if(document.head) injectUserstyles(request.userscriptsAndUserstyles);
+    else {
+      const observer = new MutationObserver(() => {
+        if (document.head) {
+          injectUserstyles(request.userscriptsAndUserstyles);
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.documentElement, {subtree: true});
     }
     userscriptsAndUserstyles = request.userscriptsAndUserstyles;
     if (firstRun && domLoaded) onReady();

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -26,8 +26,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.userscriptsAndUserstyles) {
     sendResponse("OK");
     document.querySelectorAll(".scratch-addons-css").forEach((style) => style.remove());
-    
-    if(document.head) injectUserstyles(request.userscriptsAndUserstyles);
+
+    if (document.head) injectUserstyles(request.userscriptsAndUserstyles);
     else {
       const observer = new MutationObserver(() => {
         if (document.head) {
@@ -35,7 +35,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           observer.disconnect();
         }
       });
-      observer.observe(document.documentElement, {subtree: true});
+      observer.observe(document.documentElement, { subtree: true });
     }
     userscriptsAndUserstyles = request.userscriptsAndUserstyles;
     if (firstRun && domLoaded) onReady();


### PR DESCRIPTION
Resolves #401

Most times the head loaded before userstyles were injected - however, sometimes, they didn't, causing issues were the Scratch styles were more relevant than Scratch Addons'. This fixes this issue, and I've noticed no flickering of any kind so far.