### PR TITLE
Revert "support Mac command key in mute project player"

### DIFF
--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -9,7 +9,7 @@ export default async function ({ addon, global, console }) {
     let container = button.parentElement;
     container.appendChild(icon);
     button.addEventListener("click", (e) => {
-      if (e.ctrlKey || e.metaKey) {
+      if (e.ctrlKey) {
         e.cancelBubble = true;
         e.preventDefault();
         muted = !muted;


### PR DESCRIPTION
Reverts ScratchAddons/ScratchAddons#1923
This wasn't reviewed by W_L, and also, metakey might match more than Cmd. This requires more testing.