### PR TITLE
Remove prototype handler, add /* sa-autoupdate-theme-ignore */

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -12,7 +12,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -1,7 +1,6 @@
 {
   "name": "60FPS player mode",
   "description": "Alt+Click the green flag to toggle 60FPS.",
-  "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "credits": [
     {
       "name": "Jeffalo"
@@ -13,7 +12,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
+  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -18,7 +18,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -1,7 +1,6 @@
 {
   "name": "Clone counter",
   "description": "Adds a counter in the editor which shows the total amount of clones.",
-  "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "credits": [
     {
       "name": "Jeffalo"
@@ -19,7 +18,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
+  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,6 +1,7 @@
 {
   "name": "Colored context menus",
   "description": "Makes the editor context menus colorful when right-clicking a block.",
+  "notice": "Refresh the editor after enabling this theme.",
   "credits": [
     {
       "name": "GarboMuffin"

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -19,7 +19,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor", "theme"],
   "enabledByDefault": false
 }

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Display stage on left side",
   "description": "Moves the stage to the left side of the editor.",
-  "notice": "Make sure to refresh the editor after enabling/disabling.",
+  "notice": "Refresh the editor after enabling/disabling this theme.",
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"
@@ -19,7 +19,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
+  ,
   "tags": ["editor", "theme"],
   "enabledByDefault": false
 }

--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -14,11 +14,14 @@ export default function ({ addon, global, console }) {
 
   if (addon.tab.editorMode === "editor") {
     const interval = setInterval(() => {
-      if(Blockly.getMainWorkspace()) {
+      if (Blockly.getMainWorkspace()) {
         inject(Blockly.getMainWorkspace());
         clearInterval(interval);
       }
     }, 100);
   }
-  addon.tab.addEventListener("urlChange", () => addon.tab.editorMode === "editor" && inject(Blockly.getMainWorkspace()));
+  addon.tab.addEventListener(
+    "urlChange",
+    () => addon.tab.editorMode === "editor" && inject(Blockly.getMainWorkspace())
+  );
 }

--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -1,6 +1,5 @@
 export default function ({ addon, global, console }) {
-  const inject = () => {
-    const workspace = addon.tab.traps.onceValues.workspace;
+  const inject = (workspace) => {
     const originalGetClientRect = workspace.toolbox_.getClientRect;
     workspace.toolbox_.getClientRect = function () {
       // we are trying to undo the effect of BIG_NUM in https://github.com/LLK/scratch-blocks/blob/ab26fa2960643fa38fbc7b91ca2956be66055070/core/flyout_vertical.js#L739
@@ -13,6 +12,13 @@ export default function ({ addon, global, console }) {
     };
   };
 
-  if (addon.tab.traps.onceValues.workspace) inject();
-  else addon.tab.traps.addOnceListener("workspace", inject);
+  if (addon.tab.editorMode === "editor") {
+    const interval = setInterval(() => {
+      if(Blockly.getMainWorkspace()) {
+        inject(Blockly.getMainWorkspace());
+        clearInterval(interval);
+      }
+    }, 100);
+  }
+  addon.tab.addEventListener("urlChange", () => addon.tab.editorMode === "editor" && inject(Blockly.getMainWorkspace()));
 }

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -1,3 +1,5 @@
+/* sa-autoupdate-theme-ignore */
+
 .stage-header_stage-button-icon_3zzFK {
   transform: scaleX(-1);
 }

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -8,7 +8,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -1,14 +1,14 @@
 {
   "name": "Highlight currently executing blocks",
   "description": "Adds a blue border to the blocks that are currently running in a project.",
-  "warning": "WARNING: this feature is experimental and hurts performance when running Scratch projects.",
+  "notice": "Scratch Addons v1.3.0 update: this feature is not experimental anymore, and should not affect project performance heavily.",
   "userscripts": [
     {
       "url": "userscript.js",
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
-  "tags": ["editor", "beta"],
+  ,
+  "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -1,35 +1,38 @@
 export default async function ({ addon, global, console }) {
   const virtualMachine = addon.tab.traps.onceValues.vm;
-  const removeHighlight = () =>
-    Array.prototype.forEach.call(document.querySelectorAll("path[style*='outline' i]"), (e) =>
-      e.removeAttribute("style")
-    );
-  const retireThread = virtualMachine.runtime.sequencer.__proto__.retireThread;
-  virtualMachine.runtime.sequencer.__proto__.retireThread = function (...args) {
-    removeHighlight();
-    return retireThread.apply(this, args);
-  };
-  addon.tab.traps.addManyListener("thread", (e) => {
-    if (e[addon.tab.traps.numMany] && e[addon.tab.traps.numMany] > 1) return;
-    const workspace = addon.tab.traps.onceValues.workspace;
-    const thread = e.detail.value;
-    const threadAccessKey = Symbol();
-    Object.defineProperty(thread, threadAccessKey, {
-      value: thread.blockGlowInFrame,
-      writable: true,
-    });
-    Object.defineProperty(thread, "blockGlowInFrame", {
-      get: function () {
-        return this[threadAccessKey];
-      },
-      set: function (v) {
-        this[threadAccessKey] = v;
-        if (workspace && addon.tab.editorMode === "editor") {
-          removeHighlight();
-          const block = workspace.getAllBlocks().find((b) => b.id === v);
-          if (block && block.svgPath_) block.svgPath_.style.outline = "5px solid blue";
-        }
-      },
-    });
+
+  let removeInterval = () => {};
+  if (addon.tab.editorMode === "editor") {
+    removeInterval = addInterval();
+  }
+
+  addon.tab.addEventListener("urlChange", () => {
+    if (addon.tab.editorMode === "editor") {
+      removeInterval();
+      addInterval();
+    }
+    else removeInterval();
   });
+
+  function addInterval() {
+    const interval = setInterval(() => {
+      Array.prototype.forEach.call(document.querySelectorAll("path[style*='outline' i]"), (e) =>
+        e.removeAttribute("style")
+      );
+      virtualMachine.runtime.threads.forEach((thread) => {
+        thread.stack.forEach((e) => {
+          try {
+            var next = thread.target.blocks.getNextBlock(e);
+            var blocklyBlock = Blockly.getMainWorkspace()
+              .getAllBlocks()
+              .find((e) => e.id === next);
+            if (blocklyBlock) {
+              blocklyBlock.parentBlock_.svgPath_.style.outline = "5px solid blue";
+            }
+          } catch {}
+        });
+      });
+    }, 500);
+    return () => clearInterval(interval);
+  }
 }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -10,8 +10,7 @@ export default async function ({ addon, global, console }) {
     if (addon.tab.editorMode === "editor") {
       removeInterval();
       addInterval();
-    }
-    else removeInterval();
+    } else removeInterval();
   });
 
   function addInterval() {

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -1,6 +1,7 @@
 {
   "name": "Customizable block colors",
   "description": "Edit block colors for each category in the editor.",
+  "notice": "Refresh the editor after enabling/disabling this theme.",
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -1,3 +1,28 @@
+/* sa-autoupdate-theme-ignore */
+
+path.blocklyBlockBackground[fill="#FF6680"],
+    path.blocklyBlockBackground[fill="#5CB1D6"],
+    path.blocklyBlockBackground[fill="#FFBF00"],
+    g[data-category] > path.blocklyBlockBackground {
+      stroke: #0003;
+    }
+    g[data-argument-type="dropdown"] > path,
+    g[data-argument-type="dropdown"] > rect,
+    g[data-argument-type="variable"] > rect,
+    g[data-argument-type="variable"] > path,
+    g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > path,
+    path[data-argument-type="boolean"] {
+      stroke: #0003;
+      fill: #0001;
+    }
+    g[data-argument-type*="text"] > path,
+    g > line {
+      stroke: #0002;
+    }
+    .scratchCategoryItemBubble {
+      border-color: #0003 !important;
+    }
+
 path.blocklyBlockBackground[fill="#FF6680"],
 path.blocklyBlockBackground[fill="#5CB1D6"],
 path.blocklyBlockBackground[fill="#FFBF00"],

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -1,27 +1,27 @@
 /* sa-autoupdate-theme-ignore */
 
 path.blocklyBlockBackground[fill="#FF6680"],
-    path.blocklyBlockBackground[fill="#5CB1D6"],
-    path.blocklyBlockBackground[fill="#FFBF00"],
-    g[data-category] > path.blocklyBlockBackground {
-      stroke: #0003;
-    }
-    g[data-argument-type="dropdown"] > path,
-    g[data-argument-type="dropdown"] > rect,
-    g[data-argument-type="variable"] > rect,
-    g[data-argument-type="variable"] > path,
-    g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > path,
-    path[data-argument-type="boolean"] {
-      stroke: #0003;
-      fill: #0001;
-    }
-    g[data-argument-type*="text"] > path,
-    g > line {
-      stroke: #0002;
-    }
-    .scratchCategoryItemBubble {
-      border-color: #0003 !important;
-    }
+path.blocklyBlockBackground[fill="#5CB1D6"],
+path.blocklyBlockBackground[fill="#FFBF00"],
+g[data-category] > path.blocklyBlockBackground {
+  stroke: #0003;
+}
+g[data-argument-type="dropdown"] > path,
+g[data-argument-type="dropdown"] > rect,
+g[data-argument-type="variable"] > rect,
+g[data-argument-type="variable"] > path,
+g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > path,
+path[data-argument-type="boolean"] {
+  stroke: #0003;
+  fill: #0001;
+}
+g[data-argument-type*="text"] > path,
+g > line {
+  stroke: #0002;
+}
+.scratchCategoryItemBubble {
+  border-color: #0003 !important;
+}
 
 path.blocklyBlockBackground[fill="#FF6680"],
 path.blocklyBlockBackground[fill="#5CB1D6"],

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -91,7 +91,5 @@ export default async function ({ addon, global, console }) {
     }
   }
 
-  style.textContent = stylesheet;
-
-  document.head.appendChild(style);
+  document.querySelector(".scratch-addons-theme[data-addon-id='editor-theme3']").textContent += stylesheet;
 }

--- a/addons/mouse-pos/addon.json
+++ b/addons/mouse-pos/addon.json
@@ -18,7 +18,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/mouse-pos/addon.json
+++ b/addons/mouse-pos/addon.json
@@ -1,7 +1,6 @@
 {
   "name": "Mouse position",
   "description": "Displays your mouse position next to the flag in the editor.",
-  "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "credits": [
     {
       "name": "Jeffalo"
@@ -19,7 +18,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
+  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -18,7 +18,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -1,7 +1,6 @@
 {
   "name": "Pause button",
   "description": "Adds a pause button next to the green flag. You can also programmatically pause a project in Scratch (also known as breakpoints) by creating a custom block with name \"sa-pause\" and using that block.",
-  "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "credits": [
     {
       "name": "Jeffalo"
@@ -19,7 +18,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
+  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -1,14 +1,13 @@
 {
   "name": "Confirm sprite deletion",
   "description": "Asks if you're sure when deleting a sprite inside a project.",
-  "warning": "This feature might make Scratch projects lag, especially if you're not using a powerful computer. Performance will be enhanced in future updates.",
   "userscripts": [
     {
       "url": "userscript.js",
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "traps": true,
+  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -7,7 +7,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  ,
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -1,39 +1,5 @@
 import runPersistentScripts from "./imports/run-persistent-scripts.js";
 
-function setLocalStorage(arr) {
-  const iframe = document.createElement("iframe");
-  iframe.src = "https://scratch.mit.edu/projects/0111001101100001/embed";
-  document.body.appendChild(iframe);
-  window.addEventListener(
-    "message",
-    (event) => {
-      if (event.origin === "https://scratch.mit.edu" && event.data === "ready") {
-        iframe.contentWindow.postMessage(arr, "*");
-        window.addEventListener(
-          "message",
-          (event) => {
-            if (event.origin === "https://scratch.mit.edu" && event.data === "OK") {
-              iframe.remove();
-            }
-          },
-          { once: true }
-        );
-      }
-    },
-    { once: true }
-  );
-}
-
-function setTrapsLocalStorageValue() {
-  const enabled = scratchAddons.manifests
-    .filter((obj) => scratchAddons.localState.addonsEnabled[obj.addonId])
-    .some((obj) => obj.manifest.traps);
-  setLocalStorage([{ key: "sa-trapsEnabled", value: enabled }]);
-}
-
-if (scratchAddons.localState.allReady) setTrapsLocalStorageValue();
-else scratchAddons.localEvents.addEventListener("ready", setTrapsLocalStorageValue);
-
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "getSettingsInfo") {
     sendResponse({
@@ -58,7 +24,6 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 
     if (scratchAddons.manifests.find((obj) => obj.addonId === addonId).manifest.tags.includes("theme"))
       scratchAddons.localEvents.dispatchEvent(new CustomEvent("themesUpdated"));
-    setTrapsLocalStorageValue();
   } else if (request.changeAddonSettings) {
     const { addonId, newSettings } = request.changeAddonSettings;
     scratchAddons.globalState.addonSettings[addonId] = newSettings;

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -46,7 +46,7 @@ window.addEventListener("load", () => {
 
 function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
   document.querySelectorAll(".scratch-addons-theme").forEach((style) => {
-    if(!style.textContent.startsWith("/* sa-autoupdate-theme-ignore */")) style.remove();
+    if (!style.textContent.startsWith("/* sa-autoupdate-theme-ignore */")) style.remove();
   });
   for (const userstyleUrl of userstyleUrls || []) {
     const link = document.createElement("link");

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -32,7 +32,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   } else if (request === "getInitialUrl") {
     sendResponse(initialUrl);
   } else if (request.themesUpdated) {
-    injectUserstylesAndThemes({ themes: request.themesUpdated });
+    injectUserstylesAndThemes({ themes: request.themesUpdated, isUpdate: true });
   }
 });
 chrome.runtime.sendMessage("ready");
@@ -44,8 +44,10 @@ window.addEventListener("load", () => {
   }
 });
 
-function injectUserstylesAndThemes({ userstyleUrls, themes }) {
-  document.querySelectorAll(".scratch-addons-theme").forEach((style) => style.remove());
+function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
+  document.querySelectorAll(".scratch-addons-theme").forEach((style) => {
+    if(!style.textContent.startsWith("/* sa-autoupdate-theme-ignore */")) style.remove();
+  });
   for (const userstyleUrl of userstyleUrls || []) {
     const link = document.createElement("link");
     link.rel = "stylesheet";
@@ -55,6 +57,7 @@ function injectUserstylesAndThemes({ userstyleUrls, themes }) {
   }
   for (const theme of themes) {
     for (const css of theme.styles) {
+      if (isUpdate && css.startsWith("/* sa-autoupdate-theme-ignore */")) continue;
       const style = document.createElement("style");
       style.classList.add("scratch-addons-theme");
       style.setAttribute("data-addon-id", theme.addonId);
@@ -82,7 +85,7 @@ function setCssVariables(addonSettings) {
 
 function onHeadAvailable({ globalState, addonsWithUserscripts, userstyleUrls, themes }) {
   setCssVariables(globalState.addonSettings);
-  injectUserstylesAndThemes({ userstyleUrls, themes });
+  injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate: false });
 
   const template = document.createElement("template");
   template.id = "scratch-addons";

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -37,7 +37,7 @@ function injectPrototype() {
     });
     onceTarget.dispatchEvent(specificEvent);
   };
-  
+
   Function.prototype.bind = function (...args) {
     if (Function.prototype.bind === oldPrototypes.functionBind) {
       // Just in case some code stores the bind function once on startup, then always uses it.

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -5,52 +5,12 @@ function injectPrototype() {
     arraySort: Array.prototype.sort,
     objectAssign: Object.assign,
   };
-  const extraHandlers = {
-    functionBind: [],
-    arrayPush: [],
-    arraySort: [],
-    objectAssign: [],
-  };
   // Use custom event target
   window.__scratchAddonsTraps = new EventTarget();
   const onceTarget = (__scratchAddonsTraps._targetOnce = new EventTarget());
-  const manyTarget = (__scratchAddonsTraps._targetMany = new EventTarget());
   const onceMap = (__scratchAddonsTraps._onceMap = Object.create(null));
   const trapNumOnce = (__scratchAddonsTraps._trapNumOnce = Symbol.for("trapNumOnce"));
-  const trapNumMany = (__scratchAddonsTraps._trapNumMany = Symbol.for("trapNumMany"));
 
-  /**
-   * Returns if an object matches a shape. Uses shallow compare.
-   * Shape is an object with key and value.
-   * Value can be null if the key existence is enough,
-   * but can be array if type checking is necessary.
-   * The array will be an OR (of course) and its items are
-   * expected results from typeof target[key], with one big difference:
-   * type of null is "null", not "object"
-   * @param {object.<string, *>} target target object to check.
-   * @param {object.<string, ?array.<string>>} shape shape of the expected object.
-   * @returns {boolean} validation result
-   *
-   */
-  const matchObject = (target, shape) => {
-    if (!target || typeof target !== "object") return false;
-    return Object.keys(shape).every((shapeKey) => {
-      const targetKeyType = target[shapeKey] === null ? "null" : typeof target[shapeKey];
-      // true === abort
-      if (targetKeyType === "undefined") return false;
-      if (Array.isArray(shape[shapeKey]) && !shape[shapeKey].includes(targetKeyType)) {
-        return false;
-      }
-      return true;
-    });
-  };
-
-  /**
-   * Dispatches event for "once" objects.
-   * "Once" objects are expected to be trapped at most only once per trap.
-   * @param {string} trapName name of the trap. Must be unique per trap.
-   * @param {*} value trapped value.
-   */
   const createReadyOnce = (trapName, value) => {
     if (value && typeof value === "object") {
       try {
@@ -77,272 +37,24 @@ function injectPrototype() {
     });
     onceTarget.dispatchEvent(specificEvent);
   };
-
-  /**
-   * Dispatches event for "many" objects.
-   * "Many" objects may be trapped more than once per trap.
-   * @param {string} trapName name of the trap. Must be unique per trap.
-   * @param {*} value trapped value.
-   */
-  const createReadyMany = (trapName, value) => {
-    if (value && typeof value === "object") {
-      try {
-        Object.defineProperty(value, trapNumMany, {
-          value: (value[trapNumMany] || 0) + 1,
-          configurable: true,
-        });
-      } catch (e) {
-        console.error("Error when injecting attr:", e);
-      }
-    }
-    const readyEvent = new CustomEvent("trapready", {
-      detail: {
-        trapName,
-        value,
-      },
-    });
-    manyTarget.dispatchEvent(readyEvent);
-    const specificEvent = new CustomEvent(`ready.${trapName}`, {
-      detail: {
-        value,
-      },
-    });
-    manyTarget.dispatchEvent(specificEvent);
-  };
-
-  /**
-   * fake/reconstructed Redux stats share properties of Once and Many.
-   * For this reason, state is notified using this function rather than
-   * the usual Once or Many dispatcher.
-   * @param {string} origin origin of the reducer, e.g. www, locale, gui
-   * @param {array.<string>} path path of the reducer. ['a', 'b'] means a.js "b" state.
-   * @param {*} prev previous value.
-   * @param {*} next next state. note that prev and next can be shallowly or deeply equal.
-   */
-  const notifyNewState = (origin, path, prev, next) => {
-    const ev = new CustomEvent("fakestatechanged", {
-      detail: {
-        reducerOrigin: origin,
-        path,
-        prev,
-        next,
-      },
-    });
-    __scratchAddonsTraps.dispatchEvent(ev);
-  };
-
-  const guiState = (value, ...path) => {
-    if (!onceMap.fakeGUIState) onceMap.fakeGUIState = {};
-    const realpath = path.slice(0);
-    const lastKey = path.pop();
-    let obj = onceMap.fakeGUIState;
-    for (const key of path) {
-      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
-      if (!obj.hasOwnProperty(key)) obj[key] = {};
-      obj = obj[key];
-    }
-    const prev = obj[lastKey];
-    obj[lastKey] = value;
-    notifyNewState("gui", realpath, prev, value);
-  };
-
-  const localeState = (value, key) => {
-    if (!onceMap.fakeLocaleState) onceMap.fakeLocaleState = {};
-    const prev = onceMap.fakeLocaleState[key];
-    onceMap.fakeLocaleState[key] = value;
-    notifyNewState("locale", [key], prev, value);
-  };
-
-  const wwwState = (value, ...path) => {
-    if (!onceMap.fakeWWWState) onceMap.fakeWWWState = {};
-    const realpath = path.slice(0);
-    const lastKey = path.pop();
-    let obj = onceMap.fakeWWWState;
-    for (const key of path) {
-      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
-      if (!obj.hasOwnProperty(key)) obj[key] = {};
-      obj = obj[key];
-    }
-    const prev = obj[lastKey];
-    obj[lastKey] = value;
-    notifyNewState("www", realpath, prev, value);
-  };
-
-  const override = (overrideId) => {
-    return function (...args) {
-      // Dispatch override events first, so handlers have a chance to mutate the args array before it's passed on to
-      // extra handlers defined in this file. (This allows addons to work with low-level overrides themselves.)
-      const overrideEvent = new CustomEvent("prototypecalled", {
-        detail: {
-          trapName: overrideId,
-          target: this,
-          args,
-        },
-      });
-      __scratchAddonsTraps.dispatchEvent(overrideEvent);
-      const specificEvent = new CustomEvent(`prototype.${overrideId}`, {
-        detail: {
-          target: this,
-          args,
-        },
-      });
-      __scratchAddonsTraps.dispatchEvent(specificEvent);
-
-      extraHandlers[overrideId].forEach((fn) => fn(args));
-      return oldPrototypes[overrideId].apply(this, args);
-    };
-  };
-
+  
   Function.prototype.bind = function (...args) {
-    if (args[0] && args[0].hasOwnProperty("editingTarget") && args[0].hasOwnProperty("runtime")) {
-      window._scratchAddonsScratchVM = args[0];
-      guiState(args[0], "vm");
+    if (Function.prototype.bind === oldPrototypes.functionBind) {
+      // Just in case some code stores the bind function once on startup, then always uses it.
+      return oldPrototypes.functionBind.apply(this, args);
+    } else if (args[0] && args[0].hasOwnProperty("editingTarget") && args[0].hasOwnProperty("runtime")) {
       createReadyOnce("vm", args[0]);
-      window.dispatchEvent(new CustomEvent("vmready"));
+      // After finding the VM, return to previous Function.prototype.bind
+      Function.prototype.bind = oldPrototypes.functionBind;
       return oldPrototypes.functionBind.apply(this, args);
     } else {
-      return override("functionBind").apply(this, args);
+      return oldPrototypes.functionBind.apply(this, args);
     }
   };
-  Array.prototype.push = override("arrayPush");
-  Array.prototype.sort = override("arraySort");
-  Object.assign = override("objectAssign");
-
-  // trap Thread
-  extraHandlers.arrayPush.push((args) => {
-    const maybeThread = args[0];
-    if (
-      maybeThread &&
-      matchObject(maybeThread, {
-        target: null,
-        blockContainer: null,
-        topBlock: ["string"],
-        stack: null,
-      })
-    ) {
-      createReadyMany("thread", maybeThread);
-    }
-  });
-
-  // VM trap: /components/gui/gui.jsx
-  extraHandlers.functionBind.push((args) => {
-    if (args[0] && args[0].props && args[0].props.vm) {
-      guiState(args[0].props.vm, "vm");
-      createReadyOnce("vm.propsVMBind", args[0].props.vm);
-    }
-  });
-
-  // VM trap: /lib/cloud-manager-hoc.jsx etc
-  extraHandlers.objectAssign.push((args) => {
-    if (args[3] && args[3].vm) {
-      guiState(args[3].vm, "vm");
-      createReadyOnce("vm.propsVMAssign", args[3].vm);
-    }
-  });
-
-  // Trapping ScratchBlocks is hard but possible
-  extraHandlers.functionBind.push((args) => {
-    if (args[0] && args[0].props && args[0].props.options) {
-      const connectObj = args[0];
-      // Get Blocks constructor. This is not instance, so we need to pollute prototype again.
-      if (!connectObj.constructor) return; // just in case
-      const blocksConstructor = connectObj.constructor.WrappedComponent;
-      if (!blocksConstructor) return; // it's not what we want
-      // Pollute blocksConstructor
-      const oldSetLocale = blocksConstructor.prototype.setLocale;
-      blocksConstructor.prototype.setLocale = function (...args) {
-        if (this.ScratchBlocks) createReadyOnce("ScratchBlocks", this.ScratchBlocks);
-        if (this.workspace) createReadyOnce("workspace", this.workspace);
-        return oldSetLocale.apply(this, args);
-      };
-    }
-  });
-
-  // Making fake state
-  // project-fetcher-hoc.jsx
-  extraHandlers.objectAssign.push((args) => {
-    if (!args[3]) return;
-    if (args[1] && args[1].loadingState) {
-      guiState(args[1].loadingState, "projectState", "loadingState");
-    }
-    if (args[1] && args[1].reduxProjectId) {
-      guiState(args[1].reduxProjectId, "projectState", "projectId");
-    }
-  });
-
-  // menu-bar-hoc.jsx
-  extraHandlers.objectAssign.push((args) => {
-    if (!args[3]) return;
-    if (args[1] && args[1].projectChanged) {
-      guiState(args[1].projectChanged, "projectChanged");
-    }
-  });
-
-  // vm-manager-hoc.jsx
-  extraHandlers.objectAssign.push((args) => {
-    if (!args[3]) return;
-    if (args[1] && args[1].fontsLoaded) {
-      guiState(args[1].fontsLoaded, "fontsLoaded");
-    }
-    if (args[1] && args[1].locale) {
-      localeState(args[1].locale, "locale");
-    }
-    if (args[1] && args[1].messages) {
-      localeState(args[1].messages, "messages");
-    }
-    if (args[1] && args[1].projectData) {
-      guiState(args[1].projectData, "projectState", "projectData");
-    }
-    if (args[1] && args[1].projectId) {
-      guiState(args[1].projectId, "projectState", "projectId");
-    }
-    if (args[1] && args[1].isPlayerOnly) {
-      guiState(args[1].isPlayerOnly, "mode", "isPlayerOnly");
-    }
-    if (args[1] && args[1].isStarted) {
-      guiState(args[1].isStarted, "vmStatus", "isStarted");
-    }
-  });
-  // project-saver-hoc.jsx
-  extraHandlers.objectAssign.push((args) => {
-    if (!args[3]) return;
-    if (args[1] && args[1].autoSaveTimeoutId) {
-      guiState(args[1].autoSaveTimeoutId, "timeout", "autoSaveTimeoutId");
-    }
-    if (args[1] && args[1].reduxProjectTitle) {
-      guiState(args[1].reduxProjectTitle, "projectTitle");
-    }
-  });
-
-  // navigation.jsx
-  extraHandlers.objectAssign.push((args) => {
-    if (!args[3]) return;
-    if (args[1] && args[1].accountNavOpen) {
-      wwwState(args[1].accountNavOpen, "navigation", "accountNavOpen");
-    }
-    if (args[1] && args[1].session) {
-      wwwState(args[1].session, "session");
-    }
-    if (args[1] && args[1].permissions) {
-      wwwState(args[1].permissions, "permissions");
-    }
-    if (args[1] && args[1].registrationOpen) {
-      wwwState(args[1].registrationOpen, "navigation", "registrationOpen");
-    }
-    if (args[1] && args[1].searchTerm) {
-      wwwState(args[1].searchTerm, "navigation", "searchTerm");
-    }
-    if (args[1] && args[1].unreadMessageCount) {
-      wwwState(args[1].unreadMessageCount, "messageCount", "messageCount");
-    }
-    if (args[1] && args[1].useScratch3Registration) {
-      wwwState(args[1].useScratch3Registration, "navigation", "useScratch3Registration");
-    }
-  });
 }
 
-if (localStorage.getItem("sa-trapsEnabled") === "true") {
+if (location.pathname.split("/")[1] === "projects") {
   const injectPrototypeScript = document.createElement("script");
   injectPrototypeScript.append(document.createTextNode("(" + injectPrototype + ")()"));
   (document.head || document.documentElement).appendChild(injectPrototypeScript);
-} else console.log("Scratch Addons: traps disabled");
+}

--- a/content-scripts/sa-embed.js
+++ b/content-scripts/sa-embed.js
@@ -1,8 +1,0 @@
-if (window.parent !== window) window.parent.postMessage("ready", "*");
-
-window.addEventListener("message", (event) => {
-  if (event.origin === chrome.runtime.getURL("").slice(0, -1)) {
-    event.data.forEach((obj) => localStorage.setItem(obj.key, obj.value));
-    event.source.postMessage("OK", "*");
-  }
-});

--- a/manifest.json
+++ b/manifest.json
@@ -27,12 +27,6 @@
       "matches": ["https://scratch.mit.edu/*"],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"]
-    },
-    {
-      "matches": ["https://scratch.mit.edu/projects/0111001101100001/embed"],
-      "run_at": "document_start",
-      "js": ["content-scripts/sa-embed.js"],
-      "all_frames": true
     }
   ],
   "options_ui": {


### PR DESCRIPTION
A pretty big PR
- Resolves #431. The only 2 traps used by addons nowadays are vm and workspace - and workspace can actually be obtained from the accidentally global object `window.Blockly`. So, sorry @apple502j, but at least for now, we're returning to the old "prototype handler" that only traps the VM, and nothing else.
- Because of the former, all performance warnings were removed, and the "traps" property was removed from all manifests.
- Code that handled whether to inject traps or not was removed - now, traps are always injected, as long as it's a project.
- Resolves #336, returns to previous non-trap code for editor-stepping, using a setInterval of 500ms. Beta tag removed - no addons have it as of now.
- Adds `/* sa-autoupdate-theme-ignore */`, a way for themes to ask for their userstyles to work like non-theme userstyles. This is specially important for the editor-stage-left addon, which needs a userscript to work properly (to enable sharing scripts between sprites, aka "share the love"). So now, a full refresh is needed to enable/disable it. Another addon benefits from this: Customizable block colors can now move its CSS that was previously in a JS string, to the userstyle CSS itself, and it's guaranteed not to be removed.
- Fixes bug where "share the love" would not work on editor-stage-left after going inside the editor, then outside, then inside again.