### PR TITLE
Fix double scrollbar in popup

### DIFF
--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -13,7 +13,7 @@ body {
   margin: 0 auto;
   font-family: "Sora", sans-serif;
   width: auto;
-  height: 500px;
+  height: 491px;
   overflow-x: hidden;
   overflow-y: scroll;
   background-color: #222;

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -13,7 +13,7 @@ body {
   margin: 0 auto;
   font-family: "Sora", sans-serif;
   width: auto;
-  height: 491px;
+  height: 490px;
   overflow-x: hidden;
   overflow-y: scroll;
   background-color: #222;

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -20,7 +20,7 @@ document.getElementById("settings").onclick = () => {
 };
 
 window.addEventListener("load", () => {
-  let height = window.innerHeight - 2;
+  let height = window.innerHeight - 3;
   document.documentElement.style.setProperty("--height", `${height}px`);
 });
 

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -19,6 +19,12 @@ document.getElementById("settings").onclick = () => {
   setTimeout(() => window.close(), 100);
 };
 
+window.addEventListener("load", () => {
+  let height = window.innerHeight - 2;
+  console.log(height);
+  document.documentElement.style.setProperty("--height", `${height}px`);
+});
+
 const popups = [
   {
     addonId: "scratch-messaging",

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -21,7 +21,6 @@ document.getElementById("settings").onclick = () => {
 
 window.addEventListener("load", () => {
   let height = window.innerHeight - 2;
-  console.log(height);
   document.documentElement.style.setProperty("--height", `${height}px`);
 });
 

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -3,6 +3,7 @@ html {
 }
 
 body {
+  height: var(--height, 599px);
   margin: 0;
   font-family: "Sora", sans-serif;
   color: white;
@@ -94,7 +95,7 @@ body {
 
 iframe {
   width: 400px;
-  height: 468px;
+  height: calc(var(--height, 599px) - 107px);
   overflow-x: hidden;
   overflow-y: auto;
   border: none;


### PR DESCRIPTION
**Resolves**

Resolves #600 (finally)

**Changes**

Removes the double scrollbar in the popup when browser zoom is set to more than 100%. I don't like the solution because it uses JavaScript, but I don't know how else I could fix it. I also changed the height of the messaging tab so there is no scrollbar unless there are many messages.

**Reason for changes**

#600

**Tests**

I was able to zoom up to 175% before the second scrollbar appeared.