### PR TITLE
Ctrl+click addon name to show IDs instead of names

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -115,7 +115,7 @@
                   <img v-if="addon._category === 'editor'" src="../../images/icons/puzzle.svg" class="icon-type" />
                   <img v-if="addon._category === 'community'" src="../../images/icons/web.svg" class="icon-type" />
                   <img v-if="addon._category === 'theme'" src="../../images/icons/brush.svg" class="icon-type" />
-                  {{ addon.name }}
+                  <span @click.ctrl="devShowAddonIds">{{ addon.name }}</span>
                 </div>
               </div>
               <div class="badge blue tooltip" v-if="addon._tags.recommended">

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -245,6 +245,14 @@ const vue = new Vue({
         }
       });
     },
+    devShowAddonIds(event) {
+      if (!this.versionName.endsWith("-prerelease") || this.shownAddonIds) return;
+      event.stopPropagation();
+      this.shownAddonIds = true;
+      this.manifests.forEach(manifest => {
+        manifest.name = manifest._addonId;
+      });
+    }
   },
   watch: {
     selectedTab() {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -249,10 +249,10 @@ const vue = new Vue({
       if (!this.versionName.endsWith("-prerelease") || this.shownAddonIds) return;
       event.stopPropagation();
       this.shownAddonIds = true;
-      this.manifests.forEach(manifest => {
+      this.manifests.forEach((manifest) => {
         manifest.name = manifest._addonId;
       });
-    }
+    },
   },
   watch: {
     selectedTab() {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -729,6 +729,7 @@ input[type="color"]::-webkit-color-swatch {
   position: relative;
   display: inline-block;
   border-bottom: 1px dotted rgb(255 255 255 / 0.5);
+  cursor: default;
 }
 
 .tooltip .tooltiptext {


### PR DESCRIPTION
Resolves #726 - ctrl+click any addon name in the settings page (while on prerelease), and all addon names will be replaced with addon IDs.
Minor CSS change to tags - use default cursor when hovering them, instead of the text cursor.