### PR TITLE
Fix reply button's position

### DIFF
--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -222,6 +222,7 @@ button {
   color: #0f8bc0;
   font-weight: bold;
   user-select: none;
+  text-align: right;
 }
 .comment:hover .reply-button-comment,
 .comment:hover .delete-btn {

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -24,15 +24,15 @@
           >{{ deleteStep === 0 ? "Delete" : "Click to confirm deletion" }}
         </a>
         <div class="comment-content" :class="{'comment-self' : thisComment.author === username}">
-          <span class="comment-content-text">{{{ thisComment.content }}}</span>
-          <a
+          <span class="comment-content-text">{{{ thisComment.content }}} <a
             class="reply-button-comment"
             @click="replying = true"
             :class="{'replying': replying}"
             :style="{'visibility': replying ? 'hidden' : 'visible'}"
             v-show="!deleted"
             >Reply</a
-          >
+          ></span>
+          
         </div>
         <div class="reply-box-comment" v-show="replying">
           <textarea class="reply-textarea" maxlength="500" v-model="replyBoxValue"></textarea>


### PR DESCRIPTION
**Resolves**

This solves the issue where the reply button was incorrectly placed.

Resolves 
![image](https://user-images.githubusercontent.com/68466727/97371985-e74af400-1888-11eb-8b64-57086c61f3e9.png)

**Changes**

I changed the messaging popup to move the reply button into the span that the comment is in.

**Reason for changes**

These changes should be made because the reply button should be in the correct position.

**Tests**

I have tested this pull request in Firefox 82.0.
