### PR TITLE
Editor devtools: get ready for extension

### DIFF
--- a/addons-l10n/en/editor-devtools.json
+++ b/addons-l10n/en/editor-devtools.json
@@ -1,6 +1,6 @@
 {
   "editor-devtools/help-title": "Scratch 3 Developer Tools",
-  "editor-devtools/version": "Version {version} - Released {date} {ndash} by {url}",
+  "editor-devtools/version": "Version {version} - Released {date} {ndash} by {url} and Scratch Addons contributors & translators",
   "editor-devtools/changes024": "Changes in 0.2.3 - 0.2.4",
   "editor-devtools/ctrl-space": "Ctrl + Space or Middle Click",
   "editor-devtools/ctrl-space-desc": "Experimental Feature - This pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there.",

--- a/addons-l10n/en/editor-devtools.json
+++ b/addons-l10n/en/editor-devtools.json
@@ -54,5 +54,6 @@
   "editor-devtools/show-senders": "Show senders",
   "editor-devtools/show-receivers": "Show receivers",
   "editor-devtools/show-broadcast": "Show Broadcast Senders/Receivers",
-  "editor-devtools/show-broadcast-desc": "Right-click a broadcast block, then click \"Show senders\" or \"Show receivers\". Sprites with the block will get highlighted."
+  "editor-devtools/show-broadcast-desc": "Right-click a broadcast block, then click \"Show senders\" or \"Show receivers\". Sprites with the block will get highlighted.",
+  "editor-devtools/extension-description-not-for-addon": "Scratch 3 Developer Tools to enhance your Scratch Editing Experience on https://scratch.mit.edu"
 }

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -2163,9 +2163,11 @@ export default class DevTools {
         `
                 <div id="s3devToolBar">
                     <label class='title s3devLabel' id=s3devFindLabel>
-                        <span>${this.m(
-                          "find"
-                        )} ${this.addon.self._isDevtoolsExtension ? '' : '<a href="#" class="s3devAction" id="s3devHelp" style="/*s-a*/ margin-left: 0; font-size: 10px; /*s-a*/">(?)</a>'} </span>
+                        <span>${this.m("find")} ${
+          this.addon.self._isDevtoolsExtension
+            ? ""
+            : '<a href="#" class="s3devAction" id="s3devHelp" style="/*s-a*/ margin-left: 0; font-size: 10px; /*s-a*/">(?)</a>'
+        } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
                                 <input id='s3devInp' class="s3devInp" type='search' placeholder='${this.m(
@@ -2175,9 +2177,9 @@ export default class DevTools {
                             </div>
                         </span>
                         <a id="s3devDeep" class="s3devAction s3devHide" href="#">${this.m("deep")}</a>
-                        <div ${this.addon.self._isDevtoolsExtension ? '' : 'style="display: none;"'}><a href="#" class="s3devAction" id="s3devHelp"><b>${this.m(
-                          "help"
-                        )}</b></a>
+                        <div ${
+                          this.addon.self._isDevtoolsExtension ? "" : 'style="display: none;"'
+                        }><a href="#" class="s3devAction" id="s3devHelp"><b>${this.m("help")}</b></a>
                         <a href="https://www.youtube.com/griffpatch" class="s3devAction" target="_blank" id="s3devHelp">${this.m(
                           "tutorials"
                         )}</a></div>

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -2165,7 +2165,7 @@ export default class DevTools {
                     <label class='title s3devLabel' id=s3devFindLabel>
                         <span>${this.m(
                           "find"
-                        )} <a href="#" class="s3devAction" id="s3devHelp" style="/*s-a*/ margin-left: 0; font-size: 10px; /*s-a*/">(?)</a> </span>
+                        )} ${this.addon.self._isDevtoolsExtension ? '' : '<a href="#" class="s3devAction" id="s3devHelp" style="/*s-a*/ margin-left: 0; font-size: 10px; /*s-a*/">(?)</a>'} </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
                                 <input id='s3devInp' class="s3devInp" type='search' placeholder='${this.m(
@@ -2175,7 +2175,7 @@ export default class DevTools {
                             </div>
                         </span>
                         <a id="s3devDeep" class="s3devAction s3devHide" href="#">${this.m("deep")}</a>
-                        <div style="display: none;"><a href="#" class="s3devAction" id="s3devHelp"><b>${this.m(
+                        <div ${this.addon.self._isDevtoolsExtension ? '' : 'style="display: none;"'}><a href="#" class="s3devAction" id="s3devHelp"><b>${this.m(
                           "help"
                         )}</b></a>
                         <a href="https://www.youtube.com/griffpatch" class="s3devAction" target="_blank" id="s3devHelp">${this.m(
@@ -2186,7 +2186,7 @@ export default class DevTools {
 <!--                    <a id="s3devReplace" class="s3devAction s3devHide" href="#">Replace All</a>-->
                 </div>
             `
-      ); // div style="display: none;" added by Scratch Addons
+      );
 
       this.find = document.getElementById("s3devFind");
       this.findInp = document.getElementById("s3devInp");

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -9,15 +9,15 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
   }
 
   // 0-indexed 6 = July
-  const releaseDate = new Date(2020, 6, 4);
-  const releaseDateLocalized = new Intl.DateTimeFormat(scratchAddons.l10n.locale).format(releaseDate);
+  const releaseDate = new Date(2021, 1, 8);
+  const releaseDateLocalized = new Intl.DateTimeFormat(msg.locale).format(releaseDate);
 
   const helpHTML = `
 <div id="s3devHelpPop">
 <div>
 <h1><strong>${m("help-title")}</strong></h1>
 <p>${m("version", {
-    version: "0.2.4",
+    version: "1.9.0",
     date: releaseDateLocalized,
     ndash: "&ndash;",
     url: '<a target="_blank" rel="noreferrer noopener" href="https://www.youtube.com/griffpatch">Griffpatch</a>',


### PR DESCRIPTION
- Credit Scratch Addons in help popup
- Add extension description (not addon description) to locales so that we can translate it
- Show old style "help" and "tutorials" links if extension and not addon
- Bump date and version to v1.9.0, but help popup still needs update
- Use `msg.locale` instead of `scratchAddons.l10n.locale`