### PR TITLE
Live featured project: Disable addon by default

### DIFF
--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -50,5 +50,5 @@
     }
   ],
   "tags": ["community"],
-  "enabledByDefault": true
+  "enabledByDefault": false
 }


### PR DESCRIPTION
This PR set the `enabledByDefault` value of the "Live featured project" addon to false.

I thought a post-merge PR is enough. Turns out it isn't, and the damage was done. On the bright side, at least I got some inquiries about it.

P/S: I am really pissed off rn
