### PR TITLE
Add more pages to scratchr2

### DIFF
--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -27,7 +27,12 @@
         "https://scratch.mit.edu/cloudmonitor/*",
         "https://scratch.mit.edu/403/",
         "https://scratch.mit.edu/404/",
-        "https://scratch.mit.edu/500/"
+        "https://scratch.mit.edu/500/",
+        "https://scratch.mit.edu/login",
+        "https://scratch.mit.edu/login_retry",
+        "https://scratch.mit.edu/cloudmonitor/*",
+        "https://scratch.mit.edu/accounts/login"
+
       ]
     },
     {

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -29,9 +29,7 @@
         "https://scratch.mit.edu/404/",
         "https://scratch.mit.edu/500/",
         "https://scratch.mit.edu/login",
-        "https://scratch.mit.edu/login_retry",
-        "https://scratch.mit.edu/cloudmonitor/*",
-        "https://scratch.mit.edu/accounts/*"
+        "https://scratch.mit.edu/login_retry"
       ]
     },
     {

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -31,8 +31,7 @@
         "https://scratch.mit.edu/login",
         "https://scratch.mit.edu/login_retry",
         "https://scratch.mit.edu/cloudmonitor/*",
-        "https://scratch.mit.edu/accounts/login"
-
+        "https://scratch.mit.edu/accounts/*"
       ]
     },
     {


### PR DESCRIPTION
This adds more pages to scratchr2.
Resolves #774 
Adds:   
		
		"https://scratch.mit.edu/login",
        "https://scratch.mit.edu/login_retry",
        "https://scratch.mit.edu/cloudmonitor/*",
        "https://scratch.mit.edu/accounts/login"
