### PR TITLE
Fix missing scrollbar on licenses page

### DIFF
--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -455,6 +455,7 @@ h1 {
 .licenses {
   height: 100%;
   min-height: 100vh;
+  overflow-y: auto;
 }
 
 .licenses-block {


### PR DESCRIPTION
**Resolves**

None

**Changes**

Fixes the licenses page not having a scrollbar (which is a bug I made in #1187). Can be tested on the `scratch-blocks` license.