### PR TITLE
scratchr2: use white text until JS can calculate contrast

### DIFF
--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -24,6 +24,10 @@
   ],
   "userstyles": [
     {
+      "url": "set-default-var-value.css",
+      "matches": ["https://scratch.mit.edu/*"]
+    },
+    {
       "url": "scratchr2.css",
       "matches": [
         "https://scratch.mit.edu/discuss/*",

--- a/addons/scratchr2/set-default-var-value.css
+++ b/addons/scratchr2/set-default-var-value.css
@@ -1,0 +1,6 @@
+/* sa-autoupdate-theme-ignore */
+
+html {
+  /* Set default value until JavaScript runs */
+  --scratchr2-primaryColor-isLight: 0;
+}


### PR DESCRIPTION
For obvious reasons, there's a little bit of time until JavaScript runs (lightprimary.js), until then the CSS variable `--scratchr2-primaryColor-isLight` resolves to an empty string, and the `calc()` functions that determine the color of the text in the navbar end up showing gray-ish text, instead of white, for half a second, on default addon settings.
This PR changes the default value of the variable to 0 until JS can actually calculate it, which is going to be the final result for most users that do not change the color of the navbar. The "problem" still persists but would affect less users, only the ones that change the color of the navbar to colors that do not contrast properly with white.