### PR TITLE
Fix blue usernames in messages

### DIFF
--- a/addons/scratchr2/scratchwww.css
+++ b/addons/scratchr2/scratchwww.css
@@ -21,3 +21,6 @@ a:hover,
   background-color: var(--scratchr2-primaryColor);
   color: #fff;
 }
+a.social-messages-profile-link {
+  color: inherit;
+}


### PR DESCRIPTION
Resolves #1186. Username links in messages are now black.