### PR TITLE
Add refreshRequired to manifest

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -244,5 +244,8 @@
   },
   "confirmImport": {
     "message": "Confirm"
+  },
+  "refreshRequired": {
+    "message": "Refresh the editor after enabling/disabling this theme."
   }
 }

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,13 +1,7 @@
 {
   "name": "Colored context menus",
   "description": "Makes the editor context menus colorful when right-clicking a block.",
-  "info": [
-    {
-      "type": "notice",
-      "text": "Refresh the editor after enabling/disabling this theme.",
-      "id": "refresheditor"
-    }
-  ],
+  "refreshRequired": true,
   "credits": [
     {
       "name": "GarboMuffin"

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -1,13 +1,7 @@
 {
   "name": "Display stage on left side",
   "description": "Moves the stage to the left side of the editor.",
-  "info": [
-    {
-      "type": "notice",
-      "text": "Refresh the editor after enabling/disabling this theme.",
-      "id": "refresheditor"
-    }
-  ],
+  "refreshRequired": true,
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -1,5 +1,3 @@
-/* sa-autoupdate-theme-ignore */
-
 .stage-header_stage-button-icon_3zzFK {
   transform: scaleX(-1);
 }

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -1,13 +1,7 @@
 {
   "name": "Customizable block colors",
   "description": "Edit block colors for each category in the editor.",
-  "info": [
-    {
-      "type": "notice",
-      "text": "Refresh the editor after enabling/disabling this theme.",
-      "id": "refresheditor"
-    }
-  ],
+  "refreshRequired": true,
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -1,5 +1,3 @@
-/* sa-autoupdate-theme-ignore */
-
 path.blocklyBlockBackground[fill="#FF6680"],
 path.blocklyBlockBackground[fill="#5CB1D6"],
 path.blocklyBlockBackground[fill="#FFBF00"],

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -52,7 +52,12 @@ async function getContentScriptInfo(url) {
       }
       if (styleUrls.length) {
         const styles = {};
-        data.themes.push({ addonId, styleUrls, styles });
+        data.themes.push({
+          addonId,
+          styleUrls,
+          styles,
+          refreshRequired: manifest.refreshRequired,
+        });
         for (const styleUrl of styleUrls) {
           fetchThemeStylesPromises.push(
             fetch(chrome.runtime.getURL(`/addons/${addonId}/${styleUrl}`))

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -63,7 +63,7 @@ window.addEventListener("load", () => {
 
 function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
   document.querySelectorAll(".scratch-addons-theme").forEach((style) => {
-    if (!style.textContent.startsWith("/* sa-autoupdate-theme-ignore */")) style.remove();
+    if (style.getAttribute("data-require-refresh") !== "true") style.remove();
   });
   for (const userstyleUrl of userstyleUrls || []) {
     const link = document.createElement("link");
@@ -77,11 +77,12 @@ function injectUserstylesAndThemes({ userstyleUrls, themes, isUpdate }) {
       let css = theme.styles[styleUrl];
       // Replace %addon-self-dir% for relative URLs
       css = css.replace(/\%addon-self-dir\%/g, chrome.runtime.getURL(`addons/${theme.addonId}`));
-      if (isUpdate && css.startsWith("/* sa-autoupdate-theme-ignore */")) continue;
+      if (isUpdate && theme.refreshRequired) continue;
       css += `\n/*# sourceURL=${styleUrl} */`;
       const style = document.createElement("style");
       style.classList.add("scratch-addons-theme");
       style.setAttribute("data-addon-id", theme.addonId);
+      style.setAttribute("data-require-refresh", String(theme.refreshRequired));
       style.textContent = css;
       if (document.body) document.documentElement.insertBefore(style, document.body);
       else document.documentElement.appendChild(style);

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -169,12 +169,17 @@
             </div>
             <div class="addon-settings" v-show="addon._expanded">
               <div class="addon-description-full" v-show="addon._expanded">{{ addon.description }}</div>
-              <div id="info" v-for="info of addon.info">
-                <div class="addon-warn" v-if="info.type == 'warning'" v-show="addon._expanded">
-                  <img src="../../images/icons/warning.svg" />{{ info.text }}
+              <div id="info">
+                <div v-for="info of addon.info">
+                  <div class="addon-warn" v-if="info.type == 'warning'" v-show="addon._expanded">
+                    <img src="../../images/icons/warning.svg" />{{ info.text }}
+                  </div>
+                  <div class="addon-notice" v-if="info.type == 'notice'" v-show="addon._expanded">
+                    <img src="../../images/icons/notice.svg" />{{ info.text }}
+                  </div>
                 </div>
-                <div class="addon-notice" v-if="info.type == 'notice'" v-show="addon._expanded">
-                  <img src="../../images/icons/notice.svg" />{{ info.text }}
+                <div v-if="addon.refreshRequired" class="addon-notice addon-refresh-notice" v-show="addon._expanded">
+                  <img src="../../images/icons/notice.svg" />{{ msg("refreshRequired") }}
                 </div>
               </div>
               <div class="addon-credits" v-if="addon.credits">


### PR DESCRIPTION
This changes the manifest to add `refreshRequired` which replaces `sa-autoupdate-theme-ignore`. It also shows notice on settings. `refreshRequired` should only be used for themes.