### PR TITLE
fix longer-wiwo error on others' profiles

### DIFF
--- a/addons/longer-wiwo/userscript.js
+++ b/addons/longer-wiwo/userscript.js
@@ -21,5 +21,5 @@ export default async function ({ msg }) {
     left.hide();
   });
 
-  status[0].maxLength = 255; // disallow more than 255 chars
+  status[0]?.maxLength = 255; // disallow more than 255 chars
 }


### PR DESCRIPTION
Minor thing, there's an error in the console on others' profiles becuase `status[0]` is undefined, as there is no `textarea#status`. 

<details><summary>`?.` is pretty new (but also great browser support, see https://caniuse.com/mdn-javascript_operators_optional_chaining) so here is a explimation</summary>

```javascript
object = null
console.log(object?.key)
console.log(object?.["key"])
```

will log `undefined` twice. without the `?` it would throw errors both times.


```javascript
object = {"key":"hi"}
console.log(object?.key)
console.log(object?.["key"])
```

will log `"hi"` twice. without the `?` it would do the same. 

So the `?` protects against `object is undefined` errors
</details>