### PR TITLE
Dark preview when editing forum post

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -11,7 +11,11 @@
   "userscripts": [
     {
       "url": "experimental_forums_preview.js",
-      "matches": ["https://scratch.mit.edu/discuss/topic/*", "https://scratch.mit.edu/discuss/settings/*/"]
+      "matches": [
+        "https://scratch.mit.edu/discuss/topic/*",
+        "https://scratch.mit.edu/discuss/post/*/edit/",
+        "https://scratch.mit.edu/discuss/settings/*/"
+      ]
     }
   ],
   "userstyles": [


### PR DESCRIPTION
**Resolves**

Resolves #1480

**Changes**

Makes the preview when editing a forum post dark when website dark mode is enabled.