### PR TITLE
Fix clean up deleting extension blocks

### DIFF
--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -633,7 +633,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
    * @returns {boolean}
    */
   function isBlockAnOrphan(topBlock) {
-    if (topBlock.getOutputShape() && !topBlock.getSurroundParent()) {
+    if (topBlock.getOutputShape() && topBlock.getOutputShape() != 3 && !topBlock.getSurroundParent()) {
       return true;
     }
     return false;


### PR DESCRIPTION
**Resolves**

Resolves #1194

**Changes**

The clean up feature no longer detects extension blocks as orphaned reporters. This was done by not counting the square output shape (which was originally used for text input shadow blocks) as a reporter.

**Reason for changes**

#1194

**Tests**

![extcleanup](https://user-images.githubusercontent.com/51849865/103553772-35462e80-4eae-11eb-8178-083d37e81428.gif)