### PR TITLE
Fix duration of 1 hour

### DIFF
--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -5,7 +5,7 @@ const periods = [
   },
   {
     name: "1 hour",
-    mins: 480,
+    mins: 60,
   },
   {
     name: "8 hours",


### PR DESCRIPTION
Stupid bug, I wrote 1 hour had 480 minutes instead of 60 minutes. Thanks @TheColaber!