### PR TITLE
Update addon tags, make some addons recommended

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -14,20 +14,18 @@ export default class Tab extends EventTarget {
       : document.querySelector("script[type='text/javascript']")
       ? "scratchr2"
       : null;
-    if (info.traps) {
-      this.traps = new Trap();
-      __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
-        const newEvent = new CustomEvent("fakestatechanged", {
-          detail: {
-            reducerOrigin: detail.reducerOrigin,
-            path: detail.path,
-            prev: detail.prev,
-            next: detail.next,
-          },
-        });
-        this.traps.dispatchEvent(newEvent);
+    this.traps = new Trap();
+    __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
+      const newEvent = new CustomEvent("fakestatechanged", {
+        detail: {
+          reducerOrigin: detail.reducerOrigin,
+          path: detail.path,
+          prev: detail.prev,
+          next: detail.next,
+        },
       });
-    }
+      this.traps.dispatchEvent(newEvent);
+    });
     this.redux = new ReduxHandler();
     this._waitForElementSet = new WeakSet();
   }

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -15,7 +15,7 @@ export default class Tab extends EventTarget {
       ? "scratchr2"
       : null;
     this.traps = new Trap();
-    if (__scratchAddonsTraps)
+    if (window.__scratchAddonsTraps)
       __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
         const newEvent = new CustomEvent("fakestatechanged", {
           detail: {

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -15,7 +15,7 @@ export default class Tab extends EventTarget {
       ? "scratchr2"
       : null;
     this.traps = new Trap();
-    __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
+    if (__scratchAddonsTraps) __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
       const newEvent = new CustomEvent("fakestatechanged", {
         detail: {
           reducerOrigin: detail.reducerOrigin,

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -15,17 +15,18 @@ export default class Tab extends EventTarget {
       ? "scratchr2"
       : null;
     this.traps = new Trap();
-    if (__scratchAddonsTraps) __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
-      const newEvent = new CustomEvent("fakestatechanged", {
-        detail: {
-          reducerOrigin: detail.reducerOrigin,
-          path: detail.path,
-          prev: detail.prev,
-          next: detail.next,
-        },
+    if (__scratchAddonsTraps)
+      __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
+        const newEvent = new CustomEvent("fakestatechanged", {
+          detail: {
+            reducerOrigin: detail.reducerOrigin,
+            path: detail.path,
+            prev: detail.prev,
+            next: detail.next,
+          },
+        });
+        this.traps.dispatchEvent(newEvent);
       });
-      this.traps.dispatchEvent(newEvent);
-    });
     this.redux = new ReduxHandler();
     this._waitForElementSet = new WeakSet();
   }

--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -12,6 +12,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor"],
-  "enabledByDefault": false
+  "tags": ["editor", "recommended"],
+  "enabledByDefault": true
 }

--- a/addons/animated-thumb/addon.json
+++ b/addons/animated-thumb/addon.json
@@ -17,6 +17,6 @@
       "url": "userscript.js"
     }
   ],
-  "tags": ["editor", "community"],
-  "enabledByDefault": false
+  "tags": ["editor", "community", "recommended"],
+  "enabledByDefault": true
 }

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Show exact count",
-  "description": "Shows the exact count for user and studio info.",
+  "description": "Shows the exact count for user and studio info. Uses ScratchDB for forums information.",
   "credits": [
     {
       "name": "TheColaber",
@@ -60,6 +60,6 @@
       }
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "recommended"],
   "enabledByDefault": false
 }

--- a/addons/forum-time-zones/addon.json
+++ b/addons/forum-time-zones/addon.json
@@ -8,7 +8,7 @@
       "runAtComplete": false
     }
   ],
-  "tags": ["forums", "community"],
+  "tags": ["forums", "community", "beta"],
   "enabledByDefault": false,
   "libraries": ["moment"]
 }

--- a/addons/full-signature/addon.json
+++ b/addons/full-signature/addon.json
@@ -51,6 +51,6 @@
       }
     }
   ],
-  "tags": ["community", "forums"],
-  "enabledByDefault": false
+  "tags": ["community", "forums", "recommended"],
+  "enabledByDefault": true
 }

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -73,6 +73,6 @@
       }
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "beta"],
   "enabledByDefault": false
 }

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -18,6 +18,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "beta"],
   "enabledByDefault": false
 }

--- a/addons/resizable-comment-input/addon.json
+++ b/addons/resizable-comment-input/addon.json
@@ -1,12 +1,13 @@
 {
   "name": "Resizable comment input",
-  "description": "Makes the comment input box vertically resizable.",
-  "tags": ["community"],
+  "description": "Makes the comment input box vertically resizable in projects.",
+  "tags": ["community", "recommended"],
   "credits": [{ "name": "Maximouse" }],
   "userstyles": [
     {
       "url": "userstyle.css",
       "matches": ["https://scratch.mit.edu/*"]
     }
-  ]
+  ],
+  "enabledByDefault": true
 }

--- a/addons/studio-tools/addon.json
+++ b/addons/studio-tools/addon.json
@@ -13,5 +13,5 @@
     }
   ],
   "tags": ["community", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }


### PR DESCRIPTION
Resolves #487 

- With the removal of the prototype handler, `60fps` is now recommended and turned on by default.
- The new `resizable-comments` addon will be turned on for all users.
- The new `animated-thumb` addon will be turned on for all users.
- Made `exact-count` recommended.
- `full-signature` is now recommended and will be turned on for new users.
- `forum-time-zones` and `infinite-scroll` are now beta.
- `studio-tools` will be turned on for new users.
- The new `pause` addon is beta.