### PR TITLE
Fix block switching bug with change and set variable blocks

### DIFF
--- a/addons/block-switching/userscript.js
+++ b/addons/block-switching/userscript.js
@@ -427,11 +427,13 @@ export default async function ({ addon, global, console, msg }) {
       noopSwitch,
       {
         opcode: "data_changevariableby",
+        remapValueType: { VALUE: "math_number" },
       },
     ];
     blockSwitches["data_changevariableby"] = [
       {
         opcode: "data_setvariableto",
+        remapValueType: { VALUE: "text" },
       },
       noopSwitch,
     ];
@@ -596,8 +598,7 @@ export default async function ({ addon, global, console, msg }) {
     const pasteSeparately = [];
     // Apply input remappings.
     if (opcodeData.remap) {
-      const childNodes = Array.from(xml.children);
-      for (const child of childNodes) {
+      for (const child of Array.from(xml.children)) {
         const oldName = child.getAttribute("name");
         const newName = opcodeData.remap[oldName];
         if (newName) {
@@ -616,6 +617,18 @@ export default async function ({ addon, global, console, msg }) {
           } else {
             child.setAttribute("name", newName);
           }
+        }
+      }
+    }
+    if (opcodeData.remapValueType) {
+      for (const child of Array.from(xml.children)) {
+        const name = child.getAttribute("name");
+        const newType = opcodeData.remapValueType[name];
+        if (newType) {
+          const valueNode = child.firstChild;
+          const fieldNode = valueNode.firstChild;
+          valueNode.setAttribute("type", newType);
+          fieldNode.setAttribute("name", newType === "text" ? "TEXT" : "NUM");
         }
       }
     }


### PR DESCRIPTION
**Changes**

Previously, converting a `change variable by` block to a `set variable to` block would result in a set variable block that only let you type numbers. Going the other way would result in a change variable block that let you type things that aren't numbers.

This is now fixed.