### PR TITLE
Data category tweaks update

### DIFF
--- a/addons/data-category-tweaks-v2/addon.json
+++ b/addons/data-category-tweaks-v2/addon.json
@@ -25,9 +25,15 @@
       "id": "separateLocalVariables",
       "type": "boolean",
       "default": false
+    },
+    {
+      "name": "Move Reporters Below",
+      "id": "moveReportersDown",
+      "type": "boolean",
+      "default": false
     }
   ],
-  "tags": ["editor", "beta"],
+  "tags": ["editor"],
   "enabledByDefault": false,
   "l10n": true
 }

--- a/addons/data-category-tweaks-v2/addon.json
+++ b/addons/data-category-tweaks-v2/addon.json
@@ -27,7 +27,7 @@
       "default": false
     },
     {
-      "name": "Move Reporters Below",
+      "name": "Move Reporters Under Operations",
       "id": "moveReportersDown",
       "type": "boolean",
       "default": false

--- a/addons/data-category-tweaks-v2/addon.json
+++ b/addons/data-category-tweaks-v2/addon.json
@@ -33,7 +33,7 @@
       "default": false
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabledByDefault": false,
   "l10n": true
 }


### PR DESCRIPTION
**Changes**

 - Remove beta tag under the (perhaps incorrect) assumption that no one has encountered issues with the addon
 - Resolve #1296 - Add new option: "Move Reporters Under Operations" (name not final) that moves the reporter blocks below the other blocks: https://user-images.githubusercontent.com/33787854/104348402-4f43ca80-54c7-11eb-98b2-37a446d20f0d.png
 - Update in response to settings updates immediately (previously only when switching sprites or creating a new variable, depending on the setting): https://user-images.githubusercontent.com/33787854/104348890-ddb84c00-54c7-11eb-8e7d-869840f808c9.mp4
