### PR TITLE
Fix performance when dragging blocks in the editor

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -59,7 +59,7 @@ export default class Tab extends EventTarget {
           break;
         }
       }).observe(document.documentElement, {
-        attributes: true,
+        attributes: false,
         childList: true,
         subtree: true,
       })

--- a/addons/mouse-pos/style.css
+++ b/addons/mouse-pos/style.css
@@ -21,3 +21,8 @@
   color: #5cb1d6;
   white-space: nowrap;
 }
+
+/* Use pseudo elements to avoid firing mutation observers by just moving the cursor */
+.pos-container > span::after {
+  content: attr(data-content);
+}

--- a/addons/mouse-pos/userscript.js
+++ b/addons/mouse-pos/userscript.js
@@ -26,7 +26,7 @@ export default async function ({ addon, global, console }) {
       var x = vm.runtime.ioDevices.mouse.__scratchX ? vm.runtime.ioDevices.mouse.__scratchX : 0;
       var y = vm.runtime.ioDevices.mouse.__scratchY ? vm.runtime.ioDevices.mouse.__scratchY : 0;
 
-      pos.innerText = `${x}, ${y}`;
+      pos.setAttribute("data-content", `${x}, ${y}`);
 
       Object.defineProperty(vm.runtime.ioDevices.mouse, "_scratchX", {
         get: function () {
@@ -44,7 +44,7 @@ export default async function ({ addon, global, console }) {
         },
         set: function (sety) {
           y = sety;
-          pos.innerText = `${x}, ${y}`;
+          pos.setAttribute("data-content", `${x}, ${y}`);
           return (this.__scratchY = sety);
         },
       });


### PR DESCRIPTION
A user reported through feedback that they experienced lag while using Scratch Addons. I then noticed this was obviously the mutation observers for all calls to `addon.tab.waitForElement` reacting to something. I ended up finding that dragging a block triggers attribute changes in the DOM, and the mutation observers were listening to attribute changes. There might be valid reasons for `waitForElement` that might require to listen for attribute changes, but it's not worth the performance cost.

This fixed the performance issues (using 4x slowdown simulation on Chrome devtools), except when having the "mouse position" addon by @JeffaloBob enabled. I think it's safe to guess why; moving the cursor causes a change to the DOM, which then causes all mutation observers to trigger - but not when dragging blocks, literally with any mouse movement. Because of that, I also want to optimize that addon within this PR.