### PR TITLE
Add favicon on the web pages

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Scratch Addons - Settings</title>
+    <title>Settings - Scratch Addons</title>
+    <link rel="icon" href="../../images/icon.png" />
     <link rel="stylesheet" href="style.css" />
     <link href="../../libraries/Sora.css" rel="stylesheet" />
     <script src="../../libraries/vue.js" defer></script>

--- a/webpages/settings/licenses.html
+++ b/webpages/settings/licenses.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Scratch Addons - Licenses</title>
+    <title>Licenses - Scratch Addons</title>
+    <link rel="icon" href="../../images/icon.png" />
     <link rel="stylesheet" href="style.css" />
     <link href="../../libraries/Sora.css" rel="stylesheet" />
     <script src="../../libraries/vue.js" defer></script>


### PR DESCRIPTION
There is no icon on the extension web pages. This PR adds it. Oh, and I also moved the "Scratch Addons" portion of text to the right, since it is already described on the icon.

![image](https://user-images.githubusercontent.com/11584103/98791374-8e0dc380-2437-11eb-8886-1a0f083e7168.png)
