### PR TITLE
Fix can't read report pop up text with website dark mode

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -119,3 +119,7 @@ tbody#logs * {
 #search-input {
   background-color: #fff;
 }
+
+.ui-dialog-content {
+  color: black;
+}


### PR DESCRIPTION
Resolves #1088 

The proper way to do this might be darkifying the modal, but this is OK for now.

cc @mxmou