### PR TITLE
Add a11y addon

### DIFF
--- a/addons-l10n/en/a11y.json
+++ b/addons-l10n/en/a11y.json
@@ -1,0 +1,3 @@
+{
+  "a11y/a11y-category": "Accessibility"
+}

--- a/addons-l10n/en/a11y.json
+++ b/addons-l10n/en/a11y.json
@@ -1,3 +1,5 @@
 {
-  "a11y/a11y-category": "Accessibility"
+  "a11y/a11y-category": "Accessibility",
+  "a11y/sayBubble": "Sprite is saying \"{text}\".",
+  "a11y/thinkBubble": "Sprite is thinking \"{text}\"."
 }

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,7 +1,6 @@
 {
   "name": "Accessibile Projects",
   "description": "Adds support for WAI-ARIA and custom cursors to the Scratch player.",
-  "info": [],
   "credits": [
     {
       "name": "A-E-"
@@ -19,7 +18,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["beta"],
+  "tags": ["beta","editor"],
   "enabledByDefault": false,
   "l10n": true
 }

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,0 +1,26 @@
+{
+  "name": "Accessibile Projects",
+  "description": "Adds support for WAI-ARIA and custom cursors to the Scratch player.",
+  "info": [
+  ],
+  "credits": [
+    {
+      "name": "A-E-"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "style.css",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["beta"],
+  "enabledByDefault": false,
+  "l10n": true
+}

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -28,7 +28,7 @@
   ],
   "settings": [
     {
-      "name": "Enable tab navigation for sprites.",
+      "name": "Enable tab navigation for sprites",
       "id": "tabNav",
       "type": "boolean",
       "default": false

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,8 +1,7 @@
 {
   "name": "Accessibile Projects",
   "description": "Adds support for WAI-ARIA and custom cursors to the Scratch player.",
-  "info": [
-  ],
+  "info": [],
   "credits": [
     {
       "name": "A-E-"

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,10 +1,10 @@
 {
   "name": "Project accessibility support",
-  "description": "Adds limited screen reader support to the Scratch player, including WAI-ARIA labels and roles.",
+  "description": "Adds limited support for screen readers and other assistive technology to the Scratch player, including WAI-ARIA labels and roles. It currently supports say and think bubbles, but not text in costumes. Functionality that allows projects to explicitly share labels and roles is still being tested.",
   "info": [
     {
       "type": "notice",
-      "text": "We're exploring new accessibility tools. If you've found this addon useful or have any suggestions, please send us a message through scratchaddons.com/feedback and include your Scratch username so that we can reply.",
+      "text": "We're exploring new accessibility tools. If you've found this addon useful or have any suggestions, please send us a message by clicking "Send Feedback" on the left, and include your Scratch username so that we can reply.",
       "id": "newA11yTools"
     }
   ],

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -4,7 +4,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "We're exploring new accessibility tools. If you've found this addon useful or have any suggestions, please send us a message by clicking "Send Feedback" on the left, and include your Scratch username so that we can reply.",
+      "text": "We're exploring new accessibility tools. If you've found this addon useful or have any suggestions, please send us a message by clicking \"Send Feedback\" on the left, and include your Scratch username so that we can reply.",
       "id": "newA11yTools"
     }
   ],

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Project accessibility support",
-  "description": "Adds screen reader support to the Scratch player.",
+  "description": "Adds limited screen reader support to the Scratch player, including WAI-ARIA labels and roles.",
   "info": [
     {
       "type": "notice",

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -3,7 +3,8 @@
   "description": "Adds support for WAI-ARIA and custom cursors to the Scratch player.",
   "credits": [
     {
-      "name": "A-E-"
+      "name": "A-E-",
+      "link": "https://scratch.mit.edu/users/A-E-/"
     }
   ],
   "userscripts": [
@@ -18,7 +19,15 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["beta", "editor"],
+  "settings": [
+    {
+      "name": "Enable tab navigation for sprites.",
+      "id": "tabNav",
+      "type": "boolean",
+      "default": false
+    }
+  ],
+  "tags": ["editor", "beta"],
   "enabledByDefault": false,
   "l10n": true
 }

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,6 +1,13 @@
 {
   "name": "Project accessibility support",
   "description": "Adds screen reader support to the Scratch player.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "We're exploring new accessibility tools. If you've found this addon useful or have any suggestions, please send us a message through scratchaddons.com/feedback and include your Scratch username so that we can reply.",
+      "id": "newA11yTools"
+    }
+  ],
   "credits": [
     {
       "name": "A-E-",

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -18,7 +18,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["beta","editor"],
+  "tags": ["beta", "editor"],
   "enabledByDefault": false,
   "l10n": true
 }

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Project accessibility support",
-  "description": "Adds screen reader support to the Scratch player, and blocks to set WAI-ARIA labels and roles for sprites to the editor.",
+  "description": "Adds screen reader support to the Scratch player.",
   "credits": [
     {
       "name": "A-E-",

--- a/addons/a11y/addon.json
+++ b/addons/a11y/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Accessibile Projects",
-  "description": "Adds support for WAI-ARIA and custom cursors to the Scratch player.",
+  "name": "Project accessibility support",
+  "description": "Adds screen reader support to the Scratch player, and blocks to set WAI-ARIA labels and roles for sprites to the editor.",
   "credits": [
     {
       "name": "A-E-",

--- a/addons/a11y/style.css
+++ b/addons/a11y/style.css
@@ -1,0 +1,34 @@
+#aria-container {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    opacity: 0.5;
+}
+.aria-item:focus {
+    outline: none;
+    border-color: hsla(215, 100%, 65%, 1);
+    -webkit-box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
+    box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
+}
+.aria-item {
+    position: absolute;
+    right: calc(((480/2) - var(--aria-bounds-left)) / 480 * 100% - (var(--aria-bounds-width) / 480 * 100%));
+    width: calc(var(--aria-bounds-width) / 480 * 100%);
+    height: calc(var(--aria-bounds-height) / 360 * 100%);
+    top: calc(((360/2) - var(
+    --aria-bounds-top)) / 360 * 100%);
+    border-radius: 3px;
+    border: 1px solid hsla(0, 0%, 0%, 0.15);
+    transition: 0.25s ease-out;
+}
+
+.aria-item[role="button"] {
+    cursor: pointer;
+}

--- a/addons/a11y/style.css
+++ b/addons/a11y/style.css
@@ -11,7 +11,7 @@
   z-index: 0;
   opacity: 0.5;
 }
-.aria-item:focus {
+.aria-item[tabindex]:focus {
   outline: none;
   border-color: hsla(215, 100%, 65%, 1);
   -webkit-box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
@@ -23,9 +23,11 @@
   width: calc(var(--aria-bounds-width) / 480 * 100%);
   height: calc(var(--aria-bounds-height) / 360 * 100%);
   top: calc(((360 / 2) - var(--aria-bounds-top)) / 360 * 100%);
+  transition: border 0.25s ease-out, box-shadow 0.25s ease-out;
+}
+.aria-item[tabindex] {
   border-radius: 3px;
   border: 1px solid hsla(0, 0%, 0%, 0.15);
-  transition: border 0.25s ease-out, box-shadow 0.25s ease-out;
 }
 
 .aria-item[role="button"] {

--- a/addons/a11y/style.css
+++ b/addons/a11y/style.css
@@ -1,34 +1,33 @@
 #aria-container {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-    opacity: 0.5;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  opacity: 0.5;
 }
 .aria-item:focus {
-    outline: none;
-    border-color: hsla(215, 100%, 65%, 1);
-    -webkit-box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
-    box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
+  outline: none;
+  border-color: hsla(215, 100%, 65%, 1);
+  -webkit-box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
+  box-shadow: 0 0 0 0.25rem hsla(215, 100%, 65%, 0.35);
 }
 .aria-item {
-    position: absolute;
-    right: calc(((480/2) - var(--aria-bounds-left)) / 480 * 100% - (var(--aria-bounds-width) / 480 * 100%));
-    width: calc(var(--aria-bounds-width) / 480 * 100%);
-    height: calc(var(--aria-bounds-height) / 360 * 100%);
-    top: calc(((360/2) - var(
-    --aria-bounds-top)) / 360 * 100%);
-    border-radius: 3px;
-    border: 1px solid hsla(0, 0%, 0%, 0.15);
-    transition: 0.25s ease-out;
+  position: absolute;
+  right: calc(((480 / 2) - var(--aria-bounds-left)) / 480 * 100% - (var(--aria-bounds-width) / 480 * 100%));
+  width: calc(var(--aria-bounds-width) / 480 * 100%);
+  height: calc(var(--aria-bounds-height) / 360 * 100%);
+  top: calc(((360 / 2) - var(--aria-bounds-top)) / 360 * 100%);
+  border-radius: 3px;
+  border: 1px solid hsla(0, 0%, 0%, 0.15);
+  transition: 0.25s ease-out;
 }
 
 .aria-item[role="button"] {
-    cursor: pointer;
+  cursor: pointer;
 }

--- a/addons/a11y/style.css
+++ b/addons/a11y/style.css
@@ -8,7 +8,7 @@
   padding: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
+  z-index: 0;
   opacity: 0.5;
 }
 .aria-item:focus {
@@ -25,7 +25,7 @@
   top: calc(((360 / 2) - var(--aria-bounds-top)) / 360 * 100%);
   border-radius: 3px;
   border: 1px solid hsla(0, 0%, 0%, 0.15);
-  transition: 0.25s ease-out;
+  transition: border 0.25s ease-out, box-shadow 0.25s ease-out;
 }
 
 .aria-item[role="button"] {

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -3,135 +3,133 @@ let a11yObjects = {};
 window.a11yObjects = a11yObjects;
 let blockColorOverrides = {};
 blockColorOverrides["set sprite aria role to %s"] = blockColorOverrides["set sprite label to %s"] = {
-  color: "#43cfca",
-  secondaryColor: "#3aa8a4",
-  tertiaryColor: "#3aa8a4",
+    color: "#43cfca",
+    secondaryColor: "#3aa8a4",
+    tertiaryColor: "#3aa8a4",
 };
 
 function makeWrap() {
-  wrap = document.createElement("div");
-  wrap.id = "aria-container";
-  let canvas = document.querySelector(
-    '[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas'
-  );
-  canvas.insertAdjacentElement("beforeBegin", wrap);
-  function pass2canvas(e) {
-    let o = {
-      touches: e.touches,
-      clientX: e.clientX,
-      clientY: e.clientY,
-      changedTouches: e.changedTouches,
-      deltaX: e.deltaX,
-      deltaY: e.deltaY,
-    };
-    canvas.dispatchEvent(new e.constructor(e.type, o));
-  }
-  wrap.addEventListener("mousedown", pass2canvas);
-  wrap.addEventListener("touchstart", pass2canvas);
-  wrap.addEventListener("wheel", pass2canvas);
+    wrap = document.createElement("div");
+    wrap.id = "aria-container";
+    let canvas = document.querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas');
+    canvas.insertAdjacentElement("beforeBegin", wrap);
+    function pass2canvas(e) {
+        let o = {
+            touches: e.touches,
+            clientX: e.clientX,
+            clientY: e.clientY,
+            changedTouches: e.changedTouches,
+            deltaX: e.deltaX,
+            deltaY: e.deltaY,
+        };
+        canvas.dispatchEvent(new e.constructor(e.type,o));
+    }
+    wrap.addEventListener("mousedown", pass2canvas);
+    wrap.addEventListener("touchstart", pass2canvas);
+    wrap.addEventListener("wheel", pass2canvas);
 }
 
 async function ensureWrap() {
-  while (true) {
-    await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
-      markAsSeen: true,
-    });
-    makeWrap();
-  }
+    while (true) {
+        await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
+            markAsSeen: true,
+        });
+        makeWrap();
+    }
 }
 
 function cleanUp() {
-  let targets = vm.runtime.targets.map((e) => e.id);
-  Object.keys(a11yObjects)
-    .filter((e) => !targets.includes(e))
-    .forEach((e) => {
-      a11yObjects[e].ele.remove();
-      delete a11yObjects[e];
-    });
+    let targets = vm.runtime.targets.map((e)=>e.id);
+    Object.keys(a11yObjects).filter((e)=>!targets.includes(e)).forEach((e)=>{
+        a11yObjects[e].ele.remove();
+        delete a11yObjects[e];
+    }
+    );
 }
 
 async function renderLoop() {
-  while (true) {
-    cleanUp();
-    for (let e of Object.entries(a11yObjects)) {
-      updateAria(vm.runtime.targets.filter((a) => a.id == e[0])[0]);
+    while (true) {
+        cleanUp();
+        for (let e of Object.entries(a11yObjects)) {
+            updateAria(vm.runtime.targets.filter((a)=>a.id == e[0])[0]);
+        }
+        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [["text"], ["czc6,OD@W7qzCng-$6Ut"], ["img"], ]));
+        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]]));
+        await new Promise((cb)=>requestAnimationFrame((_)=>cb()));
     }
-    vm.runtime.targets.forEach(
-      (e) =>
-        (e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [
-          ["text"],
-          ["czc6,OD@W7qzCng-$6Ut"],
-          ["img"],
-        ])
-    );
-    vm.runtime.targets.forEach(
-      (e) =>
-        (e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
-    );
-    await new Promise((cb) => requestAnimationFrame((_) => cb()));
-  }
 }
 
 let injected;
 
-const injectWorkspace = () => {
-  if (injected) {
-    return;
-  }
-  injected = true;
-
-  const workspace = Blockly.getMainWorkspace();
-  if (!workspace) throw new Error("expected workspace");
-
-  let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor;
-  let oldUpdateColor = BlockSvg.prototype.updateColour;
-  BlockSvg.prototype.updateColour = function (...a) {
-    if (this.procCode_) {
-      let p = this.procCode_;
-      if (blockColorOverrides[p.trim().toLowerCase()]) {
-        let c = blockColorOverrides[p.trim().toLowerCase()];
-        this.colour_ = c.color;
-        this.colourSecondary_ = c.secondaryColor;
-        this.colourTertiary_ = c.tertiaryColor;
-      }
+const injectWorkspace = ()=>{
+    if (injected) {
+        return;
     }
-    return oldUpdateColor.call(this, ...a);
-  };
+    injected = true;
 
-  const flyout = workspace.getFlyout();
-  if (!flyout) throw new Error("expected flyout");
+    const workspace = Blockly.getMainWorkspace();
+    if (!workspace)
+        throw new Error("expected workspace");
 
-  vm = addon.tab.traps.onceValues.vm;
-  if (!vm) throw new Error("expected vm");
+    let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor;
+    let oldUpdateColor = BlockSvg.prototype.updateColour;
+    BlockSvg.prototype.updateColour = function(...a) {
+        if (this.procCode_) {
+            let p = this.procCode_;
+            if (blockColorOverrides[p.trim().toLowerCase()]) {
+                let c = blockColorOverrides[p.trim().toLowerCase()];
+                this.colour_ = c.color;
+                this.colourSecondary_ = c.secondaryColor;
+                this.colourTertiary_ = c.tertiaryColor;
+                let updateChildColors = (function updateChildColors() {
+                    this.childBlocks_.forEach((e=>{
+                        e.setColour(e.getColour(), e.getColourSecondary(), this.getColourTertiary())
+                    }
+                    ).bind(this))
+                }
+                ).bind(this)
+                updateChildColors()
+                const oldPush = this.childBlocks_.__proto__.push.bind(this.childBlocks_)
+                this.childBlocks_.push = function(...a) {
+                    updateChildColors()
+                    return oldPush(...a)
+                }
+            }
+        }
+        return oldUpdateColor.call(this, ...a);
+    }
+    ;
 
-  // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
-  // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
-  const originalShow = flyout.constructor.prototype.show;
-  flyout.constructor.prototype.show = function (xml) {
-    this.workspace_.registerToolboxCategoryCallback("A11Y", function (e) {
-      return [
-        ...new DOMParser()
-          .parseFromString(
-            `<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
-<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,
-            "text/xml"
-          )
-          .querySelectorAll("block"),
-      ];
-    });
-    originalShow.call(this, xml);
-  };
+    const flyout = workspace.getFlyout();
+    if (!flyout)
+        throw new Error("expected flyout");
 
-  // We use Scratch's extension category mechanism to replace the data category with our own.
-  // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
-  // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
-  // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
-  const originalGetBlocksXML = vm.runtime.getBlocksXML;
-  vm.runtime.getBlocksXML = function (target) {
-    const result = originalGetBlocksXML.call(this, target);
-    result.push({
-      id: "a11ycat",
-      xml: `
+    vm = addon.tab.traps.onceValues.vm;
+    if (!vm)
+        throw new Error("expected vm");
+
+    // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
+    // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
+    const originalShow = flyout.constructor.prototype.show;
+    flyout.constructor.prototype.show = function(xml) {
+        this.workspace_.registerToolboxCategoryCallback("A11Y", function(e) {
+            return [...new DOMParser().parseFromString(`<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
+<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`, "text/xml").querySelectorAll("block"), ];
+        });
+        originalShow.call(this, xml);
+    }
+    ;
+
+    // We use Scratch's extension category mechanism to replace the data category with our own.
+    // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
+    // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
+    // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
+    const originalGetBlocksXML = vm.runtime.getBlocksXML;
+    vm.runtime.getBlocksXML = function(target) {
+        const result = originalGetBlocksXML.call(this, target);
+        result.push({
+            id: "a11ycat",
+            xml: `
           <category
             name="${safeMsg("a11y-category")}"
             id="a11ycat"
@@ -139,75 +137,80 @@ const injectWorkspace = () => {
             secondaryColour="#3aa8a4"
             custom="A11Y">
           </category>`,
-    });
-    return result;
-  };
-
-  // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
-  // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
-  // Workspace updates are slow, so don't do them unless necessary.
-  if (vm.editingTarget) {
-    vm.emitWorkspaceUpdate();
-  }
-};
-export default async function (o) {
-  let { global, console, msg } = o;
-  addon = o.addon;
-  safeMsg = o.safeMsg;
-  console.log("a11y support enabled");
-  vm = addon.tab.traps.onceValues.vm;
-  ensureWrap();
-  renderLoop();
-  const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
-  vm.runtime.sequencer.stepToProcedure = function (thread, proccode) {
-    if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
-      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-      a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
-    } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
-      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-      a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
+        });
+        return result;
     }
-    return oldStepToProcedure.call(this, thread, proccode);
-  };
-  if (addon.tab.editorMode === "editor") {
-    const interval = setInterval(() => {
-      if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
-        injectWorkspace();
-        clearInterval(interval);
-      }
-    }, 100);
-  }
-  addon.tab.addEventListener("urlChange", () => addon.tab.editorMode === "editor" && injectWorkspace());
+    ;
+
+    // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
+    // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
+    // Workspace updates are slow, so don't do them unless necessary.
+    if (vm.editingTarget) {
+        vm.emitWorkspaceUpdate();
+    }
+}
+;
+export default async function (o) {
+    let {global, console, msg} = o;
+    addon = o.addon;
+    safeMsg = o.safeMsg;
+    console.log("a11y support enabled");
+    vm = addon.tab.traps.onceValues.vm;
+    ensureWrap();
+    renderLoop();
+    const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
+    vm.runtime.sequencer.stepToProcedure = function(thread, proccode) {
+        if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
+            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+            a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
+        } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
+            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+            a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
+        }
+        return oldStepToProcedure.call(this, thread, proccode);
+    }
+    ;
+    if (addon.tab.editorMode === "editor") {
+        const interval = setInterval(()=>{
+            if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
+                injectWorkspace();
+                clearInterval(interval);
+            }
+        }
+        , 100);
+    }
+    addon.tab.addEventListener("urlChange", ()=>addon.tab.editorMode === "editor" && injectWorkspace());
 }
 
 function updateAria(target) {
-  if (!target.visible) {
-    if (a11yObjects[target.id]) {
-      if (a11yObjects[target.id].ele) a11yObjects[target.id].ele.remove();
+    if (!target.visible) {
+        if (a11yObjects[target.id]) {
+            if (a11yObjects[target.id].ele)
+                a11yObjects[target.id].ele.remove();
+        }
+        return;
     }
-    return;
-  }
-  a11yObjects[target.id] = a11yObjects[target.id] || {};
-  if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
-    a11yObjects[target.id].ele = document.createElement("div");
-    a11yObjects[target.id].ele.className = "aria-item";
-    a11yObjects[target.id].ele.dataset.spriteId = target.id;
-    a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
-    wrap.append(a11yObjects[target.id].ele);
-  }
-  let bounds = target.renderer.getBounds(target.drawableID);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
-  if (a11yObjects[target.id].role) {
-    a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
-  } else {
-    a11yObjects[target.id].ele.removeAttribute("role");
-  }
-  if (a11yObjects[target.id].label) {
-    a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
-  } else {
-    a11yObjects[target.id].ele.removeAttribute("aria-label");
-  }
+    a11yObjects[target.id] = a11yObjects[target.id] || {};
+    if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
+        a11yObjects[target.id].ele = document.createElement("div");
+        a11yObjects[target.id].ele.className = "aria-item";
+        a11yObjects[target.id].ele.dataset.spriteId = target.id;
+        a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
+        wrap.append(a11yObjects[target.id].ele);
+    }
+    let bounds = target.renderer.getBounds(target.drawableID);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
+    if (a11yObjects[target.id].role) {
+        a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
+    } else {
+        a11yObjects[target.id].ele.removeAttribute("role");
+    }
+    if (a11yObjects[target.id].label) {
+        a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
+    } else {
+        a11yObjects[target.id].ele.removeAttribute("aria-label");
+    }
 }

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -1,0 +1,149 @@
+let wrap, vm, addon, safeMsg;
+let a11yObjects = {};
+window.a11yObjects = a11yObjects;
+
+function makeWrap() {
+    wrap = document.createElement("div")
+    wrap.id = "aria-container"
+    document.querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas').insertAdjacentElement("beforeBegin", wrap)
+}
+
+async function ensureWrap() {
+    while (true) {
+        await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
+            markAsSeen: true
+        });
+        makeWrap()
+    }
+}
+
+function cleanUp() {
+    let targets = vm.runtime.targets.map(e=>e.id)
+    Object.keys(a11yObjects).filter(e=>!targets.includes(e)).forEach(e=>{
+        a11yObjects[e].ele.remove()
+        delete a11yObjects[e]
+    }
+    )
+}
+
+async function renderLoop() {
+    while (true) {
+        cleanUp()
+        for (let e of Object.entries(a11yObjects)) {
+            updateAria(vm.runtime.targets.filter(a=>a.id == e[0])[0])
+        }
+        vm.runtime.targets.forEach(e=>e.blocks._cache.procedureParamNames["set sprite aria role to %s"]=[["text"],["czc6,OD@W7qzCng-$6Ut"], ["img"]])
+        vm.runtime.targets.forEach(e=>e.blocks._cache.procedureParamNames["set sprite label to %s"]=[["text"],["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
+        await new Promise(cb=>requestAnimationFrame(_=>cb()))
+    }
+}
+
+let injected;
+
+const injectWorkspace = ()=>{
+    if (injected) {
+        return;
+    }
+    injected = true;
+
+    const workspace = Blockly.getMainWorkspace();
+    if (!workspace)
+        throw new Error("expected workspace");
+
+    const flyout = workspace.getFlyout();
+    if (!flyout)
+        throw new Error("expected flyout");
+
+    vm = addon.tab.traps.onceValues.vm;
+    if (!vm)
+        throw new Error("expected vm");
+
+    // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
+    // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
+    const originalShow = flyout.constructor.prototype.show;
+    flyout.constructor.prototype.show = function(xml) {
+        this.workspace_.registerToolboxCategoryCallback("A11Y", (function(e) {
+            return [...new DOMParser().parseFromString(`<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
+<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,"text/xml").querySelectorAll("block")]
+        }
+        ));
+        originalShow.call(this, xml);
+    }
+
+    // We use Scratch's extension category mechanism to replace the data category with our own.
+    // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
+    // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
+    // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
+    const originalGetBlocksXML = vm.runtime.getBlocksXML;
+    vm.runtime.getBlocksXML = function(target) {
+        const result = originalGetBlocksXML.call(this, target);
+        result.push({
+            id: "a11ycat",
+            xml: `
+          <category
+            name="${safeMsg("a11y-category")}"
+            id="a11ycat"
+            colour="#43cfca"
+            secondaryColour="#3aa8a4"
+            custom="A11Y">
+          </category>`,
+        });
+        return result;
+    }
+
+    // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
+    // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
+    // Workspace updates are slow, so don't do them unless necessary.
+    if (vm.editingTarget) {
+        vm.emitWorkspaceUpdate();
+    }
+}
+
+export default async function (o) {
+    let {global, console, msg} = o;
+    addon = o.addon;
+    safeMsg = o.safeMsg;
+    console.log("a11y support enabled");
+    vm = addon.tab.traps.onceValues.vm;
+    injectWorkspace()
+    ensureWrap();
+    renderLoop();
+    const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
+    vm.runtime.sequencer.stepToProcedure = function(thread, proccode) {
+        if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
+            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+            a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0]
+        } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
+            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+            a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0]
+        }
+        return oldStepToProcedure.call(this, thread, proccode);
+    }
+    ;
+}
+
+function updateAria(target) {
+    a11yObjects[target.id] = a11yObjects[target.id] || {}
+    if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
+        a11yObjects[target.id].ele = document.createElement("div")
+        a11yObjects[target.id].ele.className = "aria-item";
+        a11yObjects[target.id].ele.dataset.spriteId = target.id
+        a11yObjects[target.id].ele.setAttribute("tabindex", "-1")
+        wrap.append(a11yObjects[target.id].ele)
+    }
+    let bounds = target.renderer.getBounds(target.drawableID);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width)
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height)
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top)
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left)
+    if (a11yObjects[target.id].role) {
+        a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role)
+    } else {
+        a11yObjects[target.id].removeAttribute("role")
+    }
+    if (a11yObjects[target.id].label) {
+        a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label)
+    } else {
+        a11yObjects[target.id].ele.removeAttribute("aria-label")
+    }
+}

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -3,119 +3,135 @@ let a11yObjects = {};
 window.a11yObjects = a11yObjects;
 let blockColorOverrides = {};
 blockColorOverrides["set sprite aria role to %s"] = blockColorOverrides["set sprite label to %s"] = {
-    color: "#43cfca",
-    secondaryColor: "#3aa8a4",
-    tertiaryColor: "#3aa8a4"
-}
+  color: "#43cfca",
+  secondaryColor: "#3aa8a4",
+  tertiaryColor: "#3aa8a4",
+};
 
 function makeWrap() {
-    wrap = document.createElement("div");
-    wrap.id = "aria-container";
-    let canvas = document.querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas')
-    canvas.insertAdjacentElement("beforeBegin", wrap);
-    function pass2canvas(e) {
-        let o = {
-            touches: e.touches,
-            clientX: e.clientX,
-            clientY: e.clientY,
-            changedTouches: e.changedTouches,
-            deltaX: e.deltaX,
-            deltaY: e.deltaY
-        }
-        canvas.dispatchEvent(new e.constructor(e.type,o))
-    }
-    wrap.addEventListener('mousedown', pass2canvas);
-    wrap.addEventListener('touchstart', pass2canvas);
-    wrap.addEventListener('wheel', pass2canvas);
+  wrap = document.createElement("div");
+  wrap.id = "aria-container";
+  let canvas = document.querySelector(
+    '[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas'
+  );
+  canvas.insertAdjacentElement("beforeBegin", wrap);
+  function pass2canvas(e) {
+    let o = {
+      touches: e.touches,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      changedTouches: e.changedTouches,
+      deltaX: e.deltaX,
+      deltaY: e.deltaY,
+    };
+    canvas.dispatchEvent(new e.constructor(e.type, o));
+  }
+  wrap.addEventListener("mousedown", pass2canvas);
+  wrap.addEventListener("touchstart", pass2canvas);
+  wrap.addEventListener("wheel", pass2canvas);
 }
 
 async function ensureWrap() {
-    while (true) {
-        await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
-            markAsSeen: true,
-        });
-        makeWrap();
-    }
+  while (true) {
+    await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
+      markAsSeen: true,
+    });
+    makeWrap();
+  }
 }
 
 function cleanUp() {
-    let targets = vm.runtime.targets.map((e)=>e.id);
-    Object.keys(a11yObjects).filter((e)=>!targets.includes(e)).forEach((e)=>{
-        a11yObjects[e].ele.remove();
-        delete a11yObjects[e];
-    }
-    );
+  let targets = vm.runtime.targets.map((e) => e.id);
+  Object.keys(a11yObjects)
+    .filter((e) => !targets.includes(e))
+    .forEach((e) => {
+      a11yObjects[e].ele.remove();
+      delete a11yObjects[e];
+    });
 }
 
 async function renderLoop() {
-    while (true) {
-        cleanUp();
-        for (let e of Object.entries(a11yObjects)) {
-            updateAria(vm.runtime.targets.filter((a)=>a.id == e[0])[0]);
-        }
-        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [["text"], ["czc6,OD@W7qzCng-$6Ut"], ["img"], ]));
-        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]]));
-        await new Promise((cb)=>requestAnimationFrame((_)=>cb()));
+  while (true) {
+    cleanUp();
+    for (let e of Object.entries(a11yObjects)) {
+      updateAria(vm.runtime.targets.filter((a) => a.id == e[0])[0]);
     }
+    vm.runtime.targets.forEach(
+      (e) =>
+        (e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [
+          ["text"],
+          ["czc6,OD@W7qzCng-$6Ut"],
+          ["img"],
+        ])
+    );
+    vm.runtime.targets.forEach(
+      (e) =>
+        (e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
+    );
+    await new Promise((cb) => requestAnimationFrame((_) => cb()));
+  }
 }
 
 let injected;
 
-const injectWorkspace = ()=>{
-    if (injected) {
-        return;
+const injectWorkspace = () => {
+  if (injected) {
+    return;
+  }
+  injected = true;
+
+  const workspace = Blockly.getMainWorkspace();
+  if (!workspace) throw new Error("expected workspace");
+
+  let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor;
+  let oldUpdateColor = BlockSvg.prototype.updateColour;
+  BlockSvg.prototype.updateColour = function (...a) {
+    if (this.procCode_) {
+      let p = this.procCode_;
+      if (blockColorOverrides[p.trim().toLowerCase()]) {
+        let c = blockColorOverrides[p.trim().toLowerCase()];
+        this.colour_ = c.color;
+        this.colourSecondary_ = c.secondaryColor;
+        this.colourTertiary_ = c.tertiaryColor;
+      }
     }
-    injected = true;
+    return oldUpdateColor.call(this, ...a);
+  };
 
-    const workspace = Blockly.getMainWorkspace();
-    if (!workspace)
-        throw new Error("expected workspace");
+  const flyout = workspace.getFlyout();
+  if (!flyout) throw new Error("expected flyout");
 
-    let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor
-    let oldUpdateColor = BlockSvg.prototype.updateColour
-    BlockSvg.prototype.updateColour = function(...a) {
-        if (this.procCode_) {
-            let p = this.procCode_;
-            if (blockColorOverrides[p.trim().toLowerCase()]) {
-                let c = blockColorOverrides[p.trim().toLowerCase()]
-                this.colour_ = c.color
-                this.colourSecondary_ = c.secondaryColor
-                this.colourTertiary_ = c.tertiaryColor
-            }
-        }
-        return oldUpdateColor.call(this, ...a)
-    }
+  vm = addon.tab.traps.onceValues.vm;
+  if (!vm) throw new Error("expected vm");
 
-    const flyout = workspace.getFlyout();
-    if (!flyout)
-        throw new Error("expected flyout");
+  // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
+  // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
+  const originalShow = flyout.constructor.prototype.show;
+  flyout.constructor.prototype.show = function (xml) {
+    this.workspace_.registerToolboxCategoryCallback("A11Y", function (e) {
+      return [
+        ...new DOMParser()
+          .parseFromString(
+            `<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
+<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,
+            "text/xml"
+          )
+          .querySelectorAll("block"),
+      ];
+    });
+    originalShow.call(this, xml);
+  };
 
-    vm = addon.tab.traps.onceValues.vm;
-    if (!vm)
-        throw new Error("expected vm");
-
-    // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
-    // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
-    const originalShow = flyout.constructor.prototype.show;
-    flyout.constructor.prototype.show = function(xml) {
-        this.workspace_.registerToolboxCategoryCallback("A11Y", function(e) {
-            return [...new DOMParser().parseFromString(`<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
-<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`, "text/xml").querySelectorAll("block"), ];
-        });
-        originalShow.call(this, xml);
-    }
-    ;
-
-    // We use Scratch's extension category mechanism to replace the data category with our own.
-    // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
-    // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
-    // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
-    const originalGetBlocksXML = vm.runtime.getBlocksXML;
-    vm.runtime.getBlocksXML = function(target) {
-        const result = originalGetBlocksXML.call(this, target);
-        result.push({
-            id: "a11ycat",
-            xml: `
+  // We use Scratch's extension category mechanism to replace the data category with our own.
+  // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
+  // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
+  // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
+  const originalGetBlocksXML = vm.runtime.getBlocksXML;
+  vm.runtime.getBlocksXML = function (target) {
+    const result = originalGetBlocksXML.call(this, target);
+    result.push({
+      id: "a11ycat",
+      xml: `
           <category
             name="${safeMsg("a11y-category")}"
             id="a11ycat"
@@ -123,80 +139,75 @@ const injectWorkspace = ()=>{
             secondaryColour="#3aa8a4"
             custom="A11Y">
           </category>`,
-        });
-        return result;
-    }
-    ;
+    });
+    return result;
+  };
 
-    // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
-    // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
-    // Workspace updates are slow, so don't do them unless necessary.
-    if (vm.editingTarget) {
-        vm.emitWorkspaceUpdate();
-    }
-}
-;
-
+  // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
+  // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
+  // Workspace updates are slow, so don't do them unless necessary.
+  if (vm.editingTarget) {
+    vm.emitWorkspaceUpdate();
+  }
+};
 export default async function (o) {
-    let {global, console, msg} = o;
-    addon = o.addon;
-    safeMsg = o.safeMsg;
-    console.log("a11y support enabled");
-    vm = addon.tab.traps.onceValues.vm;
-    ensureWrap();
-    renderLoop();
-    const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
-    vm.runtime.sequencer.stepToProcedure = function(thread, proccode) {
-        if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
-            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-            a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
-        } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
-            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-            a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
-        }
-        return oldStepToProcedure.call(this, thread, proccode);
+  let { global, console, msg } = o;
+  addon = o.addon;
+  safeMsg = o.safeMsg;
+  console.log("a11y support enabled");
+  vm = addon.tab.traps.onceValues.vm;
+  ensureWrap();
+  renderLoop();
+  const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
+  vm.runtime.sequencer.stepToProcedure = function (thread, proccode) {
+    if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
+      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+      a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
+    } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
+      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+      a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
     }
-    ;
-    if (addon.tab.editorMode === "editor") {
-        const interval = setInterval(()=>{
-            if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
-                injectWorkspace();
-                clearInterval(interval);
-            }
-        }
-        , 100);
-    }
-    addon.tab.addEventListener("urlChange", ()=>addon.tab.editorMode === "editor" && injectWorkspace());
+    return oldStepToProcedure.call(this, thread, proccode);
+  };
+  if (addon.tab.editorMode === "editor") {
+    const interval = setInterval(() => {
+      if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
+        injectWorkspace();
+        clearInterval(interval);
+      }
+    }, 100);
+  }
+  addon.tab.addEventListener("urlChange", () => addon.tab.editorMode === "editor" && injectWorkspace());
 }
 
 function updateAria(target) {
-    if(!target.visible){
-        if(a11yObjects[target.id]){
-            if(a11yObjects[target.id].ele) a11yObjects[target.id].ele.remove()
-        }
-        return
+  if (!target.visible) {
+    if (a11yObjects[target.id]) {
+      if (a11yObjects[target.id].ele) a11yObjects[target.id].ele.remove();
     }
-    a11yObjects[target.id] = a11yObjects[target.id] || {};
-    if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
-        a11yObjects[target.id].ele = document.createElement("div");
-        a11yObjects[target.id].ele.className = "aria-item";
-        a11yObjects[target.id].ele.dataset.spriteId = target.id;
-        a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
-        wrap.append(a11yObjects[target.id].ele);
-    }
-    let bounds = target.renderer.getBounds(target.drawableID);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
-    if (a11yObjects[target.id].role) {
-        a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
-    } else {
-        a11yObjects[target.id].ele.removeAttribute("role");
-    }
-    if (a11yObjects[target.id].label) {
-        a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
-    } else {
-        a11yObjects[target.id].ele.removeAttribute("aria-label");
-    }
+    return;
+  }
+  a11yObjects[target.id] = a11yObjects[target.id] || {};
+  if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
+    a11yObjects[target.id].ele = document.createElement("div");
+    a11yObjects[target.id].ele.className = "aria-item";
+    a11yObjects[target.id].ele.dataset.spriteId = target.id;
+    a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
+    wrap.append(a11yObjects[target.id].ele);
+  }
+  let bounds = target.renderer.getBounds(target.drawableID);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
+  if (a11yObjects[target.id].role) {
+    a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
+  } else {
+    a11yObjects[target.id].ele.removeAttribute("role");
+  }
+  if (a11yObjects[target.id].label) {
+    a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
+  } else {
+    a11yObjects[target.id].ele.removeAttribute("aria-label");
+  }
 }

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -1,142 +1,156 @@
 let wrap, vm, addon, safeMsg, msg;
 let a11yObjects = {};
-let getTabNav=function getTabNav(){
-    return false
-}
+let getTabNav = function getTabNav() {
+  return false;
+};
 window.a11yObjects = a11yObjects;
 let blockColorOverrides = {};
 blockColorOverrides["set sprite aria role to %s"] = blockColorOverrides["set sprite label to %s"] = {
-    color: "#43cfca",
-    secondaryColor: "#3aa8a4",
-    tertiaryColor: "#3aa8a4",
+  color: "#43cfca",
+  secondaryColor: "#3aa8a4",
+  tertiaryColor: "#3aa8a4",
 };
 
 function makeWrap() {
-    wrap = document.createElement("div");
-    wrap.id = "aria-container";
-    let canvas = document.querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas');
-    canvas.insertAdjacentElement("beforeBegin", wrap);
-    function pass2canvas(e) {
-        let o = {
-            touches: e.touches,
-            clientX: e.clientX,
-            clientY: e.clientY,
-            changedTouches: e.changedTouches,
-            deltaX: e.deltaX,
-            deltaY: e.deltaY,
-        };
-        canvas.dispatchEvent(new e.constructor(e.type,o));
-    }
-    wrap.addEventListener("mousedown", pass2canvas);
-    wrap.addEventListener("touchstart", pass2canvas);
-    wrap.addEventListener("wheel", pass2canvas);
+  wrap = document.createElement("div");
+  wrap.id = "aria-container";
+  let canvas = document.querySelector(
+    '[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas'
+  );
+  canvas.insertAdjacentElement("beforeBegin", wrap);
+  function pass2canvas(e) {
+    let o = {
+      touches: e.touches,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      changedTouches: e.changedTouches,
+      deltaX: e.deltaX,
+      deltaY: e.deltaY,
+    };
+    canvas.dispatchEvent(new e.constructor(e.type, o));
+  }
+  wrap.addEventListener("mousedown", pass2canvas);
+  wrap.addEventListener("touchstart", pass2canvas);
+  wrap.addEventListener("wheel", pass2canvas);
 }
 
 async function ensureWrap() {
-    while (true) {
-        await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
-            markAsSeen: true,
-        });
-        makeWrap();
-    }
+  while (true) {
+    await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
+      markAsSeen: true,
+    });
+    makeWrap();
+  }
 }
 
 function cleanUp() {
-    let targets = vm.runtime.targets.map((e)=>e.id);
-    targets.forEach(e=>{
-        a11yObjects[e] = a11yObjects[e] || {}
-    }
-    )
-    Object.keys(a11yObjects).filter((e)=>!targets.includes(e)).forEach((e)=>{
-        a11yObjects[e].ele.remove();
-        delete a11yObjects[e];
-    }
-    );
+  let targets = vm.runtime.targets.map((e) => e.id);
+  targets.forEach((e) => {
+    a11yObjects[e] = a11yObjects[e] || {};
+  });
+  Object.keys(a11yObjects)
+    .filter((e) => !targets.includes(e))
+    .forEach((e) => {
+      a11yObjects[e].ele.remove();
+      delete a11yObjects[e];
+    });
 }
 
 async function renderLoop() {
-    while (true) {
-        cleanUp();
-        for (let e of Object.entries(a11yObjects)) {
-            updateAria(vm.runtime.targets.filter((a)=>a.id == e[0])[0]);
-        }
-        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [["text"], ["czc6,OD@W7qzCng-$6Ut"], ["img"], ]));
-        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]]));
-        await new Promise((cb)=>requestAnimationFrame((_)=>cb()));
+  while (true) {
+    cleanUp();
+    for (let e of Object.entries(a11yObjects)) {
+      updateAria(vm.runtime.targets.filter((a) => a.id == e[0])[0]);
     }
+    vm.runtime.targets.forEach(
+      (e) =>
+        (e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [
+          ["text"],
+          ["czc6,OD@W7qzCng-$6Ut"],
+          ["img"],
+        ])
+    );
+    vm.runtime.targets.forEach(
+      (e) =>
+        (e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
+    );
+    await new Promise((cb) => requestAnimationFrame((_) => cb()));
+  }
 }
 
 let injected;
 
-const injectWorkspace = ()=>{
-    if (injected) {
-        return;
+const injectWorkspace = () => {
+  if (injected) {
+    return;
+  }
+  injected = true;
+
+  const workspace = Blockly.getMainWorkspace();
+  if (!workspace) throw new Error("expected workspace");
+
+  let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor;
+  let oldUpdateColor = BlockSvg.prototype.updateColour;
+  BlockSvg.prototype.updateColour = function (...a) {
+    if (this.procCode_) {
+      let p = this.procCode_;
+      if (blockColorOverrides[p.trim().toLowerCase()]) {
+        let c = blockColorOverrides[p.trim().toLowerCase()];
+        this.colour_ = c.color;
+        this.colourSecondary_ = c.secondaryColor;
+        this.colourTertiary_ = c.tertiaryColor;
+        let updateChildColors = function updateChildColors() {
+          this.childBlocks_.forEach(
+            ((e) => {
+              e.setColour(e.getColour(), e.getColourSecondary(), this.getColourTertiary());
+            }).bind(this)
+          );
+        }.bind(this);
+        updateChildColors();
+        const oldPush = this.childBlocks_.__proto__.push.bind(this.childBlocks_);
+        this.childBlocks_.push = function (...a) {
+          updateChildColors();
+          return oldPush(...a);
+        };
+      }
     }
-    injected = true;
+    return oldUpdateColor.call(this, ...a);
+  };
 
-    const workspace = Blockly.getMainWorkspace();
-    if (!workspace)
-        throw new Error("expected workspace");
+  const flyout = workspace.getFlyout();
+  if (!flyout) throw new Error("expected flyout");
 
-    let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor;
-    let oldUpdateColor = BlockSvg.prototype.updateColour;
-    BlockSvg.prototype.updateColour = function(...a) {
-        if (this.procCode_) {
-            let p = this.procCode_;
-            if (blockColorOverrides[p.trim().toLowerCase()]) {
-                let c = blockColorOverrides[p.trim().toLowerCase()];
-                this.colour_ = c.color;
-                this.colourSecondary_ = c.secondaryColor;
-                this.colourTertiary_ = c.tertiaryColor;
-                let updateChildColors = (function updateChildColors() {
-                    this.childBlocks_.forEach((e=>{
-                        e.setColour(e.getColour(), e.getColourSecondary(), this.getColourTertiary())
-                    }
-                    ).bind(this))
-                }
-                ).bind(this)
-                updateChildColors()
-                const oldPush = this.childBlocks_.__proto__.push.bind(this.childBlocks_)
-                this.childBlocks_.push = function(...a) {
-                    updateChildColors()
-                    return oldPush(...a)
-                }
-            }
-        }
-        return oldUpdateColor.call(this, ...a);
-    }
-    ;
+  vm = addon.tab.traps.onceValues.vm;
+  if (!vm) throw new Error("expected vm");
 
-    const flyout = workspace.getFlyout();
-    if (!flyout)
-        throw new Error("expected flyout");
+  // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
+  // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
+  const originalShow = flyout.constructor.prototype.show;
+  flyout.constructor.prototype.show = function (xml) {
+    this.workspace_.registerToolboxCategoryCallback("A11Y", function (e) {
+      return [
+        ...new DOMParser()
+          .parseFromString(
+            `<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
+<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,
+            "text/xml"
+          )
+          .querySelectorAll("block"),
+      ];
+    });
+    originalShow.call(this, xml);
+  };
 
-    vm = addon.tab.traps.onceValues.vm;
-    if (!vm)
-        throw new Error("expected vm");
-
-    // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
-    // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
-    const originalShow = flyout.constructor.prototype.show;
-    flyout.constructor.prototype.show = function(xml) {
-        this.workspace_.registerToolboxCategoryCallback("A11Y", function(e) {
-            return [...new DOMParser().parseFromString(`<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
-<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`, "text/xml").querySelectorAll("block"), ];
-        });
-        originalShow.call(this, xml);
-    }
-    ;
-
-    // We use Scratch's extension category mechanism to replace the data category with our own.
-    // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
-    // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
-    // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
-    const originalGetBlocksXML = vm.runtime.getBlocksXML;
-    vm.runtime.getBlocksXML = function(target) {
-        const result = originalGetBlocksXML.call(this, target);
-        result.push({
-            id: "a11ycat",
-            xml: `
+  // We use Scratch's extension category mechanism to replace the data category with our own.
+  // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
+  // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
+  // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
+  const originalGetBlocksXML = vm.runtime.getBlocksXML;
+  vm.runtime.getBlocksXML = function (target) {
+    const result = originalGetBlocksXML.call(this, target);
+    result.push({
+      id: "a11ycat",
+      xml: `
           <category
             name="${safeMsg("a11y-category")}"
             id="a11ycat"
@@ -144,98 +158,95 @@ const injectWorkspace = ()=>{
             secondaryColour="#3aa8a4"
             custom="A11Y">
           </category>`,
-        });
-        return result;
-    }
-    ;
+    });
+    return result;
+  };
 
-    // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
-    // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
-    // Workspace updates are slow, so don't do them unless necessary.
-    if (vm.editingTarget) {
-        vm.emitWorkspaceUpdate();
-    }
-}
-;
+  // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
+  // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
+  // Workspace updates are slow, so don't do them unless necessary.
+  if (vm.editingTarget) {
+    vm.emitWorkspaceUpdate();
+  }
+};
 export default async function (o) {
-    let {global} = o;
-    getTabNav=function getTabNav(){
-        return o.addon.settings.get("tabNav")
+  let { global } = o;
+  getTabNav = function getTabNav() {
+    return o.addon.settings.get("tabNav");
+  };
+  addon = o.addon;
+  safeMsg = o.safeMsg;
+  msg = o.msg;
+  console = o.console;
+  console.log("a11y support enabled");
+  vm = addon.tab.traps.onceValues.vm;
+  ensureWrap();
+  renderLoop();
+  const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
+  vm.runtime.sequencer.stepToProcedure = function (thread, proccode) {
+    if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
+      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+      a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
+    } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
+      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+      a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
     }
-    addon = o.addon;
-    safeMsg = o.safeMsg;
-    msg=o.msg
-    console=o.console
-    console.log("a11y support enabled");
-    vm = addon.tab.traps.onceValues.vm;
-    ensureWrap();
-    renderLoop();
-    const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
-    vm.runtime.sequencer.stepToProcedure = function(thread, proccode) {
-        if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
-            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-            a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
-        } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
-            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-            a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
-        }
-        return oldStepToProcedure.call(this, thread, proccode);
-    }
-    ;
-    if (addon.tab.editorMode === "editor") {
-        const interval = setInterval(()=>{
-            if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
-                injectWorkspace();
-                clearInterval(interval);
-            }
-        }
-        , 100);
-    }
-    addon.tab.addEventListener("urlChange", ()=>addon.tab.editorMode === "editor" && injectWorkspace());
+    return oldStepToProcedure.call(this, thread, proccode);
+  };
+  if (addon.tab.editorMode === "editor") {
+    const interval = setInterval(() => {
+      if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
+        injectWorkspace();
+        clearInterval(interval);
+      }
+    }, 100);
+  }
+  addon.tab.addEventListener("urlChange", () => addon.tab.editorMode === "editor" && injectWorkspace());
 }
 
 function updateAria(target) {
-    if (!wrap)
-        return
-    if (!target.visible) {
-        if (a11yObjects[target.id]) {
-            if (a11yObjects[target.id].ele)
-                a11yObjects[target.id].ele.remove();
-        }
-        return;
+  if (!wrap) return;
+  if (!target.visible) {
+    if (a11yObjects[target.id]) {
+      if (a11yObjects[target.id].ele) a11yObjects[target.id].ele.remove();
     }
-    a11yObjects[target.id] = a11yObjects[target.id] || {};
-    if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
-        a11yObjects[target.id].ele = document.createElement("div");
-        a11yObjects[target.id].ele.className = "aria-item";
-        a11yObjects[target.id].ele.dataset.spriteId = target.id;
-        wrap.append(a11yObjects[target.id].ele);
+    return;
+  }
+  a11yObjects[target.id] = a11yObjects[target.id] || {};
+  if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
+    a11yObjects[target.id].ele = document.createElement("div");
+    a11yObjects[target.id].ele.className = "aria-item";
+    a11yObjects[target.id].ele.dataset.spriteId = target.id;
+    wrap.append(a11yObjects[target.id].ele);
+  }
+  if (getTabNav()) {
+    a11yObjects[target.id].ele.setAttribute("tabindex", "0");
+  } else {
+    a11yObjects[target.id].ele.removeAttribute("tabindex");
+  }
+  let bounds = target.renderer.getBounds(target.drawableID);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
+  if (a11yObjects[target.id].role) {
+    a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
+  } else {
+    a11yObjects[target.id].ele.removeAttribute("role");
+  }
+  let bubbleMessage = "";
+  let state = target.getCustomState("Scratch.looks");
+  if (state) {
+    if (state.text && state.text.trim()) {
+      bubbleMessage = msg(state.type + "Bubble", { text: state.text.trim() });
     }
-    if(getTabNav()){
-        a11yObjects[target.id].ele.setAttribute("tabindex", "0");
-        }else{
-            a11yObjects[target.id].ele.removeAttribute("tabindex");
-        }
-    let bounds = target.renderer.getBounds(target.drawableID);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
-    if (a11yObjects[target.id].role) {
-        a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
-    } else {
-        a11yObjects[target.id].ele.removeAttribute("role");
-    }
-    let bubbleMessage = "";
-    let state = target.getCustomState("Scratch.looks");
-    if (state) {
-        if (state.text && state.text.trim()) {
-            bubbleMessage = msg(state.type+"Bubble",{text:state.text.trim()})
-        }
-    }
-    if (a11yObjects[target.id].label || bubbleMessage) {
-        a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label?a11yObjects[target.id].label+" " + bubbleMessage:bubbleMessage);
-    } else {
-        a11yObjects[target.id].ele.removeAttribute("aria-label");
-    }
+  }
+  if (a11yObjects[target.id].label || bubbleMessage) {
+    a11yObjects[target.id].ele.setAttribute(
+      "aria-label",
+      a11yObjects[target.id].label ? a11yObjects[target.id].label + " " + bubbleMessage : bubbleMessage
+    );
+  } else {
+    a11yObjects[target.id].ele.removeAttribute("aria-label");
+  }
 }

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -81,6 +81,7 @@ async function renderLoop() {
 let injected;
 
 const injectWorkspace = () => {
+  if(!!window.ENABLE_A11Y_BLOCKS){
   if (injected) {
     return;
   }
@@ -168,6 +169,7 @@ const injectWorkspace = () => {
   if (vm.editingTarget) {
     vm.emitWorkspaceUpdate();
   }
+}
 };
 export default async function (o) {
   let { global } = o;
@@ -193,6 +195,7 @@ export default async function (o) {
     }
     return oldStepToProcedure.call(this, thread, proccode);
   };
+  
   if (addon.tab.editorMode === "editor") {
     const interval = setInterval(() => {
       if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -3,83 +3,99 @@ let a11yObjects = {};
 window.a11yObjects = a11yObjects;
 
 function makeWrap() {
-    wrap = document.createElement("div")
-    wrap.id = "aria-container"
-    document.querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas').insertAdjacentElement("beforeBegin", wrap)
+  wrap = document.createElement("div");
+  wrap.id = "aria-container";
+  document
+    .querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas')
+    .insertAdjacentElement("beforeBegin", wrap);
 }
 
 async function ensureWrap() {
-    while (true) {
-        await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
-            markAsSeen: true
-        });
-        makeWrap()
-    }
+  while (true) {
+    await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
+      markAsSeen: true,
+    });
+    makeWrap();
+  }
 }
 
 function cleanUp() {
-    let targets = vm.runtime.targets.map(e=>e.id)
-    Object.keys(a11yObjects).filter(e=>!targets.includes(e)).forEach(e=>{
-        a11yObjects[e].ele.remove()
-        delete a11yObjects[e]
-    }
-    )
+  let targets = vm.runtime.targets.map((e) => e.id);
+  Object.keys(a11yObjects)
+    .filter((e) => !targets.includes(e))
+    .forEach((e) => {
+      a11yObjects[e].ele.remove();
+      delete a11yObjects[e];
+    });
 }
 
 async function renderLoop() {
-    while (true) {
-        cleanUp()
-        for (let e of Object.entries(a11yObjects)) {
-            updateAria(vm.runtime.targets.filter(a=>a.id == e[0])[0])
-        }
-        vm.runtime.targets.forEach(e=>e.blocks._cache.procedureParamNames["set sprite aria role to %s"]=[["text"],["czc6,OD@W7qzCng-$6Ut"], ["img"]])
-        vm.runtime.targets.forEach(e=>e.blocks._cache.procedureParamNames["set sprite label to %s"]=[["text"],["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
-        await new Promise(cb=>requestAnimationFrame(_=>cb()))
+  while (true) {
+    cleanUp();
+    for (let e of Object.entries(a11yObjects)) {
+      updateAria(vm.runtime.targets.filter((a) => a.id == e[0])[0]);
     }
+    vm.runtime.targets.forEach(
+      (e) =>
+        (e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [
+          ["text"],
+          ["czc6,OD@W7qzCng-$6Ut"],
+          ["img"],
+        ])
+    );
+    vm.runtime.targets.forEach(
+      (e) =>
+        (e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
+    );
+    await new Promise((cb) => requestAnimationFrame((_) => cb()));
+  }
 }
 
 let injected;
 
-const injectWorkspace = ()=>{
-    if (injected) {
-        return;
-    }
-    injected = true;
+const injectWorkspace = () => {
+  if (injected) {
+    return;
+  }
+  injected = true;
 
-    const workspace = Blockly.getMainWorkspace();
-    if (!workspace)
-        throw new Error("expected workspace");
+  const workspace = Blockly.getMainWorkspace();
+  if (!workspace) throw new Error("expected workspace");
 
-    const flyout = workspace.getFlyout();
-    if (!flyout)
-        throw new Error("expected flyout");
+  const flyout = workspace.getFlyout();
+  if (!flyout) throw new Error("expected flyout");
 
-    vm = addon.tab.traps.onceValues.vm;
-    if (!vm)
-        throw new Error("expected vm");
+  vm = addon.tab.traps.onceValues.vm;
+  if (!vm) throw new Error("expected vm");
 
-    // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
-    // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
-    const originalShow = flyout.constructor.prototype.show;
-    flyout.constructor.prototype.show = function(xml) {
-        this.workspace_.registerToolboxCategoryCallback("A11Y", (function(e) {
-            return [...new DOMParser().parseFromString(`<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
-<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,"text/xml").querySelectorAll("block")]
-        }
-        ));
-        originalShow.call(this, xml);
-    }
+  // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
+  // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
+  const originalShow = flyout.constructor.prototype.show;
+  flyout.constructor.prototype.show = function (xml) {
+    this.workspace_.registerToolboxCategoryCallback("A11Y", function (e) {
+      return [
+        ...new DOMParser()
+          .parseFromString(
+            `<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
+<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,
+            "text/xml"
+          )
+          .querySelectorAll("block"),
+      ];
+    });
+    originalShow.call(this, xml);
+  };
 
-    // We use Scratch's extension category mechanism to replace the data category with our own.
-    // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
-    // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
-    // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
-    const originalGetBlocksXML = vm.runtime.getBlocksXML;
-    vm.runtime.getBlocksXML = function(target) {
-        const result = originalGetBlocksXML.call(this, target);
-        result.push({
-            id: "a11ycat",
-            xml: `
+  // We use Scratch's extension category mechanism to replace the data category with our own.
+  // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
+  // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
+  // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
+  const originalGetBlocksXML = vm.runtime.getBlocksXML;
+  vm.runtime.getBlocksXML = function (target) {
+    const result = originalGetBlocksXML.call(this, target);
+    result.push({
+      id: "a11ycat",
+      xml: `
           <category
             name="${safeMsg("a11y-category")}"
             id="a11ycat"
@@ -87,62 +103,62 @@ const injectWorkspace = ()=>{
             secondaryColour="#3aa8a4"
             custom="A11Y">
           </category>`,
-        });
-        return result;
-    }
+    });
+    return result;
+  };
 
-    // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
-    // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
-    // Workspace updates are slow, so don't do them unless necessary.
-    if (vm.editingTarget) {
-        vm.emitWorkspaceUpdate();
-    }
-}
+  // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
+  // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
+  // Workspace updates are slow, so don't do them unless necessary.
+  if (vm.editingTarget) {
+    vm.emitWorkspaceUpdate();
+  }
+};
 
 export default async function (o) {
-    let {global, console, msg} = o;
-    addon = o.addon;
-    safeMsg = o.safeMsg;
-    console.log("a11y support enabled");
-    vm = addon.tab.traps.onceValues.vm;
-    injectWorkspace()
-    ensureWrap();
-    renderLoop();
-    const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
-    vm.runtime.sequencer.stepToProcedure = function(thread, proccode) {
-        if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
-            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-            a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0]
-        } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
-            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-            a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0]
-        }
-        return oldStepToProcedure.call(this, thread, proccode);
+  let { global, console, msg } = o;
+  addon = o.addon;
+  safeMsg = o.safeMsg;
+  console.log("a11y support enabled");
+  vm = addon.tab.traps.onceValues.vm;
+  injectWorkspace();
+  ensureWrap();
+  renderLoop();
+  const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
+  vm.runtime.sequencer.stepToProcedure = function (thread, proccode) {
+    if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
+      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+      a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
+    } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
+      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+      a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
     }
+    return oldStepToProcedure.call(this, thread, proccode);
+  };
 }
 
 function updateAria(target) {
-    a11yObjects[target.id] = a11yObjects[target.id] || {}
-    if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
-        a11yObjects[target.id].ele = document.createElement("div")
-        a11yObjects[target.id].ele.className = "aria-item";
-        a11yObjects[target.id].ele.dataset.spriteId = target.id
-        a11yObjects[target.id].ele.setAttribute("tabindex", "-1")
-        wrap.append(a11yObjects[target.id].ele)
-    }
-    let bounds = target.renderer.getBounds(target.drawableID);
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width)
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height)
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top)
-    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left)
-    if (a11yObjects[target.id].role) {
-        a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role)
-    } else {
-        a11yObjects[target.id].removeAttribute("role")
-    }
-    if (a11yObjects[target.id].label) {
-        a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label)
-    } else {
-        a11yObjects[target.id].ele.removeAttribute("aria-label")
-    }
+  a11yObjects[target.id] = a11yObjects[target.id] || {};
+  if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
+    a11yObjects[target.id].ele = document.createElement("div");
+    a11yObjects[target.id].ele.className = "aria-item";
+    a11yObjects[target.id].ele.dataset.spriteId = target.id;
+    a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
+    wrap.append(a11yObjects[target.id].ele);
+  }
+  let bounds = target.renderer.getBounds(target.drawableID);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
+  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
+  if (a11yObjects[target.id].role) {
+    a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
+  } else {
+    a11yObjects[target.id].removeAttribute("role");
+  }
+  if (a11yObjects[target.id].label) {
+    a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
+  } else {
+    a11yObjects[target.id].ele.removeAttribute("aria-label");
+  }
 }

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -1,101 +1,121 @@
 let wrap, vm, addon, safeMsg;
 let a11yObjects = {};
 window.a11yObjects = a11yObjects;
+let blockColorOverrides = {};
+blockColorOverrides["set sprite aria role to %s"] = blockColorOverrides["set sprite label to %s"] = {
+    color: "#43cfca",
+    secondaryColor: "#3aa8a4",
+    tertiaryColor: "#3aa8a4"
+}
 
 function makeWrap() {
-  wrap = document.createElement("div");
-  wrap.id = "aria-container";
-  document
-    .querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas')
-    .insertAdjacentElement("beforeBegin", wrap);
+    wrap = document.createElement("div");
+    wrap.id = "aria-container";
+    let canvas = document.querySelector('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"] canvas')
+    canvas.insertAdjacentElement("beforeBegin", wrap);
+    function pass2canvas(e) {
+        let o = {
+            touches: e.touches,
+            clientX: e.clientX,
+            clientY: e.clientY,
+            changedTouches: e.changedTouches,
+            deltaX: e.deltaX,
+            deltaY: e.deltaY
+        }
+        canvas.dispatchEvent(new e.constructor(e.type,o))
+    }
+    wrap.addEventListener('mousedown', pass2canvas);
+    wrap.addEventListener('touchstart', pass2canvas);
+    wrap.addEventListener('wheel', pass2canvas);
 }
 
 async function ensureWrap() {
-  while (true) {
-    await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
-      markAsSeen: true,
-    });
-    makeWrap();
-  }
+    while (true) {
+        await addon.tab.waitForElement('[class*="stage_stage-wrapper_"] [class*="stage_stage_"][class*="box_box_"]', {
+            markAsSeen: true,
+        });
+        makeWrap();
+    }
 }
 
 function cleanUp() {
-  let targets = vm.runtime.targets.map((e) => e.id);
-  Object.keys(a11yObjects)
-    .filter((e) => !targets.includes(e))
-    .forEach((e) => {
-      a11yObjects[e].ele.remove();
-      delete a11yObjects[e];
-    });
+    let targets = vm.runtime.targets.map((e)=>e.id);
+    Object.keys(a11yObjects).filter((e)=>!targets.includes(e)).forEach((e)=>{
+        a11yObjects[e].ele.remove();
+        delete a11yObjects[e];
+    }
+    );
 }
 
 async function renderLoop() {
-  while (true) {
-    cleanUp();
-    for (let e of Object.entries(a11yObjects)) {
-      updateAria(vm.runtime.targets.filter((a) => a.id == e[0])[0]);
+    while (true) {
+        cleanUp();
+        for (let e of Object.entries(a11yObjects)) {
+            updateAria(vm.runtime.targets.filter((a)=>a.id == e[0])[0]);
+        }
+        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [["text"], ["czc6,OD@W7qzCng-$6Ut"], ["img"], ]));
+        vm.runtime.targets.forEach((e)=>(e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]]));
+        await new Promise((cb)=>requestAnimationFrame((_)=>cb()));
     }
-    vm.runtime.targets.forEach(
-      (e) =>
-        (e.blocks._cache.procedureParamNames["set sprite aria role to %s"] = [
-          ["text"],
-          ["czc6,OD@W7qzCng-$6Ut"],
-          ["img"],
-        ])
-    );
-    vm.runtime.targets.forEach(
-      (e) =>
-        (e.blocks._cache.procedureParamNames["set sprite label to %s"] = [["text"], ["E|XlmQQ}1C:3vH-VY2Q_"], [""]])
-    );
-    await new Promise((cb) => requestAnimationFrame((_) => cb()));
-  }
 }
 
 let injected;
 
-const injectWorkspace = () => {
-  if (injected) {
-    return;
-  }
-  injected = true;
+const injectWorkspace = ()=>{
+    if (injected) {
+        return;
+    }
+    injected = true;
 
-  const workspace = Blockly.getMainWorkspace();
-  if (!workspace) throw new Error("expected workspace");
+    const workspace = Blockly.getMainWorkspace();
+    if (!workspace)
+        throw new Error("expected workspace");
 
-  const flyout = workspace.getFlyout();
-  if (!flyout) throw new Error("expected flyout");
+    let BlockSvg = Object.values(Blockly.getMainWorkspace().getFlyout().checkboxes_)[0].block.constructor
+    let oldUpdateColor = BlockSvg.prototype.updateColour
+    BlockSvg.prototype.updateColour = function(...a) {
+        if (this.procCode_) {
+            let p = this.procCode_;
+            if (blockColorOverrides[p.trim().toLowerCase()]) {
+                let c = blockColorOverrides[p.trim().toLowerCase()]
+                this.colour_ = c.color
+                this.colourSecondary_ = c.secondaryColor
+                this.colourTertiary_ = c.tertiaryColor
+            }
+        }
+        return oldUpdateColor.call(this, ...a)
+    }
 
-  vm = addon.tab.traps.onceValues.vm;
-  if (!vm) throw new Error("expected vm");
+    const flyout = workspace.getFlyout();
+    if (!flyout)
+        throw new Error("expected flyout");
 
-  // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
-  // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
-  const originalShow = flyout.constructor.prototype.show;
-  flyout.constructor.prototype.show = function (xml) {
-    this.workspace_.registerToolboxCategoryCallback("A11Y", function (e) {
-      return [
-        ...new DOMParser()
-          .parseFromString(
-            `<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
-<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`,
-            "text/xml"
-          )
-          .querySelectorAll("block"),
-      ];
-    });
-    originalShow.call(this, xml);
-  };
+    vm = addon.tab.traps.onceValues.vm;
+    if (!vm)
+        throw new Error("expected vm");
 
-  // We use Scratch's extension category mechanism to replace the data category with our own.
-  // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
-  // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
-  // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
-  const originalGetBlocksXML = vm.runtime.getBlocksXML;
-  vm.runtime.getBlocksXML = function (target) {
-    const result = originalGetBlocksXML.call(this, target);
-    result.push({
-      id: "a11ycat",
-      xml: `
+    // Each time a new workspace is made, these callbacks are reset, so re-register whenever a flyout is shown.
+    // https://github.com/LLK/scratch-blocks/blob/61f02e4cac0f963abd93013842fe536ef24a0e98/core/flyout_base.js#L469
+    const originalShow = flyout.constructor.prototype.show;
+    flyout.constructor.prototype.show = function(xml) {
+        this.workspace_.registerToolboxCategoryCallback("A11Y", function(e) {
+            return [...new DOMParser().parseFromString(`<top><block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite aria role to %s" argumentids="[&quot;czc6,OD@W7qzCng-$6Ut&quot;]" argumentnames="[&quot;role&quot;]" argumentdefaults="[&quot;img&quot;]" warp="false"></mutation></block>
+<block type="procedures_call" gap="16"><mutation generateshadows="true" proccode="set sprite label to %s" argumentids="[&quot;E|XlmQQ}1C:3vH-VY2Q_&quot;]" argumentnames="[&quot;text&quot;]" argumentdefaults="[&quot;&quot;]" warp="false"></mutation></block></top>`, "text/xml").querySelectorAll("block"), ];
+        });
+        originalShow.call(this, xml);
+    }
+    ;
+
+    // We use Scratch's extension category mechanism to replace the data category with our own.
+    // https://github.com/LLK/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
+    // https://github.com/LLK/scratch-gui/blob/2ceab00370ad7bd8ecdf5c490e70fd02152b3e2a/src/lib/make-toolbox-xml.js#L763
+    // https://github.com/LLK/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381
+    const originalGetBlocksXML = vm.runtime.getBlocksXML;
+    vm.runtime.getBlocksXML = function(target) {
+        const result = originalGetBlocksXML.call(this, target);
+        result.push({
+            id: "a11ycat",
+            xml: `
           <category
             name="${safeMsg("a11y-category")}"
             id="a11ycat"
@@ -103,62 +123,80 @@ const injectWorkspace = () => {
             secondaryColour="#3aa8a4"
             custom="A11Y">
           </category>`,
-    });
-    return result;
-  };
+        });
+        return result;
+    }
+    ;
 
-  // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
-  // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
-  // Workspace updates are slow, so don't do them unless necessary.
-  if (vm.editingTarget) {
-    vm.emitWorkspaceUpdate();
-  }
-};
+    // If editingTarget has not been set yet, we have injected before the editor has loaded and emitWorkspaceUpdate will be called later.
+    // Otherwise, it's possible that the editor has already loaded and updated its toolbox, so force a workspace update.
+    // Workspace updates are slow, so don't do them unless necessary.
+    if (vm.editingTarget) {
+        vm.emitWorkspaceUpdate();
+    }
+}
+;
 
 export default async function (o) {
-  let { global, console, msg } = o;
-  addon = o.addon;
-  safeMsg = o.safeMsg;
-  console.log("a11y support enabled");
-  vm = addon.tab.traps.onceValues.vm;
-  injectWorkspace();
-  ensureWrap();
-  renderLoop();
-  const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
-  vm.runtime.sequencer.stepToProcedure = function (thread, proccode) {
-    if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
-      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-      a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
-    } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
-      a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
-      a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
+    let {global, console, msg} = o;
+    addon = o.addon;
+    safeMsg = o.safeMsg;
+    console.log("a11y support enabled");
+    vm = addon.tab.traps.onceValues.vm;
+    ensureWrap();
+    renderLoop();
+    const oldStepToProcedure = vm.runtime.sequencer.stepToProcedure;
+    vm.runtime.sequencer.stepToProcedure = function(thread, proccode) {
+        if (proccode.trim().toLowerCase() == "set sprite aria role to %s") {
+            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+            a11yObjects[thread.target.id].role = Object.values(thread.stackFrames[0].params)[0];
+        } else if (proccode.trim().toLowerCase() == "set sprite label to %s") {
+            a11yObjects[thread.target.id] = a11yObjects[thread.target.id] || {};
+            a11yObjects[thread.target.id].label = Object.values(thread.stackFrames[0].params)[0];
+        }
+        return oldStepToProcedure.call(this, thread, proccode);
     }
-    return oldStepToProcedure.call(this, thread, proccode);
-  };
+    ;
+    if (addon.tab.editorMode === "editor") {
+        const interval = setInterval(()=>{
+            if (typeof Blockly === "object" && Blockly.getMainWorkspace()) {
+                injectWorkspace();
+                clearInterval(interval);
+            }
+        }
+        , 100);
+    }
+    addon.tab.addEventListener("urlChange", ()=>addon.tab.editorMode === "editor" && injectWorkspace());
 }
 
 function updateAria(target) {
-  a11yObjects[target.id] = a11yObjects[target.id] || {};
-  if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
-    a11yObjects[target.id].ele = document.createElement("div");
-    a11yObjects[target.id].ele.className = "aria-item";
-    a11yObjects[target.id].ele.dataset.spriteId = target.id;
-    a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
-    wrap.append(a11yObjects[target.id].ele);
-  }
-  let bounds = target.renderer.getBounds(target.drawableID);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
-  a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
-  if (a11yObjects[target.id].role) {
-    a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
-  } else {
-    a11yObjects[target.id].removeAttribute("role");
-  }
-  if (a11yObjects[target.id].label) {
-    a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
-  } else {
-    a11yObjects[target.id].ele.removeAttribute("aria-label");
-  }
+    if(!target.visible){
+        if(a11yObjects[target.id]){
+            if(a11yObjects[target.id].ele) a11yObjects[target.id].ele.remove()
+        }
+        return
+    }
+    a11yObjects[target.id] = a11yObjects[target.id] || {};
+    if (!a11yObjects[target.id].ele || (a11yObjects[target.id].ele && !a11yObjects[target.id].ele.isConnected)) {
+        a11yObjects[target.id].ele = document.createElement("div");
+        a11yObjects[target.id].ele.className = "aria-item";
+        a11yObjects[target.id].ele.dataset.spriteId = target.id;
+        a11yObjects[target.id].ele.setAttribute("tabindex", "-1");
+        wrap.append(a11yObjects[target.id].ele);
+    }
+    let bounds = target.renderer.getBounds(target.drawableID);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-width", bounds.width);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-height", bounds.height);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-top", bounds.top);
+    a11yObjects[target.id].ele.style.setProperty("--aria-bounds-left", bounds.left);
+    if (a11yObjects[target.id].role) {
+        a11yObjects[target.id].ele.setAttribute("role", a11yObjects[target.id].role);
+    } else {
+        a11yObjects[target.id].ele.removeAttribute("role");
+    }
+    if (a11yObjects[target.id].label) {
+        a11yObjects[target.id].ele.setAttribute("aria-label", a11yObjects[target.id].label);
+    } else {
+        a11yObjects[target.id].ele.removeAttribute("aria-label");
+    }
 }

--- a/addons/a11y/userscript.js
+++ b/addons/a11y/userscript.js
@@ -119,7 +119,6 @@ export default async function (o) {
         }
         return oldStepToProcedure.call(this, thread, proccode);
     }
-    ;
 }
 
 function updateAria(target) {

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -9,6 +9,7 @@
   "editor-colored-context-menus",
   "editor-stage-left",
   "editor-theme3",
+  "a11y",
 
   "// For website:",
   "scratchr2",


### PR DESCRIPTION
**Changes**

Add a11y addon that adds a category to the toolbox with blocks to allow people to add WAI-ARIA roles and labels to their sprites.
![Two scratch blocks. The first one has the text "set sprite aria role to" then an input with the text "button" in it. The second one has the text "set sprite label to" then an input with the text "click me" in it.](https://owo.whats-th.is/AENA2on.svg)

**Reason for changes**

Scratch projects aren't accessible to people using assistive technologies. I think that is an issue.

**Tests**

I have tested it and fixed all bugs I've found.
