### PR TITLE
Fix bug caused by #1273

### DIFF
--- a/addons/scratchr2/lightprimary_scratchwww_compatibility.css
+++ b/addons/scratchr2/lightprimary_scratchwww_compatibility.css
@@ -12,7 +12,7 @@
 .intro-banner .intro-header,
 .intro-banner .intro-container,
 .title-banner.mod-messages,
-.subactions .action-buttons .action-button,
+.subactions .action-buttons .action-button:not(.remixtree-button),
 .title-banner-h1.mod-messages,
 .download .download-header,
 .download .download-header .download-info .download-copy .download-title,
@@ -43,7 +43,7 @@
 .account-nav .user-info::after,
 .button img,
 .preview .see-inside-button:before,
-.subactions .action-buttons .action-button:before,
+.subactions .action-buttons .action-button:not(.remixtree-button):before,
 .download .download-requirements span img,
 .os-chooser .button.active img,
 #footer .inner .media li img {


### PR DESCRIPTION
**Resolves**

Fixes a bug caused by #1273

**Changes**

Makes the text color on the remix tree button independent of the primary color.

**Tests**

Tested by changing the primary color to different values, the button always had white text.
