### PR TITLE
Make fixed footer border dark in dark mode

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -90,6 +90,7 @@ html > body:not(.sa-body-editor) h4 {
 }
 #footer {
   background-color: #333;
+  border-color: #606060; /* for infinite scrolling fixed footer */
   box-shadow: none;
 }
 #footer ul.footer-col li h4 {

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -109,6 +109,7 @@ body:not(.sa-body-editor) .modal-content,
 }
 .box,
 .box .box-header,
+#footer, /* for infinite scrolling fixed footer */
 .textarea,
 .news li:nth-child(even),
 .thumbnail .thumbnail-image img,


### PR DESCRIPTION
**Resolves**

https://github.com/ScratchAddons/ScratchAddons/pull/1712#issuecomment-790707723

**Changes**

Makes the border added by the "fixed footer" feature of the infinite scrolling addon dark when website dark mode is enabled.