### PR TITLE
Add fallback for pt translations

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -13,6 +13,9 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 function getL10NURLs() {
   const langCode = scratchAddons.globalState.auth.scratchLang.toLowerCase();
   const urls = [chrome.runtime.getURL(`addons-l10n/${langCode}`)];
+  if (langCode === "pt") {
+    urls.push(chrome.runtime.getURL(`addons-l10n/pt-br`));
+  }
   if (langCode.includes("-")) {
     urls.push(chrome.runtime.getURL(`addons-l10n/${langCode.split("-")[0]}`));
   }

--- a/background/l10n.js
+++ b/background/l10n.js
@@ -10,9 +10,10 @@ export default class BackgroundLocalizationProvider extends LocalizationProvider
     addonIds = ["_general", ...addonIds].filter(
       (addonId) => !addonId.startsWith("//") && !this.loaded.includes(addonId)
     );
-    const ui = chrome.i18n.getUILanguage();
+    const ui = chrome.i18n.getUILanguage().toLowerCase();
     const locales = [ui];
     if (ui.includes("-")) locales.push(ui.split("-")[0]);
+    if (ui.startsWith("pt") && ui !== "pt-br") locales.push("pt-br");
     if (!locales.includes("en")) locales.push("en");
 
     localeLoop: for (const locale of locales) {


### PR DESCRIPTION
pt (which is now lowercase) falls back to pt-br, then en. We use `pt` as `pt-pt` for Scratch compatibility.