### PR TITLE
Drag and drop files into the editor

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -80,5 +80,6 @@
   "folders",
   "block-palette-icons",
   "custom-block-shape",
-  "2d-color-picker"
+  "2d-color-picker",
+  "drag-drop"
 ]

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -12,6 +12,12 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor", "theme"],
+  "userstyles": [
+    {
+      "url": "dragged-over.css",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Drag and drop files to upload",
-  "description": "TODO lol",
+  "name": "Drag and drop files",
+  "description": "Lets you drag files from your file explorer into the sprites pane or costume list.",
   "credits": [
     {
       "name": "Sheep_maker"

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Drag and drop files",
-  "description": "Lets you drag files from your file explorer into the sprites pane or costume list.",
+  "description": "Lets you drag images and sounds from your file explorer into the sprites pane or costume/sound list.",
   "credits": [
     {
       "name": "Sheep_maker"
@@ -18,7 +18,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabledByDefault": false,
   "l10n": true
 }

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -1,0 +1,17 @@
+{
+  "name": "Drag and drop files to upload",
+  "description": "TODO lol",
+  "credits": [
+    {
+      "name": "Sheep_maker"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["editor", "theme"],
+  "enabledByDefault": false
+}

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -19,5 +19,6 @@
     }
   ],
   "tags": ["editor"],
-  "enabledByDefault": false
+  "enabledByDefault": false,
+  "l10n": true
 }

--- a/addons/drag-drop/dragged-over.css
+++ b/addons/drag-drop/dragged-over.css
@@ -1,0 +1,13 @@
+/* Based on the `stage-selector_raised` class */
+.sa-drag-area,
+.sa-drag-area div[class*="stage-selector_header_"],
+.sa-drag-area div[class*="sprite-info_sprite-info"] {
+  -webkit-transition: background-color 0.25s ease;
+  -o-transition: background-color 0.25s ease;
+  transition: background-color 0.25s ease;
+}
+.sa-dragged-over,
+.sa-dragged-over div[class*="stage-selector_header_"],
+.sa-dragged-over div[class*="sprite-info_sprite-info"] {
+  background-color: hsla(215, 100%, 77%, 1);
+}

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -2,41 +2,45 @@ export default async function ({ addon, global, console }) {
   const DRAG_AREA_CLASS = "sa-drag-area";
   const DRAG_OVER_CLASS = "sa-dragged-over";
 
-  async function droppable(dropAreaProm, fileInputProm, dragOverClass) {
-    const dropArea = await dropAreaProm;
-    const fileInput = await fileInputProm;
-    dropArea.classList.add(DRAG_AREA_CLASS);
-
-    dropArea.addEventListener("drop", (e) => {
-      fileInput.files = e.dataTransfer.files;
-      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
-      dropArea.classList.remove(DRAG_OVER_CLASS);
-      e.preventDefault();
-    });
-    dropArea.addEventListener("dragover", (e) => {
-      dropArea.classList.add(DRAG_OVER_CLASS);
-      e.preventDefault();
-    });
-    dropArea.addEventListener("dragleave", () => {
-      dropArea.classList.remove(DRAG_OVER_CLASS);
-    });
-  }
-
-  droppable(
-    addon.tab.waitForElement('div[class*="sprite-selector_sprite-selector"]'),
-    addon.tab.waitForElement('div[class*="sprite-selector_sprite-selector"] input[class*="action-menu_file-input"]')
-  );
-  droppable(
-    addon.tab.waitForElement('div[class*="stage-selector_stage-selector"]'),
-    addon.tab.waitForElement('div[class*="stage-selector_stage-selector"] input[class*="action-menu_file-input"]')
-  );
-
-  while (true) {
-    await droppable(
-      addon.tab.waitForElement('div[class*="selector_wrapper"]', { markAsSeen: true }),
-      addon.tab.waitForElement('div[class*="selector_wrapper"] input[class*="action-menu_file-input"]', {
+  async function foreverDroppable(dropAreaSelector, fileInputSelector) {
+    while (true) {
+      const dropArea = await addon.tab.waitForElement(dropAreaSelector, { markAsSeen: true });
+      const fileInput = await addon.tab.waitForElement(fileInputSelector, {
         markAsSeen: true,
-      })
-    );
+      });
+      dropArea.classList.add(DRAG_AREA_CLASS);
+
+      dropArea.addEventListener("drop", (e) => {
+        fileInput.files = e.dataTransfer.files;
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        dropArea.classList.remove(DRAG_OVER_CLASS);
+        e.preventDefault();
+      });
+      dropArea.addEventListener("dragover", (e) => {
+        dropArea.classList.add(DRAG_OVER_CLASS);
+        e.preventDefault();
+      });
+      dropArea.addEventListener("dragleave", () => {
+        dropArea.classList.remove(DRAG_OVER_CLASS);
+      });
+    }
   }
+
+  // Sprite selector
+  foreverDroppable(
+    'div[class*="sprite-selector_sprite-selector"]',
+    'div[class*="sprite-selector_sprite-selector"] input[class*="action-menu_file-input"]'
+  );
+
+  // Stage selector
+  foreverDroppable(
+    'div[class*="stage-selector_stage-selector"]',
+    'div[class*="stage-selector_stage-selector"] input[class*="action-menu_file-input"]'
+  );
+
+  // Costume/sound asset list
+  foreverDroppable(
+    'div[class*="selector_wrapper"]',
+    'div[class*="selector_wrapper"] input[class*="action-menu_file-input"]'
+  );
 }

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -1,0 +1,14 @@
+export default async function ({ addon, global, console }) {
+  window.addon = addon
+
+  const spriteSelector = await addon.tab.waitForElement('div[class*="sprite-selector_scroll-wrapper"]');
+  const spriteUpload = await addon.tab.waitForElement('input[class*="action-menu_file-input"]');
+  spriteSelector.addEventListener('drop', e => {
+    spriteUpload.files = e.dataTransfer.files;
+    spriteUpload.dispatchEvent(new Event('change', { bubbles: true }));
+    e.preventDefault();
+  });
+  spriteSelector.addEventListener('dragover', e => {
+    e.preventDefault();
+  });
+}

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -1,14 +1,33 @@
 export default async function ({ addon, global, console }) {
-  window.addon = addon
+  async function droppable(dropAreaProm, fileInputProm) {
+    const dropArea = await dropAreaProm;
+    const fileInput = await fileInputProm;
 
-  const spriteSelector = await addon.tab.waitForElement('div[class*="sprite-selector_scroll-wrapper"]');
-  const spriteUpload = await addon.tab.waitForElement('input[class*="action-menu_file-input"]');
-  spriteSelector.addEventListener('drop', e => {
-    spriteUpload.files = e.dataTransfer.files;
-    spriteUpload.dispatchEvent(new Event('change', { bubbles: true }));
-    e.preventDefault();
-  });
-  spriteSelector.addEventListener('dragover', e => {
-    e.preventDefault();
-  });
+    dropArea.addEventListener("drop", (e) => {
+      fileInput.files = e.dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      e.preventDefault();
+    });
+    dropArea.addEventListener("dragover", (e) => {
+      e.preventDefault();
+    });
+  }
+
+  droppable(
+    addon.tab.waitForElement('div[class*="sprite-selector_sprite-selector"]'),
+    addon.tab.waitForElement('div[class*="sprite-selector_sprite-selector"] input[class*="action-menu_file-input"]')
+  );
+  droppable(
+    addon.tab.waitForElement('div[class*="stage-selector_stage-selector"]'),
+    addon.tab.waitForElement('div[class*="stage-selector_stage-selector"] input[class*="action-menu_file-input"]')
+  );
+
+  while (true) {
+    await droppable(
+      addon.tab.waitForElement('div[class*="selector_wrapper"]', { markAsSeen: true }),
+      addon.tab.waitForElement('div[class*="selector_wrapper"] input[class*="action-menu_file-input"]', {
+        markAsSeen: true,
+      })
+    );
+  }
 }

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -1,15 +1,24 @@
 export default async function ({ addon, global, console }) {
-  async function droppable(dropAreaProm, fileInputProm) {
+  const DRAG_AREA_CLASS = "sa-drag-area";
+  const DRAG_OVER_CLASS = "sa-dragged-over";
+
+  async function droppable(dropAreaProm, fileInputProm, dragOverClass) {
     const dropArea = await dropAreaProm;
     const fileInput = await fileInputProm;
+    dropArea.classList.add(DRAG_AREA_CLASS);
 
     dropArea.addEventListener("drop", (e) => {
       fileInput.files = e.dataTransfer.files;
       fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      dropArea.classList.remove(DRAG_OVER_CLASS);
       e.preventDefault();
     });
     dropArea.addEventListener("dragover", (e) => {
+      dropArea.classList.add(DRAG_OVER_CLASS);
       e.preventDefault();
+    });
+    dropArea.addEventListener("dragleave", () => {
+      dropArea.classList.remove(DRAG_OVER_CLASS);
     });
   }
 


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #1227 

**Changes**

I added the ability to drag files into the costume/sound list, the sprites pane, and the stage sidebar thing. This inserts the dropped files into the same file input that is used by the "Upload Xyz" option in the slidey "Choose a Xyz" menu.

![Dragging files into the costume and sound list](https://cdn.discordapp.com/attachments/775797057926856754/822345126038208532/THE_GIF.gif)

![Dragging files into the sprites list and stage](https://cdn.discordapp.com/attachments/775797057926856754/822345712888447016/THE_GIF.gif)

**Reason for changes**

Some people, especially those not super versed with computers, prefer dragging files in from their file explorer instead of having to hunt through folders in a file selection window.

**Tests**

I dragged in various files into the drop areas I listed above. If you drag in a file that isn't supported, nothing happens. I'm not sure whether this will be incompatible with other addons, though.