### PR TITLE
add infinite scroll addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -39,5 +39,6 @@
   "better-emojis",
   "cloud-games",
   "studio-tools",
-  "last-edit-tooltip"
+  "last-edit-tooltip",
+  "infinite-scroll"
 ]

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -1,0 +1,78 @@
+{
+  "name": "Infinite Scrolling",
+  "description": "Allow for scrolling on different parts of the site without having to click to load more",
+  "credits": [
+    {
+      "name": "DatOneLefty"
+    }
+  ],
+  "settings": [
+    {
+      "name": "Forums",
+      "id": "forumScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Profile Comments",
+      "id": "profileCommentScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Project Comments",
+      "id": "projectScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Studio Comments",
+      "id": "studioScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Messages",
+      "id": "messageScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Fix Footer",
+      "id": "showFooter",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "forumScroll.js",
+      "matches": ["https://scratch.mit.edu/discuss/*"],
+      "settingMatch": {
+        "id": "forumScroll",
+        "value": true
+      }
+    },
+    {
+      "url": "buttonScroll.js",
+      "matches": [
+        "https://scratch.mit.edu/projects/*",
+        "https://scratch.mit.edu/studios/*/comments",
+        "https://scratch.mit.edu/users/*",
+        "https://scratch.mit.edu/messages"
+      ]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "userscript.css",
+      "matches": ["https://scratch.mit.edu/*"],
+      "settingMatch": {
+        "id": "showFooter",
+        "value": true
+      }
+    }
+  ],
+  "tags": ["community"],
+  "enabledByDefault": false
+}

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Infinite Scrolling",
-  "description": "Allow for scrolling on different parts of the site without having to click to load more",
+  "name": "Infinite scrolling",
+  "description": "Allow for scrolling on different parts of the site without having to click to \"load more\".",
   "credits": [
     {
       "name": "DatOneLefty"

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -1,7 +1,7 @@
 async function commentLoader(addon, heightControl, selector) {
   await addon.tab.waitForElement(selector);
   document.querySelector(selector).style.display = "none";
-  window.onscroll = async function (ev) {
+  window.addEventListener("scroll", async () => {
     if (window.scrollY + window.innerHeight >= document.getElementById(heightControl).offsetHeight - 500) {
       if (document.querySelector(selector)) {
         document.querySelector(selector).click();
@@ -9,7 +9,7 @@ async function commentLoader(addon, heightControl, selector) {
         document.querySelector(selector).style.display = "none";
       }
     }
-  };
+  });
 }
 
 export default async function ({ addon, global, console }) {

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -1,0 +1,28 @@
+async function commentLoader(addon, heightControl, selector) {
+  await addon.tab.waitForElement(selector);
+  document.querySelector(selector).style.display = "none";
+  window.onscroll = async function (ev) {
+    if (window.scrollY + window.innerHeight >= document.getElementById(heightControl).offsetHeight - 500) {
+      if (document.querySelector(selector)) {
+        document.querySelector(selector).click();
+        await addon.tab.waitForElement(selector);
+        document.querySelector(selector).style.display = "none";
+      }
+    }
+  };
+}
+
+export default async function ({ addon, global, console }) {
+  if (window.location.pathname.split("/").length == 5 && addon.settings.get("studioScroll"))
+    commentLoader(addon, "content", "#comments > div:nth-child(2) > ul > div");
+  if (window.location.pathname.split("/").length == 4 && addon.settings.get("profileCommentScroll"))
+    commentLoader(addon, "content", "#comments > div:nth-child(3) > ul > div");
+  if (window.location.pathname.split("/").length == 4 && addon.settings.get("projectScroll"))
+    commentLoader(
+      addon,
+      "view",
+      "#view > div > div.project-lower-container > div > div > div.comments-container > div.flex-row.comments-list > button"
+    );
+  if (window.location.pathname.split("/").length == 3 && addon.settings.get("messageScroll"))
+    commentLoader(addon, "view", "#view > div > div.messages-details.inner > section.messages-social > button");
+}

--- a/addons/infinite-scroll/forumScroll.js
+++ b/addons/infinite-scroll/forumScroll.js
@@ -1,0 +1,35 @@
+export default async function ({ addon, global, console }) {
+  if (window.location.pathname.split("/").length == 4) {
+    for (let show of document.getElementsByClassName("pagination")) show.style.display = "none";
+    let page = 1;
+    let lock = false;
+    window.onscroll = function (ev) {
+      if (
+        window.scrollY + window.innerHeight >=
+        document.getElementById("djangobbindex").offsetHeight - document.getElementById("footer").offsetHeight
+      ) {
+        if (!lock) {
+          lock = true;
+          page++;
+          window
+            .fetch(`https://scratch.mit.edu${document.location.pathname}?page=${page}`)
+            .catch((err) => {
+              console.log("Unable to fetch the page!");
+            })
+            .then((res) => res.text())
+            .then((data) => {
+              let parser = new DOMParser();
+              let doc = parser.parseFromString(data, "text/html");
+              let table = document.getElementById("vf").getElementsByTagName("tbody")[0];
+              let posts = doc.getElementById("vf").getElementsByTagName("tr");
+              for (let i = 1; i < posts.length; i++) {
+                let row = table.insertRow(-1);
+                row.innerHTML = posts[i].innerHTML;
+              }
+              lock = false;
+            });
+        }
+      }
+    };
+  }
+}

--- a/addons/infinite-scroll/forumScroll.js
+++ b/addons/infinite-scroll/forumScroll.js
@@ -3,7 +3,7 @@ export default async function ({ addon, global, console }) {
     for (let show of document.getElementsByClassName("pagination")) show.style.display = "none";
     let page = 1;
     let lock = false;
-    window.onscroll = function (ev) {
+    window.addEventListener("scroll", () => {
       if (
         window.scrollY + window.innerHeight >=
         document.getElementById("djangobbindex").offsetHeight - document.getElementById("footer").offsetHeight
@@ -30,6 +30,6 @@ export default async function ({ addon, global, console }) {
             });
         }
       }
-    };
+    });
   }
 }

--- a/addons/infinite-scroll/userscript.css
+++ b/addons/infinite-scroll/userscript.css
@@ -1,0 +1,17 @@
+body {
+  padding-bottom: 38px;
+}
+
+/*
+    thank you to ZenithKnight for the following footer CSS
+*/
+#footer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: 38px;
+  transition-duration: 0.5s;
+}
+#footer:hover {
+  height: 220px;
+}


### PR DESCRIPTION
**Resolves**

Adds infinite scrolling on multiple parts of the site

**Changes**

On the forums, topic listings will scroll without having to use pagination. (Forum topics themselves don't have infinite scrolling since you're most likely going to the last page anyway)

Otherwise, infinite scrolling was added to studios, profiles, projects, and messages

**Reason for changes**

Hitting buttons is hard

**Tests**

Self, using Chrome/Brave

I did my tests using 2.0 to 3.0 styling, and a little bit with normal 2.0 testing. Should work fine, but may require some CSS tweaks for the footer