### PR TITLE
Fix fixed footer on annual report

### DIFF
--- a/addons/infinite-scroll/userscript.css
+++ b/addons/infinite-scroll/userscript.css
@@ -7,6 +7,7 @@ body {
 */
 #footer {
   position: fixed;
+  top: initial;
   bottom: 0;
   width: 100%;
   height: 38px;


### PR DESCRIPTION
**Resolves**

Resolves #689 

**Changes**

Makes the *Fix footer* feature of the infinite scrolling addon work on https://scratch.mit.edu/annual-report

**Reason for changes**

#689

**Tests**

Tested, works.
