### PR TITLE
Radius for change button on profile

### DIFF
--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -148,3 +148,7 @@
 #comments .more-replies {
   background-color: #eaf1fc;
 }
+
+.portrait [data-control="edit"] {
+  border-top-left-radius: 5px;
+}


### PR DESCRIPTION
**Resolves**


Resolves #

**Changes**
Change
![Screen Shot 2020-11-24 at 7 48 09 am](https://user-images.githubusercontent.com/65277548/100013807-8f70c000-2e29-11eb-9f98-620a7cfe7c8c.png)
to
![Screen Shot 2020-11-24 at 7 48 18 am](https://user-images.githubusercontent.com/65277548/100013804-8d0e6600-2e29-11eb-88d5-5bb83064c1b7.png)
on the 3.0 styled pages

Changed "change's" radius on the top left to match the profile pic radius
This is done by:
```css
.portrait [data-control="edit"] {
  border-top-left-radius: 5px;
}
```

**Reason for changes**
Change radius to match the profile image

**Tests**
Yup, inspected
