### PR TITLE
Fix console.log memory leak caused by Scratch projects

### DIFF
--- a/content-scripts/fix-console.js
+++ b/content-scripts/fix-console.js
@@ -1,0 +1,9 @@
+function fixConsole() {
+    window._realConsole = {
+        ...console
+    };
+}
+
+const fixConsoleScript = document.createElement("script");
+fixConsoleScript.append(document.createTextNode("(" + fixConsole + ")()"));
+(document.head || document.documentElement).appendChild(fixConsoleScript);

--- a/content-scripts/fix-console.js
+++ b/content-scripts/fix-console.js
@@ -1,7 +1,7 @@
 function fixConsole() {
-    window._realConsole = {
-        ...console
-    };
+  window._realConsole = {
+    ...console,
+  };
 }
 
 const fixConsoleScript = document.createElement("script");

--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -14,12 +14,12 @@ export default async function runAddonUserscripts({ addonId, scripts, traps }) {
     );
     const loadUserscript = async () => {
       const module = await import(scriptUrl);
-      const log = console.log.bind(console, `%c[${addonId}]`, "color:darkorange; font-weight: bold;");
-      const warn = console.warn.bind(console, `%c[${addonId}]`, "color:darkorange font-weight: bold;");
+      const log = _realConsole.log.bind(console, `%c[${addonId}]`, "color:darkorange; font-weight: bold;");
+      const warn = _realConsole.warn.bind(console, `%c[${addonId}]`, "color:darkorange font-weight: bold;");
       module.default({
         addon: addonObj,
         global: globalObj,
-        console: { ...console, log, warn },
+        console: { ..._realConsole, log, warn },
       });
     };
     if (runAtComplete && document.readyState !== "complete") {

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
     {
       "matches": ["https://scratch.mit.edu/*"],
       "run_at": "document_start",
-      "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js"]
+      "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"]
     },
     {
       "matches": ["https://scratch.mit.edu/projects/0111001101100001/embed"],


### PR DESCRIPTION
Resolves #618 

Note: this issue is not caused by Scratch Addons. It's caused by Sentry, the service Scratch uses to get information about JavaScript errors, and it's only used in projects. This patch allows addons to use the native `console` object through the `console` argument of the default exported function in the modules.

Related: #566 (discussion)