### PR TITLE
Fix auto-hide block palette closing animation

### DIFF
--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -1,3 +1,9 @@
+.blocklyFlyout,
+.blocklyFlyoutScrollbar,
+.sa-lock-image {
+  transition-property: transform;
+}
+
 .blocklyFlyout.sa-flyoutClose {
   transform: translateX(-200px) !important;
 }
@@ -19,60 +25,6 @@
   z-index: 20;
   width: 20px;
   cursor: pointer;
-}
-
-@keyframes openFlyout {
-  0% {
-    transform: translateX(-200px);
-  }
-  100% {
-    transform: translateX(60px);
-  }
-}
-
-@keyframes closeFlyout {
-  0% {
-    transform: translateX(60px);
-  }
-  100% {
-    transform: translateX(-200px);
-  }
-}
-
-@keyframes openScrollbar {
-  0% {
-    transform: translateX(36.5px);
-  }
-  100% {
-    transform: translateX(296.5px);
-  }
-}
-
-@keyframes closeScrollbar {
-  0% {
-    transform: translateX(296.5px);
-  }
-  100% {
-    transform: translateX(36.5px);
-  }
-}
-
-@keyframes openLock {
-  0% {
-    transform: translateX(-260px);
-  }
-  100% {
-    transform: translateX(0px);
-  }
-}
-
-@keyframes closeLock {
-  0% {
-    transform: translateX(0px);
-  }
-  100% {
-    transform: translateX(-260px);
-  }
 }
 
 .injectionDiv {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -50,11 +50,11 @@ export default async function ({ addon, global, console }) {
       function onmouseenter(speed = {}) {
         speed = typeof speed === "object" ? getSpeedValue() : speed;
         flyOut.classList.remove("sa-flyoutClose");
-        flyOut.style.animation = `openFlyout ${speed}s 1`;
+        flyOut.style.transitionDuration = `${speed}s`;
         scrollBar.classList.remove("sa-flyoutClose");
-        scrollBar.style.animation = `openScrollbar ${speed}s 1`;
+        scrollBar.style.transitionDuration = `${speed}s`;
         lockDisplay.classList.remove("sa-flyoutClose");
-        lockDisplay.style.animation = `openLock ${speed}s 1`;
+        lockDisplay.style.transitionDuration = `${speed}s`;
         setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
       }
       function onmouseleave(e, speed = getSpeedValue()) {
@@ -65,11 +65,11 @@ export default async function ({ addon, global, console }) {
         )
           return;
         flyOut.classList.add("sa-flyoutClose");
-        flyOut.style.animation = `closeFlyout ${speed}s 1`;
+        flyOut.style.transitionDuration = `${speed}s`;
         scrollBar.classList.add("sa-flyoutClose");
-        scrollBar.style.animation = `closeScrollbar ${speed}s 1`;
+        scrollBar.style.transitionDuration = `${speed}s`;
         lockDisplay.classList.add("sa-flyoutClose");
-        lockDisplay.style.animation = `closeLock ${speed}s 1`;
+        lockDisplay.style.transitionDuration = `${speed}s`;
         setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
       }
 


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Fixes #1876

**Changes**

I've replaced the CSS animation with a transition. This removes the need to have to define an animation for each thing animated, and CSS transitions are also capable of stopping and going in a different direction midway through a transition if, say, the user wiggles their mouse around a lot.

**Reason for changes**

I've noticed that the hide animation didn't seem to work for me; the palette just disappears with the lock trailing behind.

**Tests**

This is the current animation on `master`:

<img src="https://cdn.discordapp.com/attachments/775797057926856754/825472761664110642/THE_GIF.gif" alt="Old behaviour demonstrates the hide animation not working" width="337.5">

This is the animation introduced by the PR:

<img src="https://cdn.discordapp.com/attachments/775797057926856754/825472395670192158/THE_GIF.gif" alt="New behaviour demonstrates a smoother animation" width="337.5">

I tried the various animation durations and toggle behaviours, and they seem to work the same as before.