### PR TITLE
Fix missing comma in profile statistics

### DIFF
--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -57,7 +57,7 @@ export default async function ({ addon, msg, console }) {
     );
     ranksRow.appendChild(
       createItem(
-        `#${data.statistics.ranks.loves.toLocaleString()} (#${data.statistics.ranks.country.loves})`,
+        `#${data.statistics.ranks.loves.toLocaleString()} (#${data.statistics.ranks.country.loves.toLocaleString()})`,
         msg("most-loves")
       )
     );


### PR DESCRIPTION
**Resolves**

Resolves #1890

**Changes**

Adds a missing `.toLocaleString()` to the profile statistics addon.