### PR TITLE
Dark website: don't affect editor and fullscreen

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -1,10 +1,10 @@
-body,
-h1,
-h2,
-h3,
-h4,
-h5,
-p,
+body:not(.sa-body-editor),
+body:not(.sa-body-editor) h1,
+body:not(.sa-body-editor) h2,
+body:not(.sa-body-editor) h3,
+body:not(.sa-body-editor) h4,
+body:not(.sa-body-editor) h5,
+body:not(.sa-body-editor) p,
 .news li p,
 a.social-messages-profile-link,
 .outer .sort-mode .select select,
@@ -143,12 +143,6 @@ input[type="checkbox"].formik-checkbox,
 }
 .social-message-icon {
   opacity: 0.5;
-}
-.stage-header_stage-header-wrapper-overlay_5vfJa {
-  background: #333;
-}
-.stage_stage-wrapper-overlay_fmZuD {
-  background: #282828;
 }
 .intro-banner {
   background: transparent;

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -37,6 +37,14 @@ scratchAddons.methods.getMsgCount = () => {
   return promise;
 };
 
+function bodyIsEditorClassCheck() {
+  const pathname = location.pathname.toLowerCase();
+  const split = pathname.split("/").filter(Boolean);
+  if (split.includes("editor") || split.includes("fullscreen")) document.body.classList.add("sa-body-editor");
+  else document.body.classList.remove("sa-body-editor");
+}
+bodyIsEditorClassCheck();
+
 const originalReplaceState = history.replaceState;
 history.replaceState = function () {
   const oldUrl = location.href;
@@ -45,6 +53,7 @@ history.replaceState = function () {
   for (const eventTarget of scratchAddons.eventTargets.tab) {
     eventTarget.dispatchEvent(new CustomEvent("urlChange", { detail: { oldUrl, newUrl } }));
   }
+  bodyIsEditorClassCheck();
   return returnValue;
 };
 
@@ -56,6 +65,7 @@ history.pushState = function () {
   for (const eventTarget of scratchAddons.eventTargets.tab) {
     eventTarget.dispatchEvent(new CustomEvent("urlChange", { detail: { oldUrl, newUrl } }));
   }
+  bodyIsEditorClassCheck();
   return returnValue;
 };
 


### PR DESCRIPTION
Resolves #846 

- `module.js` is now in charge of adding or removing a `sa-body-editor` class to the `<body>` element. This class is then used by "dark website" to only style the body, and also used by some very generic selectors (like `h1`) to avoid styling when the page is in either editor mode or full screen mode.
- Remove styles that affect full screen mode. We're considering full screen mode part of the editor.