### PR TITLE
fix unreadable crash message with dark-www

### DIFF
--- a/addons/dark-www/dark-www.css
+++ b/addons/dark-www/dark-www.css
@@ -652,3 +652,8 @@ img.tips-icon {
 .tips-divider {
   border-top-color: #000;
 }
+
+.crash-container {
+  border: 1px solid #000;
+  background-color: #2d2d2d;
+}


### PR DESCRIPTION
sometimes scratch crashes and it shows a error message

with dark-www, it looks like this: 
![Screenshot 2021-01-29 103611](https://user-images.githubusercontent.com/61329810/107858723-5712c980-6dfb-11eb-8912-1df0e1e56f4b.jpg)
unreadable


**Changes**

update dark-www.css, now it looks like this:
![Screenshot 2021-01-29 103638](https://user-images.githubusercontent.com/61329810/107858733-698d0300-6dfb-11eb-9993-2412f811feb4.jpg)


**Reason for changes**

it's a bug

**Tests**

works