### PR TITLE
Optimizations and bug fixes for editor-devtools

### DIFF
--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -137,7 +137,7 @@ div.s3devDDOut.vis ul.s3devDD {
 }
 
 #s3devDD > li::before {
-  content: "● ";
+  content: "\25CF "; /* ● */
 }
 
 .define {

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -2160,9 +2160,6 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
     let picklist, pickField;
 
     let dom = doms[block.id];
-    if (!dom) {
-      debugger;
-    }
 
     // dom = doms[block.type];
 

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -489,6 +489,13 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
     return topBlocks;
   }
 
+  function hidePopups(wksp) {
+    // Fire fake mouse events to trick the popup into hiding.
+    const element = wksp.getToolbox().HtmlDiv;
+    element.dispatchEvent(new MouseEvent("mousedown", { relatedTarget: element, bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mouseup", { relatedTarget: element, bubbles: true }));
+  }
+
   /**
    * A much nicer way of laying out the blocks into columns
    */
@@ -497,8 +504,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
       e.cancelBubble = true;
       e.preventDefault();
       let wksp = getWorkspace();
-      wksp.setVisible(false);
-      wksp.setVisible(true);
+      hidePopups(wksp);
       setTimeout(doCleanUp, 0);
       return;
     }
@@ -1554,9 +1560,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
 
   function clickReplace(e) {
     let wksp = getWorkspace();
-    // Toggle workspace visibility to hide the popup
-    wksp.setVisible(false);
-    wksp.setVisible(true);
+    hidePopups(wksp);
 
     setTimeout(function () {
       let wksp = getWorkspace();
@@ -1777,8 +1781,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
                       style: "user-select: none;",
                     });
                     googMenuItem.addEventListener("click", () => {
-                      wksp.setVisible(false);
-                      wksp.setVisible(true);
+                      hidePopups(wksp);
                       showBroadcastSingleton[`show${showKey}`](broadcastId);
                     });
                     googMenuItem.appendChild(googMenuItemContent);
@@ -1859,9 +1862,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
 
             function eventCopyClick(e, blockOnly) {
               let wksp = getWorkspace();
-              // Toggle workspace visibility to hide the popup
-              wksp.setVisible(false);
-              wksp.setVisible(true);
+              hidePopups(wksp);
 
               let block = wksp.getBlockById(dataId);
               if (block) {
@@ -1891,9 +1892,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
             if (pasteDiv) {
               pasteDiv.addEventListener("click", function () {
                 let wksp = getWorkspace();
-                // Toggle workspace visibility to hide the popup
-                wksp.setVisible(false);
-                wksp.setVisible(true);
+                hidePopups(wksp);
 
                 let ids = getTopBlockIDs();
 

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -607,7 +607,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
       if (unusedLocals.length > 0) {
         const unusedCount = unusedLocals.length;
         let message = msg("unused-var", {
-          count: unusedCount
+          count: unusedCount,
         });
         for (let i = 0; i < unusedLocals.length; i++) {
           let orphan = unusedLocals[i];

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -1915,7 +1915,9 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
                     }
                     if (blockOnly === 2) {
                       let block = wksp.getBlockById(dataId);
+                      startUndoGroup(wksp);
                       block.dispose(true);
+                      endUndoGroup(wksp);
                     }
                   }, 0);
                 }

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -512,7 +512,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
     }
   }
 
-  function endUndoGroup() {
+  function endUndoGroup(wksp) {
     const undoStack = wksp.undoStack_;
     // Events (responsible for undoStack updates) are delayed with a setTimeout(f, 0)
     // https://github.com/LLK/scratch-blocks/blob/f159a1779e5391b502d374fb2fdd0cb5ca43d6a2/core/events.js#L182

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -607,10 +607,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
       if (unusedLocals.length > 0) {
         const unusedCount = unusedLocals.length;
         let message = msg("unused-var", {
-          count: unusedCount,
-          it: unusedCount === 1 ? msg("it") : msg("them"),
-          plural: unusedCount === 1 ? msg("variable") : msg("variables"),
-          list: unusedCount === 1 ? msg("it-is") : msg("they-are"),
+          count: unusedCount
         });
         for (let i = 0; i < unusedLocals.length; i++) {
           let orphan = unusedLocals[i];


### PR DESCRIPTION
**Changes**

 - The addon previously used an interesting method to hide the context menu when a button is clicked: hide the entire workspace and show it again. This is horribly slow on large projects because all the styles have to get recomputed. It now uses fake events to trick it into hiding (without access to the real Blockly and without using Blockly's builtin context menu handling, this seems to be the most consistent way to do this) which makes any context menu operation (copy, cut, paste, swap variable, show senders/receivers...) significantly faster.
   - "Copy block" before & after: [2.37 seconds](https://user-images.githubusercontent.com/33787854/103255960-fca7d180-4950-11eb-9e75-e6a5ce523d02.png) to [~200ms](https://user-images.githubusercontent.com/33787854/103256058-5e683b80-4951-11eb-9bfc-8073b8aff281.png) (Runtime sprite in https://scratch.mit.edu/projects/290745095/editor/)
   - "Show senders/receivers" before & after: [236ms](https://user-images.githubusercontent.com/33787854/103256452-fa467700-4952-11eb-85b4-258987c2c869.png) to [28ms](https://user-images.githubusercontent.com/33787854/103256490-12b69180-4953-11eb-8d83-a2fff433946e.png) (Player sprite of https://scratch.mit.edu/projects/60917032/editor/)
 - Swaps, cleanups, and cuts can be undone/redone with a single undo/redo instead of many.
 - Remove leftover `debugger;` and references to removed messages

**Tests**

it probably works fine