### PR TITLE
Enable some old addons for all users on v1.3.0

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -1,6 +1,19 @@
 chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {}, addonsEnabled = {} }) => {
   const func = () => {
     let madeAnyChanges = false;
+
+    // TODO: remove on v1.4.0
+    // Turns on some old addons for existing users, after the removal of the prototype
+    // handler. To detect if this is the first run on v1.3.0 update, we check if a
+    // new addon added on v1.3.0 has an undefined value for enabled. We also make
+    // sure this is not the first run ever by checking if addonsEnabled ~= {}
+    if (Object.keys(addonsEnabled) !== 0 && addonsEnabled["animated-thumb"] === undefined) {
+      addonsEnabled["60fps"] = true;
+      addonsEnabled["full-signature"] = true;
+      addonsEnabled["studio-tools"] = true;
+      madeAnyChanges = true;
+    }
+
     for (const { manifest, addonId } of scratchAddons.manifests) {
       const settings = addonSettings[addonId] || {};
       let madeChangesToAddon = false;


### PR DESCRIPTION
This enables 60fps, studio tools and full signature for all users. Since it's been a while since Scratch Addons was Scratch Messaging, it seems to be a good time to do it.
It's possible some users did try out these new addons and then disabled them, but that should be a minority. Sadly, because of the way I coded this, it's not possible to know if a user disabled an addon themselves, or if they never enabled a non-enabled-by-default addon.