### PR TITLE
Show "beta" tag & expand if addon has warnings in settings popup

### DIFF
--- a/addons/disable-auto-save/addon.json
+++ b/addons/disable-auto-save/addon.json
@@ -1,6 +1,13 @@
 {
   "name": "Disable auto-save",
   "description": "Disables the automatic saving of projects while editing.",
+  "info": [
+    {
+      "type": "warning",
+      "text": "This will disable all types of project autosaving. Make sure to manually save your changes frequently to avoid losing them.",
+      "id": "manuallysave"
+    }
+  ],
   "credits": [
     {
       "name": "RustingRobot",
@@ -13,7 +20,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor", "beta"],
+  "tags": ["editor"],
   "enabledByDefault": false,
   "l10n": true
 }

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -164,7 +164,7 @@
               </div>
               <div class="badge purple" v-if="addon._tags.new">{{ msg("new") }}</div>
               <div class="badge darkgreen" v-if="addon._tags.forEditor">{{ msg("forEditor") }}</div>
-              <div class="badge red tooltip" v-if="addon._tags.beta">
+              <div class="badge red tooltip beta-badge" v-if="addon._tags.beta">
                 {{ msg("beta") }}
                 <div class="tooltiptext">{{ msg("betaTooltip") }}</div>
               </div>

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -304,7 +304,12 @@ const vue = (window.vue = new Vue({
         const newState = !addon._enabled;
         addon._enabled = newState;
         // Do not extend when enabling in popup mode, unless addon has warnings
-        addon._expanded = document.body.classList.contains("iframe") && !addon._expanded && (addon.info || []).every(item => item.type !== "warning") ? false : newState;
+        addon._expanded =
+          document.body.classList.contains("iframe") &&
+          !addon._expanded &&
+          (addon.info || []).every((item) => item.type !== "warning")
+            ? false
+            : newState;
         chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } });
 
         if (document.body.classList.contains("iframe")) setTimeout(() => this.popupOrderAddonsEnabledFirst(), 500);

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -303,8 +303,8 @@ const vue = (window.vue = new Vue({
       const toggle = () => {
         const newState = !addon._enabled;
         addon._enabled = newState;
-        // Do not extend when enabling in popup mode
-        addon._expanded = document.body.classList.contains("iframe") && !addon._expanded ? false : newState;
+        // Do not extend when enabling in popup mode, unless addon has warnings
+        addon._expanded = document.body.classList.contains("iframe") && !addon._expanded && (addon.info || []).every(item => item.type !== "warning") ? false : newState;
         chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } });
 
         if (document.body.classList.contains("iframe")) setTimeout(() => this.popupOrderAddonsEnabledFirst(), 500);

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -765,8 +765,11 @@ input[type="color"]::-webkit-color-swatch {
   overflow-y: hidden;
 }
 @media only screen and (max-width: 540px) {
-  .badge {
+  .badge:not(.beta-badge) {
     display: none !important;
+  }
+  .tooltiptext {
+    display: none;
   }
   .addon-description {
     display: none;


### PR DESCRIPTION
1. Shows "beta" tag in settings popup, but hides its tooltip when hovered
2. Expands enabled addons through the settings popup if addon has any warnings, so that users can read them
3. Remove "beta" tag in disable-auto-save, add warning to make sure users don't enable accidentally