### PR TITLE
Live featured project: Add option to disable alt player, fix style, etc

### DIFF
--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -45,8 +45,8 @@
       "id": "alternativePlayer",
       "name": "Alternative player",
       "type": "select",
-      "default": "TurboWarp",
-      "potentialValues": ["TurboWarp", "forkphorus"]
+      "default": "None",
+      "potentialValues": ["None", "TurboWarp", "forkphorus"]
     }
   ],
   "tags": ["community"],

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -29,20 +29,16 @@ export default async function ({ addon }) {
   wrapperElement.appendChild(iframeElement);
   if (document.querySelector('#profile-box .player [data-control="edit"]'))
     wrapperElement.appendChild(changeFeaturedElement);
-  stageElement.appendChild(wrapperElement);
+  stageElement.prepend(wrapperElement);
+
+  if (showMenu) wrapperElement.classList.add("lfp-show-menu");
+  else wrapperElement.classList.add("lfp-hide-menu");
 
   // Functions for loading embeds
 
   const loadScratch = () => {
-    wrapperElement.className = "lfp-scratch";
-
-    if (showMenu) {
-      wrapperElement.classList.add("lfp-show-menu");
-    } else {
-      iframeElement.setAttribute("height", "260");
-      wrapperElement.classList.add("lfp-hide-menu");
-    }
-
+    wrapperElement.dataset.player = "scratch";
+    if (!showMenu) iframeElement.setAttribute("height", "260");
     iframeElement.setAttribute("src", `https://scratch.mit.edu/projects/embed/${projectId}/?autostart=true`);
 
     // Auto-start Scratch players (sadly need to be done automatically)
@@ -62,44 +58,38 @@ export default async function ({ addon }) {
             subtree: true,
           });
         },
-        { once: true }
+        {
+          once: true,
+        }
       );
   };
 
   const loadTurboWarp = () => {
     iframeElement.setAttribute("src", `https://turbowarp.org/embed.html${autoPlay ? "?autoplay" : ""}#${projectId}`);
-    wrapperElement.className = "lfp-turbowarp";
-
-    if (showMenu) {
-      wrapperElement.classList.add("lfp-show-menu");
-    } else {
-      iframeElement.setAttribute("height", "260");
-      wrapperElement.classList.add("lfp-hide-menu");
-    }
+    wrapperElement.dataset.player = "turbowarp";
+    if (!showMenu) iframeElement.setAttribute("height", "260");
   };
 
   const loadForkphorus = () => {
-    wrapperElement.className = "lfp-forkphorus";
+    wrapperElement.dataset.player = "forkphorus";
     iframeElement.setAttribute(
       "src",
       `https://forkphorus.github.io/embed.html?id=${projectId}&auto-start=${autoPlay}&ui=${showMenu}`
     );
-    if (!autoPlay) frameElement.setAttribute("width", "239");
   };
 
   // Start loading the players
 
-  stageElement.classList.add("lfp-loaded");
-
-  if (forceAlternative) {
+  if (forceAlternative && alternativePlayer !== "None") {
     if (alternativePlayer === "TurboWarp") loadTurboWarp();
-    else loadForkphorus();
+    else if (alternativePlayer === "forkphorus") loadForkphorus();
   } else {
     loadScratch();
     iframeElement.addEventListener("load", () => {
       if (iframeElement.contentDocument.querySelector(".not-available-outer") !== null) {
         if (alternativePlayer === "TurboWarp") loadTurboWarp();
-        else loadForkphorus();
+        else if (alternativePlayer === "forkphorus") loadForkphorus();
+        else stageElement.removeChild(wrapperElement);
       }
     });
   }

--- a/addons/live-featured-project/style.css
+++ b/addons/live-featured-project/style.css
@@ -1,10 +1,6 @@
-.lfp-scratch.lfp-hide-menu iframe,
-.lfp-turbowarp.lfp-hide-menu iframe {
+.lfp-hide-menu[data-player="scratch"] iframe,
+.lfp-hide-menu[data-player="turbowarp"] iframe {
   margin-top: -44px;
-}
-
-.lfp-forkphorus.lfp-hide-menu iframe {
-  margin-top: -2.25rem;
 }
 
 #lfp-embed {
@@ -38,6 +34,6 @@
   display: block;
 }
 
-.stage.lfp-loaded #featured-project {
+#lfp-embed + #featured-project {
   display: none;
 }


### PR DESCRIPTION
This PR updates the "Live featured project" addon, in response of few of the user's suggestions, and to fix here and there.

- Add option "none" to disable alternative player (iframe removed if failed, thumbnail appears after that)
- Make "none" as default option for alternative player
- Fix styling of forkphorus player
- Prepend iframe instead of append
- Tidy up code