### PR TITLE
Devtools UI: change Scratch default <input> styles

### DIFF
--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -46,6 +46,16 @@ input.s3devInp {
   min-width: 100%;
   box-sizing: border-box;
   height: 1.5rem;
+
+  /* Change Scratch default styles */
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  padding-left: 0.4em;
+}
+
+input.s3devInp:focus {
+  /* Change Scratch default styles */
+  box-shadow: none;
 }
 
 /* Drop down from find button */


### PR DESCRIPTION
Slightly reverts part of #1433 - it's good to keep our styles consistent with Scratch's, but this differed too much from devtools' original design (specially with a way bigger border radius, and a box shadow on focus)