### PR TITLE
Fix 2d-color-picker in Firefox

### DIFF
--- a/addons/2d-color-picker/paint-editor.js
+++ b/addons/2d-color-picker/paint-editor.js
@@ -196,6 +196,8 @@ export default async ({ addon, console, msg }) => {
     } else updateHandleFinal(1, 1);
 
     saColorPicker.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
+
       originalPos = {
         x: parseFloat(saColorPickerHandle.style.left) + 8,
         y: parseFloat(saColorPickerHandle.style.top) + 8,


### PR DESCRIPTION
**Changes**

2d color picker addon [did not work properly in Firefox](https://user-images.githubusercontent.com/33787854/112880401-021bd180-9090-11eb-81e2-769684dd4f38.mp4) because of https://bugzilla.mozilla.org/show_bug.cgi?id=1376369, this fixes that
