### PR TITLE
Muted extension shows badge on refresh

### DIFF
--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -24,7 +24,7 @@ const periods = [
 chrome.storage.local.get("muted", (obj) => {
   if (obj.muted) contextMenuMuted();
   else contextMenuUnmuted();
-  scratchAddons.muted = obj.muted
+  scratchAddons.muted = obj.muted;
 });
 
 chrome.contextMenus.removeAll();

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -24,6 +24,7 @@ const periods = [
 chrome.storage.local.get("muted", (obj) => {
   if (obj.muted) contextMenuMuted();
   else contextMenuUnmuted();
+  scratchAddons.muted = obj.muted
 });
 
 chrome.contextMenus.removeAll();


### PR DESCRIPTION
**Resolves**

Resolves #1523

**Changes**

one line of code. it was doing this previous action because `scratchAddons.muted` was undefined leading to the badge showing. This line of code sets it to deal with that problem.

**Tests**

Works.