### PR TITLE
Use no-padding logo for the extension icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,9 +12,11 @@
     "default_title": "Scratch Addons"
   },
   "icons": {
-    "16": "images/extension-icon.png",
-    "48": "images/extension-icon.png",
-    "128": "images/extension-icon.png"
+    "16": "images/icon.png",
+    "32": "images/icon.png",
+    "48": "images/icon.png",
+    "96": "images/icon.png",
+    "128": "images/icon.png"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
For some reason, there is a padding on the extension variant of the logo, so it'll look smaller on the addons' bar (at least in Firefox). This PR changes the manifest to use `logo.png` that has no padding, so it has the same size with other icons on the address bar.