### PR TITLE
Forum search styling bugfix when logged out

### DIFF
--- a/addons/forum-search/userscript.js
+++ b/addons/forum-search/userscript.js
@@ -235,9 +235,9 @@ export default async function ({ addon, global, console }) {
   searchContent.id = "forum-search-list";
 
   // now add the search bar
-  let navIndex = document.querySelector("ul.conr");
-  navIndex.parentNode.after(searchContent);
-  navIndex.parentNode.after(search);
+  let navIndex = document.querySelector("#brdmenu");
+  navIndex.after(searchContent);
+  navIndex.after(search);
 
   search.addEventListener("submit", (e) => {
     triggerNewSearch(searchContent, searchBar.value + locationQuery, searchDropdown.value);


### PR DESCRIPTION
Resolves: if you are logged out, the search forums addon sticks the searchbar at the bottom