### PR TITLE
60fps addon enhancements

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "60FPS Player Mode",
+  "name": "60FPS player mode",
   "description": "Alt+Click the green flag to toggle 60FPS.",
   "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "credits": [

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -5,7 +5,7 @@ export default async function ({ addon, global, console }) {
 
   let altPressesCount = 0;
   let altPressedRecently = false;
-  window.addEventListener("keydown", event => {
+  window.addEventListener("keydown", (event) => {
     if (event.key === "Alt") {
       altPressesCount++;
       const pressCount = altPressesCount;

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -3,26 +3,37 @@ export default async function ({ addon, global, console }) {
 
   const vm = addon.tab.traps.onceValues.vm;
 
-  while (true) {
-    var button = await addon.tab.waitForElement("img.green-flag_green-flag_1kiAo:not([fpschecked])");
-    button.setAttribute("fpschecked", "true");
-    var mode = true;
+  let altPressesCount = 0;
+  let altPressedRecently = false;
+  window.addEventListener("keydown", event => {
+    if (event.key === "Alt") {
+      altPressesCount++;
+      const pressCount = altPressesCount;
+      altPressedRecently = true;
+      setTimeout(() => {
+        if (pressCount === altPressesCount) altPressedRecently = false;
+      }, 2500);
+    }
+  });
 
-    //console.log('just added class')
+  while (true) {
+    let button = await addon.tab.waitForElement("img.green-flag_green-flag_1kiAo:not([fpschecked])");
+    button.setAttribute("fpschecked", "true");
+    let mode = true;
 
     button.addEventListener("click", (e) => {
-      //console.log('click')
       if (e.altKey) {
-        console.log("toggle 60fps");
         mode = !mode;
         vm.setCompatibilityMode(mode);
-
-        if (mode) {
-          button.style.filter = "";
-        } else {
-          //60fps
-          button.style.filter = "hue-rotate(90deg)";
-        }
+        button.style.filter = mode ? "" : "hue-rotate(90deg)";
+      }
+    });
+    button.addEventListener("contextmenu", (e) => {
+      if (altPressedRecently) {
+        e.preventDefault();
+        mode = !mode;
+        vm.setCompatibilityMode(mode);
+        button.style.filter = mode ? "" : "hue-rotate(90deg)";
       }
     });
   }


### PR DESCRIPTION
- Normalize addon name.
- "Fixes" #425. It might not work, but it's my best attempt. If this does not solve it, I don't think anything else will. The logic I used is: when you do alt+click, the website should get notified about alt getting clicked. When you then click, it triggers a right click, so it should fire a `contextmenu` event on the green flag. If alt has been pressed for the last 2.5 and you right click the green flag, it interprets that the same way as a normal click with alt pressed (and of course, tells the browser not to open the right click context menu).