### PR TITLE
Change fixed footer border color and remove empty space above it

### DIFF
--- a/addons/infinite-scroll/userscript.css
+++ b/addons/infinite-scroll/userscript.css
@@ -1,10 +1,6 @@
-body {
-  /* scratch-www */
-  padding-bottom: 45px;
-}
-#content {
-  /* scratchr2 */
-  padding-bottom: 45px;
+body, /* scratch-www */
+#content /* scratchr2 */ {
+  padding-bottom: 31px;
 }
 
 /*
@@ -15,7 +11,7 @@ body {
   top: initial;
   bottom: 0;
   width: 100%;
-  border-top: 1px solid #b3b3b3;
+  border-top: 1px solid #d9d9d9;
   height: 32px;
   padding: 0;
   z-index: 20;


### PR DESCRIPTION
**Resolves**

None

**Changes**

Changes the fixed footer border color to `#d9d9d9` for consistency with similar elements on Scratch and removes empty space above it.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/51849865/109996721-c94a4000-7d0f-11eb-8cdb-7d5d481dee72.png)

Now:
![image](https://user-images.githubusercontent.com/51849865/109996737-cd765d80-7d0f-11eb-9559-9946d5f78431.png)