### PR TITLE
Add version on variable manager (1.11.1)

### DIFF
--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -37,7 +37,7 @@ export default async function ({ addon, global, console, msg }) {
   const feedbackButton = document.createElement("a");
   feedbackButton.className = "sa-var-manager-feedback-button";
   feedbackButton.innerText = msg("feedback");
-  feedbackButton.href = "https://scratchaddons.com/feedback?version=variable-manager";
+  feedbackButton.href = "https://scratchaddons.com/feedback?version=1.11.1+variable-manager";
   feedbackButton.target = "_blank";
   feedbackButton.rel = "noopener noreferrer";
 


### PR DESCRIPTION
This adds the version number for variable manager feedbacks, because I think Jefallo decides that he won't add one, and an unexpected influx of feedback that are coming.

I use a plus sign instead of a dash since a dash may be confused as a prerelease build. A plus sign is for build metadata, which I think it is more appropriate.

Maybe we need to update our feedback so we can also supply source parameter. We might also need to update notif so it also uses plus for now.