### PR TITLE
Rename "60FPS player mode" addon for clarity

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -1,6 +1,13 @@
 {
-  "name": "60FPS player mode",
+  "name": "Alt+GreenFlag 60FPS player mode",
   "description": "Alt+Click the green flag to toggle 60FPS.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "Projects will run twice at fast at 60FPS, because they typically run at 30FPS.",
+      "id": "projectRunsFasterNotice"
+    }
+  ],
   "credits": [
     {
       "name": "Jeffalo",
@@ -19,10 +26,11 @@
   ],
   "settings": [
     {
-      "name": "FPS",
+      "name": "Alt+GreenFlag FPS",
       "id": "framerate",
       "type": "integer",
-      "min": 1,
+      "min": 31,
+      "max": 240,
       "default": 60
     }
   ],


### PR DESCRIPTION
1. Rename addon to `Alt+GreenFlag 60FPS player mode`
2. Rename `FPS` setting to `Alt+GreenFlag FPS`
3. Set setting min to 31, and max to 240 (good luck finding a monitor with a higher refresh rate than that)