### PR TITLE
Make scrolling possible in dark mode again

### DIFF
--- a/addons/editor-dark-mode/3dark.css
+++ b/addons/editor-dark-mode/3dark.css
@@ -11,12 +11,14 @@
 .project-title-input_title-field_en5Gd:focus {
   background: var(--accent);
 }
-.gui_body-wrapper_-N0sA,
-.blocklySvg {
+.gui_body-wrapper_-N0sA {
   background: var(--main-bg);
 }
-.blocklyMainBackground {
-  fill: var(--secondary-bg) !important;
+.blocklySvg {
+  background: var(--secondary-bg);
+}
+[id^=blocklyGridPattern] line {
+  stroke: none !important;
 }
 .context-menu_context-menu_2SJM-,
 .blocklyWidgetDiv .goog-menu,

--- a/addons/editor-dark-mode/3dark.css
+++ b/addons/editor-dark-mode/3dark.css
@@ -17,7 +17,7 @@
 .blocklySvg {
   background: var(--secondary-bg);
 }
-[id^=blocklyGridPattern] line {
+[id^="blocklyGridPattern"] line {
   stroke: none !important;
 }
 .context-menu_context-menu_2SJM-,

--- a/addons/editor-dark-mode/3darker.css
+++ b/addons/editor-dark-mode/3darker.css
@@ -11,12 +11,14 @@
 .project-title-input_title-field_en5Gd:focus {
   background: var(--accent);
 }
-.gui_body-wrapper_-N0sA,
-.blocklySvg {
+.gui_body-wrapper_-N0sA {
   background: var(--main-bg);
 }
-.blocklyMainBackground {
-  fill: var(--secondary-bg) !important;
+.blocklySvg {
+  background: var(--secondary-bg);
+}
+[id^=blocklyGridPattern] line {
+  stroke: none !important;
 }
 .context-menu_context-menu_2SJM-,
 .blocklyWidgetDiv .goog-menu,

--- a/addons/editor-dark-mode/3darker.css
+++ b/addons/editor-dark-mode/3darker.css
@@ -17,7 +17,7 @@
 .blocklySvg {
   background: var(--secondary-bg);
 }
-[id^=blocklyGridPattern] line {
+[id^="blocklyGridPattern"] line {
   stroke: none !important;
 }
 .context-menu_context-menu_2SJM-,

--- a/addons/editor-dark-mode/dark-editor.css
+++ b/addons/editor-dark-mode/dark-editor.css
@@ -5,7 +5,7 @@ body {
 .blocklySvg {
   background-color: #444;
 }
-[id^=blocklyGridPattern] line {
+[id^="blocklyGridPattern"] line {
   stroke: none !important;
 }
 .blocklyFlyoutBackground {

--- a/addons/editor-dark-mode/dark-editor.css
+++ b/addons/editor-dark-mode/dark-editor.css
@@ -1,12 +1,12 @@
 body {
   background-color: black;
 }
-.blocklyMainBackground {
-  fill: #444 !important;
-}
 /**.blocklyBlockCanvas { filter: brightness(0.9) saturate(0) !important; }**/
 .blocklySvg {
-  background-color: #222 !important;
+  background-color: #444;
+}
+[id^=blocklyGridPattern] line {
+  stroke: none !important;
 }
 .blocklyFlyoutBackground {
   fill: #222 !important;


### PR DESCRIPTION
**Resolves**

Resolves #1834

**Changes**

Fixed a bug that made scrolling with the mouse wheel impossible in Chrome in all editor dark modes except Experimental Dark.