### PR TITLE
Make "mute project" addon recommended

### DIFF
--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -13,6 +13,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "l10n": true
 }


### PR DESCRIPTION
This was a 2.0 feature so it should be recommended.
It's close to being enabled by default, but I don't think we're going to turn any new addons by default.