### PR TITLE
cloud-games: add loading indicator, do not request data in parallel

### DIFF
--- a/addons-l10n/en/cloud-games.json
+++ b/addons-l10n/en/cloud-games.json
@@ -1,4 +1,5 @@
 {
   "cloud-games/popup-title": "Scratch Addons - Cloud games",
-  "cloud-games/no-users": "No users currently playing"
+  "cloud-games/no-users": "No users currently playing",
+  "cloud-games/loading": "Loading... ({done}/{amount})"
 }

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -26,6 +26,13 @@ a:hover {
   text-decoration: underline;
 }
 
+.loading {
+  text-align: center;
+  font-size: 0.9rem;
+  padding-top: 1rem;
+  font-weight: bold;
+}
+
 .title {
   top: 0;
   z-index: 999;

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -10,21 +10,28 @@
     <script src="./popup.js" type="module"></script>
   </head>
 
-  <body style="display: none" v-show="loaded">
-    <div class="games" v-for="project of projectsSorted">
-      <div class="title">
-        <a class="project-name" :href="'https://scratch.mit.edu/projects/' + project.id" target="_blank"
-          >{{ project.title }}</a
-        >
-        <span class="float-right"><img class="small-icon" src="../../images/icons/users.svg" /> {{ project.amt }}</span>
-      </div>
-      <div class="project-details" v-show="true || project.amt > 0 && project.extended">
-        <div class="username-list">
-          <a v-for="user of project.users" :href="'https://scratch.mit.edu/users/' + user" target="_blank"
-            >{{ user }}</a
+  <body style="display: none" v-show="true">
+    <div v-show="projects.length === 0 || projects.length !== projectsChecked" style="text-align: center; font-size: 0.9rem; padding-top: 1rem; font-weight: bold">
+      {{ loadingMsg }}
+    </div>
+    <div v-show="loaded">
+      <div class="games" v-for="project of projectsSorted">
+        <div class="title">
+          <a class="project-name" :href="'https://scratch.mit.edu/projects/' + project.id" target="_blank"
+            >{{ project.title }}</a
+          >
+          <span class="float-right"
+            ><img class="small-icon" src="../../images/icons/users.svg" /> {{ project.amt }}</span
           >
         </div>
-        <div class="username-list" v-show="project.amt === 0">{{ messages.noUsersMsg }}</div>
+        <div class="project-details" v-show="true || project.amt > 0 && project.extended">
+          <div class="username-list">
+            <a v-for="user of project.users" :href="'https://scratch.mit.edu/users/' + user" target="_blank"
+              >{{ user }}</a
+            >
+          </div>
+          <div class="username-list" v-show="project.amt === 0">{{ messages.noUsersMsg }}</div>
+        </div>
       </div>
     </div>
   </body>

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -11,12 +11,7 @@
   </head>
 
   <body style="display: none" v-show="true">
-    <div
-      v-show="projects.length === 0 || projects.length !== projectsChecked"
-      style="text-align: center; font-size: 0.9rem; padding-top: 1rem; font-weight: bold"
-    >
-      {{ loadingMsg }}
-    </div>
+    <div class="loading" v-show="projects.length === 0 || projects.length !== projectsChecked">{{ loadingMsg }}</div>
     <div v-show="loaded">
       <div class="games" v-for="project of projectsSorted">
         <div class="title">

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -11,7 +11,10 @@
   </head>
 
   <body style="display: none" v-show="true">
-    <div v-show="projects.length === 0 || projects.length !== projectsChecked" style="text-align: center; font-size: 0.9rem; padding-top: 1rem; font-weight: bold">
+    <div
+      v-show="projects.length === 0 || projects.length !== projectsChecked"
+      style="text-align: center; font-size: 0.9rem; padding-top: 1rem; font-weight: bold"
+    >
       {{ loadingMsg }}
     </div>
     <div v-show="loaded">

--- a/popups/cloud-games/popup.js
+++ b/popups/cloud-games/popup.js
@@ -24,38 +24,51 @@ import WebsiteLocalizationProvider from "../../libraries/website-l10n.js";
       projects: [],
       loaded: false,
       messages: { noUsersMsg: l10n.get("cloud-games/no-users") },
+      projectsChecked: 0,
     },
     computed: {
       projectsSorted() {
         return this.projects.sort((b, a) => a.amt - b.amt);
       },
+      loadingMsg() {
+        return l10n.get("cloud-games/loading", { done: this.projectsChecked, amount: this.projects.length || "?" });
+      },
     },
     methods: {
-      async setCloudDataForProject(projectObject) {
-        const res = await fetch(
-          `https://clouddata.scratch.mit.edu/logs?projectid=${projectObject.id}&limit=40&offset=0`
-        );
-        const json = await res.json();
-        const dateNow = Date.now();
-        const usersSet = new Set();
-        for (const varChange of json) {
-          if (dateNow - varChange.timestamp > 60000) break;
-          usersSet.add(varChange.user);
-        }
-        projectObject.amt = usersSet.size;
-        projectObject.users = Array.from(usersSet);
+      setCloudDataForProject(projectObject, i) {
+        return new Promise((resolve) => {
+          setTimeout(async () => {
+            const res = await fetch(
+              `https://clouddata.scratch.mit.edu/logs?projectid=${projectObject.id}&limit=40&offset=0`
+            );
+            const json = await res.json();
+            const dateNow = Date.now();
+            const usersSet = new Set();
+            for (const varChange of json) {
+              if (dateNow - varChange.timestamp > 60000) break;
+              usersSet.add(varChange.user);
+            }
+            projectObject.amt = usersSet.size;
+            projectObject.users = Array.from(usersSet);
+            this.projectsChecked++;
+            if (this.projectsChecked / this.projects.length > 0.5) {
+              // Show UI even tho it's not ready, if a majority of projects loaded
+              this.loaded = true;
+            }
+            resolve();
+          }, i * 125);
+        });
       },
     },
     async created() {
       document.title = l10n.get("cloud-games/popup-title");
       const res = await fetch("https://api.scratch.mit.edu/studios/539952/projects/?limit=40");
       const projects = await res.json();
+      // TODO: add currently opened game to projects array. Sort function should put it on top
       this.projects = projects
         .map((project) => ({ title: project.title, id: project.id, amt: 0, users: [], extended: true }))
         .reverse();
-
-      await Promise.all(this.projects.map((project) => this.setCloudDataForProject(project)));
-      this.loaded = true;
+      await Promise.all(this.projects.map((project, i) => this.setCloudDataForProject(project, i)));
     },
   });
 })();


### PR DESCRIPTION
1. Adds loading indicator
2. Shows incomplete data after more than 50% of projects loaded, but keeps the loading indicator until 100% loads
3. Instead of starting each request in parallel, request every 125ms