### PR TITLE
chrome.contextMenus API: use onClicked listener instead of inline onclick

### DIFF
--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -30,7 +30,7 @@ chrome.storage.local.get("muted", (obj) => {
 chrome.contextMenus.removeAll();
 let currentMenuItem = null;
 
-chrome.contextMenus.onClicked.addListener(({parentMenuItemId, menuItemId}) => {
+chrome.contextMenus.onClicked.addListener(({ parentMenuItemId, menuItemId }) => {
   if (parentMenuItemId === "mute") {
     const mins = Number(menuItemId.split("_")[1]);
     contextMenuMuted();

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -30,6 +30,17 @@ chrome.storage.local.get("muted", (obj) => {
 chrome.contextMenus.removeAll();
 let currentMenuItem = null;
 
+chrome.contextMenus.onClicked.addListener(({parentMenuItemId, menuItemId}) => {
+  if (parentMenuItemId === "mute") {
+    const mins = Number(menuItemId.split("_")[1]);
+    contextMenuMuted();
+    muteForMins(mins);
+  } else if (menuItemId === "unmute") {
+    contextMenuUnmuted();
+    unmute();
+  }
+});
+
 function contextMenuUnmuted() {
   if (currentMenuItem === "unmute") chrome.contextMenus.remove("unmute");
   currentMenuItem = "mute";
@@ -40,13 +51,10 @@ function contextMenuUnmuted() {
   });
   for (const period of periods) {
     chrome.contextMenus.create({
+      id: `mute_${period.mins}`,
       title: period.name,
       parentId: "mute",
       contexts: ["browser_action"],
-      onclick: () => {
-        contextMenuMuted();
-        muteForMins(period.mins);
-      },
     });
   }
   chrome.browserAction.setIcon({
@@ -64,10 +72,6 @@ function contextMenuMuted() {
     id: "unmute",
     title: chrome.i18n.getMessage("unmute"),
     contexts: ["browser_action"],
-    onclick: () => {
-      contextMenuUnmuted();
-      unmute();
-    },
   });
   chrome.browserAction.setIcon({
     path: {


### PR DESCRIPTION
Inline `onclick` won't be supported in manifest v3, so worth changing now