### PR TITLE
Add "urlChanged" event to addon.tab

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -5,8 +5,9 @@ import dataURLToBlob from "../../libraries/data-url-to-blob.js";
 const DATA_PNG = "data:image/png;base64,";
 const template = document.getElementById("scratch-addons");
 
-export default class Tab {
+export default class Tab extends EventTarget {
   constructor(info) {
+    super();
     scratchAddons.eventTargets.tab.push(this);
     this.clientVersion = document.querySelector("meta[name='format-detection']")
       ? "scratch-www"

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -27,6 +27,17 @@ scratchAddons.methods.getMsgCount = () => {
   return promise;
 };
 
+const originalReplaceState = history.replaceState;
+history.replaceState = function() {
+  const oldUrl = location.href;
+  const newUrl = new URL(arguments[2], document.baseURI).href;
+  const returnValue = originalReplaceState.apply(history, arguments);
+  for (const eventTarget of scratchAddons.eventTargets.tab) {
+    eventTarget.dispatchEvent(new CustomEvent("urlChange", { detail: { oldUrl, newUrl } }))
+  }
+  return returnValue;
+}
+
 const observer = new MutationObserver((mutationsList) => {
   for (const mutation of mutationsList) {
     const attr = mutation.attributeName;

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -28,15 +28,15 @@ scratchAddons.methods.getMsgCount = () => {
 };
 
 const originalReplaceState = history.replaceState;
-history.replaceState = function() {
+history.replaceState = function () {
   const oldUrl = location.href;
   const newUrl = new URL(arguments[2], document.baseURI).href;
   const returnValue = originalReplaceState.apply(history, arguments);
   for (const eventTarget of scratchAddons.eventTargets.tab) {
-    eventTarget.dispatchEvent(new CustomEvent("urlChange", { detail: { oldUrl, newUrl } }))
+    eventTarget.dispatchEvent(new CustomEvent("urlChange", { detail: { oldUrl, newUrl } }));
   }
   return returnValue;
-}
+};
 
 const observer = new MutationObserver((mutationsList) => {
   for (const mutation of mutationsList) {


### PR DESCRIPTION
Resolves #442, not exactly as I described however. This event triggers after any URL change (not navigations, of course). Right now, as far as I know, this can only happen inside projects, when editor mode changes. However in the future this might happen for something else, who knows! So let's try to cover as many use cases as possible.