### PR TITLE
Run addons in iframes

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,6 +1,6 @@
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "sendContentScriptInfo") {
-    chrome.tabs.sendMessage(sender.tab.id, "getInitialUrl", {frameId: sender.tab.frameId}, async (res) => {
+    chrome.tabs.sendMessage(sender.tab.id, "getInitialUrl", { frameId: sender.tab.frameId }, async (res) => {
       if (res) {
         chrome.tabs.sendMessage(sender.tab.id, { contentScriptInfo: await getContentScriptInfo(res) });
       }
@@ -92,7 +92,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       try {
         await new Promise((resolve, reject) => {
           // Message the main frame of the tab, if we get a response, it's scratch.mit.edu
-          chrome.tabs.sendMessage(request.tabId, "getInitialUrl", {frameId: 0}, (res) => {
+          chrome.tabs.sendMessage(request.tabId, "getInitialUrl", { frameId: 0 }, (res) => {
             if (res) resolve();
           });
           setTimeout(reject, 500);
@@ -120,7 +120,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 
     let timesSent = 0;
     const interval = setInterval(() => {
-      chrome.tabs.sendMessage(request.tabId, { contentScriptInfo: data }, {frameId: request.frameId}, (res) => {
+      chrome.tabs.sendMessage(request.tabId, { contentScriptInfo: data }, { frameId: request.frameId }, (res) => {
         if (res) removeInterval(`${request.tabId},${request.frameId}`, interval, messageListener);
       });
       timesSent++;
@@ -128,7 +128,11 @@ chrome.webRequest.onBeforeRequest.addListener(
     }, 100);
 
     messageListener = (request, sender, sendResponse) => {
-      if (request === "ready" && sender.tab.id === request.tabId && sender.tab.frameId === requestAnimationFrame.frameId) {
+      if (
+        request === "ready" &&
+        sender.tab.id === request.tabId &&
+        sender.tab.frameId === requestAnimationFrame.frameId
+      ) {
         chrome.tabs.sendMessage(
           request.tabId,
           { contentScriptInfo: data },
@@ -159,9 +163,13 @@ scratchAddons.localEvents.addEventListener("themesUpdated", () => {
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
       if (tab.url || (!tab.url && typeof browser !== "undefined")) {
-        chrome.tabs.sendMessage(tab.id, "getInitialUrl", {frameId: 0}, async (res) => {
+        chrome.tabs.sendMessage(tab.id, "getInitialUrl", { frameId: 0 }, async (res) => {
           if (res) {
-            chrome.tabs.sendMessage(tab.id, { themesUpdated: (await getContentScriptInfo(res)).themes }, {frameId: 0});
+            chrome.tabs.sendMessage(
+              tab.id,
+              { themesUpdated: (await getContentScriptInfo(res)).themes },
+              { frameId: 0 }
+            );
           }
         });
       }

--- a/background/handle-messages.js
+++ b/background/handle-messages.js
@@ -123,7 +123,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "getMsgCount") {
     (async () => {
       const count = await scratchAddons.methods.getMsgCount();
-      chrome.tabs.sendMessage(sender.tab.id, { setMsgCount: count });
+      chrome.tabs.sendMessage(sender.tab.id, { setMsgCount: count }, {frameId: request.tab.frameId});
     })();
   }
 });

--- a/background/handle-messages.js
+++ b/background/handle-messages.js
@@ -123,7 +123,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "getMsgCount") {
     (async () => {
       const count = await scratchAddons.methods.getMsgCount();
-      chrome.tabs.sendMessage(sender.tab.id, { setMsgCount: count }, {frameId: request.tab.frameId});
+      chrome.tabs.sendMessage(sender.tab.id, { setMsgCount: count }, { frameId: request.tab.frameId });
     })();
   }
 });

--- a/background/imports/global-state.js
+++ b/background/imports/global-state.js
@@ -40,6 +40,9 @@ class StateProxy {
 }
 
 function messageForAllTabs(message) {
+  // May log errors to the console in Firefox, where we don't have the permission
+  // to read URLs from tabs even if we have content scripts on them.
+  // No need to specify frame IDs, because this message should also arrive to iframes.
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach(
       (tab) => (tab.url || (!tab.url && typeof browser !== "undefined")) && chrome.tabs.sendMessage(tab.id, message)

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,11 +1,17 @@
+try {
+  if (window.parent.location.origin !== "https://scratch.mit.edu") throw "Scratch Addons: not first party iframe";
+} catch {
+  throw "Scratch Addons: not first party iframe";
+}
+
 let initialUrl = location.href;
 let path = new URL(initialUrl).pathname.substring(1);
-if (path[path.length - 1] === "/") path += "/";
+if (path[path.length - 1] !== "/") path += "/";
 const pathArr = path.split("/");
 if (pathArr[0] === "scratch-addons-extension") {
   if (pathArr[1] === "settings") chrome.runtime.sendMessage("openSettingsOnThisTab");
 }
-if (path === "discuss/3/topic/add//") window.addEventListener("load", forumWarning);
+if (path === "discuss/3/topic/add/") window.addEventListener("load", forumWarning);
 
 let receivedContentScriptInfo = false;
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/manifest.json
+++ b/manifest.json
@@ -22,12 +22,14 @@
     {
       "matches": ["https://scratch.mit.edu/*"],
       "run_at": "document_start",
-      "js": ["content-scripts/cs.js"]
+      "js": ["content-scripts/cs.js"],
+      "all_frames": true
     },
     {
       "matches": ["https://scratch.mit.edu/*"],
       "run_at": "document_start",
-      "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"]
+      "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],
+      "all_frames": true
     }
   ],
   "options_ui": {


### PR DESCRIPTION
Resolves #702

Caveats:
- `about:blank` iframes not supported (at least for now)
- No theme autoupdate in iframes (at least for now)
- Only first party iframes run addons. If example.com embeds a Scratch project, it won't run addons on it.

This means, pause button & 60fps and live featured project now work together:
![image](https://user-images.githubusercontent.com/17484114/100791571-2de7bd00-33f8-11eb-82bb-3cb2a986ad03.png)
