### PR TITLE
Editor devtools: remove outdated strings & 0.x change list

### DIFF
--- a/addons-l10n/en/editor-devtools.json
+++ b/addons-l10n/en/editor-devtools.json
@@ -51,9 +51,5 @@
   "editor-devtools/variables": "variables",
   "editor-devtools/insert": "Insert",
   "editor-devtools/start-typing": "Start Typing...",
-  "editor-devtools/show-senders": "Show senders",
-  "editor-devtools/show-receivers": "Show receivers",
-  "editor-devtools/show-broadcast": "Show Broadcast Senders/Receivers",
-  "editor-devtools/show-broadcast-desc": "Right-click a broadcast block, then click \"Show senders\" or \"Show receivers\". Sprites with the block will get highlighted.",
   "editor-devtools/extension-description-not-for-addon": "Scratch 3 Developer Tools to enhance your Scratch Editing Experience on https://scratch.mit.edu"
 }

--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -34,16 +34,11 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
     url: '<a target="_blank" rel="noreferrer noopener" href="https://www.youtube.com/griffpatch">Griffpatch</a>',
   })}</p>
 <hr />
-<h2><strong>${m("changes024")}</strong></h2>
-<p><strong>${m("ctrl-space")}</strong> &ndash; ${m("ctrl-space-desc")}</p>
-<p><strong>${m("fixes")}</strong> &ndash; ${m("fixes-desc")}</p>
-<hr />
 <h2><strong>${m("code-tab-features")}</strong></h2>
 <p><strong>${m("interactive-find-bar")}</strong> - ${m("interactive-find-bar-desc")}</p>
 <p><strong>${m("improved-tidy-up")}</strong> &ndash; ${m("improved-tidy-up-desc")}</p>
 <p><strong>${m("copy-to-clipboard")}</strong> &ndash; ${m("copy-to-clipboard-desc")}</p>
 <p><strong>${m("paste-from-clipboard")}</strong> &ndash; ${m("paste-from-clipboard-desc")}</p>
-<p><strong>${m("show-broadcast")}</strong> &ndash; ${m("show-broadcast-desc")}</p>
 <p><strong>${m("swap-variable")}</strong> &ndash; ${m("swap-variable-desc")}</p>
 <p><strong>${m("middleclick")}</strong> &ndash; ${m("middleclick-desc")}</p>
 <p><strong>${m("ctrl-lr")}</strong> &ndash; ${m("ctrl-lr-desc")}</p>


### PR DESCRIPTION
Fixes #1435 kinda - not sure how and where to advertise Scratch Addons properly, might do it on next release.
Removes now unused strings from outdated show sender/receiver functionality. This functionality has been moved to the search bar.
It would be cool to have a better feature list for v1.10.