### PR TITLE
Partially revert #669

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -86,7 +86,7 @@
     },
     {
       "name": "extensions",
-      "id": "extensions-color",
+      "id": "Pen-color",
       "type": "color",
       "default": "#0FBD8C"
     }
@@ -119,7 +119,7 @@
         "data-color": "#ee7d16",
         "data-lists-color": "#cc5b22",
         "custom-color": "#632d99",
-        "extensions-color": "#0e9a6c"
+        "Pen-color": "#0e9a6c"
       }
     }
   ],

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -86,18 +86,6 @@ g > line {
   background-color: var(--editorTheme3-extensionsColor);
 }
 
-[data-category="Pen"] > path.blocklyBlockBackground,
-[data-category="Music"] > path.blocklyBlockBackground,
-[data-category="Video Sensing"] > path.blocklyBlockBackground,
-[data-category="Text to Speech"] > path.blocklyBlockBackground,
-[data-category="Translate"] > path.blocklyBlockBackground,
-[data-category="Makey Makey"] > path.blocklyBlockBackground,
-[data-category="micro:bit"] > path.blocklyBlockBackground,
-[data-category="LEGO EV3"] > path.blocklyBlockBackground,
-[data-category="BOOST"] > path.blocklyBlockBackground {
-  fill: var(--editorTheme3-extensionsColor);
-}
-
 .blocklyEditableText rect {
   fill: var(--editorTheme3-customColor);
 }

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -60,8 +60,9 @@ export default async function ({ addon, global, console }) {
       color: "#FF6680",
       alt: "myBlocks",
     },
-    extensions: {
+    Pen: { // For historical reasons, this is called "Pen".
       color: "#0FBD8C",
+      alt: "pen",
     },
   };
 

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -60,7 +60,8 @@ export default async function ({ addon, global, console }) {
       color: "#FF6680",
       alt: "myBlocks",
     },
-    Pen: { // For historical reasons, this is called "Pen".
+    Pen: {
+      // For historical reasons, this is called "Pen".
       color: "#0FBD8C",
       alt: "pen",
     },


### PR DESCRIPTION
Partially reverts #669

- Removes duplicate CSS
- Revert changes to addon settings ID so that settings are not lost during updates.