### PR TITLE
Fix invisible studio follower count

### DIFF
--- a/addons/dark-www/experimental_studio.css
+++ b/addons/dark-www/experimental_studio.css
@@ -4,7 +4,7 @@
 }
 #tabs {
   height: 30px;
-  background: #282828;
+  background: var(--scratchr2-dark-boxbg, transparent);
 }
 #tabs li {
   border: none;


### PR DESCRIPTION
**Resolves**

Resolves #1576

**Changes**

Fixes the studio follower count being invisible when website dark mode is enabled without Scratch 2.0 → 3.0.
