### PR TITLE
Forcibly disable video sensing auto-loading

### DIFF
--- a/background/background.html
+++ b/background/background.html
@@ -1,11 +1,11 @@
 <head>
   <meta charset="UTF-8" />
 
-  <!-- Transition from Scratch Messaging Extension -->
-  <script src="transition.js" type="module"></script>
-
   <!-- Declare scratchAddons object, create global and local state -->
   <script src="declare-scratchaddons-object.js" type="module"></script>
+
+  <!-- Transition between versions -->
+  <script src="transition.js" type="module"></script>
 
   <!-- Load manifests into memory -->
   <script src="load-addon-manifests.js" type="module"></script>

--- a/background/transition.js
+++ b/background/transition.js
@@ -8,6 +8,18 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     chrome.runtime.getManifest().version_name.includes("-prerelease") === false
   ) {
     chrome.tabs.create({ url: "https://scratchaddons.com/welcome" });
+  } else if (
+    details.previousVersion &&
+    /^1\.1[01]\.0/g.test(details.previousVersion)
+  ) {
+    scratchAddons.localEvents.addEventListener("ready", () => {
+      const loadExtension = scratchAddons.globalState.addonSettings["load-extensions"];
+      if (!loadExtension || !loadExtension.videoSensing) return;
+      loadExtension.videoSensing = false;
+      chrome.storage.sync.set({
+        addonSettings: scratchAddons.globalState.addonSettings,
+      });
+    });
   }
 
   if (details.reason === "install") {

--- a/background/transition.js
+++ b/background/transition.js
@@ -8,10 +8,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     chrome.runtime.getManifest().version_name.includes("-prerelease") === false
   ) {
     chrome.tabs.create({ url: "https://scratchaddons.com/welcome" });
-  } else if (
-    details.previousVersion &&
-    /^1\.1[01]\.0/g.test(details.previousVersion)
-  ) {
+  } else if (details.previousVersion && /^1\.1[01]\.0/g.test(details.previousVersion)) {
     scratchAddons.localEvents.addEventListener("ready", () => {
       const loadExtension = scratchAddons.globalState.addonSettings["load-extensions"];
       if (!loadExtension || !loadExtension.videoSensing) return;


### PR DESCRIPTION
This change forcibly disables video sensing on load-extensions settings for users from 1.10/1.11. It is likely that a lot of 1.10 users who enabled this new addon via the popup have been annoyed by video sensing being added on all projects - and this is also a performance concern.

We did this before, we can do it again.

TODO: should we add some sort of notes (e.g. page to show) for those who are affected, telling them they can re-enable it (with some performance downsides)?