### PR TITLE
Add msg.locale property

### DIFF
--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -17,11 +17,13 @@ export default async function runAddonUserscripts({ addonId, scripts, traps }) {
       const module = await import(scriptUrl);
       const log = _realConsole.log.bind(console, `%c[${addonId}]`, "color:darkorange; font-weight: bold;");
       const warn = _realConsole.warn.bind(console, `%c[${addonId}]`, "color:darkorange font-weight: bold;");
+      const msg = (key, placeholders) => scratchAddons.l10n.get(`${addonId}/${key}`, placeholders);
+      msg.locale = scratchAddons.l10n.locale;
       module.default({
         addon: addonObj,
         global: globalObj,
         console: { ..._realConsole, log, warn },
-        msg: (key, placeholders) => scratchAddons.l10n.get(`${addonId}/${key}`, placeholders),
+        msg,
         safeMsg: (key, placeholders) => scratchAddons.l10n.escaped(`${addonId}/${key}`, placeholders),
       });
     };


### PR DESCRIPTION
editor-devtools has been using `scratchAddons.l10n.locale` to get the locale code. In order to make devtools its own independent extension, we're moving this to `msg.locale` so that the extension does not need to access `window.scratchAddons` in order to work.
I'm not modifying editor-devtools in this PR in order to avoid conflicts.