### PR TITLE
Add warning to editor-stage-left

### DIFF
--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -1,6 +1,7 @@
 {
   "name": "Display stage on left side",
   "description": "Moves the stage to the left side of the editor.",
+  "warning": "Make sure to refresh the editor after enabling/disabling.",
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"


### PR DESCRIPTION
If it's enabled/disabled and the editor isn't refreshed, it will be very buggy because the userscript keeps running. This should be fixed in the next update, providing a way for userscripts to know when their userstyles have been removed.