### PR TITLE
Make discuss-button enabled by default

### DIFF
--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -31,6 +31,6 @@
     }
   ],
   "tags": ["community", "forums"],
-  "enabledByDefault": false,
+  "enabledByDefault": true,
   "l10n": true
 }


### PR DESCRIPTION

**Changes**

Made the discuss button addon enabled by default.

**Reason for changes**

The discuss button is something many users want.
