### PR TITLE
Remove video sensing from loading by default

### DIFF
--- a/addons/load-extensions/addon.json
+++ b/addons/load-extensions/addon.json
@@ -24,7 +24,7 @@
       "name": "Video Sensing",
       "id": "videoSensing",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     {
       "name": "Text to Speech",


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->



**Changes**

<!-- Please describe the changes you've made. -->
Make the load extension addon doesn’t load the video sensing by default
**Reason for changes**

<!-- Why should these changes be made? -->
Video sensing automatically turns on the camera but the user doesn’t notice and it can make scratch lag
**Tests**

<!-- Have you tested this pull request? If so, how? -->
Yes. I try  it on chrome and Firefox