### PR TITLE
Don't inject dark mode into remixtree, do not style scratch 3.0 search bar

### DIFF
--- a/addons/editor-dark-mode/3dark.css
+++ b/addons/editor-dark-mode/3dark.css
@@ -167,14 +167,14 @@ div.custom-procedures_option-card_BtHt3 {
 .library-item_library-item-name_2qMXu {
   color: var(--text) !important;
 }
-input[type="text"]:not([name="title"]),
+input[type="text"]:not([name="title"]):not([name="q"]),
 .input_input-form_1Y0wX,
 .prompt_variable-name-text-input_1iu8- {
   background: var(--accent);
   color: var(--text) !important;
 }
-input[type="text"]:not([name="title"]):hover,
-input[type="text"]:not([name="title"]):focus {
+input[type="text"]:not([name="title"]):not([name="q"]):hover,
+input[type="text"]:not([name="title"]):not([name="q"]):focus {
   background: var(--accent);
   filter: brightness(90%);
 }

--- a/addons/editor-dark-mode/3darker.css
+++ b/addons/editor-dark-mode/3darker.css
@@ -166,14 +166,14 @@ div.custom-procedures_option-card_BtHt3 {
 .library-item_library-item-name_2qMXu {
   color: var(--text) !important;
 }
-input[type="text"]:not([name="title"]),
+input[type="text"]:not([name="title"]):not([name="q"]),
 .input_input-form_1Y0wX,
 .prompt_variable-name-text-input_1iu8- {
   background: var(--accent);
   color: var(--text) !important;
 }
-input[type="text"]:not([name="title"]):hover,
-input[type="text"]:not([name="title"]):focus {
+input[type="text"]:not([name="title"]):not([name="q"]):hover,
+input[type="text"]:not([name="title"]):not([name="q"]):focus {
   background: var(--accent);
   filter: brightness(90%);
 }

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -12,7 +12,12 @@
   "userstyles": [
     {
       "url": "dark-editor.css",
-      "matches": ["https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"],
+      "matches": [
+        "https://scratch.mit.edu/projects/*/",
+        "https://scratch.mit.edu/projects/*/editor",
+        "https://scratch.mit.edu/projects/*/fullscreen",
+        "https://scratch.mit.edu/projects/editor"
+      ],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "Dark editor"
@@ -20,7 +25,12 @@
     },
     {
       "url": "3dark.css",
-      "matches": ["https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"],
+      "matches": [
+        "https://scratch.mit.edu/projects/*/",
+        "https://scratch.mit.edu/projects/*/editor",
+        "https://scratch.mit.edu/projects/*/fullscreen",
+        "https://scratch.mit.edu/projects/editor"
+      ],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "3.Dark"
@@ -28,7 +38,12 @@
     },
     {
       "url": "3darker.css",
-      "matches": ["https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"],
+      "matches": [
+        "https://scratch.mit.edu/projects/*/",
+        "https://scratch.mit.edu/projects/*/editor",
+        "https://scratch.mit.edu/projects/*/fullscreen",
+        "https://scratch.mit.edu/projects/editor"
+      ],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "3.Darker"

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -12,7 +12,7 @@
   "userstyles": [
     {
       "url": "dark-editor.css",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "Dark editor"
@@ -20,7 +20,7 @@
     },
     {
       "url": "3dark.css",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "3.Dark"
@@ -28,7 +28,7 @@
     },
     {
       "url": "3darker.css",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"],
       "setting_match": {
         "setting_id": "selectedMode",
         "setting_value": "3.Darker"

--- a/addons/editor-dark-mode/dark-editor.css
+++ b/addons/editor-dark-mode/dark-editor.css
@@ -189,16 +189,16 @@ body {
   fill: hsla(215, 60%, 40%, 1) !important;
 }
 
-input:not([name="title"]) {
+input:not([name="title"]):not([name="q"]) {
   background: #444;
   color: #fff !important;
 }
 
-input::placeholder {
+input:not([name="title"]):not([name="q"])::placeholder {
   color: #ddd;
 }
 
-input:focus {
+input:not([name="title"]):not([name="q"]):focus {
   box-shadow: 0 0 0 0.25rem hsla(215, 100%, 55%, 0.45) !important;
 }
 


### PR DESCRIPTION
Resolves #389

I thought I was going to throw a bunch of CSS `:not()`s so that dark mode wouldn't apply to the search input, but then I realized I could just change the single pattern to these 4, where the editor is reachable without a redirect or new navigation: `"https://scratch.mit.edu/projects/*/", "https://scratch.mit.edu/projects/*/editor", "https://scratch.mit.edu/projects/*/fullscreen", "https://scratch.mit.edu/projects/editor"`

I also fixed some slight changes to the search bar by the dark modes in the normal project page search bar (not the remix tree one)