### PR TITLE
Exact Count Addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -44,5 +44,5 @@
   "infinite-scroll",
   "mouse-pos",
   "clones",
-  "exact-count
+  "exact-count"
 ]

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -43,5 +43,6 @@
   "last-edit-tooltip",
   "infinite-scroll",
   "mouse-pos",
-  "clones"
+  "clones",
+  "exact-count
 ]

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -1,0 +1,50 @@
+{
+  "name": "Show exact count",
+  "description": "Shows the exact count for user and studio info instead of just 100+.",
+  "credits": [
+    {
+      "name": "TheColaber",
+      "link": "https://scratch.mit.edu/users/TheColaber"
+    },
+    {
+      "name": "mxmou"
+    },
+    {
+      "name": "World_Languages"
+    }
+  ],
+  "settings": [
+    {
+      "name": "Exact count for profiles",
+      "id": "user",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Exact count for studios",
+      "id": "studio",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "user.js",
+      "matches": ["https://scratch.mit.edu/users/*/"],
+      "settingMatch": {
+        "id": "user",
+        "value": true
+      }
+    },
+    {
+      "url": "studio.js",
+      "matches": ["https://scratch.mit.edu/studios/*"],
+      "settingMatch": {
+        "id": "studio",
+        "value": true
+      }
+    }
+  ],
+  "tags": ["community"],
+  "enabledByDefault": false
+}

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Show exact count",
-  "description": "Shows the exact count for user and studio info instead of just 100+.",
+  "description": "Shows the exact count for user and studio info.",
   "credits": [
     {
       "name": "TheColaber",
@@ -15,7 +15,7 @@
   ],
   "settings": [
     {
-      "name": "Exact count for profiles",
+      "name": "Exact counts for profiles",
       "id": "user",
       "type": "boolean",
       "default": true

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -7,7 +7,8 @@
       "link": "https://scratch.mit.edu/users/TheColaber"
     },
     {
-      "name": "mxmou"
+      "name": "Maximouse",
+      "link": "https://mxmou.github.io/exactcount"
     },
     {
       "name": "World_Languages"

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -9,10 +9,10 @@ export default async function({
     request.onreadystatechange = function() {
       if (request.readyState == 4) {
         let pageLen = JSON.parse(request.response).length
-        if (pageLen == 20) {
+        if (pageLen == 40) {
           countProjects(url, offset + delta, delta, callback);
         } else if (pageLen > 0) {
-          let count = 20 * (offset-1) + pageLen;
+          let count = 40 * (offset-1) + pageLen;
           callback(count);
         } else {
           offset -= delta;
@@ -26,7 +26,7 @@ export default async function({
 
 
   if (document.querySelector("[data-count=projects]").innerText == "100+") {
-    const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + (/[0-9]+/).exec(location.href)[0] + "/projects/?limit=20&offset=";
+    const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + (/[0-9]+/).exec(location.href)[0] + "/projects/?limit=40&offset=";
     countProjects(apiUrlPrefix, 0, 10000, function(count) {
       document.querySelector("[data-count=projects]").innerText = count;
     });

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -26,7 +26,7 @@ export default async function({
 
 
   if (document.querySelector("[data-count=projects]").innerText == "100+") {
-    const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + (/[0-9]+/).exec(location.href)[0] + "/projects/?limit=40&offset=";
+    const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + (/[0-9]+/).exec(location.pathname)[0] + "/projects/?limit=40&offset=";
     countProjects(apiUrlPrefix, 0, 10000, function(count) {
       document.querySelector("[data-count=projects]").innerText = count;
     });

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -3,48 +3,31 @@ export default async function({
   global,
   console
 }) {
-  function countProjects(url, page, delta, callback) {
+  function countProjects(url, offset, delta, callback) {
     const request = new XMLHttpRequest();
-    request.open("GET", url + page + "/");
+    request.open("GET", url + offset);
     request.onreadystatechange = function() {
       if (request.readyState == 4) {
-        if (request.status == 200) {
-          countProjects(url, page + delta, delta, callback);
-        } else if (request.status == 404) {
-          if (page != 1) {
-            if (delta == 1) {
-              const correctReq = new XMLHttpRequest();
-              correctReq.open("GET", url + (page - 1) + "/");
-              correctReq.onreadystatechange = function() {
-                if (correctReq.readyState == 4) {
-                  if (correctReq.status == 200) {
-                    const parser = new DOMParser();
-                    const list = parser.parseFromString(
-                      "<ul id='projects'>" + correctReq.responseText + "</ul>", "text/html"
-                    );
-                    let count = 60 * (page - 2);
-                    count += list.querySelector("#projects").querySelectorAll("ul > li").length;
-                    callback(count);
-                  }
-                }
-              };
-              correctReq.send();
-            } else {
-              page -= delta;
-              delta /= 10;
-              countProjects(url, page + delta, delta, callback);
-            }
-          }
+        let pageLen = JSON.parse(request.response).length
+        if (pageLen == 20) {
+          countProjects(url, offset + delta, delta, callback);
+        } else if (pageLen > 0) {
+          let count = 20 * (offset-1) + pageLen;
+          callback(count);
+        } else {
+          offset -= delta;
+          delta /= 10;
+          countProjects(url, offset + delta, delta, callback);
         }
       }
-    };
+    }
     request.send();
   }
 
+
   if (document.querySelector("[data-count=projects]").innerText == "100+") {
-    const studio = (/[0-9]+/).exec(location.href)[0];
-    const apiUrlPrefix = "https://scratch.mit.edu/site-api/projects/in/" + studio + "/";
-    countProjects(apiUrlPrefix, 1, 100, function(count) {
+    const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + (/[0-9]+/).exec(location.href)[0] + "/projects/?limit=20&offset=";
+    countProjects(apiUrlPrefix, 0, 10000, function(count) {
       document.querySelector("[data-count=projects]").innerText = count;
     });
   }

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -12,7 +12,7 @@ export default async function({
         if (pageLen == 40) {
           countProjects(url, offset + delta, delta, callback);
         } else if (pageLen > 0) {
-          let count = 40 * (offset-1) + pageLen;
+          let count = 40 * offset + pageLen;
           callback(count);
         } else {
           offset -= delta;

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -1,0 +1,51 @@
+export default async function({
+  addon,
+  global,
+  console
+}) {
+  function countProjects(url, page, delta, callback) {
+    const request = new XMLHttpRequest();
+    request.open("GET", url + page + "/");
+    request.onreadystatechange = function() {
+      if (request.readyState == 4) {
+        if (request.status == 200) {
+          countProjects(url, page + delta, delta, callback);
+        } else if (request.status == 404) {
+          if (page != 1) {
+            if (delta == 1) {
+              const correctReq = new XMLHttpRequest();
+              correctReq.open("GET", url + (page - 1) + "/");
+              correctReq.onreadystatechange = function() {
+                if (correctReq.readyState == 4) {
+                  if (correctReq.status == 200) {
+                    const parser = new DOMParser();
+                    const list = parser.parseFromString(
+                      "<ul id='projects'>" + correctReq.responseText + "</ul>", "text/html"
+                    );
+                    let count = 60 * (page - 2);
+                    count += list.querySelector("#projects").querySelectorAll("ul > li").length;
+                    callback(count);
+                  }
+                }
+              };
+              correctReq.send();
+            } else {
+              page -= delta;
+              delta /= 10;
+              countProjects(url, page + delta, delta, callback);
+            }
+          }
+        }
+      }
+    };
+    request.send();
+  }
+
+  if (document.querySelector("[data-count=projects]").innerText == "100+") {
+    const studio = (/[0-9]+/).exec(location.href)[0];
+    const apiUrlPrefix = "https://scratch.mit.edu/site-api/projects/in/" + studio + "/";
+    countProjects(apiUrlPrefix, 1, 100, function(count) {
+      document.querySelector("[data-count=projects]").innerText = count;
+    });
+  }
+}

--- a/addons/exact-count/user.js
+++ b/addons/exact-count/user.js
@@ -1,0 +1,57 @@
+export default async function({
+  addon,
+  global,
+  console
+}) {
+  let url = window.location.href;
+  let user1 = url.substring(30, 100);
+  let username = user1.substring(0, user1.indexOf('/'));
+  let dalength = document.getElementsByClassName("box-head").length;
+
+  getUserData({
+    "boxheadName":"Shared Projects",
+    "url":"projects",
+    "boxNumber": 1
+  });
+  getUserData({
+    "boxheadName":"Favorite Projects",
+    "url":"favorites",
+    "boxNumber": 2
+  });
+  getUserData({
+    "boxheadName":"Studios I'm Following",
+    "url":"studios_following",
+    "boxNumber": 3
+  });
+  getUserData({
+    "boxheadName":"Studios I Curate",
+    "url":"studios",
+    "boxNumber": 4
+  });
+  getUserData({
+    "boxheadName":"Following",
+    "url":"following",
+    "boxNumber": 5
+  });
+  getUserData({
+    "boxheadName":"Followers",
+    "url":"followers",
+    "boxNumber": 6
+  });
+
+  function getUserData(details) {
+
+      let xmlhttp = new XMLHttpRequest();
+      xmlhttp.onreadystatechange = function() {
+        if (xmlhttp.readyState === 4 && xmlhttp.status === 200) {
+          let response = xmlhttp.responseText;
+          let find = response.search("<h2>");
+          let follownum = response.substring(find, find + 200).match(/\(([^)]+)\)/)[1];
+          let a =`${details.boxheadName} (${follownum})`;
+          document.querySelectorAll(".box-head h4")[details.boxNumber-1].innerText = a
+        }
+      }
+      xmlhttp.open('GET', `https://scratch.mit.edu/users/${username}/${details.url}/`, true);
+      xmlhttp.send();
+  }
+}


### PR DESCRIPTION
**Resolves**

Resolves #66 
Resolves #68

**Changes**

Added the exact count of user info on profiles and the exact count of a studio's project count.

**Reason for changes**

It's convenient. Please lmk if you want something in the setting to be changed or anything else.

**Tests**

Works on chrome. I noticed that @mxmou's studio script will throw errors for 404s so if anyone knows what causes this lmk.

**Credit**

@mxmou for the studio script and @WorldLanguages for the base of the profile script. I then changed it up a bit so it is useful for all box heads.