### PR TITLE
Introduce addon.tab.scratchClass

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -150,4 +150,29 @@ export default class Tab extends Listenable {
     const worker = new Worker(workerURL);
     return new Promise((resolve) => worker.addEventListener("message", () => resolve(worker), { once: true }));
   }
+
+  scratchClass(...args) {
+    let res = "";
+    args
+      .filter((arg) => typeof arg === "string")
+      .forEach((classNameToFind) => {
+        if (scratchAddons.classNames.loaded) {
+          res +=
+            scratchAddons.classNames.arr.find(
+              (className) =>
+                className.startsWith(classNameToFind + "_") && className.length === classNameToFind.length + 6
+            ) || "";
+        } else {
+          res += `scratchAddonsScratchClass/${classNameToFind}`;
+        }
+        res += " ";
+      });
+    if (typeof args[args.length - 1] === "object") {
+      const options = args[args.length - 1];
+      const classNames = Array.isArray(options.others) ? options.others : [options.others];
+      classNames.forEach((string) => (res += string + " "));
+    }
+    res = res.slice(0, -1);
+    return res;
+  }
 }

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -151,7 +151,7 @@ export default class Tab extends Listenable {
     return new Promise((resolve) => worker.addEventListener("message", () => resolve(worker), { once: true }));
   }
 
-    /**
+  /**
    * Gets the hashed class name for a Scratch stylesheet class name.
    * @param {...*} args Unhashed class names.
    * @param {object} opts - options.

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -173,6 +173,8 @@ export default class Tab extends Listenable {
       classNames.forEach((string) => (res += string + " "));
     }
     res = res.slice(0, -1);
+    // Sanitize just in case
+    res = res.replace(/"/g, "");
     return res;
   }
 }

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -151,6 +151,13 @@ export default class Tab extends Listenable {
     return new Promise((resolve) => worker.addEventListener("message", () => resolve(worker), { once: true }));
   }
 
+    /**
+   * Gets the hashed class name for a Scratch stylesheet class name.
+   * @param {...*} args Unhashed class names.
+   * @param {object} opts - options.
+   * @param {String[]|String} opts.others - Non-Scratch class or classes to merge.
+   * @returns {string} Hashed class names.
+   */
   scratchClass(...args) {
     let res = "";
     args

--- a/addons/animated-thumb/userscript.js
+++ b/addons/animated-thumb/userscript.js
@@ -7,17 +7,17 @@ export default async function ({ addon, global, console, msg }) {
     });
     if (!document.querySelector("[class^='author-info_username-line']")) {
       let setthumb = document.createElement("div");
-      setthumb.classList.add("menu-bar_menu-bar-item_oLDa-");
+      setthumb.classList.add(addon.tab.scratchClass("menu-bar_menu-bar-item"));
       setthumb.title = msg("added-by");
       let thumbinner = document.createElement("span");
       thumbinner.setAttribute(
         "class",
-        "button_outlined-button_1bS__ menu-bar_menu-bar-button_3IDN0 community-button_community-button_2Lo_g"
-      );
+        addon.tab.scratchClass("button_outlined-button", "menu-bar_menu-bar-button", "community-button_community-button"
+      ));
       thumbinner.setAttribute("role", "button");
       setthumb.append(thumbinner);
       let thumbcontent = document.createElement("div");
-      setthumb.classList.add("button_content_3jdgj");
+      setthumb.classList.add(addon.tab.scratchClass("button_content"));
       thumbinner.append(thumbcontent);
       let thumbspan = document.createElement("span");
       thumbspan.innerText = msg("set-thumbnail");

--- a/addons/animated-thumb/userscript.js
+++ b/addons/animated-thumb/userscript.js
@@ -12,8 +12,12 @@ export default async function ({ addon, global, console, msg }) {
       let thumbinner = document.createElement("span");
       thumbinner.setAttribute(
         "class",
-        addon.tab.scratchClass("button_outlined-button", "menu-bar_menu-bar-button", "community-button_community-button"
-      ));
+        addon.tab.scratchClass(
+          "button_outlined-button",
+          "menu-bar_menu-bar-button",
+          "community-button_community-button"
+        )
+      );
       thumbinner.setAttribute("role", "button");
       setthumb.append(thumbinner);
       let thumbcontent = document.createElement("div");

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1365,11 +1365,15 @@ export default class DevTools {
           contextMenu.insertAdjacentHTML(
             "beforeend",
             `
-                            <div class="${this.addon.tab.scratchClass("context-menu_menu-item", { others: ["react-contextmenu-item", "s3devSTT"] })}" role="menuitem"
+                            <div class="${this.addon.tab.scratchClass("context-menu_menu-item", {
+                              others: ["react-contextmenu-item", "s3devSTT"],
+                            })}" role="menuitem"
                                 tabindex="-1" aria-disabled="false" style="border-top: 1px solid hsla(0, 0%, 0%, 0.15);"><span>${this.m(
                                   "top"
                                 )}</span></div>
-                            <div class="${this.addon.tab.scratchClass("context-menu_menu-item", { others: ["react-contextmenu-item", "s3devSTT"] })}" role="menuitem"
+                            <div class="${this.addon.tab.scratchClass("context-menu_menu-item", {
+                              others: ["react-contextmenu-item", "s3devSTT"],
+                            })}" role="menuitem"
                                 tabindex="-1" aria-disabled="false"><span>${this.m("bottom")}</span></div>
                         `
           );
@@ -1636,9 +1640,9 @@ export default class DevTools {
                     <span style="display:none;">${this.m("insert")} </span>
                     <span id=s3devInsert class="s3devWrap">
                         <div id='s3devIDDOut' class="s3devDDOut">
-                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", { others : "s3devInp" })}" type='search' placeholder='${this.m(
-                              "start-typing"
-                            )}' autocomplete='off'>
+                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", {
+                              others: "s3devInp",
+                            })}" type='search' placeholder='${this.m("start-typing")}' autocomplete='off'>
                             <ul id='s3devIDD' class="s3devDD"></ul>
                         </div>
                     </span>
@@ -2173,9 +2177,9 @@ export default class DevTools {
         } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
-                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", { others: "s3devInp" })}" type='search' placeholder='${this.m(
-                                  "find-placeholder"
-                                )}' autocomplete='off'>
+                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", {
+                                  others: "s3devInp",
+                                })}" type='search' placeholder='${this.m("find-placeholder")}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>
                             </div>
                         </span>

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1640,7 +1640,7 @@ export default class DevTools {
                     <span style="display:none;">${this.m("insert")} </span>
                     <span id=s3devInsert class="s3devWrap">
                         <div id='s3devIDDOut' class="s3devDDOut">
-                            <input id='s3devIInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m(
+                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", { others : "s3devInp" })}" type='search' placeholder='${this.m(
                               "start-typing"
                             )}' autocomplete='off'>
                             <ul id='s3devIDD' class="s3devDD"></ul>
@@ -2177,7 +2177,7 @@ export default class DevTools {
         } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
-                                <input id='s3devInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m(
+                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", { others : "s3devInp" })}" type='search' placeholder='${this.m(
                                   "find-placeholder"
                                 )}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1640,9 +1640,7 @@ export default class DevTools {
                     <span style="display:none;">${this.m("insert")} </span>
                     <span id=s3devInsert class="s3devWrap">
                         <div id='s3devIDDOut' class="s3devDDOut">
-                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", {
-                              others: "s3devInp",
-                            })}" type='search' placeholder='${this.m("start-typing")}' autocomplete='off'>
+                            <input id='s3devIInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m("start-typing")}' autocomplete='off'>
                             <ul id='s3devIDD' class="s3devDD"></ul>
                         </div>
                     </span>
@@ -2177,9 +2175,7 @@ export default class DevTools {
         } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
-                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", {
-                                  others: "s3devInp",
-                                })}" type='search' placeholder='${this.m("find-placeholder")}' autocomplete='off'>
+                                <input id='s3devInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m("find-placeholder")}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>
                             </div>
                         </span>

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1640,7 +1640,9 @@ export default class DevTools {
                     <span style="display:none;">${this.m("insert")} </span>
                     <span id=s3devInsert class="s3devWrap">
                         <div id='s3devIDDOut' class="s3devDDOut">
-                            <input id='s3devIInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m("start-typing")}' autocomplete='off'>
+                            <input id='s3devIInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m(
+                              "start-typing"
+                            )}' autocomplete='off'>
                             <ul id='s3devIDD' class="s3devDD"></ul>
                         </div>
                     </span>
@@ -2175,7 +2177,9 @@ export default class DevTools {
         } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
-                                <input id='s3devInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m("find-placeholder")}' autocomplete='off'>
+                                <input id='s3devInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m(
+                                  "find-placeholder"
+                                )}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>
                             </div>
                         </span>

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1365,11 +1365,11 @@ export default class DevTools {
           contextMenu.insertAdjacentHTML(
             "beforeend",
             `
-                            <div class="react-contextmenu-item context-menu_menu-item_3cioN s3devSTT" role="menuitem"
+                            <div class="${this.addon.tab.scratchClass("context-menu_menu-item", { others: ["react-contextmenu-item", "s3devSTT"] })}" role="menuitem"
                                 tabindex="-1" aria-disabled="false" style="border-top: 1px solid hsla(0, 0%, 0%, 0.15);"><span>${this.m(
                                   "top"
                                 )}</span></div>
-                            <div class="react-contextmenu-item context-menu_menu-item_3cioN s3devSTT" role="menuitem"
+                            <div class="${this.addon.tab.scratchClass("context-menu_menu-item", { others: ["react-contextmenu-item", "s3devSTT"] })}" role="menuitem"
                                 tabindex="-1" aria-disabled="false"><span>${this.m("bottom")}</span></div>
                         `
           );
@@ -1636,7 +1636,7 @@ export default class DevTools {
                     <span style="display:none;">${this.m("insert")} </span>
                     <span id=s3devInsert class="s3devWrap">
                         <div id='s3devIDDOut' class="s3devDDOut">
-                            <input id='s3devIInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m(
+                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", { others : "s3devInp" })}" type='search' placeholder='${this.m(
                               "start-typing"
                             )}' autocomplete='off'>
                             <ul id='s3devIDD' class="s3devDD"></ul>
@@ -2173,7 +2173,7 @@ export default class DevTools {
         } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
-                                <input id='s3devInp' class="s3devInp input_input-form_l9eYg" type='search' placeholder='${this.m(
+                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", { others: "s3devInp" })}" type='search' placeholder='${this.m(
                                   "find-placeholder"
                                 )}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1640,9 +1640,9 @@ export default class DevTools {
                     <span style="display:none;">${this.m("insert")} </span>
                     <span id=s3devInsert class="s3devWrap">
                         <div id='s3devIDDOut' class="s3devDDOut">
-                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", { others : "s3devInp" })}" type='search' placeholder='${this.m(
-                              "start-typing"
-                            )}' autocomplete='off'>
+                            <input id='s3devIInp' class="${this.addon.tab.scratchClass("input_input-form", {
+                              others: "s3devInp",
+                            })}" type='search' placeholder='${this.m("start-typing")}' autocomplete='off'>
                             <ul id='s3devIDD' class="s3devDD"></ul>
                         </div>
                     </span>
@@ -2177,9 +2177,9 @@ export default class DevTools {
         } </span>
                         <span id=s3devFind class="s3devWrap">
                             <div id='s3devDDOut' class="s3devDDOut">
-                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", { others : "s3devInp" })}" type='search' placeholder='${this.m(
-                                  "find-placeholder"
-                                )}' autocomplete='off'>
+                                <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", {
+                                  others: "s3devInp",
+                                })}" type='search' placeholder='${this.m("find-placeholder")}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>
                             </div>
                         </span>

--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -44,7 +44,8 @@
 /* Find Input Box */
 input.s3devInp {
   min-width: 100%;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
+  /* !important required for extension, because CSS injection method (and hence order) differs from addon */
   height: 1.5rem;
 
   /* Change Scratch default styles */

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -21,8 +21,12 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
 <div class="${addon.tab.scratchClass("modal_header")}">
   <div class="${addon.tab.scratchClass("modal_header-item", "modal_header-item-title")}">${m("help-title")}</div>
   <div class="${addon.tab.scratchClass("modal_header-item", "modal_header-item-close")}">
-    <div class="${addon.tab.scratchClass("close-button_close-button", "close-button_large", { others: "close-button"})}">
-	  <img class="${addon.tab.scratchClass("close-button_close-icon")}" src="/static/assets/cb666b99d3528f91b52f985dfb102afa.svg">
+    <div class="${addon.tab.scratchClass("close-button_close-button", "close-button_large", {
+      others: "close-button",
+    })}">
+	  <img class="${addon.tab.scratchClass(
+      "close-button_close-icon"
+    )}" src="/static/assets/cb666b99d3528f91b52f985dfb102afa.svg">
 	</div>
   </div>
 </div>

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -14,14 +14,15 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
   const releaseDate = new Date(2021, 1, 8);
   const releaseDateLocalized = new Intl.DateTimeFormat(msg.locale).format(releaseDate);
 
+  // TODO: use addon.tab.scratchClass sanitized
   const helpHTML = `
-<div id="s3devHelpPop" class="modal_modal-overlay_1Lcbx">
-<div class="modal_modal-content_1h3ll">
-<div class="modal_header_1h7ps">
-  <div class="modal_header-item_2zQTd modal_header-item-title_tLOU5">${m("help-title")}</div>
-  <div class="modal_header-item_2zQTd modal_header-item-close_2XDeL">
-    <div class="close-button close-button_close-button_lOp2G close-button_large_2oadS">
-	  <img class="close-button_close-icon_HBCuO" src="/static/assets/cb666b99d3528f91b52f985dfb102afa.svg">
+<div id="s3devHelpPop" class="${addon.tab.scratchClass("modal_modal-overlay")}">
+<div class="${addon.tab.scratchClass("modal_modal-content")}">
+<div class="${addon.tab.scratchClass("modal_header")}">
+  <div class="${addon.tab.scratchClass("modal_header-item", "modal_header-item-title")}">${m("help-title")}</div>
+  <div class="${addon.tab.scratchClass("modal_header-item", "modal_header-item-close")}">
+    <div class="${addon.tab.scratchClass("close-button_close-button", "close-button_large", { others: "close-button"})}">
+	  <img class="${addon.tab.scratchClass("close-button_close-icon")}" src="/static/assets/cb666b99d3528f91b52f985dfb102afa.svg">
 	</div>
   </div>
 </div>

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -14,7 +14,6 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
   const releaseDate = new Date(2021, 1, 8);
   const releaseDateLocalized = new Intl.DateTimeFormat(msg.locale).format(releaseDate);
 
-  // TODO: use addon.tab.scratchClass sanitized
   const helpHTML = `
 <div id="s3devHelpPop" class="${addon.tab.scratchClass("modal_modal-overlay")}">
 <div class="${addon.tab.scratchClass("modal_modal-content")}">

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -48,8 +48,8 @@ export default async function ({ addon, msg }) {
         "load",
         function callback() {
           const observer = new MutationObserver(() => {
-            if (iframeElement.contentDocument.querySelector(".loader_fullscreen_29EhP") === null) {
-              iframeElement.contentDocument.querySelector(".green-flag_green-flag_1kiAo").click();
+            if (iframeElement.contentDocument.querySelector("[class^='loader_fullscreen']") === null) {
+              iframeElement.contentDocument.querySelector("[class^='green-flag_green-flag']").click();
               observer.disconnect();
             }
           });

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -7,17 +7,17 @@ export default async ({ addon, console, msg }) => {
     });
     const getOptions = () => {
       const recordOption = Object.assign(document.createElement("div"), {
-        className: "modal_modal-overlay_1Lcbx",
+        className: addon.tab.scratchClass("modal_modal-overlay"),
       });
       const recordOptionPopup = Object.assign(document.createElement("div"), {
-        className: "mediaRecorderPopup modal_modal-content_1h3ll",
+        className: addon.tab.scratchClass("modal_modal-content", {others: "mediaRecorderPopup"}),
       });
       const recordOptionHeader = Object.assign(document.createElement("div"), {
-        className: "modal_header_1h7ps",
+        className: addon.tab.scratchClass("modal_header"),
       });
       recordOptionHeader.appendChild(
         Object.assign(document.createElement("div"), {
-          className: "modal_header-item_2zQTd modal_header-item-title_tLOU5",
+          className: addon.tab.scratchClass("modal_header-item", "modal_header-item-title"),
           textContent: msg("option-title"),
           title: msg("added-by"),
         })
@@ -42,7 +42,7 @@ export default async ({ addon, console, msg }) => {
         max: 300,
         defaultValue: 30,
         id: "recordOptionSecondsInput",
-        className: "prompt_variable-name-text-input_1iu8-",
+        className: addon.tab.scratchClass("prompt_variable-name-text-input"),
       });
       const recordOptionSecondsLabel = Object.assign(document.createElement("label"), {
         htmlFor: "recordOptionSecondsInput",
@@ -130,7 +130,7 @@ export default async ({ addon, console, msg }) => {
       };
 
       const buttonRow = Object.assign(document.createElement("div"), {
-        className: "mediaRecorderPopupButtons prompt_button-row_3Wc5Z",
+        className: addon.tab.scratchClass("prompt_button-row", {others:"mediaRecorderPopupButtons"}),
       });
       const cancelButton = Object.assign(document.createElement("button"), {
         textContent: msg("cancel"),
@@ -139,7 +139,7 @@ export default async ({ addon, console, msg }) => {
       buttonRow.appendChild(cancelButton);
       const startButton = Object.assign(document.createElement("button"), {
         textContent: msg("start"),
-        className: "prompt_ok-button_3QFdD",
+        className: addon.tab.scratchClass("prompt_ok-button"),
       });
       startButton.addEventListener(
         "click",

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -10,7 +10,7 @@ export default async ({ addon, console, msg }) => {
         className: addon.tab.scratchClass("modal_modal-overlay"),
       });
       const recordOptionPopup = Object.assign(document.createElement("div"), {
-        className: addon.tab.scratchClass("modal_modal-content", {others: "mediaRecorderPopup"}),
+        className: addon.tab.scratchClass("modal_modal-content", { others: "mediaRecorderPopup" }),
       });
       const recordOptionHeader = Object.assign(document.createElement("div"), {
         className: addon.tab.scratchClass("modal_header"),
@@ -130,7 +130,7 @@ export default async ({ addon, console, msg }) => {
       };
 
       const buttonRow = Object.assign(document.createElement("div"), {
-        className: addon.tab.scratchClass("prompt_button-row", {others:"mediaRecorderPopupButtons"}),
+        className: addon.tab.scratchClass("prompt_button-row", { others: "mediaRecorderPopupButtons" }),
       });
       const cancelButton = Object.assign(document.createElement("button"), {
         textContent: msg("cancel"),

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -114,6 +114,14 @@ function loadClasses() {
   scratchAddons.classNames.arr = [
     ...new Set(
       [...document.styleSheets]
+        .filter(
+          (styleSheet) =>
+            !(
+              styleSheet.ownerNode.textContent.startsWith(
+                "/* DO NOT EDIT\n@todo This file is copied from GUI and should be pulled out into a shared library."
+              ) && styleSheet.ownerNode.textContent.includes("input_input-form")
+            )
+        )
         .map((e) => {
           try {
             return [...e.cssRules];

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -24,6 +24,7 @@ scratchAddons.eventTargets = {
   settings: [],
   tab: [],
 };
+scratchAddons.classNames = { loaded: false };
 
 const pendingPromises = {};
 pendingPromises.msgCount = [];
@@ -107,4 +108,51 @@ observer.observe(template, { attributes: true });
 
 for (const addon of addons) {
   if (addon.scripts.length) runAddonUserscripts(addon);
+}
+
+function loadClasses() {
+  scratchAddons.classNames.arr = [
+    ...new Set(
+      [...document.styleSheets]
+        .map((e) => {
+          try {
+            return [...e.cssRules];
+          } catch (e) {
+            return [];
+          }
+        })
+        .flat()
+        .map((e) => e.selectorText)
+        .filter((e) => e)
+        .map((e) => e.match(/(([\w-]+?)_([\w-]+)_([\w\d-]+))/g))
+        .filter((e) => e)
+        .flat()
+    ),
+  ];
+  scratchAddons.classNames.loaded = true;
+  document.querySelectorAll("[class*='scratchAddonsScratchClass/']").forEach((el) => {
+    [...el.classList]
+      .filter((className) => className.startsWith("scratchAddonsScratchClass"))
+      .map((className) => className.substring(className.indexOf("/") + 1))
+      .forEach((classNameToFind) =>
+        el.classList.replace(
+          `scratchAddonsScratchClass/${classNameToFind}`,
+          scratchAddons.classNames.arr.find(
+            (className) =>
+              className.startsWith(classNameToFind + "_") && className.length === classNameToFind.length + 6
+          ) || `scratchAddonsScratchClass/${classNameToFind}`
+        )
+      );
+  });
+}
+
+if(document.querySelector("title")) loadClasses();
+else {
+const stylesObserver = new MutationObserver((mutationsList) => {
+  if (document.querySelector("title")) {
+    stylesObserver.disconnect();
+    loadClasses();
+  }
+});
+stylesObserver.observe(document.head, { childList: true });
 }

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -146,13 +146,13 @@ function loadClasses() {
   });
 }
 
-if(document.querySelector("title")) loadClasses();
+if (document.querySelector("title")) loadClasses();
 else {
-const stylesObserver = new MutationObserver((mutationsList) => {
-  if (document.querySelector("title")) {
-    stylesObserver.disconnect();
-    loadClasses();
-  }
-});
-stylesObserver.observe(document.head, { childList: true });
+  const stylesObserver = new MutationObserver((mutationsList) => {
+    if (document.querySelector("title")) {
+      stylesObserver.disconnect();
+      loadClasses();
+    }
+  });
+  stylesObserver.observe(document.head, { childList: true });
 }

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -119,7 +119,9 @@ function loadClasses() {
             !(
               styleSheet.ownerNode.textContent.startsWith(
                 "/* DO NOT EDIT\n@todo This file is copied from GUI and should be pulled out into a shared library."
-              ) && styleSheet.ownerNode.textContent.includes("input_input-form")
+              ) &&
+              (styleSheet.ownerNode.textContent.includes("input_input-form") ||
+                styleSheet.ownerNode.textContent.includes("label_input-group_"))
             )
         )
         .map((e) => {


### PR DESCRIPTION
`addon.tab.scratchClass` is a handy function that should make it easier for us to be consistent with Scratch UI.
It accepts multiple arguments, for example 
```js
addon.tab.scratchClass("modal_header-item", "modal_header-item-title")
```
returns `modal_header-item_2zQTd modal_header-item-title_tLOU5`.

It also accepts an option object, that allows us to merge Scratch and non-Scratch classes automatically, for example: 
```js
addon.tab.scratchClass("modal_modal-content", { others: "mediaRecorderPopup" })
```
 returns `modal_modal-content_1h3ll mediaRecorderPopup`. (`others` can be either a string or array)

If an addon calls this function before the classes are available, they temporarily fallback to `scratchAddonsScratchClass/[classNameToFind]`, and after the classes load, all elements with these get their classes replaced accordingly.