### PR TITLE
Use SAB as the placeholder author on the Transifex workflow

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -12,8 +12,14 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Push and pull strings
         uses: ScratchAddons/l10n-script@main
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
I don't know, this change is quite small, and I think it is better to use ScratchAddons-Bot so checks and workflows work (if that's an issue), and for, you know, uniformity.