### PR TITLE
Add note to bitmap images copying addon

### DIFF
--- a/addons/bitmap-copy/addon.json
+++ b/addons/bitmap-copy/addon.json
@@ -1,6 +1,7 @@
 {
   "name": "Bitmap images copying",
   "description": "Allows you to actually copy a bitmap image from the paint editor, so that you can paste it in other websites or software.",
+  "warning": "\"Right click → copy\" is not supported. You must press Ctrl+C while a bitmap image is selected.",
   "userscripts": [
     {
       "url": "userscript.js",


### PR DESCRIPTION
We've received through feedback that someone tried to copy the <canvas> so this note should clear up the confusion.