### PR TITLE
Fix some bugs in project-notes-tabs

### DIFF
--- a/addons/project-notes-tabs/addon.json
+++ b/addons/project-notes-tabs/addon.json
@@ -10,7 +10,8 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["https://scratch.mit.edu/projects/*"],
+      "runAtComplete": false
     }
   ],
   "userstyles": [

--- a/addons/project-notes-tabs/style.css
+++ b/addons/project-notes-tabs/style.css
@@ -1,7 +1,5 @@
 .tabs-sa {
   display: flex;
-  width: -moz-fit-content;
-  width: fit-content;
   overflow: hidden;
   margin-bottom: 0 !important;
 }

--- a/addons/project-notes-tabs/style.css
+++ b/addons/project-notes-tabs/style.css
@@ -3,6 +3,7 @@
   width: -moz-fit-content;
   width: fit-content;
   overflow: hidden;
+  margin-bottom: 0 !important;
 }
 
 .tab-choice-sa {
@@ -18,6 +19,7 @@
   border-radius: 12px 12px 0 0;
   border-color: rgba(77, 151, 255, 0.1);
   background-color: rgb(63 120 202 / 4%);
+  margin-left: 5px;
 }
 
 .tab-choice-sa span {
@@ -26,11 +28,16 @@
   font-weight: bold;
 }
 
-.sa-selected {
+.tab-choice-selected-sa {
   background-color: rgba(77, 151, 255, 0.1);
 }
 
+.description-block {
+  overflow: auto;
+  margin-bottom: 0 !important;
+}
+
 .project-description {
-  height: -webkit-fill-available;
-  width: -moz-available;
+  height: 100%;
+  box-sizing: border-box;
 }

--- a/addons/project-notes-tabs/userscript.js
+++ b/addons/project-notes-tabs/userscript.js
@@ -1,8 +1,8 @@
 export default async function ({ addon, global, console }) {
-  const instructionsLabel = addon.tab.scratchMessage("project.instructionsLabel");
-  const creditsLabel = addon.tab.scratchMessage("project.notesAndCreditsLabel");
   while (true) {
     let projectNotes = await addon.tab.waitForElement(".project-notes", { markAsSeen: true });
+    const instructionsLabel = addon.tab.scratchMessage("project.instructionsLabel");
+    const creditsLabel = addon.tab.scratchMessage("project.notesAndCreditsLabel");
     let allLabels = document.querySelectorAll(".project-textlabel").length;
     for (let i = 0; i < allLabels; i++) {
       document.querySelector(".project-textlabel").remove();
@@ -28,7 +28,7 @@ export default async function ({ addon, global, console }) {
     for (var i = 0; i < tabs.querySelectorAll(".tab-choice-sa").length; i++) {
       tabs.querySelectorAll(".tab-choice-sa")[i].addEventListener("click", function (e) {
         selectTab(
-          (e.path[0].classList.length ? e.path[0].children[0] : e.path[0]).innerText === instructionsLabel ? 0 : 1
+          e.target.closest(".tab-choice-sa").innerText === instructionsLabel ? 0 : 1
         );
       });
     }

--- a/addons/project-notes-tabs/userscript.js
+++ b/addons/project-notes-tabs/userscript.js
@@ -2,7 +2,7 @@ export default async function ({ addon, global, console }) {
   async function remixHandler() {
     while (true) {
       await addon.tab.waitForElement(".remix-credit", { markAsSeen: true });
-      projectNotes.insertBefore(tabs, document.querySelector(".description-block"));
+      projectNotes.insertBefore(tabs, projectNotes.querySelector(".description-block"));
     }
   }
 

--- a/addons/project-notes-tabs/userscript.js
+++ b/addons/project-notes-tabs/userscript.js
@@ -1,50 +1,52 @@
 export default async function ({ addon, global, console }) {
+  async function remixHandler() {
+    while (true) {
+      await addon.tab.waitForElement(".remix-credit", { markAsSeen: true });
+      projectNotes.insertBefore(tabs, document.querySelector(".description-block"));
+    }
+  }
+
+  let projectNotes;
+  let tabs;
+
   while (true) {
-    let projectNotes = await addon.tab.waitForElement(".project-notes", { markAsSeen: true });
-    const instructionsLabel = addon.tab.scratchMessage("project.instructionsLabel");
-    const creditsLabel = addon.tab.scratchMessage("project.notesAndCreditsLabel");
-    let allLabels = document.querySelectorAll(".project-textlabel").length;
-    for (let i = 0; i < allLabels; i++) {
-      document.querySelector(".project-textlabel").remove();
+    projectNotes = await addon.tab.waitForElement(".project-notes", { markAsSeen: true });
+
+    const labels = document.querySelectorAll(".project-textlabel");
+    const descriptions = document.querySelectorAll(".description-block");
+    const tabButtons = [];
+    const sectionCount = descriptions.length;
+    for (const label of labels) {
+      label.remove();
     }
-    let tabs = projectNotes.insertBefore(
-      document.createElement("div"),
-      projectNotes.querySelector(".description-block")
-    );
+
+    tabs = projectNotes.insertBefore(document.createElement("div"), projectNotes.querySelector(".description-block"));
     tabs.classList.add("tabs-sa");
-    tabs.style.marginBottom = "0px";
-    if (allLabels - 1) {
-      let intTab = tabs.appendChild(document.createElement("div"));
-      intTab.classList.add("tab-choice-sa");
-      let innerTab = intTab.appendChild(document.createElement("span"));
-      innerTab.innerText = instructionsLabel;
-      intTab.style.marginLeft = "5px";
+
+    if (!remixHandler.run) {
+      remixHandler.run = true;
+      remixHandler();
     }
-    let notesTab = tabs.appendChild(document.createElement("div"));
-    notesTab.classList.add("tab-choice-sa");
-    let innerTab = notesTab.appendChild(document.createElement("span"));
-    innerTab.innerText = creditsLabel;
-    if (!(allLabels - 1)) notesTab.style.marginLeft = "5px";
-    for (var i = 0; i < tabs.querySelectorAll(".tab-choice-sa").length; i++) {
-      tabs.querySelectorAll(".tab-choice-sa")[i].addEventListener("click", function (e) {
-        selectTab(
-          e.target.closest(".tab-choice-sa").innerText === instructionsLabel ? 0 : 1
-        );
-      });
+
+    for (let i = 0; i < sectionCount; i++) {
+      const tab = document.createElement("div");
+      tab.classList.add("tab-choice-sa");
+      const inner = document.createElement("span");
+      inner.innerText = labels[i].innerText;
+      tab.appendChild(inner);
+      tab.addEventListener("click", () => selectTab(i));
+      tabButtons.push(tab);
+      tabs.appendChild(tab);
     }
-    selectTab(0);
-    function selectTab(tab) {
-      tabs.querySelectorAll(".tab-choice-sa")[tab].classList.add("sa-selected");
-      tabs.querySelectorAll(".tab-choice-sa")[!tab + 0].classList.remove("sa-selected");
-      document.querySelectorAll(".description-block")[tab].style.marginBottom = "0rem";
-      document.querySelectorAll(".description-block")[tab].style.display = "block";
-      document.querySelectorAll(".description-block")[!tab + 0].style.display = "none";
-    }
-    (async function remixHandler() {
-      while (true) {
-        await addon.tab.waitForElement(".remix-credit", { markAsSeen: true });
-        projectNotes.insertBefore(tabs, projectNotes.querySelector(".description-block"));
+
+    function selectTab(index) {
+      for (let i = 0; i < sectionCount; i++) {
+        const selected = i === index;
+        tabButtons[i].classList.toggle("tab-choice-selected-sa", selected);
+        descriptions[i].style.display = selected ? "" : "none";
       }
-    })();
+    }
+
+    selectTab(0);
   }
 }


### PR DESCRIPTION
**Changes**

Here's the bugs in project-notes-tabs that this fixes:

 - the tab buttons did not work at all in Firefox
 - instructions would not fill empty space in Firefox
 - it would throw errors and stop working after the initial page load when there is only one section
 - if the project only had instructions, the tab would be called "Notes and credits"
 - the tab buttons could occasionally appear above the remix credit box
 - there was a brief period of time (before onload) where the unmodified instructions and n&c are shown without tabs.

**Tests**

Tested on these projects (just found from trending) in Chrome and Firefox:

 - https://scratch.mit.edu/projects/467543815/
 - https://scratch.mit.edu/projects/455720538/
 - https://scratch.mit.edu/projects/455488994/

Editing descriptions still works. Doesn't break if you go in/out of editor. Remixing a project works fine
