### PR TITLE
Link advisories page instead of updating it every vuln

### DIFF
--- a/security.md
+++ b/security.md
@@ -11,8 +11,6 @@ please report it (see below).
 If you find a vulnerability within Scratch Addons (any repository belonging to the organization) please contact World_Languages privately by emailing worldxlanguages@gmail.com.
 If you don't get a response within 48 hours, please create an issue in this repository mentioning you sent an email.
 
-# Vulnerabilities Disclosed
-Here are the vulnerabilities that have been discovered and disclosed:
-| Name               | Affected | Fix   | CVSS | CVE                | Advisory                                                                                         |
-|--------------------|----------|-------|----------|--------------------|--------------------------------------------------------------------------------------------------|
-| More Links DOM XSS | <=1.3.1  | 1.3.2 | 7.6      | (not assigned yet) | [GitHub](https://github.com/ScratchAddons/ScratchAddons/security/advisories/GHSA-6qfq-px3r-xj4p) |
+## Vulnerabilities Disclosed
+
+See our advisories that we have published for vulnerabilities that we have disclosed on [this page](https://github.com/ScratchAddons/ScratchAddons/security/advisories?state=published).


### PR DESCRIPTION
Instead of updating it every vulnerability (and causing that pop-up appear every time), how about just link it to [this page](https://github.com/ScratchAddons/ScratchAddons/security/advisories?state=published)? The page is used to list our advisories, so why another list?

Reminder that people can click our Security tab and check either our policy or the advisories list.