### PR TITLE
Bump to v1.4.0

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -14,18 +14,6 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
       "Scratch Addons ping": "addons-ping",
     };
 
-    // TODO: remove on v1.4.0
-    // Turns on some old addons for existing users, after the removal of the prototype
-    // handler. To detect if this is the first run on v1.3.0 update, we check if a
-    // new addon added on v1.3.0 has an undefined value for enabled. We also make
-    // sure this is not the first run ever by checking if addonsEnabled ~= {}
-    if (Object.keys(addonsEnabled) !== 0 && addonsEnabled["animated-thumb"] === undefined) {
-      addonsEnabled["60fps"] = true;
-      addonsEnabled["full-signature"] = true;
-      addonsEnabled["studio-tools"] = true;
-      madeAnyChanges = true;
-    }
-
     for (const { manifest, addonId } of scratchAddons.manifests) {
       const settings = addonSettings[addonId] || {};
       let madeChangesToAddon = false;

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "1.4.0",
-  "version_name": "1.4.0-prerelease",
+  "version_name": "1.4.0",
   "default_locale": "en",
   "background": {
     "page": "background/background.html"


### PR DESCRIPTION
Removes a ` TODO: remove on v1.4.0`, bumps to non-prerelease v1.4.0