### PR TITLE
Fix emoji appearance on Scratch 2.0 Pages

### DIFF
--- a/addons/better-emojis/userscript.js
+++ b/addons/better-emojis/userscript.js
@@ -16,13 +16,14 @@ export default async function ({ addon, global, console }) {
     checkEmojiNew(emoji);
   }
 
+
   // Defines a MutationObserver to detect when new elements are added to the page.
   // A TreeWalker is used to navigate any new nodes and locate potential emojis.
   let obs = new MutationObserver(function (mutations, observer) {
     const treeWalker = document.createTreeWalker(body, NodeFilter.SHOW_ELEMENT);
     let currentNode = treeWalker.currentNode;
     while (currentNode) {
-      if (typeof currentNode.className === "string") {
+      if (currentNode.className) {
         if (currentNode.className.includes("easter-egg")) checkEmoji(currentNode);
         else if (currentNode.className.includes("emoji")) checkEmojiNew(currentNode);
       }
@@ -38,83 +39,70 @@ export default async function ({ addon, global, console }) {
 
   // Sets the src of the given Scratch 2.0 cat emoji to a custom image
   function checkEmoji(el) {
-    switch (el.src) {
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/cat.png":
-        el.src = addon.self.dir + "/images/cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/aww-cat.png":
-        el.src = addon.self.dir + "/images/aww-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/cool-cat.png":
-        el.src = addon.self.dir + "/images/cool-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/tongue-out-cat.png":
-        el.src = addon.self.dir + "/images/tongue-out-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/wink-cat.png":
-        el.src = addon.self.dir + "/images/wink-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/lol-cat.png":
-        el.src = addon.self.dir + "/images/lol-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/upside-down-cat.png":
-        el.src = addon.self.dir + "/images/upside-down-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/huh-cat.png":
-        el.src = addon.self.dir + "/images/cute-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/love-it-cat.png":
-        el.src = addon.self.dir + "/images/love-it-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/fav-it-cat.png":
-        el.src = addon.self.dir + "/images/fav-it-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/rainbow-cat.png":
-        el.src = addon.self.dir + "/images/rainbow-cat.svg";
-        break;
-      case "https://cdn.scratch.mit.edu/scratchr2/static/__6da311946763a4f4f2002998c0e04ee9__/images/easter_eggs/pizza-cat.png":
-        el.src = addon.self.dir + "/images/pizza-cat.svg";
-    }
+    if (el.src.includes("images/easter_eggs/cat.png"))
+      el.src = addon.self.dir + "/images/cat.svg";
+    if (el.src.includes("images/easter_eggs/aww-cat.png"))
+      el.src = addon.self.dir + "/images/aww-cat.svg";
+    if (el.src.includes("images/easter_eggs/cool-cat.png"))
+      el.src = addon.self.dir + "/images/cool-cat.svg";
+    if (el.src.includes("images/easter_eggs/tongue-out-cat.png"))
+      el.src = addon.self.dir + "/images/tongue-out-cat.svg";
+    if (el.src.includes("images/easter_eggs/wink-cat.png"))
+      el.src = addon.self.dir + "/images/wink-cat.svg";
+    if (el.src.includes("images/easter_eggs/lol-cat.png"))
+      el.src = addon.self.dir + "/images/lol-cat.svg";
+    if (el.src.includes("images/easter_eggs/upside-down-cat.png"))
+      el.src = addon.self.dir + "/images/upside-down-cat.svg";
+    if (el.src.includes("images/easter_eggs/huh-cat.png"))
+      el.src = addon.self.dir + "/images/cute-cat.svg";
+    if (el.src.includes("images/easter_eggs/love-it-cat.png"))
+      el.src = addon.self.dir + "/images/love-it-cat.svg";
+    if (el.src.includes("images/easter_eggs/fav-it-cat.png"))
+      el.src = addon.self.dir + "/images/fav-it-cat.svg";
+    if (el.src.includes("images/easter_eggs/rainbow-cat.png"))
+      el.src = addon.self.dir + "/images/rainbow-cat.svg";
+    if (el.src.includes("images/easter_eggs/pizza-cat.png"))
+      el.src = addon.self.dir + "/images/pizza-cat.svg";
   }
+}
 
-  // Sets the src of the given Scratch 3.0 cat emoji to a custom image
-  function checkEmojiNew(el) {
-    switch (el.src) {
-      case "https://scratch.mit.edu/images/emoji/cat.png":
-        el.src = addon.self.dir + "/images/cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/aww-cat.png":
-        el.src = addon.self.dir + "/images/aww-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/cool-cat.png":
-        el.src = addon.self.dir + "/images/cool-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/tongue-out-cat.png":
-        el.src = addon.self.dir + "/images/tongue-out-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/wink-cat.png":
-        el.src = addon.self.dir + "/images/wink-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/lol-cat.png":
-        el.src = addon.self.dir + "/images/lol-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/upside-down-cat.png":
-        el.src = addon.self.dir + "/images/upside-down-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/huh-cat.png":
-        el.src = addon.self.dir + "/images/cute-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/love-it-cat.png":
-        el.src = addon.self.dir + "/images/love-it-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/fav-it-cat.png":
-        el.src = addon.self.dir + "/images/fav-it-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/rainbow-cat.png":
-        el.src = addon.self.dir + "/images/rainbow-cat.svg";
-        break;
-      case "https://scratch.mit.edu/images/emoji/pizza-cat.png":
-        el.src = addon.self.dir + "/images/pizza-cat.svg";
-    }
+// Sets the src of the given Scratch 3.0 cat emoji to a custom image
+function checkEmojiNew(el) {
+  switch (el.src) {
+    case "https://scratch.mit.edu/images/emoji/cat.png":
+      el.src = addon.self.dir + "/images/cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/aww-cat.png":
+      el.src = addon.self.dir + "/images/aww-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/cool-cat.png":
+      el.src = addon.self.dir + "/images/cool-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/tongue-out-cat.png":
+      el.src = addon.self.dir + "/images/tongue-out-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/wink-cat.png":
+      el.src = addon.self.dir + "/images/wink-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/lol-cat.png":
+      el.src = addon.self.dir + "/images/lol-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/upside-down-cat.png":
+      el.src = addon.self.dir + "/images/upside-down-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/huh-cat.png":
+      el.src = addon.self.dir + "/images/cute-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/love-it-cat.png":
+      el.src = addon.self.dir + "/images/love-it-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/fav-it-cat.png":
+      el.src = addon.self.dir + "/images/fav-it-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/rainbow-cat.png":
+      el.src = addon.self.dir + "/images/rainbow-cat.svg";
+      break;
+    case "https://scratch.mit.edu/images/emoji/pizza-cat.png":
+      el.src = addon.self.dir + "/images/pizza-cat.svg";
   }
 }


### PR DESCRIPTION
**Resolves**

Just realized that the link to emojis on 2.0-styled pages are apparently not static. I have accounted for this now, to ensure that they will always be properly detected

Resolves #

**Changes**

The code now checks for telling parts of the image SRC, rather than the entire thing