### PR TITLE
Add a warning on the Scratch forums to avoid posts about Scratch Addons

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -160,8 +160,9 @@ function forumWarning() {
     reportLink.target = "_blank";
     reportLink.innerText = "report it here";
     let text1 = document.createElement("span");
-    text1.innerText = "Message added by the Scratch Addons extension: make sure the bug you're about to report still happens when "
-      + "all browser extensions are disabled, including Scratch Addons. If you believe a bug is caused by Scratch Addons, please ";
+    text1.innerText =
+      "Message added by the Scratch Addons extension: make sure the bug you're about to report still happens when " +
+      "all browser extensions are disabled, including Scratch Addons. If you believe a bug is caused by Scratch Addons, please ";
     let text3 = document.createElement("span");
     text3.innerText = ".";
     addonError.appendChild(text1);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -36,7 +36,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 chrome.runtime.sendMessage("ready");
 window.addEventListener("load", () => {
-  forumWarning()
+  forumWarning();
   if (!receivedContentScriptInfo) {
     // This might happen sometimes, the background page might not
     // have seen this tab loading, for example, at startup.
@@ -146,32 +146,32 @@ function onHeadAvailable({ globalState, addonsWithUserscripts, userstyleUrls, th
 
 function forumWarning() {
   if (window.location.pathname == "/discuss/3/topic/add/") {
-    let postArea = document.querySelector("form#post > label")
+    let postArea = document.querySelector("form#post > label");
     if (postArea) {
-      var errorList = document.querySelector("form#post > label > ul")
+      var errorList = document.querySelector("form#post > label > ul");
       if (!errorList) {
-        let typeArea = postArea.querySelector("strong")
-        errorList = document.createElement("ul")
-        errorList.classList.add("errorlist")
-        postArea.insertBefore(errorList, typeArea)
+        let typeArea = postArea.querySelector("strong");
+        errorList = document.createElement("ul");
+        errorList.classList.add("errorlist");
+        postArea.insertBefore(errorList, typeArea);
       }
-      let addonError = document.createElement("li")
-      let reportLink = document.createElement("a")
-      reportLink.href = "https://scratchaddons.com/feedback"
-      reportLink.innerText = "here"
-      let text1 = document.createElement("span")
+      let addonError = document.createElement("li");
+      let reportLink = document.createElement("a");
+      reportLink.href = "https://scratchaddons.com/feedback";
+      reportLink.innerText = "here";
+      let text1 = document.createElement("span");
       text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
-      let text2 = document.createElement("span")
+      let text2 = document.createElement("span");
       text2.innerText = ". Suggestions for an addons? Then talk about it ";
-      let text3 = document.createElement("span")
+      let text3 = document.createElement("span");
       text3.innerText = ".";
-      addonError.appendChild(text1)
-      addonError.appendChild(reportLink)
-      addonError.appendChild(text2)
+      addonError.appendChild(text1);
+      addonError.appendChild(reportLink);
+      addonError.appendChild(text2);
       reportLink = reportLink.cloneNode(true);
-      addonError.appendChild(reportLink)
-      addonError.appendChild(text3)
-      errorList.appendChild(addonError)
+      addonError.appendChild(reportLink);
+      addonError.appendChild(text3);
+      errorList.appendChild(addonError);
     }
   }
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -145,12 +145,12 @@ function onHeadAvailable({ globalState, addonsWithUserscripts, userstyleUrls, th
 }
 
 function forumWarning() {
-  if (document.querySelectorAll(".linksb > ul li a")[1].innerText == "Bugs and Glitches") {
+  if (window.location.pathname == "/discuss/3/topic/add/") {
     let postArea = document.querySelector("form#post > label")
     if (postArea) {
       var errorList = document.querySelector("form#post > label > ul")
       if (!errorList) {
-        let typeArea = postArea.querySelector("div")
+        let typeArea = postArea.querySelector("strong")
         errorList = document.createElement("ul")
         errorList.classList.add("errorlist")
         postArea.insertBefore(errorList, typeArea)

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -5,6 +5,7 @@ const pathArr = path.split("/");
 if (pathArr[0] === "scratch-addons-extension") {
   if (pathArr[1] === "settings") chrome.runtime.sendMessage("openSettingsOnThisTab");
 }
+if (path === "discuss/3/topic/add//") window.addEventListener("load", forumWarning);
 
 let receivedContentScriptInfo = false;
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -36,7 +37,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 chrome.runtime.sendMessage("ready");
 window.addEventListener("load", () => {
-  if (path == "discuss/3/topic/add//") forumWarning();
   if (!receivedContentScriptInfo) {
     // This might happen sometimes, the background page might not
     // have seen this tab loading, for example, at startup.
@@ -157,17 +157,14 @@ function forumWarning() {
     let addonError = document.createElement("li");
     let reportLink = document.createElement("a");
     reportLink.href = "https://scratchaddons.com/feedback";
-    reportLink.innerText = "here";
+    reportLink.target = "_blank";
+    reportLink.innerText = "report it here";
     let text1 = document.createElement("span");
-    text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
-    let text2 = document.createElement("span");
-    text2.innerText = ". Suggestions for an addons? Then talk about it ";
+    text1.innerText = "Message added by the Scratch Addons extension: make sure the bug you're about to report still happens when "
+      + "all browser extensions are disabled, including Scratch Addons. If you believe a bug is caused by Scratch Addons, please ";
     let text3 = document.createElement("span");
     text3.innerText = ".";
     addonError.appendChild(text1);
-    addonError.appendChild(reportLink);
-    addonError.appendChild(text2);
-    reportLink = reportLink.cloneNode(true);
     addonError.appendChild(reportLink);
     addonError.appendChild(text3);
     errorList.appendChild(addonError);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -36,7 +36,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 chrome.runtime.sendMessage("ready");
 window.addEventListener("load", () => {
-  forumWarning();
+  if (path == "discuss/3/topic/add//") forumWarning();
   if (!receivedContentScriptInfo) {
     // This might happen sometimes, the background page might not
     // have seen this tab loading, for example, at startup.
@@ -145,33 +145,31 @@ function onHeadAvailable({ globalState, addonsWithUserscripts, userstyleUrls, th
 }
 
 function forumWarning() {
-  if (window.location.pathname == "/discuss/3/topic/add/") {
-    let postArea = document.querySelector("form#post > label");
-    if (postArea) {
-      var errorList = document.querySelector("form#post > label > ul");
-      if (!errorList) {
-        let typeArea = postArea.querySelector("strong");
-        errorList = document.createElement("ul");
-        errorList.classList.add("errorlist");
-        postArea.insertBefore(errorList, typeArea);
-      }
-      let addonError = document.createElement("li");
-      let reportLink = document.createElement("a");
-      reportLink.href = "https://scratchaddons.com/feedback";
-      reportLink.innerText = "here";
-      let text1 = document.createElement("span");
-      text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
-      let text2 = document.createElement("span");
-      text2.innerText = ". Suggestions for an addons? Then talk about it ";
-      let text3 = document.createElement("span");
-      text3.innerText = ".";
-      addonError.appendChild(text1);
-      addonError.appendChild(reportLink);
-      addonError.appendChild(text2);
-      reportLink = reportLink.cloneNode(true);
-      addonError.appendChild(reportLink);
-      addonError.appendChild(text3);
-      errorList.appendChild(addonError);
+  let postArea = document.querySelector("form#post > label");
+  if (postArea) {
+    var errorList = document.querySelector("form#post > label > ul");
+    if (!errorList) {
+      let typeArea = postArea.querySelector("strong");
+      errorList = document.createElement("ul");
+      errorList.classList.add("errorlist");
+      postArea.insertBefore(errorList, typeArea);
     }
+    let addonError = document.createElement("li");
+    let reportLink = document.createElement("a");
+    reportLink.href = "https://scratchaddons.com/feedback";
+    reportLink.innerText = "here";
+    let text1 = document.createElement("span");
+    text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
+    let text2 = document.createElement("span");
+    text2.innerText = ". Suggestions for an addons? Then talk about it ";
+    let text3 = document.createElement("span");
+    text3.innerText = ".";
+    addonError.appendChild(text1);
+    addonError.appendChild(reportLink);
+    addonError.appendChild(text2);
+    reportLink = reportLink.cloneNode(true);
+    addonError.appendChild(reportLink);
+    addonError.appendChild(text3);
+    errorList.appendChild(addonError);
   }
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -145,31 +145,33 @@ function onHeadAvailable({ globalState, addonsWithUserscripts, userstyleUrls, th
 }
 
 function forumWarning() {
-  let postArea = document.querySelector("form#post > label")
-  if (postArea) {
-    var errorList = document.querySelector("form#post > label > ul")
-    if (!errorList) {
-      let typeArea = postArea.querySelector("div")
-      errorList = document.createElement("ul")
-      errorList.classList.add("errorlist")
-      postArea.insertBefore(errorList, typeArea)
+  if (document.querySelectorAll(".linksb > ul li a")[1].innerText == "Bugs and Glitches") {
+    let postArea = document.querySelector("form#post > label")
+    if (postArea) {
+      var errorList = document.querySelector("form#post > label > ul")
+      if (!errorList) {
+        let typeArea = postArea.querySelector("div")
+        errorList = document.createElement("ul")
+        errorList.classList.add("errorlist")
+        postArea.insertBefore(errorList, typeArea)
+      }
+      let addonError = document.createElement("li")
+      let reportLink = document.createElement("a")
+      reportLink.href = "https://scratchaddons.com/feedback"
+      reportLink.innerText = "here"
+      let text1 = document.createElement("span")
+      text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
+      let text2 = document.createElement("span")
+      text2.innerText = ". Suggestions for an addons? Then talk about it ";
+      let text3 = document.createElement("span")
+      text3.innerText = ".";
+      addonError.appendChild(text1)
+      addonError.appendChild(reportLink)
+      addonError.appendChild(text2)
+      reportLink = reportLink.cloneNode(true);
+      addonError.appendChild(reportLink)
+      addonError.appendChild(text3)
+      errorList.appendChild(addonError)
     }
-    let addonError = document.createElement("li")
-    let reportLink = document.createElement("a")
-    reportLink.href = "https://scratchaddons.com/feedback"
-    reportLink.innerText = "here"
-    let text1 = document.createElement("span")
-    text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
-    let text2 = document.createElement("span")
-    text2.innerText = ". Suggestions for an addons? Then talk about it ";
-    let text3 = document.createElement("span")
-    text3.innerText = ".";
-    addonError.appendChild(text1)
-    addonError.appendChild(reportLink)
-    addonError.appendChild(text2)
-    reportLink = reportLink.cloneNode(true);
-    addonError.appendChild(reportLink)
-    addonError.appendChild(text3)
-    errorList.appendChild(addonError)
   }
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -36,6 +36,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 chrome.runtime.sendMessage("ready");
 window.addEventListener("load", () => {
+  forumWarning()
   if (!receivedContentScriptInfo) {
     // This might happen sometimes, the background page might not
     // have seen this tab loading, for example, at startup.
@@ -141,4 +142,34 @@ function onHeadAvailable({ globalState, addonsWithUserscripts, userstyleUrls, th
     }
   });
   observer.observe(template, { attributes: true });
+}
+
+function forumWarning() {
+  let postArea = document.querySelector("form#post > label")
+  if (postArea) {
+    var errorList = document.querySelector("form#post > label > ul")
+    if (!errorList) {
+      let typeArea = postArea.querySelector("div")
+      errorList = document.createElement("ul")
+      errorList.classList.add("errorlist")
+      postArea.insertBefore(errorList, typeArea)
+    }
+    let addonError = document.createElement("li")
+    let reportLink = document.createElement("a")
+    reportLink.href = "https://scratchaddons.com/feedback"
+    reportLink.innerText = "here"
+    let text1 = document.createElement("span")
+    text1.innerText = "Is this about a bug or glitch? Make sure it isn't from ScratchAddons. If it is, report it ";
+    let text2 = document.createElement("span")
+    text2.innerText = ". Suggestions for an addons? Then talk about it ";
+    let text3 = document.createElement("span")
+    text3.innerText = ".";
+    addonError.appendChild(text1)
+    addonError.appendChild(reportLink)
+    addonError.appendChild(text2)
+    reportLink = reportLink.cloneNode(true);
+    addonError.appendChild(reportLink)
+    addonError.appendChild(text3)
+    errorList.appendChild(addonError)
+  }
 }


### PR DESCRIPTION
**Resolves**

Resolves #552

**Changes**

I've added this warning to the forum when posting:
![image](https://user-images.githubusercontent.com/72760579/97794533-d7f1e080-1bd1-11eb-9520-7873da7d393d.png)


**Reason for changes**

It's pretty common...

**Tests**

Well it works on chrome. 

Btw Please someone tell me how to run prettier. I need to know...
