### PR TITLE
Revert "Add translation badges"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 <img src="https://raw.githubusercontent.com/ScratchAddons/ScratchAddons/master/images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
 # Welcome to Scratch Addons' repository!
+
 [![](https://img.shields.io/github/stars/ScratchAddons/ScratchAddons?color=blue&style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/stargazers) 
 [![](https://img.shields.io/github/forks/ScratchAddons/ScratchAddons?color=blue&style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/network/members)
 [![](https://img.shields.io/github/watchers/ScratchAddons/ScratchAddons?color=blue&style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/watchers) 
 [![](https://img.shields.io/github/issues/ScratchAddons/ScratchAddons?color=green&style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/issues) 
 [![](https://img.shields.io/github/issues-pr/ScratchAddons/ScratchAddons?color=green&style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/pulls) 
-[![](https://img.shields.io/github/license/ScratchAddons/ScratchAddons?style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/blob/master/LICENSE) 
-[![](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Ftransifex-api.herokuapp.com%2Fbadge%2Fscratch-addons%2Fproject%2Fscratch-addons-extension%2Ftranslated.json&style=flat-square&label=Amount%20Translated)](https://www.transifex.com/scratch-addons/scratch-addons-extension/dashboard/)
-[![](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Ftransifex-api.herokuapp.com%2Fbadge%2Fscratch-addons%2Fproject%2Fscratch-addons-extension%2Freviewed.json&style=flat-square&label=Amount%20Reviewed)](https://www.transifex.com/scratch-addons/scratch-addons-extension/dashboard/)
+[![](https://img.shields.io/github/license/ScratchAddons/ScratchAddons?style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/blob/master/LICENSE) <!-- 2 spaces -->  
 [![](https://img.shields.io/chrome-web-store/v/fbeffbjdlemaoicjdapfpikkikjoneco?style=flat-square&logo=google-chrome&logoColor=white&label=version&color=4285F4)](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco)
 [![](https://img.shields.io/chrome-web-store/users/fbeffbjdlemaoicjdapfpikkikjoneco?style=flat-square&logo=google-chrome&logoColor=white&label=users&color=4285F4)](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco)
 [![](https://img.shields.io/amo/v/scratch-messaging-extension?style=flat-square&logo=firefox-browser&logoColor=white&label=version&color=FF7139)](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/)


### PR DESCRIPTION
I think it is inappropriate to add the translation badges on the README. The focus of the repository is for the development in code, not localization/translation. I think it is better to put it on the wiki or some kind.

By the way, I did this on my Android phone, because my computer is still in use. Probably better than some of you guys copying and pasting code from your local enviroment to the GitHub editor.