### PR TITLE
Scratch Messaging: z-index fixes, tooltip hover fixes

### DIFF
--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -264,7 +264,7 @@ button {
 
 #bottom-bar {
   position: fixed;
-  z-index: 999;
+  z-index: 10000;
   bottom: 0;
   left: 0;
   right: 0;

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -276,7 +276,7 @@
         <div class="message-type-title" :style="{zIndex: 9999 - i}">
           <a class="message-type-title-text" @click="openProject(project.id)">{{ project.title }}</a>
           <span class="float-right">
-            <div class="tooltip" style="display: inline-block; margin-right: 6px">
+            <div class="tooltip" style="display: inline-block; padding-left: 6px; padding-right: 6px;">
               <span v-show="project.loveCount"
                 ><img class="small-icon colored" src="../../images/icons/heart.svg" /> {{project.loveCount}}</span
               >

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -276,7 +276,7 @@
         <div class="message-type-title" :style="{zIndex: 9999 - i}">
           <a class="message-type-title-text" @click="openProject(project.id)">{{ project.title }}</a>
           <span class="float-right">
-            <div class="tooltip" style="display: inline-block; padding-left: 6px; padding-right: 6px;">
+            <div class="tooltip" style="display: inline-block; padding-left: 6px; padding-right: 6px">
               <span v-show="project.loveCount"
                 ><img class="small-icon colored" src="../../images/icons/heart.svg" /> {{project.loveCount}}</span
               >

--- a/webpages/styles/components/tooltips.css
+++ b/webpages/styles/components/tooltips.css
@@ -34,7 +34,7 @@
   top: -3px;
   right: 95%;
   margin-left: 0;
-  margin-right: 15px;
+  margin-right: 4px;
   transform: none;
 }
 


### PR DESCRIPTION
- Bottom bar should always be on top of lovers & favers tooltip, as well as project titles
- It's now easier to move your cursor above the tooltip in order to click in a username - previously you had to move your cursor fast or just at the right height.