### PR TITLE
Fix Scratch 2.0 → 3.0 button styling on scratch-www pages

### DIFF
--- a/addons/remix-tree-button/button.css
+++ b/addons/remix-tree-button/button.css
@@ -1,6 +1,5 @@
 .remixtree-button::before {
   background-image: url("https://scratch.mit.edu/svgs/project/remix-white.svg");
-  background-color: #4d97ff;
   display: inline-block;
   margin-right: 0.25rem;
   background-repeat: no-repeat;

--- a/addons/scratchr2/lightprimary_scratchwww_compatibility.css
+++ b/addons/scratchr2/lightprimary_scratchwww_compatibility.css
@@ -12,7 +12,7 @@
 .intro-banner .intro-header,
 .intro-banner .intro-container,
 .title-banner.mod-messages,
-.subactions .action-buttons .action-button:not(.remixtree-button),
+.subactions .action-buttons .action-button,
 .title-banner-h1.mod-messages,
 .download .download-header,
 .download .download-header .download-info .download-copy .download-title,
@@ -43,7 +43,7 @@
 .account-nav .user-info::after,
 .button img,
 .preview .see-inside-button:before,
-.subactions .action-buttons .action-button:not(.remixtree-button):before,
+.subactions .action-buttons .action-button:before,
 .download .download-requirements span img,
 .os-chooser .button.active img,
 #footer .inner .media li img {

--- a/addons/scratchr2/scratchwww.css
+++ b/addons/scratchr2/scratchwww.css
@@ -27,6 +27,9 @@ a:hover,
   background-color: var(--scratchr2-primaryColor);
   color: #fff;
 }
+.banner-button {
+  background-color: #ffab1a;
+}
 a.social-messages-profile-link {
   color: inherit;
 }


### PR DESCRIPTION
**Resolves**

Resolves #1268

**Changes**

- Fixed blue share button
- Fixed incorrectly styled remix tree button
