### PR TITLE
Update signature.css to make the divider line stationary

### DIFF
--- a/addons/full-signature/signature.css
+++ b/addons/full-signature/signature.css
@@ -1,4 +1,4 @@
-.postsignature {
+.postsignature > div:last-child {
   overflow-y: auto !important;
   resize: vertical;
   max-height: fit-content !important;


### PR DESCRIPTION
This makes the divider line stay in one place, so it does not look like the signature is part of the post.

**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

I would have made an issue, but I could fix it so i did

**Changes**

edided the css selector

**Reason for changes**

to make it look nicer

**Tests**

I tested it through DevTools