### PR TITLE
Improve mute addon

### DIFF
--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -1,19 +1,19 @@
 export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
+  let muted = false;
+  let icon = document.createElement("img");
+  icon.src = "/static/assets/e21225ab4b675bc61eed30cfb510c288.svg";
+  icon.style.display = "none";
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
     let container = button.parentElement;
-    let icon = document.createElement("img");
     container.appendChild(icon);
-    icon.src = "/static/assets/e21225ab4b675bc61eed30cfb510c288.svg";
-    icon.style.display = "none";
-    let mode = false;
     button.addEventListener("click", (e) => {
       if (e.ctrlKey) {
         e.cancelBubble = true;
         e.preventDefault();
-        mode = !mode;
-        if (mode) {
+        muted = !muted;
+        if (muted) {
           vm.editingTarget.blocks.runtime.audioEngine.audioContext.suspend();
           icon.style.display = "block";
         } else {

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -14,10 +14,10 @@ export default async function ({ addon, global, console }) {
         e.preventDefault();
         muted = !muted;
         if (muted) {
-          vm.editingTarget.blocks.runtime.audioEngine.audioContext.suspend();
+          vm.runtime.audioEngine.inputNode.gain.value = 0;
           icon.style.display = "block";
         } else {
-          vm.editingTarget.blocks.runtime.audioEngine.audioContext.resume();
+          vm.runtime.audioEngine.inputNode.gain.value = 1;
           icon.style.display = "none";
         }
       }


### PR DESCRIPTION
**Changes**

 - Fix mute icon disappearing when entering/leaving editor while muted
 - Instead of suspending the entire audio context, it's just muted, so blocks like "play sound until done" will keep running instead of getting stuck
