### PR TITLE
Use Comlink instead of `template#scratch-addons`, stop spamming contentScriptInfo

### DIFF
--- a/addon-api/content-script/Addon.js
+++ b/addon-api/content-script/Addon.js
@@ -10,7 +10,7 @@ export default class UserscriptAddon extends Addon {
   constructor(info) {
     super(info);
     this._addonId = info.id;
-    this.__path = document.getElementById("scratch-addons").getAttribute("data-path");
+    this.__path = `${new URL(import.meta.url).origin}/`;
     this.tab = new Tab(info);
     this.self.disabled = false;
   }

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -5,7 +5,6 @@ import dataURLToBlob from "../../libraries/data-url-to-blob.js";
 import getWorkerScript from "./worker.js";
 
 const DATA_PNG = "data:image/png;base64,";
-const template = document.getElementById("scratch-addons");
 
 /**
  * APIs specific to userscripts.
@@ -104,12 +103,8 @@ export default class Tab extends Listenable {
       return navigator.clipboard.write(items);
     } else {
       // Firefox needs Content Script
-      template.setAttribute("data-clipboard-image", dataURL);
-      return this.waitForElement("[data-clipboard]").then((el) => {
-        const attr = el.dataset.clipboard;
-        el.removeAttribute("data-clipboard");
-        if (attr === "success") return Promise.resolve();
-        return Promise.reject(new Error(`Error inside clipboard handler: ${attr}`));
+      return scratchAddons.methods.copyImage(dataURL).catch((err) => {
+        return Promise.reject(new Error(`Error inside clipboard handler: ${err}`));
       });
     }
   }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,8 +1,8 @@
 const o = chrome.tabs.sendMessage; // TODO: remove
-chrome.tabs.sendMessage = function() {
+chrome.tabs.sendMessage = function () {
   console.trace();
   return o.apply(chrome.tabs, arguments);
-}
+};
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "openSettingsOnThisTab")
@@ -111,7 +111,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (!request.contentScriptReady) return;
   // TODO: what if it's not in the cache already? test on startup. localState ready might even be false
   console.log("contentScriptReady");
-  const identity = createCsIdentity({ tabId: sender.tab.id, frameId: sender.frameId, url: request.contentScriptReady.url });
+  const identity = createCsIdentity({
+    tabId: sender.tab.id,
+    frameId: sender.frameId,
+    url: request.contentScriptReady.url,
+  });
   const info = csInfoCache.get(identity);
   sendResponse(info);
   csInfoCache.delete(identity);

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,9 +1,3 @@
-const o = chrome.tabs.sendMessage; // TODO: remove
-chrome.tabs.sendMessage = function () {
-  console.trace();
-  return o.apply(chrome.tabs, arguments);
-};
-
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "openSettingsOnThisTab")
     chrome.tabs.update(sender.tab.id, { url: chrome.runtime.getURL("webpages/settings/index.html") });

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -99,7 +99,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       // Another content script with same identity took our
       // place in the csInfoCache map while the promise resolved
       return;
-    };
+    }
     csInfoCache.set(identity, { loading: false, info, timestamp: Date.now() });
     scratchAddons.localEvents.dispatchEvent(new CustomEvent("csInfoCacheUpdated"));
   },
@@ -114,7 +114,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 // will redirect to /studios/104/ (with a slash)
 // If a cache entry is too old, remove it
 chrome.alarms.create("cleanCsInfoCache", { periodInMinutes: 1 });
-chrome.alarms.onAlarm.addListener(alarm => {
+chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === "cleanCsInfoCache") {
     csInfoCache.forEach((obj, key) => {
       if (!obj.loading) {
@@ -153,17 +153,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         csInfoCache.delete(identity);
       }
     } else {
-      getContentScriptInfo(request.contentScriptReady.url).then(info => {
+      getContentScriptInfo(request.contentScriptReady.url).then((info) => {
         sendResponse(info);
       });
       return true;
     }
   } else {
     // Wait until manifests, addon.auth and addon.settings are ready
-    scratchAddons.localEvents.addEventListener("ready", async () => {
-      const info = await getContentScriptInfo(request.contentScriptReady.url);
-      sendResponse(info);
-    }, { once: true });
+    scratchAddons.localEvents.addEventListener(
+      "ready",
+      async () => {
+        const info = await getContentScriptInfo(request.contentScriptReady.url);
+        sendResponse(info);
+      },
+      { once: true }
+    );
     return true;
   }
 });

--- a/background/handle-messages.js
+++ b/background/handle-messages.js
@@ -121,7 +121,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request === "getMsgCount") {
     (async () => {
       const count = await scratchAddons.methods.getMsgCount();
-      chrome.tabs.sendMessage(sender.tab.id, { setMsgCount: count }, { frameId: sender.tab.frameId });
+      chrome.tabs.sendMessage(sender.tab.id, { setMsgCount: { count } }, { frameId: sender.tab.frameId });
     })();
   }
 });

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -176,9 +176,8 @@ async function onInfoAvailable({ globalState, l10njson, addonsWithUserscripts, a
       setCssVariables(request.newGlobalState.addonSettings);
     } else if (request.fireEvent) {
       _page_.fireEvent(request.fireEvent);
-    } else if (typeof request.setMsgCount !== "undefined") {
+    } else if (request.setMsgCount) {
       _page_.setMsgCount(request.setMsgCount);
-      // TODO: this is ugly
     } else if (request === "getRunningAddons") {
       const userscripts = addonsWithUserscripts.map((obj) => obj.addonId);
       const userstyles = addonsWithUserstyles.map((obj) => obj.addonId);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,3 +1,14 @@
+window.onmessage = e => {
+  if (e.data.wappalyzer) return;
+  console.log(e)
+}; // TODO: remove
+
+chrome.runtime.sendMessage({ contentScriptReady: { url: location.href }}, res => {
+  // TODO: firefox if(res)
+  console.log("received response!", res);
+  onInfoAvailable(res);
+});
+
 try {
   if (window.parent.location.origin !== "https://scratch.mit.edu") throw "Scratch Addons: not first party iframe";
 } catch {
@@ -7,6 +18,62 @@ try {
 const DOLLARS = ["$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"];
 
 const promisify = (callbackFn) => (...args) => new Promise((resolve) => callbackFn(...args, resolve));
+
+let _page_ = null;
+
+const comlinkIframesDiv = document.createElement("div");
+comlinkIframesDiv.id = "scratchaddons-iframes";
+const comlinkIframe1 = document.createElement("iframe");
+comlinkIframe1.id = "scratchaddons-iframe-1";
+comlinkIframe1.style.display = "none";
+const comlinkIframe2 = comlinkIframe1.cloneNode();
+comlinkIframe2.id = "scratchaddons-iframe-2";
+const comlinkIframe3 = comlinkIframe1.cloneNode();
+comlinkIframe3.id = "scratchaddons-iframe-3";
+const comlinkIframe4 = comlinkIframe1.cloneNode();
+comlinkIframe4.id = "scratchaddons-iframe-4";
+comlinkIframesDiv.appendChild(comlinkIframe1,);
+comlinkIframesDiv.appendChild(comlinkIframe2);
+comlinkIframesDiv.appendChild(comlinkIframe3);
+comlinkIframesDiv.appendChild(comlinkIframe4);
+document.documentElement.appendChild(comlinkIframesDiv);
+
+const cs = {
+  requestMsgCount() {
+    chrome.runtime.sendMessage("getMsgCount");
+  },
+  copyImage(dataURL) {
+    // Firefox only
+    return new Promise((resolve, reject) => {
+      browser.runtime.sendMessage({ clipboardDataURL: dataURL }).then(
+        (res) => {
+          resolve();
+        },
+        (res) => {
+          reject(res.toString());
+        }
+      );
+    });
+  }
+};
+Comlink.expose(cs, Comlink.windowEndpoint(comlinkIframe1.contentWindow, comlinkIframe2.contentWindow));
+
+const pageComlinkScript = document.createElement("script");
+pageComlinkScript.src = chrome.runtime.getURL("libraries/comlink.js");
+document.documentElement.appendChild(pageComlinkScript);
+
+const moduleScript = document.createElement("script");
+moduleScript.type = "module";
+moduleScript.src = chrome.runtime.getURL("content-scripts/inject/module.js");
+
+(async () => {
+  await new Promise(resolve => {
+    moduleScript.addEventListener("load", resolve);
+  });
+  _page_ = Comlink.wrap(Comlink.windowEndpoint(comlinkIframe3.contentWindow, comlinkIframe4.contentWindow));
+})();
+
+document.documentElement.appendChild(moduleScript);
 
 let initialUrl = location.href;
 let path = new URL(initialUrl).pathname.substring(1);
@@ -25,39 +92,12 @@ if (path === "discuss/3/topic/add/") {
   });
 }
 
-let receivedContentScriptInfo = false;
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log("[Message from background]", request);
-  if (request.contentScriptInfo) {
-    // The request wasn't for this exact URL, might happen sometimes
-    if (request.contentScriptInfo.url !== initialUrl) return;
-    // Only run once - updates go through themesUpdated
-    if (receivedContentScriptInfo) return;
-    receivedContentScriptInfo = true;
-    sendResponse("OK");
-
-    if (document.head) onHeadAvailable(request.contentScriptInfo);
-    else {
-      const observer = new MutationObserver(() => {
-        if (document.head) {
-          onHeadAvailable(request.contentScriptInfo);
-          observer.disconnect();
-        }
-      });
-      observer.observe(document.documentElement, { subtree: true, childList: true });
-    }
-  } else if (request === "getInitialUrl") {
+  if (request === "getInitialUrl") {
     sendResponse(initialUrl);
   } else if (request.themesUpdated) {
     injectUserstylesAndThemes({ themes: request.themesUpdated, isUpdate: true });
-  }
-});
-chrome.runtime.sendMessage("ready");
-window.addEventListener("load", () => {
-  if (!receivedContentScriptInfo) {
-    // This might happen sometimes, the background page might not
-    // have seen this tab loading, for example, at startup.
-    chrome.runtime.sendMessage("sendContentScriptInfo");
   }
 });
 
@@ -111,32 +151,34 @@ function setCssVariables(addonSettings) {
   }
 }
 
-function onHeadAvailable({ globalState, l10njson, addonsWithUserscripts, addonsWithUserstyles, themes }) {
+async function onInfoAvailable({ globalState, l10njson, addonsWithUserscripts, addonsWithUserstyles, themes }) {
   setCssVariables(globalState.addonSettings);
+  // TODO: we previously made sure <head> was available before injecting
+  // userstyles and themes. Now we don't. Is this a problem?
   injectUserstylesAndThemes({ addonsWithUserstyles, themes, isUpdate: false });
 
-  const template = document.createElement("template");
-  template.id = "scratch-addons";
-  template.setAttribute("data-path", chrome.runtime.getURL(""));
-  template.setAttribute("data-userscripts", JSON.stringify(addonsWithUserscripts));
-  template.setAttribute("data-global-state", JSON.stringify(globalState));
-  template.setAttribute("data-l10njson", JSON.stringify(l10njson));
-  document.head.appendChild(template);
+  if (!_page_) {
+    await new Promise(resolve => {
+      // We're registering this load event after the load event that
+      // sets _page_, so we can guarantee _page_ exists now
+      moduleScript.addEventListener("load", resolve);
+    });
+  }
 
-  const script = document.createElement("script");
-  script.type = "module";
-  script.src = chrome.runtime.getURL("content-scripts/inject/module.js");
-  document.head.appendChild(script);
+  _page_.globalState = globalState;
+  _page_.l10njson = l10njson;
+  _page_.addonsWithUserscripts = addonsWithUserscripts;
+  _page_.dataReady = true;
 
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.newGlobalState) {
-      template.setAttribute("data-global-state", JSON.stringify(request.newGlobalState));
+      _page_.globalState = request.newGlobalState;
       setCssVariables(request.newGlobalState.addonSettings);
     } else if (request.fireEvent) {
-      const eventDetails = JSON.stringify(request.fireEvent);
-      template.setAttribute(`data-fire-event__${Date.now()}`, eventDetails);
+      _page_.fireEvent(request.fireEvent);
     } else if (typeof request.setMsgCount !== "undefined") {
-      template.setAttribute("data-msgcount", request.setMsgCount);
+      _page_.setMsgCount(request.setMsgCount);
+      // TODO: this is ugly
     } else if (request === "getRunningAddons") {
       const userscripts = addonsWithUserscripts.map((obj) => obj.addonId);
       const userstyles = addonsWithUserstyles.map((obj) => obj.addonId);
@@ -152,41 +194,6 @@ function onHeadAvailable({ globalState, l10njson, addonsWithUserscripts, addonsW
       });
     }
   });
-
-  const observer = new MutationObserver((mutationsList) => {
-    for (const mutation of mutationsList) {
-      const attr = mutation.attributeName;
-      const attrType = attr.substring(0, attr.indexOf("__"));
-      const attrRawVal = template.getAttribute(attr);
-      let attrVal;
-      try {
-        attrVal = JSON.parse(attrRawVal);
-      } catch (err) {
-        attrVal = attrRawVal;
-      }
-      if (attrVal === null) return;
-      console.log("[Attribute update]", attr + ":", attrVal);
-      const removeAttr = () => template.removeAttribute(attr);
-      if (attrType === "data-request-msgcount") {
-        chrome.runtime.sendMessage("getMsgCount");
-        removeAttr();
-      }
-      if (attr === "data-clipboard-image" && typeof browser !== "undefined") {
-        const dataURL = attrVal;
-        removeAttr();
-        browser.runtime.sendMessage({ clipboardDataURL: dataURL }).then(
-          (res) => {
-            template.setAttribute("data-clipboard", "success");
-          },
-          (res) => {
-            console.error("Error inside clipboard: ", res);
-            template.setAttribute("data-clipboard", res.toString());
-          }
-        );
-      }
-    }
-  });
-  observer.observe(template, { attributes: true });
 }
 
 const escapeHTML = (str) => str.replace(/([<>'"&])/g, (_, l) => `&#${l.charCodeAt(0)};`);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,9 +1,9 @@
-window.onmessage = e => {
+window.onmessage = (e) => {
   if (e.data.wappalyzer) return;
-  console.log(e)
+  console.log(e);
 }; // TODO: remove
 
-chrome.runtime.sendMessage({ contentScriptReady: { url: location.href }}, res => {
+chrome.runtime.sendMessage({ contentScriptReady: { url: location.href } }, (res) => {
   // TODO: firefox if(res)
   console.log("received response!", res);
   onInfoAvailable(res);
@@ -32,7 +32,7 @@ const comlinkIframe3 = comlinkIframe1.cloneNode();
 comlinkIframe3.id = "scratchaddons-iframe-3";
 const comlinkIframe4 = comlinkIframe1.cloneNode();
 comlinkIframe4.id = "scratchaddons-iframe-4";
-comlinkIframesDiv.appendChild(comlinkIframe1,);
+comlinkIframesDiv.appendChild(comlinkIframe1);
 comlinkIframesDiv.appendChild(comlinkIframe2);
 comlinkIframesDiv.appendChild(comlinkIframe3);
 comlinkIframesDiv.appendChild(comlinkIframe4);
@@ -54,7 +54,7 @@ const cs = {
         }
       );
     });
-  }
+  },
 };
 Comlink.expose(cs, Comlink.windowEndpoint(comlinkIframe1.contentWindow, comlinkIframe2.contentWindow));
 
@@ -67,7 +67,7 @@ moduleScript.type = "module";
 moduleScript.src = chrome.runtime.getURL("content-scripts/inject/module.js");
 
 (async () => {
-  await new Promise(resolve => {
+  await new Promise((resolve) => {
     moduleScript.addEventListener("load", resolve);
   });
   _page_ = Comlink.wrap(Comlink.windowEndpoint(comlinkIframe3.contentWindow, comlinkIframe4.contentWindow));
@@ -158,7 +158,7 @@ async function onInfoAvailable({ globalState, l10njson, addonsWithUserscripts, a
   injectUserstylesAndThemes({ addonsWithUserstyles, themes, isUpdate: false });
 
   if (!_page_) {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       // We're registering this load event after the load event that
       // sets _page_, so we can guarantee _page_ exists now
       moduleScript.addEventListener("load", resolve);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -146,9 +146,17 @@ function setCssVariables(addonSettings) {
 
 async function onInfoAvailable({ globalState, l10njson, addonsWithUserscripts, addonsWithUserstyles, themes }) {
   setCssVariables(globalState.addonSettings);
-  // TODO: we previously made sure <head> was available before injecting
-  // userstyles and themes. Now we don't. Is this a problem?
-  injectUserstylesAndThemes({ addonsWithUserstyles, themes, isUpdate: false });
+  // Just in case, make sure the <head> loaded before injecting styles
+  if (document.head) injectUserstylesAndThemes({ addonsWithUserstyles, themes, isUpdate: false });
+  else {
+    const observer = new MutationObserver(() => {
+      if (document.head) {
+        injectUserstylesAndThemes({ addonsWithUserstyles, themes, isUpdate: false });
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.documentElement, { subtree: true, childList: true });
+  }
 
   if (!_page_) {
     await new Promise((resolve) => {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,8 +1,3 @@
-window.onmessage = (e) => {
-  if (e.data.wappalyzer) return;
-  console.log(e);
-}; // TODO: remove
-
 chrome.runtime.sendMessage({ contentScriptReady: { url: location.href } }, (res) => {
   // TODO: firefox if(res)
   console.log("received response!", res);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,7 +1,5 @@
 chrome.runtime.sendMessage({ contentScriptReady: { url: location.href } }, (res) => {
-  // TODO: firefox if(res)
-  console.log("received response!", res);
-  onInfoAvailable(res);
+  if (res) onInfoAvailable(res);
 });
 
 try {

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -51,7 +51,7 @@ const page = {
       );
     }
   },
-  setMsgCount({count}) {
+  setMsgCount({ count }) {
     pendingPromises.msgCount.forEach((promiseResolver) => promiseResolver(count));
     pendingPromises.msgCount = [];
   },

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -71,8 +71,7 @@ function onDataReady() {
 
   scratchAddons.methods = {};
   scratchAddons.methods.getMsgCount = () => {
-    // TODO: not sure why we do this (pending promises arr), just transitioning to comlink for now
-    _cs_.requestMsgCount();
+    if (!pendingPromises.msgCount.length) _cs_.requestMsgCount();
     let promiseResolver;
     const promise = new Promise((resolve) => (promiseResolver = resolve));
     pendingPromises.msgCount.push(promiseResolver);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -59,7 +59,6 @@ const page = {
 Comlink.expose(page, Comlink.windowEndpoint(comlinkIframe4.contentWindow, comlinkIframe3.contentWindow));
 
 function onDataReady() {
-  debugger;
   const addons = page.addonsWithUserscripts;
 
   scratchAddons.l10n = new Localization(page.l10njson);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -54,12 +54,12 @@ const page = {
   setMsgCount(count) {
     pendingPromises.msgCount.forEach((promiseResolver) => promiseResolver(count));
     pendingPromises.msgCount = [];
-  }
+  },
 };
 Comlink.expose(page, Comlink.windowEndpoint(comlinkIframe4.contentWindow, comlinkIframe3.contentWindow));
 
 function onDataReady() {
-debugger;
+  debugger;
   const addons = page.addonsWithUserscripts;
 
   scratchAddons.l10n = new Localization(page.l10njson);
@@ -81,7 +81,7 @@ debugger;
   };
   scratchAddons.methods.copyImage = async (dataURL) => {
     return _cs_.copyImage(dataURL);
-  }
+  };
 
   const runUserscripts = () => {
     for (const addon of addons) {
@@ -102,7 +102,6 @@ debugger;
     });
     observer.observe(document.documentElement, { subtree: true, childList: true });
   }
-
 }
 
 function bodyIsEditorClassCheck() {

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -25,7 +25,7 @@ const page = {
   },
 
   l10njson: null, // Only set once
-  addonsWithUserscripts: null, // Onlu set once
+  addonsWithUserscripts: null, // Only set once
 
   _dataReady: false,
   get dataReady() {

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -87,9 +87,9 @@ function onDataReady() {
     }
   };
 
-  // We guarantee document.head won't throw in userscripts
-  // TODO: preload locals and files *before* head is available,
-  // but run addons after <head> is added.
+  // Note: we currently load userscripts and locales after head loaded
+  // We could do that before head loaded just fine, as long as we don't
+  // actually *run* the addons before document.head is defined.
   if (document.head) runUserscripts();
   else {
     const observer = new MutationObserver(() => {

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -51,7 +51,7 @@ const page = {
       );
     }
   },
-  setMsgCount(count) {
+  setMsgCount({count}) {
     pendingPromises.msgCount.forEach((promiseResolver) => promiseResolver(count));
     pendingPromises.msgCount = [];
   },

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -194,11 +194,10 @@ function loadClasses() {
 if (document.querySelector("title")) loadClasses();
 else {
   const stylesObserver = new MutationObserver((mutationsList) => {
-    console.log(mutationsList); // TODO: test
     if (document.querySelector("title")) {
       stylesObserver.disconnect();
       loadClasses();
     }
   });
-  stylesObserver.observe(document.documentElement, { childList: true });
+  stylesObserver.observe(document.documentElement, { childList: true, subtree: true });
 }

--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -5,9 +5,7 @@ export default async function runAddonUserscripts({ addonId, scripts, traps }) {
   const globalObj = Object.create(null);
   for (const scriptInfo of scripts) {
     const { url: scriptPath, runAtComplete } = scriptInfo;
-    const scriptUrl = `${document
-      .getElementById("scratch-addons")
-      .getAttribute("data-path")}addons/${addonId}/${scriptPath}`;
+    const scriptUrl = `${new URL(import.meta.url).origin}/addons/${addonId}/${scriptPath}`;
     console.log(
       `%cDebug addons/${addonId}/${scriptPath}: ${scriptUrl}, runAtComplete: ${runAtComplete}`,
       "color:red; font-weight: bold; font-size: 1.2em;"
@@ -30,7 +28,6 @@ export default async function runAddonUserscripts({ addonId, scripts, traps }) {
       });
     };
     if (runAtComplete && document.readyState !== "complete") {
-      console.log(`Waiting for onload: ${addonId}`);
       window.addEventListener("load", () => loadUserscript(), { once: true });
     } else {
       await loadUserscript();

--- a/libraries/CREDITS.md
+++ b/libraries/CREDITS.md
@@ -9,6 +9,7 @@ Third-party libraries included are:
 - [tinycolor2 1.4.2](https://raw.githubusercontent.com/bgrins/TinyColor/1.4.2/dist/tinycolor-min.js) (MIT)
 - [Chart.js 2.9.4](https://unpkg.com/chart.js@2.9.4/dist/Chart.min.js) (MIT)
 - [color-picker-web-component 1.0.17](https://unpkg.com/color-picker-web-component@1.0.17/dist/color-picker-esm.js) (MIT)
+- [comlink 4.3.0](https://unpkg.com/comlink@4.3.0/dist/umd/comlink.js) (Apache-2.0)
 
 
 Note that these libraries are either from official release websites or from unpkg (which distributes the content uploaded to NPM as-is).

--- a/libraries/comlink.js
+++ b/libraries/comlink.js
@@ -1,0 +1,317 @@
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (global = global || self, factory(global.Comlink = {}));
+  }(this, (function (exports) { 'use strict';
+  
+    /**
+     * Copyright 2019 Google Inc. All Rights Reserved.
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+    const proxyMarker = Symbol("Comlink.proxy");
+    const createEndpoint = Symbol("Comlink.endpoint");
+    const releaseProxy = Symbol("Comlink.releaseProxy");
+    const throwMarker = Symbol("Comlink.thrown");
+    const isObject = (val) => (typeof val === "object" && val !== null) || typeof val === "function";
+    /**
+     * Internal transfer handle to handle objects marked to proxy.
+     */
+    const proxyTransferHandler = {
+        canHandle: (val) => isObject(val) && val[proxyMarker],
+        serialize(obj) {
+            const { port1, port2 } = new MessageChannel();
+            expose(obj, port1);
+            return [port2, [port2]];
+        },
+        deserialize(port) {
+            port.start();
+            return wrap(port);
+        },
+    };
+    /**
+     * Internal transfer handler to handle thrown exceptions.
+     */
+    const throwTransferHandler = {
+        canHandle: (value) => isObject(value) && throwMarker in value,
+        serialize({ value }) {
+            let serialized;
+            if (value instanceof Error) {
+                serialized = {
+                    isError: true,
+                    value: {
+                        message: value.message,
+                        name: value.name,
+                        stack: value.stack,
+                    },
+                };
+            }
+            else {
+                serialized = { isError: false, value };
+            }
+            return [serialized, []];
+        },
+        deserialize(serialized) {
+            if (serialized.isError) {
+                throw Object.assign(new Error(serialized.value.message), serialized.value);
+            }
+            throw serialized.value;
+        },
+    };
+    /**
+     * Allows customizing the serialization of certain values.
+     */
+    const transferHandlers = new Map([
+        ["proxy", proxyTransferHandler],
+        ["throw", throwTransferHandler],
+    ]);
+    function expose(obj, ep = self) {
+        ep.addEventListener("message", function callback(ev) {
+            if (!ev || !ev.data) {
+                return;
+            }
+            const { id, type, path } = Object.assign({ path: [] }, ev.data);
+            const argumentList = (ev.data.argumentList || []).map(fromWireValue);
+            let returnValue;
+            try {
+                const parent = path.slice(0, -1).reduce((obj, prop) => obj[prop], obj);
+                const rawValue = path.reduce((obj, prop) => obj[prop], obj);
+                switch (type) {
+                    case 0 /* GET */:
+                        {
+                            returnValue = rawValue;
+                        }
+                        break;
+                    case 1 /* SET */:
+                        {
+                            parent[path.slice(-1)[0]] = fromWireValue(ev.data.value);
+                            returnValue = true;
+                        }
+                        break;
+                    case 2 /* APPLY */:
+                        {
+                            returnValue = rawValue.apply(parent, argumentList);
+                        }
+                        break;
+                    case 3 /* CONSTRUCT */:
+                        {
+                            const value = new rawValue(...argumentList);
+                            returnValue = proxy(value);
+                        }
+                        break;
+                    case 4 /* ENDPOINT */:
+                        {
+                            const { port1, port2 } = new MessageChannel();
+                            expose(obj, port2);
+                            returnValue = transfer(port1, [port1]);
+                        }
+                        break;
+                    case 5 /* RELEASE */:
+                        {
+                            returnValue = undefined;
+                        }
+                        break;
+                }
+            }
+            catch (value) {
+                returnValue = { value, [throwMarker]: 0 };
+            }
+            Promise.resolve(returnValue)
+                .catch((value) => {
+                return { value, [throwMarker]: 0 };
+            })
+                .then((returnValue) => {
+                const [wireValue, transferables] = toWireValue(returnValue);
+                ep.postMessage(Object.assign(Object.assign({}, wireValue), { id }), transferables);
+                if (type === 5 /* RELEASE */) {
+                    // detach and deactive after sending release response above.
+                    ep.removeEventListener("message", callback);
+                    closeEndPoint(ep);
+                }
+            });
+        });
+        if (ep.start) {
+            ep.start();
+        }
+    }
+    function isMessagePort(endpoint) {
+        return endpoint.constructor.name === "MessagePort";
+    }
+    function closeEndPoint(endpoint) {
+        if (isMessagePort(endpoint))
+            endpoint.close();
+    }
+    function wrap(ep, target) {
+        return createProxy(ep, [], target);
+    }
+    function throwIfProxyReleased(isReleased) {
+        if (isReleased) {
+            throw new Error("Proxy has been released and is not useable");
+        }
+    }
+    function createProxy(ep, path = [], target = function () { }) {
+        let isProxyReleased = false;
+        const proxy = new Proxy(target, {
+            get(_target, prop) {
+                throwIfProxyReleased(isProxyReleased);
+                if (prop === releaseProxy) {
+                    return () => {
+                        return requestResponseMessage(ep, {
+                            type: 5 /* RELEASE */,
+                            path: path.map((p) => p.toString()),
+                        }).then(() => {
+                            closeEndPoint(ep);
+                            isProxyReleased = true;
+                        });
+                    };
+                }
+                if (prop === "then") {
+                    if (path.length === 0) {
+                        return { then: () => proxy };
+                    }
+                    const r = requestResponseMessage(ep, {
+                        type: 0 /* GET */,
+                        path: path.map((p) => p.toString()),
+                    }).then(fromWireValue);
+                    return r.then.bind(r);
+                }
+                return createProxy(ep, [...path, prop]);
+            },
+            set(_target, prop, rawValue) {
+                throwIfProxyReleased(isProxyReleased);
+                // FIXME: ES6 Proxy Handler `set` methods are supposed to return a
+                // boolean. To show good will, we return true asynchronously ¯\_(ツ)_/¯
+                const [value, transferables] = toWireValue(rawValue);
+                return requestResponseMessage(ep, {
+                    type: 1 /* SET */,
+                    path: [...path, prop].map((p) => p.toString()),
+                    value,
+                }, transferables).then(fromWireValue);
+            },
+            apply(_target, _thisArg, rawArgumentList) {
+                throwIfProxyReleased(isProxyReleased);
+                const last = path[path.length - 1];
+                if (last === createEndpoint) {
+                    return requestResponseMessage(ep, {
+                        type: 4 /* ENDPOINT */,
+                    }).then(fromWireValue);
+                }
+                // We just pretend that `bind()` didn’t happen.
+                if (last === "bind") {
+                    return createProxy(ep, path.slice(0, -1));
+                }
+                const [argumentList, transferables] = processArguments(rawArgumentList);
+                return requestResponseMessage(ep, {
+                    type: 2 /* APPLY */,
+                    path: path.map((p) => p.toString()),
+                    argumentList,
+                }, transferables).then(fromWireValue);
+            },
+            construct(_target, rawArgumentList) {
+                throwIfProxyReleased(isProxyReleased);
+                const [argumentList, transferables] = processArguments(rawArgumentList);
+                return requestResponseMessage(ep, {
+                    type: 3 /* CONSTRUCT */,
+                    path: path.map((p) => p.toString()),
+                    argumentList,
+                }, transferables).then(fromWireValue);
+            },
+        });
+        return proxy;
+    }
+    function myFlat(arr) {
+        return Array.prototype.concat.apply([], arr);
+    }
+    function processArguments(argumentList) {
+        const processed = argumentList.map(toWireValue);
+        return [processed.map((v) => v[0]), myFlat(processed.map((v) => v[1]))];
+    }
+    const transferCache = new WeakMap();
+    function transfer(obj, transfers) {
+        transferCache.set(obj, transfers);
+        return obj;
+    }
+    function proxy(obj) {
+        return Object.assign(obj, { [proxyMarker]: true });
+    }
+    function windowEndpoint(w, context = self, targetOrigin = "*") {
+        return {
+            postMessage: (msg, transferables) => w.postMessage(msg, targetOrigin, transferables),
+            addEventListener: context.addEventListener.bind(context),
+            removeEventListener: context.removeEventListener.bind(context),
+        };
+    }
+    function toWireValue(value) {
+        for (const [name, handler] of transferHandlers) {
+            if (handler.canHandle(value)) {
+                const [serializedValue, transferables] = handler.serialize(value);
+                return [
+                    {
+                        type: 3 /* HANDLER */,
+                        name,
+                        value: serializedValue,
+                    },
+                    transferables,
+                ];
+            }
+        }
+        return [
+            {
+                type: 0 /* RAW */,
+                value,
+            },
+            transferCache.get(value) || [],
+        ];
+    }
+    function fromWireValue(value) {
+        switch (value.type) {
+            case 3 /* HANDLER */:
+                return transferHandlers.get(value.name).deserialize(value.value);
+            case 0 /* RAW */:
+                return value.value;
+        }
+    }
+    function requestResponseMessage(ep, msg, transfers) {
+        return new Promise((resolve) => {
+            const id = generateUUID();
+            ep.addEventListener("message", function l(ev) {
+                if (!ev.data || !ev.data.id || ev.data.id !== id) {
+                    return;
+                }
+                ep.removeEventListener("message", l);
+                resolve(ev.data);
+            });
+            if (ep.start) {
+                ep.start();
+            }
+            ep.postMessage(Object.assign({ id }, msg), transfers);
+        });
+    }
+    function generateUUID() {
+        return new Array(4)
+            .fill(0)
+            .map(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16))
+            .join("-");
+    }
+  
+    exports.createEndpoint = createEndpoint;
+    exports.expose = expose;
+    exports.proxy = proxy;
+    exports.proxyMarker = proxyMarker;
+    exports.releaseProxy = releaseProxy;
+    exports.transfer = transfer;
+    exports.transferHandlers = transferHandlers;
+    exports.windowEndpoint = windowEndpoint;
+    exports.wrap = wrap;
+  
+    Object.defineProperty(exports, '__esModule', { value: true });
+  
+  })));
+  //# sourceMappingURL=comlink.js.map

--- a/libraries/comlink.js
+++ b/libraries/comlink.js
@@ -1,317 +1,317 @@
 (function (global, factory) {
-    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
-    typeof define === 'function' && define.amd ? define(['exports'], factory) :
-    (global = global || self, factory(global.Comlink = {}));
-  }(this, (function (exports) { 'use strict';
-  
-    /**
-     * Copyright 2019 Google Inc. All Rights Reserved.
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    const proxyMarker = Symbol("Comlink.proxy");
-    const createEndpoint = Symbol("Comlink.endpoint");
-    const releaseProxy = Symbol("Comlink.releaseProxy");
-    const throwMarker = Symbol("Comlink.thrown");
-    const isObject = (val) => (typeof val === "object" && val !== null) || typeof val === "function";
-    /**
-     * Internal transfer handle to handle objects marked to proxy.
-     */
-    const proxyTransferHandler = {
-        canHandle: (val) => isObject(val) && val[proxyMarker],
-        serialize(obj) {
-            const { port1, port2 } = new MessageChannel();
-            expose(obj, port1);
-            return [port2, [port2]];
-        },
-        deserialize(port) {
-            port.start();
-            return wrap(port);
-        },
-    };
-    /**
-     * Internal transfer handler to handle thrown exceptions.
-     */
-    const throwTransferHandler = {
-        canHandle: (value) => isObject(value) && throwMarker in value,
-        serialize({ value }) {
-            let serialized;
-            if (value instanceof Error) {
-                serialized = {
-                    isError: true,
-                    value: {
-                        message: value.message,
-                        name: value.name,
-                        stack: value.stack,
-                    },
-                };
-            }
-            else {
-                serialized = { isError: false, value };
-            }
-            return [serialized, []];
-        },
-        deserialize(serialized) {
-            if (serialized.isError) {
-                throw Object.assign(new Error(serialized.value.message), serialized.value);
-            }
-            throw serialized.value;
-        },
-    };
-    /**
-     * Allows customizing the serialization of certain values.
-     */
-    const transferHandlers = new Map([
-        ["proxy", proxyTransferHandler],
-        ["throw", throwTransferHandler],
-    ]);
-    function expose(obj, ep = self) {
-        ep.addEventListener("message", function callback(ev) {
-            if (!ev || !ev.data) {
-                return;
-            }
-            const { id, type, path } = Object.assign({ path: [] }, ev.data);
-            const argumentList = (ev.data.argumentList || []).map(fromWireValue);
-            let returnValue;
-            try {
-                const parent = path.slice(0, -1).reduce((obj, prop) => obj[prop], obj);
-                const rawValue = path.reduce((obj, prop) => obj[prop], obj);
-                switch (type) {
-                    case 0 /* GET */:
-                        {
-                            returnValue = rawValue;
-                        }
-                        break;
-                    case 1 /* SET */:
-                        {
-                            parent[path.slice(-1)[0]] = fromWireValue(ev.data.value);
-                            returnValue = true;
-                        }
-                        break;
-                    case 2 /* APPLY */:
-                        {
-                            returnValue = rawValue.apply(parent, argumentList);
-                        }
-                        break;
-                    case 3 /* CONSTRUCT */:
-                        {
-                            const value = new rawValue(...argumentList);
-                            returnValue = proxy(value);
-                        }
-                        break;
-                    case 4 /* ENDPOINT */:
-                        {
-                            const { port1, port2 } = new MessageChannel();
-                            expose(obj, port2);
-                            returnValue = transfer(port1, [port1]);
-                        }
-                        break;
-                    case 5 /* RELEASE */:
-                        {
-                            returnValue = undefined;
-                        }
-                        break;
-                }
-            }
-            catch (value) {
-                returnValue = { value, [throwMarker]: 0 };
-            }
-            Promise.resolve(returnValue)
-                .catch((value) => {
-                return { value, [throwMarker]: 0 };
-            })
-                .then((returnValue) => {
-                const [wireValue, transferables] = toWireValue(returnValue);
-                ep.postMessage(Object.assign(Object.assign({}, wireValue), { id }), transferables);
-                if (type === 5 /* RELEASE */) {
-                    // detach and deactive after sending release response above.
-                    ep.removeEventListener("message", callback);
-                    closeEndPoint(ep);
-                }
-            });
-        });
-        if (ep.start) {
-            ep.start();
-        }
-    }
-    function isMessagePort(endpoint) {
-        return endpoint.constructor.name === "MessagePort";
-    }
-    function closeEndPoint(endpoint) {
-        if (isMessagePort(endpoint))
-            endpoint.close();
-    }
-    function wrap(ep, target) {
-        return createProxy(ep, [], target);
-    }
-    function throwIfProxyReleased(isReleased) {
-        if (isReleased) {
-            throw new Error("Proxy has been released and is not useable");
-        }
-    }
-    function createProxy(ep, path = [], target = function () { }) {
-        let isProxyReleased = false;
-        const proxy = new Proxy(target, {
-            get(_target, prop) {
-                throwIfProxyReleased(isProxyReleased);
-                if (prop === releaseProxy) {
-                    return () => {
-                        return requestResponseMessage(ep, {
-                            type: 5 /* RELEASE */,
-                            path: path.map((p) => p.toString()),
-                        }).then(() => {
-                            closeEndPoint(ep);
-                            isProxyReleased = true;
-                        });
-                    };
-                }
-                if (prop === "then") {
-                    if (path.length === 0) {
-                        return { then: () => proxy };
-                    }
-                    const r = requestResponseMessage(ep, {
-                        type: 0 /* GET */,
-                        path: path.map((p) => p.toString()),
-                    }).then(fromWireValue);
-                    return r.then.bind(r);
-                }
-                return createProxy(ep, [...path, prop]);
-            },
-            set(_target, prop, rawValue) {
-                throwIfProxyReleased(isProxyReleased);
-                // FIXME: ES6 Proxy Handler `set` methods are supposed to return a
-                // boolean. To show good will, we return true asynchronously ¯\_(ツ)_/¯
-                const [value, transferables] = toWireValue(rawValue);
-                return requestResponseMessage(ep, {
-                    type: 1 /* SET */,
-                    path: [...path, prop].map((p) => p.toString()),
-                    value,
-                }, transferables).then(fromWireValue);
-            },
-            apply(_target, _thisArg, rawArgumentList) {
-                throwIfProxyReleased(isProxyReleased);
-                const last = path[path.length - 1];
-                if (last === createEndpoint) {
-                    return requestResponseMessage(ep, {
-                        type: 4 /* ENDPOINT */,
-                    }).then(fromWireValue);
-                }
-                // We just pretend that `bind()` didn’t happen.
-                if (last === "bind") {
-                    return createProxy(ep, path.slice(0, -1));
-                }
-                const [argumentList, transferables] = processArguments(rawArgumentList);
-                return requestResponseMessage(ep, {
-                    type: 2 /* APPLY */,
-                    path: path.map((p) => p.toString()),
-                    argumentList,
-                }, transferables).then(fromWireValue);
-            },
-            construct(_target, rawArgumentList) {
-                throwIfProxyReleased(isProxyReleased);
-                const [argumentList, transferables] = processArguments(rawArgumentList);
-                return requestResponseMessage(ep, {
-                    type: 3 /* CONSTRUCT */,
-                    path: path.map((p) => p.toString()),
-                    argumentList,
-                }, transferables).then(fromWireValue);
-            },
-        });
-        return proxy;
-    }
-    function myFlat(arr) {
-        return Array.prototype.concat.apply([], arr);
-    }
-    function processArguments(argumentList) {
-        const processed = argumentList.map(toWireValue);
-        return [processed.map((v) => v[0]), myFlat(processed.map((v) => v[1]))];
-    }
-    const transferCache = new WeakMap();
-    function transfer(obj, transfers) {
-        transferCache.set(obj, transfers);
-        return obj;
-    }
-    function proxy(obj) {
-        return Object.assign(obj, { [proxyMarker]: true });
-    }
-    function windowEndpoint(w, context = self, targetOrigin = "*") {
-        return {
-            postMessage: (msg, transferables) => w.postMessage(msg, targetOrigin, transferables),
-            addEventListener: context.addEventListener.bind(context),
-            removeEventListener: context.removeEventListener.bind(context),
-        };
-    }
-    function toWireValue(value) {
-        for (const [name, handler] of transferHandlers) {
-            if (handler.canHandle(value)) {
-                const [serializedValue, transferables] = handler.serialize(value);
-                return [
-                    {
-                        type: 3 /* HANDLER */,
-                        name,
-                        value: serializedValue,
-                    },
-                    transferables,
-                ];
-            }
-        }
-        return [
-            {
-                type: 0 /* RAW */,
-                value,
-            },
-            transferCache.get(value) || [],
-        ];
-    }
-    function fromWireValue(value) {
-        switch (value.type) {
-            case 3 /* HANDLER */:
-                return transferHandlers.get(value.name).deserialize(value.value);
-            case 0 /* RAW */:
-                return value.value;
-        }
-    }
-    function requestResponseMessage(ep, msg, transfers) {
-        return new Promise((resolve) => {
-            const id = generateUUID();
-            ep.addEventListener("message", function l(ev) {
-                if (!ev.data || !ev.data.id || ev.data.id !== id) {
-                    return;
-                }
-                ep.removeEventListener("message", l);
-                resolve(ev.data);
-            });
-            if (ep.start) {
-                ep.start();
-            }
-            ep.postMessage(Object.assign({ id }, msg), transfers);
-        });
-    }
-    function generateUUID() {
-        return new Array(4)
-            .fill(0)
-            .map(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16))
-            .join("-");
-    }
-  
-    exports.createEndpoint = createEndpoint;
-    exports.expose = expose;
-    exports.proxy = proxy;
-    exports.proxyMarker = proxyMarker;
-    exports.releaseProxy = releaseProxy;
-    exports.transfer = transfer;
-    exports.transferHandlers = transferHandlers;
-    exports.windowEndpoint = windowEndpoint;
-    exports.wrap = wrap;
-  
-    Object.defineProperty(exports, '__esModule', { value: true });
-  
-  })));
-  //# sourceMappingURL=comlink.js.map
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = global || self, factory(global.Comlink = {}));
+}(this, (function (exports) { 'use strict';
+
+  /**
+   * Copyright 2019 Google Inc. All Rights Reserved.
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  const proxyMarker = Symbol("Comlink.proxy");
+  const createEndpoint = Symbol("Comlink.endpoint");
+  const releaseProxy = Symbol("Comlink.releaseProxy");
+  const throwMarker = Symbol("Comlink.thrown");
+  const isObject = (val) => (typeof val === "object" && val !== null) || typeof val === "function";
+  /**
+   * Internal transfer handle to handle objects marked to proxy.
+   */
+  const proxyTransferHandler = {
+      canHandle: (val) => isObject(val) && val[proxyMarker],
+      serialize(obj) {
+          const { port1, port2 } = new MessageChannel();
+          expose(obj, port1);
+          return [port2, [port2]];
+      },
+      deserialize(port) {
+          port.start();
+          return wrap(port);
+      },
+  };
+  /**
+   * Internal transfer handler to handle thrown exceptions.
+   */
+  const throwTransferHandler = {
+      canHandle: (value) => isObject(value) && throwMarker in value,
+      serialize({ value }) {
+          let serialized;
+          if (value instanceof Error) {
+              serialized = {
+                  isError: true,
+                  value: {
+                      message: value.message,
+                      name: value.name,
+                      stack: value.stack,
+                  },
+              };
+          }
+          else {
+              serialized = { isError: false, value };
+          }
+          return [serialized, []];
+      },
+      deserialize(serialized) {
+          if (serialized.isError) {
+              throw Object.assign(new Error(serialized.value.message), serialized.value);
+          }
+          throw serialized.value;
+      },
+  };
+  /**
+   * Allows customizing the serialization of certain values.
+   */
+  const transferHandlers = new Map([
+      ["proxy", proxyTransferHandler],
+      ["throw", throwTransferHandler],
+  ]);
+  function expose(obj, ep = self) {
+      ep.addEventListener("message", function callback(ev) {
+          if (!ev || !ev.data) {
+              return;
+          }
+          const { id, type, path } = Object.assign({ path: [] }, ev.data);
+          const argumentList = (ev.data.argumentList || []).map(fromWireValue);
+          let returnValue;
+          try {
+              const parent = path.slice(0, -1).reduce((obj, prop) => obj[prop], obj);
+              const rawValue = path.reduce((obj, prop) => obj[prop], obj);
+              switch (type) {
+                  case 0 /* GET */:
+                      {
+                          returnValue = rawValue;
+                      }
+                      break;
+                  case 1 /* SET */:
+                      {
+                          parent[path.slice(-1)[0]] = fromWireValue(ev.data.value);
+                          returnValue = true;
+                      }
+                      break;
+                  case 2 /* APPLY */:
+                      {
+                          returnValue = rawValue.apply(parent, argumentList);
+                      }
+                      break;
+                  case 3 /* CONSTRUCT */:
+                      {
+                          const value = new rawValue(...argumentList);
+                          returnValue = proxy(value);
+                      }
+                      break;
+                  case 4 /* ENDPOINT */:
+                      {
+                          const { port1, port2 } = new MessageChannel();
+                          expose(obj, port2);
+                          returnValue = transfer(port1, [port1]);
+                      }
+                      break;
+                  case 5 /* RELEASE */:
+                      {
+                          returnValue = undefined;
+                      }
+                      break;
+              }
+          }
+          catch (value) {
+              returnValue = { value, [throwMarker]: 0 };
+          }
+          Promise.resolve(returnValue)
+              .catch((value) => {
+              return { value, [throwMarker]: 0 };
+          })
+              .then((returnValue) => {
+              const [wireValue, transferables] = toWireValue(returnValue);
+              ep.postMessage(Object.assign(Object.assign({}, wireValue), { id }), transferables);
+              if (type === 5 /* RELEASE */) {
+                  // detach and deactive after sending release response above.
+                  ep.removeEventListener("message", callback);
+                  closeEndPoint(ep);
+              }
+          });
+      });
+      if (ep.start) {
+          ep.start();
+      }
+  }
+  function isMessagePort(endpoint) {
+      return endpoint.constructor.name === "MessagePort";
+  }
+  function closeEndPoint(endpoint) {
+      if (isMessagePort(endpoint))
+          endpoint.close();
+  }
+  function wrap(ep, target) {
+      return createProxy(ep, [], target);
+  }
+  function throwIfProxyReleased(isReleased) {
+      if (isReleased) {
+          throw new Error("Proxy has been released and is not useable");
+      }
+  }
+  function createProxy(ep, path = [], target = function () { }) {
+      let isProxyReleased = false;
+      const proxy = new Proxy(target, {
+          get(_target, prop) {
+              throwIfProxyReleased(isProxyReleased);
+              if (prop === releaseProxy) {
+                  return () => {
+                      return requestResponseMessage(ep, {
+                          type: 5 /* RELEASE */,
+                          path: path.map((p) => p.toString()),
+                      }).then(() => {
+                          closeEndPoint(ep);
+                          isProxyReleased = true;
+                      });
+                  };
+              }
+              if (prop === "then") {
+                  if (path.length === 0) {
+                      return { then: () => proxy };
+                  }
+                  const r = requestResponseMessage(ep, {
+                      type: 0 /* GET */,
+                      path: path.map((p) => p.toString()),
+                  }).then(fromWireValue);
+                  return r.then.bind(r);
+              }
+              return createProxy(ep, [...path, prop]);
+          },
+          set(_target, prop, rawValue) {
+              throwIfProxyReleased(isProxyReleased);
+              // FIXME: ES6 Proxy Handler `set` methods are supposed to return a
+              // boolean. To show good will, we return true asynchronously ¯\_(ツ)_/¯
+              const [value, transferables] = toWireValue(rawValue);
+              return requestResponseMessage(ep, {
+                  type: 1 /* SET */,
+                  path: [...path, prop].map((p) => p.toString()),
+                  value,
+              }, transferables).then(fromWireValue);
+          },
+          apply(_target, _thisArg, rawArgumentList) {
+              throwIfProxyReleased(isProxyReleased);
+              const last = path[path.length - 1];
+              if (last === createEndpoint) {
+                  return requestResponseMessage(ep, {
+                      type: 4 /* ENDPOINT */,
+                  }).then(fromWireValue);
+              }
+              // We just pretend that `bind()` didn’t happen.
+              if (last === "bind") {
+                  return createProxy(ep, path.slice(0, -1));
+              }
+              const [argumentList, transferables] = processArguments(rawArgumentList);
+              return requestResponseMessage(ep, {
+                  type: 2 /* APPLY */,
+                  path: path.map((p) => p.toString()),
+                  argumentList,
+              }, transferables).then(fromWireValue);
+          },
+          construct(_target, rawArgumentList) {
+              throwIfProxyReleased(isProxyReleased);
+              const [argumentList, transferables] = processArguments(rawArgumentList);
+              return requestResponseMessage(ep, {
+                  type: 3 /* CONSTRUCT */,
+                  path: path.map((p) => p.toString()),
+                  argumentList,
+              }, transferables).then(fromWireValue);
+          },
+      });
+      return proxy;
+  }
+  function myFlat(arr) {
+      return Array.prototype.concat.apply([], arr);
+  }
+  function processArguments(argumentList) {
+      const processed = argumentList.map(toWireValue);
+      return [processed.map((v) => v[0]), myFlat(processed.map((v) => v[1]))];
+  }
+  const transferCache = new WeakMap();
+  function transfer(obj, transfers) {
+      transferCache.set(obj, transfers);
+      return obj;
+  }
+  function proxy(obj) {
+      return Object.assign(obj, { [proxyMarker]: true });
+  }
+  function windowEndpoint(w, context = self, targetOrigin = "*") {
+      return {
+          postMessage: (msg, transferables) => w.postMessage(msg, targetOrigin, transferables),
+          addEventListener: context.addEventListener.bind(context),
+          removeEventListener: context.removeEventListener.bind(context),
+      };
+  }
+  function toWireValue(value) {
+      for (const [name, handler] of transferHandlers) {
+          if (handler.canHandle(value)) {
+              const [serializedValue, transferables] = handler.serialize(value);
+              return [
+                  {
+                      type: 3 /* HANDLER */,
+                      name,
+                      value: serializedValue,
+                  },
+                  transferables,
+              ];
+          }
+      }
+      return [
+          {
+              type: 0 /* RAW */,
+              value,
+          },
+          transferCache.get(value) || [],
+      ];
+  }
+  function fromWireValue(value) {
+      switch (value.type) {
+          case 3 /* HANDLER */:
+              return transferHandlers.get(value.name).deserialize(value.value);
+          case 0 /* RAW */:
+              return value.value;
+      }
+  }
+  function requestResponseMessage(ep, msg, transfers) {
+      return new Promise((resolve) => {
+          const id = generateUUID();
+          ep.addEventListener("message", function l(ev) {
+              if (!ev.data || !ev.data.id || ev.data.id !== id) {
+                  return;
+              }
+              ep.removeEventListener("message", l);
+              resolve(ev.data);
+          });
+          if (ep.start) {
+              ep.start();
+          }
+          ep.postMessage(Object.assign({ id }, msg), transfers);
+      });
+  }
+  function generateUUID() {
+      return new Array(4)
+          .fill(0)
+          .map(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16))
+          .join("-");
+  }
+
+  exports.createEndpoint = createEndpoint;
+  exports.expose = expose;
+  exports.proxy = proxy;
+  exports.proxyMarker = proxyMarker;
+  exports.releaseProxy = releaseProxy;
+  exports.transfer = transfer;
+  exports.transferHandlers = transferHandlers;
+  exports.windowEndpoint = windowEndpoint;
+  exports.wrap = wrap;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+})));
+//# sourceMappingURL=comlink.js.map

--- a/libraries/license-info.json
+++ b/libraries/license-info.json
@@ -8,5 +8,6 @@
   "vue": "MIT",
   "tinycolor2": "MIT",
   "chartjs": "MIT",
-  "color-picker-web-component": "MIT"
+  "color-picker-web-component": "MIT",
+  "//TODO:": ""
 }

--- a/libraries/license-info.json
+++ b/libraries/license-info.json
@@ -9,5 +9,5 @@
   "tinycolor2": "MIT",
   "chartjs": "MIT",
   "color-picker-web-component": "MIT",
-  "//TODO:": ""
+  "comlink": "Apache-2.0"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     {
       "matches": ["https://scratch.mit.edu/*"],
       "run_at": "document_start",
-      "js": ["content-scripts/cs.js"],
+      "js": ["libraries/comlink.js", "content-scripts/cs.js"],
       "all_frames": true
     },
     {

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -399,7 +399,9 @@
             >
           </p>
           <p>
-            <a href="./licenses.html?libraries=intl-messageformat,vue,color-picker-web-component,comlink" target="_blank"
+            <a
+              href="./licenses.html?libraries=intl-messageformat,vue,color-picker-web-component,comlink"
+              target="_blank"
               >{{ msg("libraryCredits") }}</a
             >
           </p>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -399,7 +399,7 @@
             >
           </p>
           <p>
-            <a href="./licenses.html?libraries=intl-messageformat,vue,color-picker-web-component" target="_blank"
+            <a href="./licenses.html?libraries=intl-messageformat,vue,color-picker-web-component,comlink" target="_blank"
               >{{ msg("libraryCredits") }}</a
             >
           </p>


### PR DESCRIPTION
Resolves #1659 
- Adds Comlink for CS <> page communication. For it to work properly I had to use 4 about:blank iframes, not ideal but not a big deal either. Good part of using 4 iframes is that they message each other, so no message goes through the main Scratch frame, which should help avoid conflicts with other extensions.
- Previously, neither module.js nor theme CSS were injected until there was a `<head>`. That limitation was now removed, but userscripts should still be executed after the `<head>` is created.
- Use `import.meta.url` instead of `template#scratch-addons[data-path]`
- Introduce `scratchAddons.methods.copyImage` for copying images on Firefox without needing Tab.js to use the template element
- I could list every change, but TL;DR is that everything that previously used HTML attributes in the `<template id="scratch-addons">` element now uses Comlink.
- Code is way cleaner now, we can magically access objects from "the other world" thanks to Comlink :)

Resolves #703 (not done, but good enough to test Comlink)
- After some testing, I concluded there's no need to spam contentScriptInfo - requiring the content script to ask for it when it executed works just fine (reminder: the purpose of all this "spam" was to make "website dark mode" loads fast enough so that user does not notice flicker)
- However, we still want to preload what addons and themes will be needed in that page to load them ASAP, so we'll have a `Map` object that caches contentScriptInfo by listening to `chrome.webRequest.beforeRequest`, which obviously gets fired before the content script has a chance to execute while the page is loading.