### PR TITLE
Remove notice for editor stepping addon

### DIFF
--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -1,13 +1,6 @@
 {
   "name": "Highlight currently executing blocks",
   "description": "Adds a blue border to the blocks that are currently running in a project.",
-  "extra": [
-    {
-      "type": "notice",
-      "text": "Scratch Addons v1.3.0 update: this feature is not experimental anymore, and should not affect project performance heavily.",
-      "id": "experimentalupdate"
-    }
-  ],
   "userscripts": [
     {
       "url": "userscript.js",


### PR DESCRIPTION
The addon was misnamed anyway so had no effect for a while... if you go to the current version or the released version of SA you won't see it anyway... The message is for 1.3.0 and we are on 1.8.0... it's time.