### PR TITLE
Fix some bugs in folders addon

### DIFF
--- a/addons-l10n/en/folders.json
+++ b/addons-l10n/en/folders.json
@@ -7,5 +7,6 @@
   "folders/remove-folder": "remove folder",
   "folders/remove-from-folder": "remove from folder",
   "folders/rename-folder-prompt": "Rename folder to:",
-  "folders/name-prompt": "Name of folder:"
+  "folders/name-prompt": "Name of folder:",
+  "folders/name-not-allowed": "Invalid folder name"
 }

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -73,6 +73,10 @@ export default async function ({ addon, global, console, msg }) {
     return basename;
   };
 
+  const isValidFolderName = (name) => {
+    return !name.includes(DIVIDER);
+  };
+
   const RESERVED_NAMES = ["_mouse_", "_stage_", "_edge_", "_myself_", "_random_"];
   const ensureNotReserved = (name) => {
     if (RESERVED_NAMES) return `${name}2`;
@@ -671,6 +675,10 @@ export default async function ({ addon, global, console, msg }) {
           if (newName === null) {
             return;
           }
+          if (!isValidFolderName(newName)) {
+            alert(msg("name-not-allowed"));
+            return;
+          }
           // Empty name will remove the folder
           if (!newName) {
             newName = null;
@@ -711,6 +719,10 @@ export default async function ({ addon, global, console, msg }) {
         const createFolder = () => {
           const name = prompt(msg("name-prompt"), getNameWithoutFolder(data.realName));
           if (name === null) {
+            return;
+          }
+          if (!isValidFolderName(name)) {
+            alert(msg("name-not-allowed"));
             return;
           }
           setFolder(name);

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -79,7 +79,7 @@ export default async function ({ addon, global, console, msg }) {
 
   const RESERVED_NAMES = ["_mouse_", "_stage_", "_edge_", "_myself_", "_random_"];
   const ensureNotReserved = (name) => {
-    if (RESERVED_NAMES) return `${name}2`;
+    if (RESERVED_NAMES.includes(name)) return `${name}2`;
     return name;
   };
 

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -257,6 +257,19 @@ export default async function ({ addon, global, console, msg }) {
     throw new Error('Can not comprehend SpriteSelectorItem');
   };
 
+  const verifyVM = (vm) => {
+    const target = vm.runtime.targets[0];
+    if (
+      typeof vm.installTargets === 'function' &&
+      typeof vm.addCostume === 'function' &&
+      typeof vm.addSound === 'function' &&
+      typeof vm.reorderTarget === 'function' &&
+      typeof target.reorderCostume === 'function' &&
+      typeof target.reorderSound === 'function'
+    ) return;
+    throw new Error('Can not comprehend VM');
+  };
+
   const patchSortableHOC = (SortableHOC, type) => {
     // SortableHOC should be: https://github.com/LLK/scratch-gui/blob/29d9851778febe4e69fa5111bf7559160611e366/src/lib/sortable-hoc.jsx#L8
 
@@ -1068,6 +1081,7 @@ export default async function ({ addon, global, console, msg }) {
     const spriteSelectorItemInstance = spriteSelectorItemElement[reactInternalKey].child.child.child.stateNode;
     verifySortableHOC(sortableHOCInstance);
     verifySpriteSelectorItem(spriteSelectorItemInstance);
+    verifyVM(vm);
     patchSortableHOC(sortableHOCInstance.constructor, TYPE_SPRITES);
     patchSpriteSelectorItem(spriteSelectorItemInstance.constructor);
     sortableHOCInstance.saInitialSetup();

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -496,10 +496,17 @@ export default async function ({ addon, global, console, msg }) {
         } else if (type === TYPE_ASSETS) {
           currentAssetFolder = folder;
         }
-        if (
-          this.props.selectedId !== prevProps.selectedId ||
-          this.props.selectedItemIndex !== prevProps.selectedItemIndex
-        ) {
+        let selectedItemChanged;
+        if (this.props.selectedId) {
+          selectedItemChanged = this.props.selectedId !== prevProps.selectedId;
+        } else {
+          selectedItemChanged = (
+            this.props.items[this.props.selectedItemIndex] &&
+            prevProps.items[prevProps.selectedItemIndex] &&
+            this.props.items[this.props.selectedItemIndex].name !== prevProps.items[prevProps.selectedItemIndex].name
+          );
+        }
+        if (selectedItemChanged) {
           if (!selectedItem.isStage) {
             if (typeof folder === "string" && !this.state.folders.includes(folder)) {
               this.setState((prevState) => ({

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -227,6 +227,36 @@ export default async function ({ addon, global, console, msg }) {
     vm.editingTarget.sprite.sounds = fixOrderOfItemsInFolders(vm.editingTarget.sprite.sounds);
   };
 
+  const verifySortableHOC = (sortableHOCInstance) => {
+    const SortableHOC = sortableHOCInstance.constructor;
+    if (
+      Array.isArray(sortableHOCInstance.props.items) &&
+      (typeof sortableHOCInstance.props.selectedId === 'string' || typeof sortableHOCInstance.props.selectedItemIndex === 'number') &&
+      typeof SortableHOC.prototype.componentDidMount === 'undefined' &&
+      typeof SortableHOC.prototype.componentDidUpdate === 'undefined' &&
+      typeof SortableHOC.prototype.componentWillReceiveProps === 'function' &&
+      typeof SortableHOC.prototype.handleAddSortable === 'function' &&
+      typeof SortableHOC.prototype.handleRemoveSortable === 'function' &&
+      typeof SortableHOC.prototype.setRef === 'function'
+    ) return;
+    throw new Error('Can not comprehend SortableHOC');
+  };
+
+  const verifySpriteSelectorItem = (spriteSelectorItemInstance) => {
+    const SpriteSelectorItem = spriteSelectorItemInstance.constructor;
+    if (
+      typeof spriteSelectorItemInstance.props.asset === 'object' &&
+      typeof spriteSelectorItemInstance.props.name === 'string' &&
+      typeof spriteSelectorItemInstance.props.dragType === 'string' &&
+      typeof SpriteSelectorItem.prototype.handleClick === 'function' &&
+      typeof SpriteSelectorItem.prototype.setRef === 'function' &&
+      typeof SpriteSelectorItem.prototype.handleDelete === 'function' &&
+      typeof SpriteSelectorItem.prototype.handleDuplicate === 'function' &&
+      typeof SpriteSelectorItem.prototype.handleExport === 'function'
+    ) return;
+    throw new Error('Can not comprehend SpriteSelectorItem');
+  };
+
   const patchSortableHOC = (SortableHOC, type) => {
     // SortableHOC should be: https://github.com/LLK/scratch-gui/blob/29d9851778febe4e69fa5111bf7559160611e366/src/lib/sortable-hoc.jsx#L8
 
@@ -1036,6 +1066,8 @@ export default async function ({ addon, global, console, msg }) {
     reactInternalKey = Object.keys(spriteSelectorItemElement).find((i) => i.startsWith(REACT_INTERNAL_PREFIX));
     const sortableHOCInstance = getSortableHOCFromElement(spriteSelectorItemElement);
     const spriteSelectorItemInstance = spriteSelectorItemElement[reactInternalKey].child.child.child.stateNode;
+    verifySortableHOC(sortableHOCInstance);
+    verifySpriteSelectorItem(spriteSelectorItemInstance);
     patchSortableHOC(sortableHOCInstance.constructor, TYPE_SPRITES);
     patchSpriteSelectorItem(spriteSelectorItemInstance.constructor);
     sortableHOCInstance.saInitialSetup();
@@ -1046,6 +1078,7 @@ export default async function ({ addon, global, console, msg }) {
   {
     const selectorListItem = await addon.tab.waitForElement("[class*='selector_list-item']");
     const sortableHOCInstance = getSortableHOCFromElement(selectorListItem);
+    verifySortableHOC(sortableHOCInstance);
     patchSortableHOC(sortableHOCInstance.constructor, TYPE_ASSETS);
     sortableHOCInstance.saInitialSetup();
   }

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -211,20 +211,37 @@ export default async function ({ addon, global, console, msg }) {
         result.push(item);
       }
     }
-    return result.flat();
+    const flatResult = result.flat();
+    for (let i = 0; i < items.length; i++) {
+      if (result[i] !== items[i]) {
+        return {items: flatResult, changed: true};
+      }
+    }
+    return {items: flatResult, changed: false};
   };
 
   const fixTargetOrder = () => {
-    vm.runtime.targets = fixOrderOfItemsInFolders(vm.runtime.targets);
-    vm.emitTargetsUpdate();
+    const {items, changed} = fixOrderOfItemsInFolders(vm.runtime.targets);
+    if (changed) {
+      vm.runtime.targets = items;
+      vm.emitTargetsUpdate();
+    }
   };
 
   const fixCostumeOrder = () => {
-    vm.editingTarget.sprite.costumes = fixOrderOfItemsInFolders(vm.editingTarget.sprite.costumes);
+    const {items, changed} = fixOrderOfItemsInFolders(vm.editingTarget.sprite.costumes);
+    if (changed) {
+      vm.editingTarget.sprite.costumes = items;
+      vm.emitTargetsUpdate();
+    }
   };
 
   const fixSoundOrder = () => {
-    vm.editingTarget.sprite.sounds = fixOrderOfItemsInFolders(vm.editingTarget.sprite.sounds);
+    const {items, changed} = fixOrderOfItemsInFolders(vm.editingTarget.sprite.sounds);
+    if (changed) {
+      vm.editingTarget.sprite.sounds = items;
+      vm.emitTargetsUpdate();
+    }
   };
 
   const verifySortableHOC = (sortableHOCInstance) => {

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -218,14 +218,14 @@ export default async function ({ addon, global, console, msg }) {
     const flatResult = result.flat();
     for (let i = 0; i < items.length; i++) {
       if (result[i] !== items[i]) {
-        return {items: flatResult, changed: true};
+        return { items: flatResult, changed: true };
       }
     }
-    return {items: flatResult, changed: false};
+    return { items: flatResult, changed: false };
   };
 
   const fixTargetOrder = () => {
-    const {items, changed} = fixOrderOfItemsInFolders(vm.runtime.targets);
+    const { items, changed } = fixOrderOfItemsInFolders(vm.runtime.targets);
     if (changed) {
       vm.runtime.targets = items;
       vm.emitTargetsUpdate();
@@ -233,7 +233,7 @@ export default async function ({ addon, global, console, msg }) {
   };
 
   const fixCostumeOrder = () => {
-    const {items, changed} = fixOrderOfItemsInFolders(vm.editingTarget.sprite.costumes);
+    const { items, changed } = fixOrderOfItemsInFolders(vm.editingTarget.sprite.costumes);
     if (changed) {
       vm.editingTarget.sprite.costumes = items;
       vm.emitTargetsUpdate();
@@ -241,7 +241,7 @@ export default async function ({ addon, global, console, msg }) {
   };
 
   const fixSoundOrder = () => {
-    const {items, changed} = fixOrderOfItemsInFolders(vm.editingTarget.sprite.sounds);
+    const { items, changed } = fixOrderOfItemsInFolders(vm.editingTarget.sprite.sounds);
     if (changed) {
       vm.editingTarget.sprite.sounds = items;
       vm.emitTargetsUpdate();
@@ -252,43 +252,47 @@ export default async function ({ addon, global, console, msg }) {
     const SortableHOC = sortableHOCInstance.constructor;
     if (
       Array.isArray(sortableHOCInstance.props.items) &&
-      (typeof sortableHOCInstance.props.selectedId === 'string' || typeof sortableHOCInstance.props.selectedItemIndex === 'number') &&
-      typeof SortableHOC.prototype.componentDidMount === 'undefined' &&
-      typeof SortableHOC.prototype.componentDidUpdate === 'undefined' &&
-      typeof SortableHOC.prototype.componentWillReceiveProps === 'function' &&
-      typeof SortableHOC.prototype.handleAddSortable === 'function' &&
-      typeof SortableHOC.prototype.handleRemoveSortable === 'function' &&
-      typeof SortableHOC.prototype.setRef === 'function'
-    ) return;
-    throw new Error('Can not comprehend SortableHOC');
+      (typeof sortableHOCInstance.props.selectedId === "string" ||
+        typeof sortableHOCInstance.props.selectedItemIndex === "number") &&
+      typeof SortableHOC.prototype.componentDidMount === "undefined" &&
+      typeof SortableHOC.prototype.componentDidUpdate === "undefined" &&
+      typeof SortableHOC.prototype.componentWillReceiveProps === "function" &&
+      typeof SortableHOC.prototype.handleAddSortable === "function" &&
+      typeof SortableHOC.prototype.handleRemoveSortable === "function" &&
+      typeof SortableHOC.prototype.setRef === "function"
+    )
+      return;
+    throw new Error("Can not comprehend SortableHOC");
   };
 
   const verifySpriteSelectorItem = (spriteSelectorItemInstance) => {
     const SpriteSelectorItem = spriteSelectorItemInstance.constructor;
     if (
-      typeof spriteSelectorItemInstance.props.asset === 'object' &&
-      typeof spriteSelectorItemInstance.props.name === 'string' &&
-      typeof spriteSelectorItemInstance.props.dragType === 'string' &&
-      typeof SpriteSelectorItem.prototype.handleClick === 'function' &&
-      typeof SpriteSelectorItem.prototype.setRef === 'function' &&
-      typeof SpriteSelectorItem.prototype.handleDelete === 'function' &&
-      typeof SpriteSelectorItem.prototype.handleDuplicate === 'function' &&
-      typeof SpriteSelectorItem.prototype.handleExport === 'function'
-    ) return;
-    throw new Error('Can not comprehend SpriteSelectorItem');
+      typeof spriteSelectorItemInstance.props.asset === "object" &&
+      typeof spriteSelectorItemInstance.props.name === "string" &&
+      typeof spriteSelectorItemInstance.props.dragType === "string" &&
+      typeof SpriteSelectorItem.prototype.handleClick === "function" &&
+      typeof SpriteSelectorItem.prototype.setRef === "function" &&
+      typeof SpriteSelectorItem.prototype.handleDelete === "function" &&
+      typeof SpriteSelectorItem.prototype.handleDuplicate === "function" &&
+      typeof SpriteSelectorItem.prototype.handleExport === "function"
+    )
+      return;
+    throw new Error("Can not comprehend SpriteSelectorItem");
   };
 
   const verifyVM = (vm) => {
     const target = vm.runtime.targets[0];
     if (
-      typeof vm.installTargets === 'function' &&
-      typeof vm.addCostume === 'function' &&
-      typeof vm.addSound === 'function' &&
-      typeof vm.reorderTarget === 'function' &&
-      typeof target.reorderCostume === 'function' &&
-      typeof target.reorderSound === 'function'
-    ) return;
-    throw new Error('Can not comprehend VM');
+      typeof vm.installTargets === "function" &&
+      typeof vm.addCostume === "function" &&
+      typeof vm.addSound === "function" &&
+      typeof vm.reorderTarget === "function" &&
+      typeof target.reorderCostume === "function" &&
+      typeof target.reorderSound === "function"
+    )
+      return;
+    throw new Error("Can not comprehend VM");
   };
 
   const patchSortableHOC = (SortableHOC, type) => {
@@ -505,11 +509,10 @@ export default async function ({ addon, global, console, msg }) {
         if (this.props.selectedId) {
           selectedItemChanged = this.props.selectedId !== prevProps.selectedId;
         } else {
-          selectedItemChanged = (
+          selectedItemChanged =
             this.props.items[this.props.selectedItemIndex] &&
             prevProps.items[prevProps.selectedItemIndex] &&
-            this.props.items[this.props.selectedItemIndex].name !== prevProps.items[prevProps.selectedItemIndex].name
-          );
+            this.props.items[this.props.selectedItemIndex].name !== prevProps.items[prevProps.selectedItemIndex].name;
         }
         if (selectedItemChanged) {
           if (!selectedItem.isStage) {

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -73,6 +73,12 @@ export default async function ({ addon, global, console, msg }) {
     return basename;
   };
 
+  const RESERVED_NAMES = ["_mouse_", "_stage_", "_edge_", "_myself_", "_random_"];
+  const ensureNotReserved = (name) => {
+    if (RESERVED_NAMES) return `${name}2`;
+    return name;
+  };
+
   const untilInEditor = () => {
     if (addon.tab.editorMode === "editor") return;
     return new Promise((resolve, reject) => {
@@ -566,7 +572,7 @@ export default async function ({ addon, global, console, msg }) {
             for (const target of vm.runtime.targets) {
               if (target.isOriginal) {
                 if (getFolderFromName(target.getName()) === data.folder) {
-                  vm.renameSprite(target.id, setFolderOfName(target.getName(), newName));
+                  vm.renameSprite(target.id, ensureNotReserved(setFolderOfName(target.getName(), newName)));
                 }
               }
             }
@@ -616,7 +622,7 @@ export default async function ({ addon, global, console, msg }) {
         const setFolder = (folder) => {
           if (component.props.dragType === "SPRITE") {
             const target = vm.runtime.getTargetById(component.props.id);
-            vm.renameSprite(component.props.id, setFolderOfName(target.getName(), folder));
+            vm.renameSprite(component.props.id, ensureNotReserved(setFolderOfName(target.getName(), folder)));
             fixTargetOrder();
             vm.emitWorkspaceUpdate();
           } else if (component.props.dragType === "COSTUME") {
@@ -953,7 +959,7 @@ export default async function ({ addon, global, console, msg }) {
             this.emitTargetsUpdate();
           },
           rename: (item, name) => {
-            this.renameSprite(item.id, name);
+            this.renameSprite(item.id, ensureNotReserved(name));
           },
           getVMItemFromGUIItem: (item, targets) => {
             return targets.find((i) => i.id === item.id);

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -491,10 +491,11 @@ export default async function ({ addon, global, console, msg }) {
       const selectedItem = getSelectedItem(this);
       if (selectedItem) {
         const folder = getFolderFromName(selectedItem.name);
+        const currentFolder = this.state.folders.includes(folder) ? folder : null;
         if (type === TYPE_SPRITES) {
-          currentSpriteFolder = folder;
+          currentSpriteFolder = currentFolder;
         } else if (type === TYPE_ASSETS) {
-          currentAssetFolder = folder;
+          currentAssetFolder = currentFolder;
         }
         let selectedItemChanged;
         if (this.props.selectedId) {


### PR DESCRIPTION
**Changes**

 - Fix #1732 - the item will be renamed to something like `_mouse_2`
 - This addon does a lot of terrible things to Scratch internals, so some checks were added to ensure that if Scratch ever refactors this, the addon should (hopefully) gracefully abort instead of leaving things in a half-broken state
 - Fix some issues when creating costume/sound folders with items that are already in folders
 - Fix dragging closed costume/sound folders causing folders to open
 - Fix new items being able to automatically move into closed folders
 - Do not allow `//` to be used in folder names when creating and renaming folders
