### PR TITLE
Improve hex color picker CSS

### DIFF
--- a/addons/color-picker/paint-editor.js
+++ b/addons/color-picker/paint-editor.js
@@ -63,7 +63,7 @@ export default async ({ addon, console, msg }) => {
       value: defaultColor || "#000000",
     });
     const saColorPickerText = Object.assign(document.createElement("input"), {
-      className: "sa-color-picker-text sa-color-picker-paint-text",
+      className: "sa-color-picker-text sa-color-picker-paint-text input_input-form_1Y0wX",
       type: "text",
       pattern: "^#?([0-9a-fA-F]{3}){1,2}$",
       placeholder: msg("hex"),

--- a/addons/color-picker/style.css
+++ b/addons/color-picker/style.css
@@ -1,22 +1,59 @@
 .sa-color-picker {
   display: flex;
-  margin-top: 0.5rem;
+}
+
+.sa-color-picker-code {
+  margin: 8px 0;
+}
+
+.sa-color-picker-paint {
+  margin-top: 16px;
+  margin-bottom: 4px;
 }
 
 .sa-color-picker > .sa-color-picker-color {
   border: none;
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
   padding: 0;
+  padding-left: 0.6rem;
+  padding-right: 0.4rem;
   margin: 0 0 0 0.5rem;
   outline: none;
-  width: 30px;
-  height: 30px;
+  box-sizing: border-box;
+  width: 3rem;
+  height: 2rem;
 }
 
 .sa-color-picker > .sa-color-picker-text {
+  box-sizing: border-box;
+  width: calc(150px - 3rem);
+}
+
+.sa-color-picker > .sa-color-picker-code-text {
   border-radius: 0;
-  border-color: rgba(0, 0, 0, 0.15);
+  border-top-right-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-sizing: border-box;
+  width: calc(150px - 3rem);
+  height: 2rem;
+  padding: 0 0.75rem;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: bold;
+  transition: all 0.25s ease-out;
+}
+
+.sa-color-picker > .sa-color-picker-code-text:focus {
   outline: none;
-  width: 115px;
+  border-color: hsla(215, 100%, 65%, 1);
+  box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
+}
+
+.sa-color-picker > .sa-color-picker-paint-text {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 body.sa-hide-eye-dropper-background div[class*="stage_color-picker-background"] {


### PR DESCRIPTION
**Resolves**

Resolves #1126

**Changes**

Improves the styling of the hex color picker addon. Now it looks good in all dark mode variants.
![Screenshot with Experimental Dark](https://user-images.githubusercontent.com/51849865/103406299-870f5180-4b5a-11eb-8861-e358a98d8b17.png)

**Reason for changes**

#1126, and consistency with Scratch's design.

**Tests**

See screenshot above.
