### PR TITLE
Color setting input: 250ms cooldown on change

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -230,7 +230,7 @@
                     type="color"
                     class="setting-input color"
                     v-model="addonSettings[addon._addonId][setting.id]"
-                    @input="updateSettings(addon)"
+                    @input="updateSettings(addon, {wait: 250, settingId: setting.id})"
                     :disabled="!addon._enabled"
                     v-if="setting.type === 'color'"
                     :placeholder="setting.default"

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -211,11 +211,16 @@ const vue = new Vue({
       this.addonSettings[addon._addonId][id] = newValue;
       this.updateSettings(addon);
     },
-    updateSettings(addon) {
-      chrome.runtime.sendMessage({
-        changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] },
-      });
-      console.log("Updated", this.addonSettings[addon._addonId]);
+    updateSettings(addon, { wait = 0, settingId = null } = {}) {
+      const value = settingId && this.addonSettings[addon._addonId][settingId];
+      setTimeout(() => {
+        if (!settingId || settingId && this.addonSettings[addon._addonId][settingId] === value) {
+          chrome.runtime.sendMessage({
+            changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] },
+          });
+          console.log("Updated", this.addonSettings[addon._addonId]);
+        }
+      }, wait);
     },
     loadPreset(preset, addon) {
       if (window.confirm(chrome.i18n.getMessage("confirmPreset"))) {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -214,7 +214,7 @@ const vue = new Vue({
     updateSettings(addon, { wait = 0, settingId = null } = {}) {
       const value = settingId && this.addonSettings[addon._addonId][settingId];
       setTimeout(() => {
-        if (!settingId || settingId && this.addonSettings[addon._addonId][settingId] === value) {
+        if (!settingId || (settingId && this.addonSettings[addon._addonId][settingId] === value)) {
           chrome.runtime.sendMessage({
             changeAddonSettings: { addonId: addon._addonId, newSettings: this.addonSettings[addon._addonId] },
           });


### PR DESCRIPTION
Before this PR, color settings would update every time the inputs fired oninput, which meant multiple times per second. This might cause memory leaks because the setting themselves are changing multiple times per second. It could also cause significant hard drive write activity (to be honest, I could hear it while testing on Firefox - drive go brr when changing color settings)
With this PR, color settings are only updated after 250ms without changes. RAM usage might temporarily appear to skyrocket, but it's used by the settings page, not the background page, so after the settings page is closed all that can be cleared.