### PR TITLE
Update tags and addon names

### DIFF
--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -1,7 +1,6 @@
 {
   "name": "Display stage on left side",
   "description": "Moves the stage to the left side of the editor.",
-  "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"

--- a/addons/forum-search/addon.json
+++ b/addons/forum-search/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Forum Search",
+  "name": "Forums search",
   "description": "Adds a post search to the forum homepage. Uses ScratchDB for information.",
   "credits": [
     {
@@ -18,6 +18,6 @@
       "matches": ["https://scratch.mit.edu/discuss/*"]
     }
   ],
-  "tags": ["forums", "community", "beta"],
+  "tags": ["forums", "community"],
   "enabled_by_default": false
 }

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Scratch 2.0 → 3.0",
   "description": "Makes Scratch 2.0-styled pages look like Scratch 3.0.",
-  "tags": ["community", "theme"],
+  "tags": ["community", "theme", "recommended"],
   "credits": [
     {
       "name": "Maximouse",


### PR DESCRIPTION
- I don't like adding themes as "recommended", but the Scratch 2.0 → 3.0 addon deserves it.
- Renamed "Forum Search" to "Forums search", since other addons also use "forums" instead of "forum". It's also not really beta anymore.
- The warning for `editor-stage-left` is outdated.