### PR TITLE
Fix #511: make sure className is a string

### DIFF
--- a/addons/better-emojis/userscript.js
+++ b/addons/better-emojis/userscript.js
@@ -22,7 +22,7 @@ export default async function ({ addon, global, console }) {
     const treeWalker = document.createTreeWalker(body, NodeFilter.SHOW_ELEMENT);
     let currentNode = treeWalker.currentNode;
     while (currentNode) {
-      if (currentNode.className) {
+      if (typeof currentNode.className === "string") {
         if (currentNode.className.includes("easter-egg")) checkEmoji(currentNode);
         else if (currentNode.className.includes("emoji")) checkEmojiNew(currentNode);
       }


### PR DESCRIPTION
Oh, good old JavaScript. The className can be truthy and not be a string, who knew...