### PR TITLE
Refactor traps

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -14,19 +14,7 @@ export default class Tab extends EventTarget {
       : document.querySelector("script[type='text/javascript']")
       ? "scratchr2"
       : null;
-    this.traps = new Trap();
-    if (window.__scratchAddonsTraps)
-      __scratchAddonsTraps.addEventListener("fakestatechanged", ({ detail }) => {
-        const newEvent = new CustomEvent("fakestatechanged", {
-          detail: {
-            reducerOrigin: detail.reducerOrigin,
-            path: detail.path,
-            prev: detail.prev,
-            next: detail.next,
-          },
-        });
-        this.traps.dispatchEvent(newEvent);
-      });
+    this.traps = new Trap(this);
     this.redux = new ReduxHandler();
     this._waitForElementSet = new WeakSet();
   }

--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -1,87 +1,46 @@
 export default class Trap extends EventTarget {
-  constructor() {
+  constructor(tab) {
     super();
-  }
-  /**
-   * @type {object.<string, *>} mapping for the Once objects trapped.
-   */
-  get onceValues() {
-    return __scratchAddonsTraps._onceMap;
-  }
-  /**
-   * @type {symbol} Symbol for accessing props of trapped objects.
-   */
-  get numOnce() {
-    return __scratchAddonsTraps._trapNumOnce;
-  }
-  /**
-   * @type {symbol} Symbol for accessing props of trapped objects.
-   */
-  get numMany() {
-    return __scratchAddonsTraps._trapNumMany;
+    this._react_internal_key = undefined;
+    this._isWWW = tab.clientVersion === "scratch-www";
+    this._getEditorMode = () => this._isWWW && tab.editorMode;
+    this._waitForElement = (q) => tab.waitForElement(q, { markAsSeen: true });
+    
+    this._cache = Object.create(null);
   }
 
-  /**
-   * Adds listener for Once objects trapped.
-   * @param {string} trapName Trap name to listen to. Can be '*' for any.
-   * @param {function} fn callback passed to addEventListener.
-   */
-  addOnceListener(trapName, fn) {
-    const eventName = trapName === "*" ? "trapready" : `ready.${trapName}`;
-    if (!__scratchAddonsTraps._targetOnce) throw new Error("Event target not initialized");
-    __scratchAddonsTraps._targetOnce.addEventListener(eventName, fn);
+  get vm() {
+    if (!this._getEditorMode()) throw new Error("Cannot access vm on non-project page");
+    return __scratchAddonsTraps._onceMap.vm;
   }
-
-  /**
-   * Removes listener for Once objects trapped.
-   * @param {string} trapName Trap name to listen to. Can be '*' for any.
-   * @param {function} fn callback passed to removeEventListener.
-   */
-  removeOnceListener(trapName, fn) {
-    const eventName = trapName === "*" ? "trapready" : `ready.${trapName}`;
-    if (!__scratchAddonsTraps._targetOnce) throw new Error("Event target not initialized");
-    __scratchAddonsTraps._targetOnce.removeEventListener(eventName, fn);
+  
+  get REACT_INTERNAL_PREFIX() {
+    return "__reactInternalInstance$"
   }
-
-  /**
-   * Adds listener for Many objects trapped.
-   * @param {string} trapName Trap name to listen to. Can be '*' for any.
-   * @param {function} fn callback passed to addEventListener.
-   */
-  addManyListener(trapName, fn) {
-    const eventName = trapName === "*" ? "trapready" : `ready.${trapName}`;
-    if (!__scratchAddonsTraps._targetMany) throw new Error("Event target not initialized");
-    __scratchAddonsTraps._targetMany.addEventListener(eventName, fn);
-  }
-
-  /**
-   * Removes listener for Many objects trapped.
-   * @param {string} trapName Trap name to listen to. Can be '*' for any.
-   * @param {function} fn callback passed to removeEventListener.
-   */
-  removeManyListener(trapName, fn) {
-    const eventName = trapName === "*" ? "trapready" : `ready.${trapName}`;
-    if (!__scratchAddonsTraps._targetMany) throw new Error("Event target not initialized");
-    __scratchAddonsTraps._targetMany.removeEventListener(eventName, fn);
-  }
-
-  /**
-   * Adds listener for prototype functions trapped.
-   * @param {string} trapName Trap name to listen to. Can be '*' for any.
-   * @param {function} fn callback passed to addEventListener.
-   */
-  addPrototypeListener(trapName, fn) {
-    const eventName = trapName === "*" ? "prototypecalled" : `prototype.${trapName}`;
-    __scratchAddonsTraps.addEventListener(eventName, fn);
-  }
-
-  /**
-   * Removes listener for prototype functions trapped.
-   * @param {string} trapName Trap name to listen to. Can be '*' for any.
-   * @param {function} fn callback passed to removeEventListener.
-   */
-  removePrototypeListener(trapName, fn) {
-    const eventName = trapName === "*" ? "prototypecalled" : `prototype.${trapName}`;
-    __scratchAddonsTraps.removeEventListener(eventName, fn);
+  
+  async getBlockly() {
+    if (this._cache.Blockly) return this._cache.Blockly;
+    const editorMode = this._getEditorMode();
+    if (!editorMode || editorMode === "embed") throw new Error("Cannot access Blockly on this page");
+    const BLOCKS_CLASS = "[class^=\"gui_blocks-wrapper\"]";
+    let elem = document.querySelector(BLOCKS_CLASS);
+    if (!elem) {
+      elem = await this._waitForElement(BLOCKS_CLASS);
+    }
+    if (!this._react_internal_key) {
+      this._react_internal_key = Object.keys(elem).find(key => key.startsWith(this.REACT_INTERNAL_PREFIX));
+    }
+    const internal = elem[this._react_internal_key];
+    let childable = internal;
+    /* eslint-disable no-empty */
+    while (
+      childable = childable.child,
+      !childable ||
+      !childable.stateNode ||
+      !childable.stateNode.ScratchBlocks
+    ) {
+    }
+    /* eslint-enable no-empty */
+    return this._cache.Blockly = childable.stateNode.ScratchBlocks;
   }
 }

--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -5,7 +5,7 @@ export default class Trap extends EventTarget {
     this._isWWW = tab.clientVersion === "scratch-www";
     this._getEditorMode = () => this._isWWW && tab.editorMode;
     this._waitForElement = (q) => tab.waitForElement(q, { markAsSeen: true });
-    
+
     this._cache = Object.create(null);
   }
 
@@ -13,34 +13,28 @@ export default class Trap extends EventTarget {
     if (!this._getEditorMode()) throw new Error("Cannot access vm on non-project page");
     return __scratchAddonsTraps._onceMap.vm;
   }
-  
+
   get REACT_INTERNAL_PREFIX() {
-    return "__reactInternalInstance$"
+    return "__reactInternalInstance$";
   }
-  
+
   async getBlockly() {
     if (this._cache.Blockly) return this._cache.Blockly;
     const editorMode = this._getEditorMode();
     if (!editorMode || editorMode === "embed") throw new Error("Cannot access Blockly on this page");
-    const BLOCKS_CLASS = "[class^=\"gui_blocks-wrapper\"]";
+    const BLOCKS_CLASS = '[class^="gui_blocks-wrapper"]';
     let elem = document.querySelector(BLOCKS_CLASS);
     if (!elem) {
       elem = await this._waitForElement(BLOCKS_CLASS);
     }
     if (!this._react_internal_key) {
-      this._react_internal_key = Object.keys(elem).find(key => key.startsWith(this.REACT_INTERNAL_PREFIX));
+      this._react_internal_key = Object.keys(elem).find((key) => key.startsWith(this.REACT_INTERNAL_PREFIX));
     }
     const internal = elem[this._react_internal_key];
     let childable = internal;
     /* eslint-disable no-empty */
-    while (
-      childable = childable.child,
-      !childable ||
-      !childable.stateNode ||
-      !childable.stateNode.ScratchBlocks
-    ) {
-    }
+    while (((childable = childable.child), !childable || !childable.stateNode || !childable.stateNode.ScratchBlocks)) {}
     /* eslint-enable no-empty */
-    return this._cache.Blockly = childable.stateNode.ScratchBlocks;
+    return (this._cache.Blockly = childable.stateNode.ScratchBlocks);
   }
 }

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -1,6 +1,6 @@
 export default async function ({ addon, global, console }) {
   let gloabal_fps = 30;
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
   let altPressesCount = 0;
   let altPressedRecently = false;
   window.addEventListener("keydown", (event) => {

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, global, console, msg }) {
   console.log("clones counter enabled");
 
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
 
   vm.runtime.__cloneCounter = vm.runtime._cloneCounter;
 

--- a/addons/data-category-tweaks-v2/userscript.js
+++ b/addons/data-category-tweaks-v2/userscript.js
@@ -119,7 +119,7 @@ export default async function ({ addon, global, console, msg, safeMsg }) {
     const flyout = workspace.getFlyout();
     if (!flyout) throw new Error("expected flyout");
 
-    vm = addon.tab.traps.onceValues.vm;
+    vm = addon.tab.traps.vm;
     if (!vm) throw new Error("expected vm");
 
     const DataCategory = workspace.toolboxCategoryCallbacks_.VARIABLE;

--- a/addons/editor-devtools/show-broadcast.js
+++ b/addons/editor-devtools/show-broadcast.js
@@ -3,7 +3,7 @@
 export default class ShowBroadcast {
   constructor(addon) {
     this.addon = addon;
-    this.vm = this.addon.tab.traps.onceValues.vm;
+    this.vm = this.addon.tab.traps.vm;
     this.highlights = {
       timeoutId: 0,
       callback: () => {},

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, global, console }) {
-  const virtualMachine = addon.tab.traps.onceValues.vm;
+  const virtualMachine = addon.tab.traps.vm;
 
   let removeInterval = () => {};
   if (addon.tab.editorMode === "editor") {

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -44,7 +44,7 @@ export default async ({ addon, console, msg }) => {
       recordBuffer = [];
       isRecording = true;
       recordElem.textContent = msg("stop");
-      const vm = addon.tab.traps.onceValues.vm;
+      const vm = addon.tab.traps.vm;
       const stream = vm.runtime.renderer.canvas.captureStream();
       const mediaStreamDestination = vm.runtime.audioEngine.audioContext.createMediaStreamDestination();
       vm.runtime.audioEngine.inputNode.connect(mediaStreamDestination);

--- a/addons/mouse-pos/userscript.js
+++ b/addons/mouse-pos/userscript.js
@@ -3,7 +3,7 @@ export default async function ({ addon, global, console }) {
 
   let pos = null;
 
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
 
   vm.runtime.ioDevices.mouse.__scratchX = vm.runtime.ioDevices.mouse._scratchX;
   vm.runtime.ioDevices.mouse.__scratchY = vm.runtime.ioDevices.mouse._scratchY;

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, global, console }) {
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
     let mode = false;

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -389,7 +389,7 @@ export default async function ({ addon, global, console, msg }) {
 
     removeOnionLayers();
 
-    const vm = addon.tab.traps.onceValues.vm;
+    const vm = addon.tab.traps.vm;
     if (!vm) {
       return;
     }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, global, console, msg }) {
   console.log("pause enabled");
 
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
 
   var playing = true;
   var threads = [];

--- a/addons/project-info/blockcount.js
+++ b/addons/project-info/blockcount.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, console, msg }) {
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
 
   const getBlockCount = () => {
     let blockCount = 0;

--- a/addons/project-info/projectstats.js
+++ b/addons/project-info/projectstats.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, console, msg }) {
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
 
   const getBlockCount = () => {
     let blockCount = 0;

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -1,6 +1,6 @@
 export default async ({ addon, console, msg }) => {
   if (!addon.tab.redux.state) return console.warn("Redux is not available!");
-  const vm = addon.tab.traps.onceValues.vm;
+  const vm = addon.tab.traps.vm;
   if (!vm) return;
   const oldDeleteSprite = vm.deleteSprite;
   vm.deleteSprite = function (...args) {

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -43,7 +43,7 @@ async function getContentScriptInfo(url) {
           runAtComplete: typeof script.runAtComplete === "boolean" ? script.runAtComplete : true,
         });
     }
-    if (userscripts.length) data.addonsWithUserscripts.push({ addonId, scripts: userscripts, traps: manifest.traps });
+    if (userscripts.length) data.addonsWithUserscripts.push({ addonId, scripts: userscripts });
 
     if (manifest.tags.includes("theme")) {
       const styleUrls = [];

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -1,58 +1,24 @@
 function injectPrototype() {
-  const oldPrototypes = {
-    functionBind: Function.prototype.bind,
-    arrayPush: Array.prototype.push,
-    arraySort: Array.prototype.sort,
-    objectAssign: Object.assign,
-  };
+  const oldBind = Function.prototype.bind;
   // Use custom event target
   window.__scratchAddonsTraps = new EventTarget();
-  const onceTarget = (__scratchAddonsTraps._targetOnce = new EventTarget());
   const onceMap = (__scratchAddonsTraps._onceMap = Object.create(null));
-  const trapNumOnce = (__scratchAddonsTraps._trapNumOnce = Symbol.for("trapNumOnce"));
-
-  const createReadyOnce = (trapName, value) => {
-    if (value && typeof value === "object") {
-      try {
-        Object.defineProperty(value, trapNumOnce, {
-          value: (value[trapNumOnce] || 0) + 1,
-          configurable: true,
-        });
-      } catch (e) {
-        console.error("Error when injecting attr:", e);
-      }
-    }
-    onceMap[trapName] = value;
-    const readyEvent = new CustomEvent("trapready", {
-      detail: {
-        trapName,
-        value,
-      },
-    });
-    onceTarget.dispatchEvent(readyEvent);
-    const specificEvent = new CustomEvent(`ready.${trapName}`, {
-      detail: {
-        value,
-      },
-    });
-    onceTarget.dispatchEvent(specificEvent);
-  };
 
   Function.prototype.bind = function (...args) {
-    if (Function.prototype.bind === oldPrototypes.functionBind) {
+    if (Function.prototype.bind === oldBind) {
       // Just in case some code stores the bind function once on startup, then always uses it.
-      return oldPrototypes.functionBind.apply(this, args);
+      return oldBind.apply(this, args);
     } else if (
       args[0] &&
       Object.prototype.hasOwnProperty.call(args[0], "editingTarget") &&
       Object.prototype.hasOwnProperty.call(args[0], "runtime")
     ) {
-      createReadyOnce("vm", args[0]);
+      onceMap.vm = args[0];
       // After finding the VM, return to previous Function.prototype.bind
-      Function.prototype.bind = oldPrototypes.functionBind;
-      return oldPrototypes.functionBind.apply(this, args);
+      Function.prototype.bind = oldBind;
+      return oldBind.apply(this, args);
     } else {
-      return oldPrototypes.functionBind.apply(this, args);
+      return oldBind.apply(this, args);
     }
   };
 }


### PR DESCRIPTION
- Removes unused APIs
- Adds an async function `traps.getBlockly` which can be used to obtain real Blockly used by Scratch (not `globalThis.Blockly`)