### PR TITLE
Remix Tree Button Fixes

### DIFF
--- a/addons/remix-tree-button/addon.json
+++ b/addons/remix-tree-button/addon.json
@@ -15,6 +15,12 @@
       "runAtComplete": false
     }
   ],
+  "userstyles": [
+    {
+      "url": "button.css",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
   "settings": [
     {
       "name": "Button Color",

--- a/addons/remix-tree-button/button.css
+++ b/addons/remix-tree-button/button.css
@@ -1,0 +1,12 @@
+.remixtree-button::before {
+  background-image: url("https://scratch.mit.edu/svgs/project/remix-white.svg");
+  display: inline-block;
+  margin-right: 0.25rem;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
+  width: 0.875rem;
+  height: 0.875rem;
+  vertical-align: bottom;
+  content: "";
+}

--- a/addons/remix-tree-button/main.js
+++ b/addons/remix-tree-button/main.js
@@ -10,26 +10,17 @@ export default async function ({ addon, global, console }) {
 
         const remixtreeSpan = document.createElement("span");
         remixtreeSpan.innerText = "Remix Tree";
-        const remixtreeImg = document.createElement("img");
-        remixtreeImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/remix-white.svg");
-        remixtreeImg.setAttribute("height", "15px");
-        remixtree.style.marginRight = "5px"; //no, i will not do this through userstyle, i simply won't.
-
         remixtree.className = "button action-button remixtree-button";
         remixtree.id = "scratchAddonsRemixTreeBtn";
-        remixtree.appendChild(remixtreeImg);
         remixtree.appendChild(remixtreeSpan);
         remixtree.addEventListener("click", () => {
-          if (window.location.href.endsWith("/")) window.location.href.split("#")[0] += "remixtree";
-          // not the best way to get rid of the hash, but...
-          else window.location.href.split("#")[0] += "/remixtree";
+          window.location.href = `https://scratch.mit.edu/projects/${
+            window.location.href.split("projects")[1].split("/")[1]
+          }/remixtree`;
         });
-        remixtree.style.display = "flex";
-        remixtree.style.alignItems = "center";
         if (addon.settings.get("buttonColor")) {
           remixtree.style.backgroundColor = addon.settings.get("buttonColor");
         }
-
         subactions.appendChild(remixtree);
       });
     }


### PR DESCRIPTION
**Changes**

The remix tree button was wildly inconsistent when trying to open the link. This fixes that with some better code to grab the project id

The remix icon was also reimplemented to be identical to the other project buttons, and the custom color has been set to automatically update
