### PR TITLE
Show icon when project is muted

### DIFF
--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -2,14 +2,24 @@ export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
+    let container = button.parentElement;
+    let icon = document.createElement("img");
+    container.appendChild(icon);
+    icon.src = "/static/assets/e21225ab4b675bc61eed30cfb510c288.svg";
+    icon.style.display = "none";
     let mode = false;
     button.addEventListener("click", (e) => {
       if (e.ctrlKey) {
         e.cancelBubble = true;
         e.preventDefault();
         mode = !mode;
-        if (mode) vm.editingTarget.blocks.runtime.audioEngine.audioContext.suspend();
-        else vm.editingTarget.blocks.runtime.audioEngine.audioContext.resume();
+        if (mode) {
+          vm.editingTarget.blocks.runtime.audioEngine.audioContext.suspend();
+          icon.style.display = "block";
+        } else {
+          vm.editingTarget.blocks.runtime.audioEngine.audioContext.resume();
+          icon.style.display = "none";
+        }
       }
     });
   }


### PR DESCRIPTION
**Resolves**

Resolves #1362

**Changes**

Adds an icon shown when a project is muted.

![image](https://user-images.githubusercontent.com/51849865/105852592-f6a32000-5fe4-11eb-9568-2ade0000c823.png)
