### PR TITLE
Fix unreadable search bar

### DIFF
--- a/addons/dark-www/experimental_forums.css
+++ b/addons/dark-www/experimental_forums.css
@@ -2,6 +2,13 @@
 #brdheader {
   background: #075e46;
 }
+#forum-search-form {
+  background-color: inherit;
+  border-top-color: #606060;
+}
+#forum-search-dropdown {
+  border-color: #606060;
+}
 .forum-search-list .blockpost {
   color: #fff;
 }

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -100,6 +100,14 @@ html > body:not(.sa-body-editor) h4 {
 }
 #topnav form.search .glass {
   border-right: none;
+  background: url("https://scratch.mit.edu/images/nav-search-glass.png") no-repeat center center;
+  background-size: 14px 14px;
+}
+#topnav form.search input[type="text"] {
+  background: rgba(0, 0, 0, 0.1);
+}
+#topnav form.search input[type="text"]::placeholder {
+  color: rgba(255, 255, 255, 0.75);
 }
 #topnav ul.account-nav .logged-in-user .dropdown-menu {
   border: 1px solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
**Resolves**

Resolves #1353

**Changes**

Fixes incorrect styling of the search bar and forum search when webside dark mode is enabled without Scratch 2.0 → 3.0.

**Reason for changes**

Text in the search bar was unreadable.

**Tests**

![Screenshot](https://user-images.githubusercontent.com/51849865/105150952-aa983d00-5b05-11eb-9e47-1415f5d3a534.png)
