### PR TITLE
scratch-messaging: correct handling of Scratch Team comments

### DIFF
--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -159,13 +159,15 @@ export default async function ({ addon, global, console, setTimeout, setInterval
             1
           );
         }
+        const author = child.querySelector(".name").textContent.trim();
         childrenComments[`${resourceType[0]}_${childId}`] = {
-          author: child.querySelector(".name").textContent.trim(),
+          author: author.replace("*", ""),
           authorId: Number(child.querySelector(".reply").getAttribute("data-commentee-id")),
           content: fixCommentContent(child.querySelector(".content").innerHTML),
           date: child.querySelector(".time").getAttribute("title"),
           children: null,
           childOf: `${resourceType[0]}_${parentId}`,
+          scratchTeam: author.includes("*"),
         };
       }
 
@@ -178,13 +180,15 @@ export default async function ({ addon, global, console, setTimeout, setInterval
       }
 
       if (foundComment) {
+        const parentAuthor = parentComment.querySelector(".name").textContent.trim();
         commentsObj[`${resourceType[0]}_${parentId}`] = {
-          author: parentComment.querySelector(".name").textContent.trim(),
+          author: parentAuthor.replace("*", ""),
           authorId: Number(parentComment.querySelector(".reply").getAttribute("data-commentee-id")),
           content: fixCommentContent(parentComment.querySelector(".content").innerHTML),
           date: parentComment.querySelector(".time").getAttribute("title"),
           children: Object.keys(childrenComments),
           childOf: null,
+          scratchTeam: parentAuthor.includes("*"),
         };
         for (const childCommentId of Object.keys(childrenComments)) {
           commentsObj[childCommentId] = childrenComments[childCommentId];

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -16,7 +16,8 @@
         class="comment"
         :class="{'child-comment': !isParent, 'unread': unread, 'comment-me' : thisComment.author === username}"
       >
-        <a class="comment-author" @click="openProfile(thisComment.author)">{{ thisComment.author }}</a>{{ thisComment.scratchTeam ? "*" : "" }}
+        <a class="comment-author" @click="openProfile(thisComment.author)">{{ thisComment.author }}</a>{{
+        thisComment.scratchTeam ? "*" : "" }}
         <span class="comment-time" v-show="deleteStep !== 1 && !deleted">
           · {{ commentTimeAgo }}&nbsp;&nbsp;
           <img

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -16,7 +16,7 @@
         class="comment"
         :class="{'child-comment': !isParent, 'unread': unread, 'comment-me' : thisComment.author === username}"
       >
-        <a class="comment-author" @click="openProfile(thisComment.author)">{{ thisComment.author }}</a>
+        <a class="comment-author" @click="openProfile(thisComment.author)">{{ thisComment.author }}</a>{{ thisComment.scratchTeam ? "*" : "" }}
         <span class="comment-time" v-show="deleteStep !== 1 && !deleted">
           · {{ commentTimeAgo }}&nbsp;&nbsp;
           <img


### PR DESCRIPTION
Links to Scratch Team users' profiles on Scratch Messaging no longer includes an asterisk. Asterisks are still visible; they are just not inside the URL.