### PR TITLE
Make theme userstyles ordered

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -45,7 +45,9 @@ async function getContentScriptInfo(url) {
           fetchThemeStylesPromises.push(
             fetch(chrome.runtime.getURL(`/addons/${addonId}/${styleUrl}`))
               .then((res) => res.text())
-              .then((text) => {styles[styleUrl] = text})
+              .then((text) => {
+                styles[styleUrl] = text;
+              })
           );
         }
       }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -39,13 +39,13 @@ async function getContentScriptInfo(url) {
         if (userscriptMatches({ url }, style, addonId)) styleUrls.push(style.url);
       }
       if (styleUrls.length) {
-        const styles = [];
-        data.themes.push({ addonId, styles });
+        const styles = {};
+        data.themes.push({ addonId, styleUrls, styles });
         for (const styleUrl of styleUrls) {
           fetchThemeStylesPromises.push(
             fetch(chrome.runtime.getURL(`/addons/${addonId}/${styleUrl}`))
               .then((res) => res.text())
-              .then((text) => styles.push(text))
+              .then((text) => {styles[styleUrl] = text})
           );
         }
       }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -56,7 +56,8 @@ function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
     else document.documentElement.appendChild(link);
   }
   for (const theme of themes) {
-    for (const css of theme.styles) {
+    for (const styleUrl of theme.styleUrls) {
+      const css = theme.styles[styleUrl];
       if (isUpdate && css.startsWith("/* sa-autoupdate-theme-ignore */")) continue;
       const style = document.createElement("style");
       style.classList.add("scratch-addons-theme");


### PR DESCRIPTION
**Resolves**

Resolves #700

**Changes**

Theme userstyles now load in the same order as they are listed in `addon.json`.

**Reason for changes**

This makes them predictable.

**Tests**

I opened the editor with editor dark mode enabled and the styles were in correct order.
