### PR TITLE
Settings page: do not extend disabled addon on shift + click enable

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -320,7 +320,9 @@ const vue = (window.vue = new Vue({
           !addon._expanded &&
           (addon.info || []).every((item) => item.type !== "warning")
             ? false
-            : (event.shiftKey ? false : newState);
+            : event.shiftKey
+            ? false
+            : newState;
         chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } });
 
         if (document.body.classList.contains("iframe")) setTimeout(() => this.popupOrderAddonsEnabledFirst(), 500);

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -309,6 +309,9 @@ const vue = (window.vue = new Vue({
     },
     toggleAddonRequest(addon) {
       const toggle = () => {
+        // Prevents selecting text when the shift key is being help down
+        event.preventDefault();
+
         const newState = !addon._enabled;
         addon._enabled = newState;
         // Do not extend when enabling in popup mode, unless addon has warnings
@@ -317,7 +320,7 @@ const vue = (window.vue = new Vue({
           !addon._expanded &&
           (addon.info || []).every((item) => item.type !== "warning")
             ? false
-            : newState;
+            : (event.shiftKey ? false : newState);
         chrome.runtime.sendMessage({ changeEnabledState: { addonId: addon._addonId, newState } });
 
         if (document.body.classList.contains("iframe")) setTimeout(() => this.popupOrderAddonsEnabledFirst(), 500);


### PR DESCRIPTION
**Changes**

Creates a check to see if shift is being held down, if so... do not expand the addon.

**Reason for changes**

Makes it easier to enable multiple addons quick.

**Tests**

I promise I won't have to change a single line of code.