### PR TITLE
Create alternative.css

### DIFF
--- a/webpages/settings/alternative.css
+++ b/webpages/settings/alternative.css
@@ -1,0 +1,9 @@
+@import url("../styles/colors.css");
+@import url("../styles/components/tooltips.css");
+@import url("../styles/components/badges.css");
+@import url("../styles/components/categories.css");
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans&display=swap");
+
+body {
+  font-family: "DM Sans", sans-serif;
+}


### PR DESCRIPTION
Contains DM Sans, to improve readability, please add an option to use this CSS file over the other ones

**Resolves**

Resolves #1123

**Changes**

Adds a new CSS file that can be used over both light and dark. Please make it usable from More Settings.

**Reason for changes**

Sora is hard to read.

**Tests**

No tests, first we need a way to activate the CSS from More Settings
