### PR TITLE
Add beta tag to "more links"

### DIFF
--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -16,7 +16,7 @@
       ]
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "beta"],
   "libraries": ["linkify"],
   "enabledByDefault": false,
   "l10n": true


### PR DESCRIPTION
Me and others have experienced some lag while browsing the website, likely Linkify blocking the main thread. As a first measure we should likely mark this addon as beta.

cc @Hans5958 