### PR TITLE
Fix infinite scrolling layout

### DIFF
--- a/addons/infinite-scroll/userscript.css
+++ b/addons/infinite-scroll/userscript.css
@@ -1,5 +1,10 @@
 body {
-  padding-bottom: 38px;
+  /* scratch-www */
+  padding-bottom: 45px;
+}
+#content {
+  /* scratchr2 */
+  padding-bottom: 45px;
 }
 
 /*
@@ -10,10 +15,14 @@ body {
   top: initial;
   bottom: 0;
   width: 100%;
-  height: 38px;
+  height: 46px;
+  padding: 0;
   z-index: 20;
   transition-duration: 0.5s;
 }
+#footer .container {
+  padding-top: 20px;
+}
 #footer:hover {
-  height: 220px;
+  height: 300px;
 }


### PR DESCRIPTION
**Resolves**

Resolves #1325

**Changes**

Removes the blank space above the fixed footer when you scroll to the bottom on a scratchr2 page.
