### PR TITLE
Details before submitting v1.2.0

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -12,7 +12,7 @@
 
   "// For website:",
   "scratchr2",
-  "dark-www",
+  "// TODO // dark-www",
 
   "// Other addons:",
   "editor-searchable-dropdowns",

--- a/background/transition.js
+++ b/background/transition.js
@@ -2,5 +2,8 @@ chrome.runtime.onInstalled.addListener((details) => {
   if (details.previousVersion && details.previousVersion.startsWith("0")) {
     chrome.tabs.create({ url: "https://scratchaddons.com/scratch-messaging-transition" });
   }
+  else if(details.reason === "install") {
+    chrome.tabs.create({ url: "https://scratchaddons.com/welcome" });
+  }
 });
 chrome.runtime.setUninstallURL("https://scratchaddons.com/farewell");

--- a/background/transition.js
+++ b/background/transition.js
@@ -1,8 +1,7 @@
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.previousVersion && details.previousVersion.startsWith("0")) {
     chrome.tabs.create({ url: "https://scratchaddons.com/scratch-messaging-transition" });
-  }
-  else if(details.reason === "install") {
+  } else if (details.reason === "install") {
     chrome.tabs.create({ url: "https://scratchaddons.com/welcome" });
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Scratch Addons",
   "description": "Scratch Addons provides new features and themes for the scratch.mit.edu website and project editor.",
   "version": "1.2.0",
-  "version_name": "1.2.0-prerelease",
+  "version_name": "1.2.0",
   "background": {
     "page": "background/background.html"
   },

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -46,6 +46,7 @@ a:hover {
   display: flex;
   align-items: center;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  user-select: none;
 }
 
 .project-name {

--- a/popups/scratch-messaging/light.css
+++ b/popups/scratch-messaging/light.css
@@ -44,7 +44,8 @@ body::-webkit-scrollbar-thumb {
   filter: none;
 }
 
-.comment.unread {
+.comment.unread,
+.unread .comment {
   background-color: #fff;
 }
 

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -92,6 +92,7 @@ button {
   cursor: default;
   display: flex;
   align-items: center;
+  user-select: none;
 }
 .message-type-title:not(.hover-reverse) {
   position: sticky;


### PR DESCRIPTION
- Disable `dark-www` by commenting it out from addons.json
- Add install page /welcome
- Remove `prerelease` from version name
- Make titles in both popups unselectable, so that a double click extends and reduces the category without selecting the text.