### PR TITLE
Fix "custom Colors addon makes devtools highlighting not work"

### DIFF
--- a/addons/editor-devtools/blockly/BlockFlasher.js
+++ b/addons/editor-devtools/blockly/BlockFlasher.js
@@ -22,7 +22,7 @@ export default class BlockFlasher {
      * @private
      */
     function _flash() {
-      myFlash.block.setColour(flashOn ? "#ffff80" : myFlash.colour);
+      myFlash.block.svgPath_.style.fill = flashOn ? "#ffff80" : myFlash.colour;
       flashOn = !flashOn;
       count--;
       if (count > 0) {


### PR DESCRIPTION


**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #1545

**Changes**

The Blockly method just edited the `fill` attribute, which is overridden by the stylesheet. This way edits the `style` attribute, which overrides everything.

**Reason for changes**

it's a bug

**Tests**

it works