### PR TITLE
Remove unnecessary word "theme"

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -241,12 +241,8 @@
                 <div class="filter-selector">
                   <div class="filter-text">Theme:</div>
                   <div class="filter-options">
-                    <div class="filter-option" :class="{'sel': theme === true}" @click="setTheme(true)">
-                      Light Theme
-                    </div>
-                    <div class="filter-option" :class="{'sel': theme === false}" @click="setTheme(false)">
-                      Dark Theme
-                    </div>
+                    <div class="filter-option" :class="{'sel': theme === true}" @click="setTheme(true)">Light</div>
+                    <div class="filter-option" :class="{'sel': theme === false}" @click="setTheme(false)">Dark</div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
In this PR, I remove the word "theme" from the "Dark Theme" and the "Light Theme" phrase as it is unnecessary because it is already described that the settings are for themes.

This might be too minor and subjective, so it is open for discussion.

If this got rejected, how about we talk about the capitalization?