### PR TITLE
add radius to backpack

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -22,3 +22,8 @@
   flex-direction: row-reverse;
   overflow-x: hidden;
 }
+
+[dir="ltr"] .backpack_backpack-header_6ltCS {
+    border-top-right-radius: 0rem;
+    border-top-left-radius: 0.5rem;
+}

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -24,6 +24,6 @@
 }
 
 [dir="ltr"] .backpack_backpack-header_6ltCS {
-    border-top-right-radius: 0rem;
-    border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0rem;
+  border-top-left-radius: 0.5rem;
 }


### PR DESCRIPTION

**Changes**
change
![Screen Shot 2020-11-22 at 9 15 26 am](https://user-images.githubusercontent.com/65277548/99888788-5dcdec80-2ca3-11eb-87e5-d4a66f297a4e.png)
to
![Screen Shot 2020-11-22 at 9 17 09 am](https://user-images.githubusercontent.com/65277548/99888812-8bb33100-2ca3-11eb-8d91-2636e5933802.png)
on left stage with;
```css
[dir="ltr"] .backpack_backpack-header_6ltCS {
    border-top-right-radius: 0rem;
    border-top-left-radius: 0.5rem;
}
```
I looks a little better now :)
**Reason for changes**
Idk why, but this just makes the backpack div not look pointy on the left stage mode.
**Tests**
Yup, it works

![Screen Shot 2020-11-22 at 9 17 09 am](https://user-images.githubusercontent.com/65277548/99888812-8bb33100-2ca3-11eb-8d91-2636e5933802.png)