### PR TITLE
Add source URL to theme CSS

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -61,6 +61,7 @@ function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
       // Replace %addon-self-dir% for relative URLs
       css = css.replace(/\%addon-self-dir\%/g, chrome.runtime.getURL(`addons/${theme.addonId}`));
       if (isUpdate && css.startsWith("/* sa-autoupdate-theme-ignore */")) continue;
+      css += `\n/*# sourceURL=${styleUrl} */`;
       const style = document.createElement("style");
       style.classList.add("scratch-addons-theme");
       style.setAttribute("data-addon-id", theme.addonId);


### PR DESCRIPTION
Theme CSS is not injected as <link rel="stylesheet">, but as <style>, to improve speed. This means the original URL for the style is lost in devtools.
Used to look like this:
![image](https://user-images.githubusercontent.com/17484114/100147544-44cb6400-2e7a-11eb-83d5-56a5cb0f967b.png)
Now looks like this:
![image](https://user-images.githubusercontent.com/17484114/100147480-2feed080-2e7a-11eb-90ee-1087e6549df6.png)
