### PR TITLE
Fix unreadable message count on bright primary color

### DIFF
--- a/addons/scratchr2/lightprimary_compatibility.css
+++ b/addons/scratchr2/lightprimary_compatibility.css
@@ -35,7 +35,7 @@ button.grey,
   );
 }
 #topnav form.search .glass,
-#topnav ul.account-nav .messages .messages-icon,
+#topnav ul.account-nav .messages .messages-icon::before,
 #topnav ul.account-nav .my-stuff .mystuff-icon,
 #topnav .dropdown .caret,
 .button:not(.grey) .icon-sm {

--- a/addons/scratchr2/lightprimary_scratchwww_compatibility.css
+++ b/addons/scratchr2/lightprimary_scratchwww_compatibility.css
@@ -38,7 +38,7 @@
   );
 }
 #navigation .inner > ul > li.search .btn-search,
-#navigation .messages > a,
+#navigation .messages > a::before,
 #navigation .mystuff > a,
 .account-nav .user-info::after,
 .button img,
@@ -50,6 +50,23 @@
   filter: brightness(calc(1 - var(--scratchr2-primaryColor-isLight) * (1 - 0.4)));
 }
 
+#navigation .messages > a {
+  background-image: none;
+}
+#navigation .messages > a::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: url(https://scratch.mit.edu/images/nav-notifications.png) no-repeat center center;
+  background-size: 45%;
+}
+#navigation .messages > a:hover::before {
+  background-size: 50%;
+}
 .preview .remix-button,
 .os-chooser .button:not(.active) {
   color: #fff;

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -357,15 +357,26 @@ h4 {
   padding: 13px 10px 4px 10px;
 }
 #topnav ul.account-nav .messages .messages-icon {
-  background-image: url("https://scratch.mit.edu/images/nav-notifications.png");
-  background-size: 45%;
+  background-image: none;
   width: 30px;
   height: 33px;
   padding: 13px 10px 4px 10px;
   position: relative;
 }
+#topnav ul.account-nav .messages .messages-icon::before {
+  /* Move icon into a pseudo-element so filters can be applied to it separately */
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: url("https://scratch.mit.edu/images/nav-notifications.png") no-repeat center center;
+  background-size: 45%;
+}
 #topnav ul.account-nav .my-stuff .mystuff-icon:hover,
-#topnav ul.account-nav .messages .messages-icon:hover {
+#topnav ul.account-nav .messages .messages-icon:hover::before {
   background-size: 50%;
 }
 #topnav ul.account-nav .messages .notificationsCount {


### PR DESCRIPTION
**Resolves**

Resolves #1320

**Changes**

Makes the message count readable when the primary color is set to a bright color in Scratch 2.0 → 3.0.
