### PR TITLE
Show full areas: Fix capitalization on "Load more"

### DIFF
--- a/addons/full-signature/working.js
+++ b/addons/full-signature/working.js
@@ -4,7 +4,7 @@ export default async function ({ addon, global, console }) {
   container.classList.add("load-more-wibd-container");
   let loadMore = container.appendChild(document.createElement("button"));
   loadMore.classList.add("load-more-wibd");
-  loadMore.innerText = "Load More";
+  loadMore.innerText = "Load more";
   let dataLoaded = 6;
   loadMore.addEventListener(
     "click",


### PR DESCRIPTION
It seems that the capitalization of the "Load more" button is not the same as the other "Load more" button on the bottom of the comments. (pictured below)

![image](https://user-images.githubusercontent.com/11584103/98784660-07a0b400-242e-11eb-9c20-4b6c43c2e20d.png)

This PR fixes it.