### PR TITLE
Remove addon.fetch, introduce ?sareferer URL parameter for background requests

### DIFF
--- a/addons/full-signature/happen.js
+++ b/addons/full-signature/happen.js
@@ -13,13 +13,17 @@ export default async function ({ addon, global, console, msg }) {
     loadMore.addEventListener("click", async function () {
       dataLoaded += 5;
       if (dataLoaded > fetched.length) {
-        await addon
-          .fetch(
-            `
+        await fetch(
+          `
           https://api.scratch.mit.edu/users/${addon.auth.username}/following/users/activity?limit=40&offset=${
-              Math.floor(dataLoaded / 40) * 40
-            }`
-          )
+            Math.floor(dataLoaded / 40) * 40
+          }`,
+          {
+            headers: {
+              "X-Token": addon.auth.xToken,
+            },
+          }
+        )
           .then((response) => response.json())
           .then((rows) => {
             rows

--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -230,8 +230,9 @@ export default async function ({ addon, global, console, setTimeout, setInterval
     return new Promise((resolve) => {
       // For some weird reason, this only works with XHR in Chrome...
       const xhr = new XMLHttpRequest();
-      xhr.open("POST", `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/add/`, true);
-      xhr.setRequestHeader("X-ScratchAddons-Uses-Fetch", "true");
+      xhr.open("POST", `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/add/?sareferer`, true);
+      xhr.setRequestHeader("x-csrftoken", addon.auth.csrfToken);
+      xhr.setRequestHeader("x-requested-with", "XMLHttpRequest");
 
       xhr.onload = function () {
         if (xhr.status === 200) {
@@ -253,8 +254,9 @@ export default async function ({ addon, global, console, setTimeout, setInterval
   function deleteComment({ resourceType, resourceId, commentId }) {
     return new Promise((resolve) => {
       const xhr = new XMLHttpRequest();
-      xhr.open("POST", `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/del/`, true);
-      xhr.setRequestHeader("X-ScratchAddons-Uses-Fetch", "true");
+      xhr.open("POST", `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/del/?sareferer`, true);
+      xhr.setRequestHeader("x-csrftoken", addon.auth.csrfToken);
+      xhr.setRequestHeader("x-requested-with", "XMLHttpRequest");
 
       xhr.onload = function () {
         if (xhr.status === 200) {

--- a/addons/studio-tools/mystuff.js
+++ b/addons/studio-tools/mystuff.js
@@ -8,11 +8,11 @@ export default async function ({ addon, global, console, msg }) {
       leaveButton.setAttribute("data-id", item.parentElement.querySelector(".title a").href.match(/[0-9]+/g));
       leaveButton.addEventListener("click", async function (e) {
         if (confirm(msg("leave-confirm"))) {
-          await addon.fetch(
+          await fetch(
             `https://scratch.mit.edu/site-api/users/curators-in/${leaveButton.getAttribute(
               "data-id"
             )}/remove/?usernames=${Scratch.INIT_DATA.LOGGED_IN_USER.model.username}`,
-            { method: "PUT" }
+            { method: "PUT", headers: { "x-csrftoken": addon.auth.csrfToken, "x-requested-with": "XMLHttpRequest" } }
           );
           window.location.reload();
         }

--- a/background/handle-fetch.js
+++ b/background/handle-fetch.js
@@ -1,50 +1,23 @@
 const extraInfoSpec = ["blocking", "requestHeaders"];
-const extraInfoSpec2 = ["blocking", "responseHeaders"];
-if (Object.prototype.hasOwnProperty.call(chrome.webRequest.OnBeforeSendHeadersOptions, "EXTRA_HEADERS")) {
+if (Object.prototype.hasOwnProperty.call(chrome.webRequest.OnBeforeSendHeadersOptions, "EXTRA_HEADERS"))
   extraInfoSpec.push("extraHeaders");
-  extraInfoSpec2.push("extraHeaders");
-}
-
-const optionRequestIds = [];
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
   function (details) {
     if (details.originUrl) {
       // Firefox
       const origin = new URL(details.originUrl).origin;
-      if (origin !== chrome.runtime.getURL("").slice(0, -1) && origin !== "https://scratch.mit.edu") return;
+      if (origin !== chrome.runtime.getURL("").slice(0, -1)) return;
     } else if (
       // Chrome
-      details.initiator !== chrome.runtime.getURL("").slice(0, -1) &&
-      details.initiator !== "https://scratch.mit.edu"
+      details.initiator !== chrome.runtime.getURL("").slice(0, -1)
     )
       return;
 
-    let interceptRequest = optionRequestIds.includes(details.requestId);
-    if (!interceptRequest && details.requestHeaders) {
-      for (let i = 0; i < details.requestHeaders.length; i++) {
-        const headerName = details.requestHeaders[i].name;
-        if (headerName === "X-ScratchAddons-Uses-Fetch") {
-          interceptRequest = true;
-        }
-      }
-    }
-    if (interceptRequest) {
+    if (details.url.endsWith("?sareferer") || details.url.endsWith("&sareferer")) {
       details.requestHeaders.push({
         name: "Referer",
         value: "https://scratch.mit.edu/",
-      });
-      details.requestHeaders.push({
-        name: "X-csrftoken",
-        value: scratchAddons.globalState.auth.csrfToken,
-      });
-      details.requestHeaders.push({
-        name: "X-Token",
-        value: scratchAddons.globalState.auth.xToken,
-      });
-      details.requestHeaders.push({
-        name: "X-Requested-With",
-        value: "XMLHttpRequest",
       });
       return {
         requestHeaders: details.requestHeaders,
@@ -58,23 +31,29 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
   extraInfoSpec
 );
 
-chrome.webRequest.onHeadersReceived.addListener(
-  function (details) {
-    if (details.method === "OPTIONS" && details.responseHeaders) {
-      for (let i = 0; i < details.responseHeaders.length; i++) {
-        const headerName = details.responseHeaders[i].name;
-        if (headerName === "access-control-allow-headers") {
-          details.responseHeaders[i].value += ", x-scratchaddons-uses-fetch";
-          return {
-            responseHeaders: details.responseHeaders,
-          };
-        }
-      }
+/*
+
+// declarativeNetRequest alternative
+
+chrome.declarativeNetRequest.updateDynamicRules({
+  removeRuleIds: [1],
+  addRules: [{
+    id: 1,
+    priority: 1,
+    action: {
+      type: "modifyHeaders",
+      requestHeaders: [{
+        header: "Referer",
+        operation: "set",
+        value: "https://scratch.mit.edu/"
+      }]
+    },
+    condition: {
+      domains: [chrome.runtime.id],
+      regexFilter: "^https:\\/\\/(api\\.|clouddata\\.|)scratch\\.mit\\.edu\\/.*(\\?|\\&)sareferer",
+      resourceTypes: ["xmlhttprequest"]
     }
-  },
-  {
-    urls: ["https://scratch.mit.edu/*", "https://api.scratch.mit.edu/*", "https://clouddata.scratch.mit.edu/*"],
-    types: ["xmlhttprequest"],
-  },
-  extraInfoSpec2
-);
+  }]
+});
+
+*/

--- a/background/handle-messages.js
+++ b/background/handle-messages.js
@@ -52,11 +52,9 @@ async function updateMsgCount() {
   }
 }
 scratchAddons.methods.clearMessages = async function () {
-  const res = await fetch("https://scratch.mit.edu/site-api/messages/messages-clear/", {
+  const res = await fetch("https://scratch.mit.edu/site-api/messages/messages-clear/?sareferer", {
     method: "POST",
-    headers: {
-      "X-ScratchAddons-Uses-Fetch": "true",
-    },
+    headers: { "x-csrftoken": scratchAddons.globalState.auth.csrfToken, "x-requested-with": "XMLHttpRequest" },
   });
   if (res.ok) {
     lastCountCheck = Date.now();


### PR DESCRIPTION
1. Removes the single use of `addon.fetch` in userscripts. Instead of using this magic function, userscripts should manually add corresponding headers manually, with the help of `addon.auth.csrfToken` if needed.
2. `addon.fetch` was used in the background page in order to add an artificial `Referer` header in some POST requests to Scratch 2.0 API endpoints that require it. This is a problem that is obviously only present in background requests - userscript requests send the Referer header just fine because they're running under a scratch.mit.edu tab. The old `X-ScratchAddons-Uses-Fetch` header was removed in favor of adding `?sareferer` or `&sareferer` at the end of the URL. This new approach is compatible with the new `chrome.declarativeNetRequest` API we will have to use after we migrate to manifest v3 (see issue #1535)