### PR TITLE
Dark mode little changes

### DIFF
--- a/addons/editor-dark-mode/3dark.css
+++ b/addons/editor-dark-mode/3dark.css
@@ -25,6 +25,10 @@
 .Popover-body {
   background: var(--accent) /*s-a* !important *s-a*/;
   color: var(--text) /*s-a* !important *s-a*/;
+}
+.context-menu_context-menu_2SJM-,
+.blocklyWidgetDiv .goog-menu,
+.Popover-body {
   border: 1px solid white;
 }
 .goog-menuitem-content,

--- a/addons/editor-dark-mode/3darker.css
+++ b/addons/editor-dark-mode/3darker.css
@@ -2,7 +2,7 @@
   --main-bg: #111111;
   --secondary-bg: #151515;
   --accent: #202020;
-  --text: #bfbfbf;
+  --text: #ffffff;
 }
 .menu-bar_main-menu_3wjWH,
 .modal_header_1h7ps,
@@ -25,6 +25,10 @@
 .Popover-body {
   background: var(--accent) /*s-a* !important *s-a*/;
   color: var(--text) /*s-a* !important *s-a*/;
+}
+.context-menu_context-menu_2SJM-,
+.blocklyWidgetDiv .goog-menu,
+.Popover-body {
   border: 1px solid white;
 }
 .goog-menuitem-content,

--- a/addons/editor-dark-mode/dark-editor.css
+++ b/addons/editor-dark-mode/dark-editor.css
@@ -159,7 +159,7 @@ body {
 }
 
 [class^="gui_tab"] span {
-  font-weight: 800;
+  /* s-a */ font-weight: 700;
 }
 
 [class^="gui_tab"] li:not([aria-selected="true"]) > span {
@@ -289,4 +289,9 @@ input:not([name="title"]):not([name="q"]):focus {
 
 [class^="tool-select-base_tool-select"] {
   filter: brightness(2) saturate(0.25);
+}
+
+/* s-a */
+.paint-editor_button-group-button-icon_10kVn, .color-picker_swatch-icon_Z7osI, .scratchCategoryId-music > .scratchCategoryItemIcon {
+  filter: brightness(100);
 }

--- a/addons/editor-dark-mode/dark-editor.css
+++ b/addons/editor-dark-mode/dark-editor.css
@@ -159,7 +159,8 @@ body {
 }
 
 [class^="gui_tab"] span {
-  /* s-a */ font-weight: 700;
+  /* s-a */
+  font-weight: 700;
 }
 
 [class^="gui_tab"] li:not([aria-selected="true"]) > span {
@@ -292,6 +293,8 @@ input:not([name="title"]):not([name="q"]):focus {
 }
 
 /* s-a */
-.paint-editor_button-group-button-icon_10kVn, .color-picker_swatch-icon_Z7osI, .scratchCategoryId-music > .scratchCategoryItemIcon {
+.paint-editor_button-group-button-icon_10kVn,
+.color-picker_swatch-icon_Z7osI,
+.scratchCategoryId-music > .scratchCategoryItemIcon {
   filter: brightness(100);
 }

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -1,10 +1,8 @@
 html {
   font-size: 15px;
   height: 100%;
-}
-html.fullscreen {
-  font-size: 15px;
-  background-color: #e1e1e150;
+  scrollbar-width: thin;
+  scrollbar-color: #ff7b26 #adf;
 }
 
 body {

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -1,6 +1,8 @@
 html {
   font-size: 15px;
   height: 100%;
+  scrollbar-width: thin;
+  scrollbar-color: #ff7b26 #adf;
 }
 html.fullscreen {
   font-size: 15px;

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -17,6 +17,8 @@ const popups = [
   },
 ];
 
+let currentPopup = popups[0];
+
 for (const popup of popups) {
   const el = document.createElement("div");
   el.classList.add("popup-name");
@@ -37,12 +39,14 @@ for (const popup of popups) {
     popoutA.appendChild(img);
     el.appendChild(popoutA);
   }
-  el.onclick = () => setPopup(popup);
+  el.onclick = () => currentPopup !== popup && setPopup(popup);
   document.getElementById("popup-chooser").appendChild(el);
 }
-setPopup(popups[0]);
+
+setPopup(currentPopup);
 
 function setPopup(popup) {
+  currentPopup = popup;
   document.getElementById("iframe").src = `../../popups/${popup.url}`;
   if (document.querySelector(".popup-name.sel")) document.querySelector(".popup-name.sel").classList.remove("sel");
   document.querySelector(`.popup-name[data-id="${popup.addonId}"]`).classList.add("sel");


### PR DESCRIPTION
(Forgot to make a new branch, stayed in the old one. Sorry!)

- This is fairly subjective I admit, but the font-weight of 800 in dark-editor.css is a bit extreme. I lowered it into 700 until we provide more customization options.
- Remove a border that shouldn't be in 3.Dark and 3.Darker
- Change var(--text) to white on 3.Darker so that text is more readable. In the future, we should provide the past color back if the user decides to use Scratch 2.0 colors: https://github.com/infinitytec/2.0-Colors