### PR TITLE
Add support for %addon-self-dir% in themes CSS

### DIFF
--- a/addons/scratchr2/assets/caret.svg
+++ b/addons/scratchr2/assets/caret.svg
@@ -1,0 +1,2 @@
+<!-- The dropdown caret used on Scratch 3.0 website for select elements -->
+<svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="48" height="64"><path d="M24 37.43a1.88 1.88 0 0 1-1.33-.55l-5.11-5.11a1.87 1.87 0 0 1 0-2.64c.73-.73 12.14-.73 12.87 0a1.87 1.87 0 0 1 0 2.64l-5.11 5.11a1.86 1.86 0 0 1-1.32.55z" fill="#b3b3b3"/><path style="isolation:isolate" fill="#231f20" opacity=".1" d="M.01 0h1v64h-1z"/></svg>

--- a/addons/scratchr2/assets/caret_hover.svg
+++ b/addons/scratchr2/assets/caret_hover.svg
@@ -1,0 +1,2 @@
+<!-- The dropdown caret used on Scratch 3.0 website for select elements on hover -->
+<svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="48" height="64"><path style="isolation:isolate" fill="#231f20" opacity=".1" d="M.01 0h48v64h-48z"/><path d="M24 37.58a1.88 1.88 0 0 1-1.33-.58l-5.11-5.11a1.89 1.89 0 0 1 0-2.65c.73-.73 12.14-.73 12.87 0a1.87 1.87 0 0 1 0 2.64L25.32 37a1.86 1.86 0 0 1-1.32.58z" fill="#b3b3b3"/></svg>

--- a/addons/scratchr2/experimental_dark_compatibility.css
+++ b/addons/scratchr2/experimental_dark_compatibility.css
@@ -1,5 +1,5 @@
 :root {
-  --scratchr2-dropdown-image: url(https://mxmou.github.io/customize-scratch/assets/caret.svg);
+  --scratchr2-dropdown-image: url(%addon-self-dir%/assets/caret.svg);
   --scratchr2-link-color: #4d97ff;
   --scratchr2-active-color: active;
   --scratchr2-dark-boxbg: #282828;

--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -105,16 +105,16 @@
   height: 46px;
   border-color: rgba(0, 0, 0, 0.1);
   transition: border-color 0.5s ease;
-  background: #fafafa url("https://mxmou.github.io/customize-scratch/assets/caret.svg") no-repeat right center;
+  background: #fafafa url("%addon-self-dir%/assets/caret.svg") no-repeat right center;
   color: #575e75;
   font-weight: normal;
 }
 .action-bar .inner .dropdown:hover {
-  background-image: url("https://mxmou.github.io/customize-scratch/assets/caret_hover.svg");
+  background-image: url("%addon-self-dir%/assets/caret_hover.svg");
 }
 .action-bar .inner .dropdown:focus,
 .action-bar .inner .dropdown.open {
-  background-image: url("https://mxmou.github.io/customize-scratch/assets/caret_hover.svg");
+  background-image: url("%addon-self-dir%/assets/caret_hover.svg");
   border-color: #4d97ff;
 }
 .action-bar .inner .dropdown .dropdown-toggle {

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -125,13 +125,13 @@ select {
   height: 48px;
   border: 1px solid rgba(0, 0, 0, 0.1);
   transition: border-color 0.5s ease;
-  background: #fafafa url("https://mxmou.github.io/customize-scratch/assets/caret.svg") no-repeat right center;
+  background: #fafafa url("%addon-self-dir%/assets/caret.svg") no-repeat right center;
   color: #575e75;
   font-size: 14px;
 }
 select:hover,
 select:focus {
-  background-image: url("https://mxmou.github.io/customize-scratch/assets/caret_hover.svg");
+  background-image: url("%addon-self-dir%/assets/caret_hover.svg");
 }
 select:focus {
   border-color: #4d97ff;

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -57,7 +57,9 @@ function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
   }
   for (const theme of themes) {
     for (const styleUrl of theme.styleUrls) {
-      const css = theme.styles[styleUrl];
+      let css = theme.styles[styleUrl];
+      // Replace %addon-self-dir% for relative URLs
+      css = css.replace(/\%addon-self-dir\%/g, chrome.runtime.getURL(`addons/${theme.addonId}`));
       if (isUpdate && css.startsWith("/* sa-autoupdate-theme-ignore */")) continue;
       const style = document.createElement("style");
       style.classList.add("scratch-addons-theme");


### PR DESCRIPTION
Resolves #741 

Any instance of the string `%addon-self-dir%` in a CSS file of a theme will be replaced with the value of `addon.self.dir` for that addon.