### PR TITLE
Settings page: remove messaging related addons should go first

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -543,9 +543,6 @@ chrome.runtime.sendMessage("getSettingsInfo", async ({ manifests, addonsEnabled,
     } else return 1;
   });
   if (!document.body.classList.contains("iframe")) {
-    // Messaging related addons should always go first no matter what (rule broken below)
-    manifests.sort((a, b) => (a.addonId === "msg-count-badge" ? -1 : b.addonId === "msg-count-badge" ? 1 : 0));
-    manifests.sort((a, b) => (a.addonId === "scratch-messaging" ? -1 : b.addonId === "scratch-messaging" ? 1 : 0));
     // New addons should always go first no matter what
     manifests.sort((a, b) => (NEW_ADDONS.includes(a.addonId) ? -1 : NEW_ADDONS.includes(b.addonId) ? 1 : 0));
     vue.manifests = manifests.map(({ manifest }) => manifest);


### PR DESCRIPTION
It's been a while since the Scratch Messaging transition, and these 2 addons are now in the "popup features" category