### PR TITLE
Make sure translators don't repeat word "Scratch"

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -270,12 +270,14 @@
     "message": "Keep in mind, all features are togglable! To enable or disable them, go to the settings page by clicking this extension’s icon under “extensions” in the top-right corner of your browser, and then click the gear icon."
   },
   "extensionStoreDescription4": {
-    "message": "No usernames or passwords are stored, and you are required to be signed into your Scratch account in your browser for some features to work."
+    "message": "No usernames or passwords are stored, and you are required to be signed into your Scratch account in your browser for some features to work.",
+    "description": "NOTE: please only mention \"Scratch\" once on this string, do not repeat this word."
   },
   "extensionStoreDescription5": {
     "message": "This extension is open source software licensed under GPL v3.\nTo contribute or check the source code: https://github.com/ScratchAddons\nFor more information, go to: ScratchAddons.com"
   },
   "extensionStoreDescription6": {
-    "message": "This project is not affiliated, associated, or in any way officially connected with the Scratch website, Team, Foundation, or any of its affiliates."
+    "message": "This project is not affiliated, associated, or in any way officially connected with the Scratch website, Team, Foundation, or any of its affiliates.",
+    "description": "NOTE: please only mention \"Scratch\" once on this string, do not repeat this word."
   }
 }


### PR DESCRIPTION
Adds description to _locales asking translators this, to avoid keyword spam rejection on Chrome Web Store.