### PR TITLE
Forum search and 2.0 → 3.0 compatibility

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -1,7 +1,7 @@
 [
   "// Note: these addons need this exact order to work properly,",
   "// because the first in the list gets their CSS injected first,",
-  "// and so on, and we want dark mode to make other addons dark.",
+  "// and so on, and we want themes to override other styles.",
   "// For editor:",
   "editor-searchable-dropdowns",
   "editor-devtools",
@@ -10,6 +10,7 @@
   "editor-stage-left",
 
   "// For website:",
+  "forum-search",
   "scratchr2",
 
   "// Other addons:",
@@ -29,7 +30,6 @@
   "youtube-fullscreen",
   "data-category-tweaks",
   "full-signature",
-  "forum-search",
   "60fps",
   "better-emojis",
   "cloud-games"

--- a/addons/forum-search/userscript.css
+++ b/addons/forum-search/userscript.css
@@ -6,6 +6,14 @@
   display: none;
 }
 
+.forum-search-list .blockpost .box-head a {
+  display: inline-block;
+  max-width: 60%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .post_body_html img {
   max-width: 100%;
 }

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -24,8 +24,9 @@
   border: none;
   border-radius: 0;
   background: #0fbd8c;
+  color: #fff;
 }
-#brdheader .box-head {
+#brdheader > .box-head {
   width: 942px;
   margin: auto;
   padding: 0;
@@ -50,6 +51,29 @@
 }
 #brdmenu a:hover {
   text-decoration: underline;
+}
+#brdheader form {
+  width: 942px;
+  margin: auto;
+  margin-top: 8px;
+}
+#forum-search-input {
+  width: calc(85% - 8px);
+  margin-right: 8px;
+  height: 48px;
+}
+.forum-search-list {
+  width: 942px;
+  margin: auto;
+  padding: 0;
+  margin-top: 8px;
+}
+.forum-search-list .blockpost {
+  width: 100%;
+  color: #575e75;
+}
+.forum-search-list .blockpost div.box {
+  background: #4d97ff;
 }
 #brdfooter {
   margin-top: 40px;


### PR DESCRIPTION
**Resolves**

Resolves #416

**Changes**

Makes forum search and Scratch 2.0 → 3.0 compatible.

**Reason for changes**

Previously, when Scratch 2.0 → 3.0 was enabled, forum search looked terrible.

**Tests**

![Screenshot](https://user-images.githubusercontent.com/51849865/95174464-641f0c80-07ba-11eb-8d63-dd75a818fc0b.png)

