### PR TITLE
Editor devtools extension: run even if window.initGUI is truthy

### DIFF
--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -2,9 +2,7 @@ import DevTools from "./DevTools.js";
 
 export default async function ({ addon, global, console, msg, safeMsg: m }) {
   // noinspection JSUnresolvedVariable
-  if (
-    !addon.self._isDevtoolsExtension && window.initGUI
-  ) {
+  if (!addon.self._isDevtoolsExtension && window.initGUI) {
     console.log("Extension running, stopping addon");
     return;
   }

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -3,8 +3,7 @@ import DevTools from "./DevTools.js";
 export default async function ({ addon, global, console, msg, safeMsg: m }) {
   // noinspection JSUnresolvedVariable
   if (
-    !addon.self._isDevtoolsExtension &&
-    (window.initGUI || document.head.classList.contains("griffpatchDevtoolsExtensionEnabled"))
+    !addon.self._isDevtoolsExtension && window.initGUI
   ) {
     console.log("Extension running, stopping addon");
     return;

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -3,8 +3,8 @@ import DevTools from "./DevTools.js";
 export default async function ({ addon, global, console, msg, safeMsg: m }) {
   // noinspection JSUnresolvedVariable
   if (
-    window.initGUI ||
-    (!addon.self._isDevtoolsExtension && document.head.classList.contains("griffpatchDevtoolsExtensionEnabled"))
+    !addon.self._isDevtoolsExtension &&
+    (window.initGUI || document.head.classList.contains("griffpatchDevtoolsExtensionEnabled"))
   ) {
     console.log("Extension running, stopping addon");
     return;


### PR DESCRIPTION
The extension will set window.initGUI to make sure Scratch Addons <v1.9 doesn't run the editor-devtools addon