### PR TITLE
Fix incorrectly placed scrollbar in Firefox with profile banner addon

### DIFF
--- a/addons/better-featured-project/userstyle.css
+++ b/addons/better-featured-project/userstyle.css
@@ -115,3 +115,6 @@
 #lfp-change-featured {
   display: none !important;
 }
+#bio-readonly {
+  width: 285px;
+}


### PR DESCRIPTION
**Resolves**

Resolves #1076

**Changes**

Fixes an incorrectly placed scrollbar in Firefox when the profile page banner addon is enabled.