### PR TITLE
Remove albanian translations

### DIFF
--- a/_locales/sq/messages.json
+++ b/_locales/sq/messages.json
@@ -1,1 +1,0 @@
-{"1hour":{"message":"Për 1 orë"},"8hours":{"message":"Për 8 orë"},"24hours":{"message":"Për 24 orë"},"extensionName":{"message":"Scratch Addons"}}

--- a/addons-l10n/sq/_general.json
+++ b/addons-l10n/sq/_general.json
@@ -1,1 +1,0 @@
-{"_locale":"sq","_locale_name":"shqip"}

--- a/addons-l10n/sq/data-category-tweaks-v2.json
+++ b/addons-l10n/sq/data-category-tweaks-v2.json
@@ -1,1 +1,0 @@
-{"data-category-tweaks-v2/list-category":"Listat"}

--- a/addons-l10n/sq/onion-skinning.json
+++ b/addons-l10n/sq/onion-skinning.json
@@ -1,1 +1,0 @@
-{"onion-skinning/merge":"Bashkoj","onion-skinning/front":"Përpara","onion-skinning/behind":"Mbrapa"}

--- a/addons-l10n/sq/scratch-messaging.json
+++ b/addons-l10n/sq/scratch-messaging.json
@@ -1,1 +1,0 @@
-{"scratch-messaging/delete":"Heq"}


### PR DESCRIPTION
It was added by error. The language is already removed from Transifex.