### PR TITLE
More consistent error pages with Scratch 2.0 → 3.0

### DIFF
--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -54,25 +54,7 @@
     },
     {
       "url": "scratchr2_errors.css",
-      "matches": [
-        "https://scratch.mit.edu/discuss/*",
-        "https://scratch.mit.edu/mystuff/",
-        "https://scratch.mit.edu/users/*",
-        "https://scratch.mit.edu/classes/*",
-        "https://scratch.mit.edu/studios/*",
-        "https://scratch.mit.edu/projects/*/remixes/",
-        "https://scratch.mit.edu/projects/*/studios/",
-        "https://scratch.mit.edu/projects/*/remixtree/",
-        "https://scratch.mit.edu/accounts/*",
-        "https://scratch.mit.edu/statistics/",
-        "https://scratch.mit.edu/info/quotes/",
-        "https://scratch.mit.edu/info/ext_download/",
-        "https://scratch.mit.edu/cloudmonitor/*",
-        "https://scratch.mit.edu/403/",
-        "https://scratch.mit.edu/404/",
-        "https://scratch.mit.edu/500/",
-        "https://scratch.mit.edu/news"
-      ]
+      "matches": ["https://scratch.mit.edu/*"]
     },
     {
       "url": "scratchwww.css",

--- a/addons/scratchr2/scratchr2_errors.css
+++ b/addons/scratchr2/scratchr2_errors.css
@@ -4,6 +4,7 @@
   border-radius: 0;
   border: none;
   background: transparent;
+  box-shadow: none;
 }
 #page-500 {
   width: 100%;


### PR DESCRIPTION
**Resolves**

Resolves #1976

**Changes**

Makes 404s more consistent when Scratch 2.0 → 3.0 is enabled. Some still don't have the 3.0 navigation bar because that would require #23.