### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.md export-ignore
+LICENSE export-ignore
+.* export-ignore


### PR DESCRIPTION
This makes it so that zip exports don't include:
- .md files
- The .github folder
- Anything starting in .
This will make downloads cleaner and faster, as well as not including those files in releases. (Which will make those download faster, also.)
