### PR TITLE
Fix some bugs in hide-flyout

### DIFF
--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -29,7 +29,7 @@
   z-index: 20;
   width: 20px;
   cursor: pointer;
-  top: 44px;
+  top: 46px;
   left: 280px;
 }
 

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -18,6 +18,7 @@
 
 .sa-flyout-placeHolder {
   position: absolute;
+  left: 61px;
 }
 
 .sa-lock-image {
@@ -25,6 +26,7 @@
   z-index: 20;
   width: 20px;
   cursor: pointer;
+  left: 280px;
 }
 
 .injectionDiv {

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -19,6 +19,9 @@
 .sa-flyout-placeHolder {
   position: absolute;
   left: 61px;
+  top: 44px;
+  height: 100%;
+  width: 251px;
 }
 
 .sa-lock-image {
@@ -26,6 +29,7 @@
   z-index: 20;
   width: 20px;
   cursor: pointer;
+  top: 44px;
   left: 280px;
 }
 

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -25,13 +25,10 @@ export default async function ({ addon, global, console }) {
       };
 
       function positionElements() {
-        let addition = flyOut.classList.contains("sa-flyoutClose") ? 260 : 0;
         placeHolderDiv.style.height = `${flyOut.getBoundingClientRect().height - 20}px`;
         placeHolderDiv.style.width = `${flyOut.getBoundingClientRect().width}px`;
-        placeHolderDiv.style.left = `${flyOut.getBoundingClientRect().left + addition}px`;
         placeHolderDiv.style.top = `${flyOut.getBoundingClientRect().top}px`;
         lockDisplay.style.top = `${flyOut.getBoundingClientRect().top}px`;
-        lockDisplay.style.left = `${flyOut.getBoundingClientRect().right - 32 + addition}px`;
       }
 
       // Only append if we don't have "categoryclick" on

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -1,6 +1,7 @@
 export default async function ({ addon, global, console }) {
   var placeHolderDiv = null,
     lockDisplay = null,
+    toggleSetting = addon.settings.get("toggle"),
     flyoutLock = false;
   while (true) {
     let flyOut = await addon.tab.waitForElement(".blocklyFlyout", { markAsSeen: true });
@@ -11,7 +12,7 @@ export default async function ({ addon, global, console }) {
       // Placeholder Div
       if (placeHolderDiv) placeHolderDiv.remove();
       placeHolderDiv = document.createElement("div");
-      if (addon.settings.get("toggle") === "hover") document.body.appendChild(placeHolderDiv);
+      if (toggleSetting === "hover") document.body.appendChild(placeHolderDiv);
       placeHolderDiv.className = "sa-flyout-placeHolder";
 
       // Lock Img
@@ -32,7 +33,7 @@ export default async function ({ addon, global, console }) {
       }
 
       // Only append if we don't have "categoryclick" on
-      if (addon.settings.get("toggle") === "hover") document.body.appendChild(lockDisplay);
+      if (toggleSetting === "hover") document.body.appendChild(lockDisplay);
 
       function getSpeedValue() {
         let data = {
@@ -57,7 +58,7 @@ export default async function ({ addon, global, console }) {
       function onmouseleave(e, speed = getSpeedValue()) {
         // If we go behind the flyout or the user has locked it, let's return
         if (
-          (addon.settings.get("toggle") !== "cathover" && e && e.clientX <= scrollBar.getBoundingClientRect().left) ||
+          (toggleSetting !== "cathover" && e && e.clientX <= scrollBar.getBoundingClientRect().left) ||
           flyoutLock
         )
           return;
@@ -75,7 +76,7 @@ export default async function ({ addon, global, console }) {
       let toggle = true,
         selectedCat = null,
         justStart = true;
-      if (addon.settings.get("toggle") === "hover")
+      if (toggleSetting === "hover")
         (placeHolderDiv.onmouseenter = onmouseenter), (blocklySvg.onmouseenter = onmouseleave);
 
       addon.tab.redux.initialize();
@@ -104,18 +105,18 @@ export default async function ({ addon, global, console }) {
         }
       });
 
-      if (addon.settings.get("toggle") === "cathover") onmouseleave(null, 0);
+      if (toggleSetting === "cathover") onmouseleave(null, 0);
 
       while (true) {
         let category = await addon.tab.waitForElement(".scratchCategoryMenuItem", { markAsSeen: true });
         category.onclick = (e) => {
-          if (toggle && selectedCat === category && addon.settings.get("toggle") === "category")
+          if (toggle && selectedCat === category && toggleSetting === "category")
             onmouseleave(), (selectedCat = category), (justStart = false);
           else if (!toggle) onmouseenter(), (selectedCat = category), (justStart = false);
           else return (selectedCat = category), (justStart = false);
-          if (addon.settings.get("toggle") === "category") toggle = !toggle;
+          if (toggleSetting === "category") toggle = !toggle;
         };
-        if (addon.settings.get("toggle") === "cathover")
+        if (toggleSetting === "cathover")
           (category.onmouseover = onmouseenter), (flyOut.onmouseleave = onmouseleave);
       }
     })();

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -48,7 +48,7 @@ export default async function ({ addon, global, console }) {
 
   let startedCategoryLoop = false;
   function startCategoryLoop() {
-    if (toggleSetting === "category" || toggleSetting === "cathover" && !startedCategoryLoop) {
+    if (toggleSetting === "category" || (toggleSetting === "cathover" && !startedCategoryLoop)) {
       startedCategoryLoop = true;
       (async () => {
         while (true) {
@@ -72,7 +72,7 @@ export default async function ({ addon, global, console }) {
           }
         }
       })();
-    }  
+    }
   }
 
   addon.tab.redux.initialize();

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -8,12 +8,6 @@ export default async function ({ addon, global, console }) {
   let toggleSetting = addon.settings.get("toggle");
   let flyoutLock = false;
 
-  function positionElements() {
-    placeHolderDiv.style.height = `${flyOut.getBoundingClientRect().height - 20}px`;
-    placeHolderDiv.style.width = `${flyOut.getBoundingClientRect().width}px`;
-    placeHolderDiv.style.top = `${flyOut.getBoundingClientRect().top}px`;
-    lockDisplay.style.top = `${flyOut.getBoundingClientRect().top}px`;
-  }
   function getSpeedValue() {
     let data = {
       none: "0",
@@ -55,12 +49,6 @@ export default async function ({ addon, global, console }) {
     addon.tab.redux.initialize();
     addon.tab.redux.addEventListener("statechanged", (e) => {
       switch (e.detail.action.type) {
-        // Event casted when switch to small or normal size stage or when screen size changed.
-        case "scratch-gui/StageSize/SET_STAGE_SIZE":
-        case "scratch-gui/workspace-metrics/UPDATE_METRICS":
-          positionElements();
-          break;
-
         // Event casted when you switch between tabs
         case "scratch-gui/navigation/ACTIVATE_TAB":
           // always 0, 1, 2
@@ -68,7 +56,6 @@ export default async function ({ addon, global, console }) {
           placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
           if (e.detail.action.activeTabIndex === 0) {
             onmouseenter(0);
-            positionElements();
             toggle = true;
           }
           break;
@@ -110,11 +97,12 @@ export default async function ({ addon, global, console }) {
     flyOut = await addon.tab.waitForElement(".blocklyFlyout", { markAsSeen: true });
     let blocklySvg = await addon.tab.waitForElement(".blocklySvg", { markAsSeen: true });
     scrollBar = document.querySelector(".blocklyFlyoutScrollbar");
+    const tabs = document.querySelector('[class^="gui_tabs"]');
 
     // Placeholder Div
     if (placeHolderDiv) placeHolderDiv.remove();
     placeHolderDiv = document.createElement("div");
-    if (toggleSetting === "hover") document.body.appendChild(placeHolderDiv);
+    if (toggleSetting === "hover") tabs.appendChild(placeHolderDiv);
     placeHolderDiv.className = "sa-flyout-placeHolder";
 
     // Lock Img
@@ -128,10 +116,8 @@ export default async function ({ addon, global, console }) {
     };
 
     // Only append if we don't have "categoryclick" on
-    if (toggleSetting === "hover") document.body.appendChild(lockDisplay);
+    if (toggleSetting === "hover") tabs.appendChild(lockDisplay);
 
-    // position elements which closes flyout on load
-    positionElements();
     if (toggleSetting === "hover") {
       placeHolderDiv.onmouseenter = onmouseenter;
       blocklySvg.onmouseenter = onmouseleave;

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -1,13 +1,12 @@
 export default async function ({ addon, global, console }) {
   let placeHolderDiv = null;
   let lockDisplay = null;
+  let flyOut = null;
+  let scrollBar = null;
   let toggle = true;
   let selectedCategory = null;
   let toggleSetting = addon.settings.get("toggle");
   let flyoutLock = false;
-
-  let flyOut;
-  let scrollBar;
 
   function positionElements() {
     placeHolderDiv.style.height = `${flyOut.getBoundingClientRect().height - 20}px`;
@@ -36,10 +35,7 @@ export default async function ({ addon, global, console }) {
   }
   function onmouseleave(e, speed = getSpeedValue()) {
     // If we go behind the flyout or the user has locked it, let's return
-    if (
-      (toggleSetting !== "cathover" && e && e.clientX <= scrollBar.getBoundingClientRect().left) ||
-      flyoutLock
-    )
+    if ((toggleSetting !== "cathover" && e && e.clientX <= scrollBar.getBoundingClientRect().left) || flyoutLock)
       return;
     flyOut.classList.add("sa-flyoutClose");
     flyOut.style.transitionDuration = `${speed}s`;
@@ -89,8 +85,11 @@ export default async function ({ addon, global, console }) {
         // always 0, 1, 2
         lockDisplay.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
         placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
-        if (e.detail.action.activeTabIndex === 0)
-          onmouseenter(0), positionElements(), (toggle = true);
+        if (e.detail.action.activeTabIndex === 0) {
+          onmouseenter(0);
+          positionElements();
+          toggle = true;
+        }
         break;
       // Event casted when you switch between tabs
       case "scratch-gui/mode/SET_PLAYER":

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -46,29 +46,33 @@ export default async function ({ addon, global, console }) {
     setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
   }
 
-  if (toggleSetting === "category" || toggleSetting === "cathover") {
-    (async () => {
-      while (true) {
-        let category = await addon.tab.waitForElement(".scratchCategoryMenuItem", { markAsSeen: true });
-        category.onclick = (e) => {
-          if (toggle && selectedCategory === category && toggleSetting === "category") {
-            onmouseleave();
-            selectedCategory = category;
-          } else if (!toggle) {
-            onmouseenter();
-            selectedCategory = category;
-          } else {
-            selectedCategory = category;
-            return;
+  let startedCategoryLoop = false;
+  function startCategoryLoop() {
+    if (toggleSetting === "category" || toggleSetting === "cathover" && !startedCategoryLoop) {
+      startedCategoryLoop = true;
+      (async () => {
+        while (true) {
+          let category = await addon.tab.waitForElement(".scratchCategoryMenuItem", { markAsSeen: true });
+          category.onclick = () => {
+            if (toggle && selectedCategory === category && toggleSetting === "category") {
+              onmouseleave();
+              selectedCategory = category;
+            } else if (!toggle) {
+              onmouseenter();
+              selectedCategory = category;
+            } else {
+              selectedCategory = category;
+              return;
+            }
+            if (toggleSetting === "category") toggle = !toggle;
+          };
+          if (toggleSetting === "cathover") {
+            category.onmouseover = onmouseenter;
+            flyOut.onmouseleave = onmouseleave;
           }
-          if (toggleSetting === "category") toggle = !toggle;
-        };
-        if (toggleSetting === "cathover") {
-          category.onmouseover = onmouseenter;
-          flyOut.onmouseleave = onmouseleave;
         }
-      }
-    })();
+      })();
+    }  
   }
 
   addon.tab.redux.initialize();
@@ -132,5 +136,7 @@ export default async function ({ addon, global, console }) {
     }
 
     if (toggleSetting === "cathover") onmouseleave(null, 0);
+
+    startCategoryLoop();
   }
 }

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -55,14 +55,22 @@ export default async function ({ addon, global, console }) {
       while (true) {
         let category = await addon.tab.waitForElement(".scratchCategoryMenuItem", { markAsSeen: true });
         category.onclick = (e) => {
-          if (toggle && selectedCategory === category && toggleSetting === "category")
-            onmouseleave(), (selectedCategory = category);
-          else if (!toggle) onmouseenter(), (selectedCategory = category);
-          else return (selectedCategory = category);
+          if (toggle && selectedCategory === category && toggleSetting === "category") {
+            onmouseleave();
+            selectedCategory = category;
+          } else if (!toggle) {
+            onmouseenter();
+            selectedCategory = category;
+          } else {
+            selectedCategory = category;
+            return;
+          }
           if (toggleSetting === "category") toggle = !toggle;
         };
-        if (toggleSetting === "cathover")
-          (category.onmouseover = onmouseenter), (flyOut.onmouseleave = onmouseleave);
+        if (toggleSetting === "cathover") {
+          category.onmouseover = onmouseenter;
+          flyOut.onmouseleave = onmouseleave;
+        }
       }
     })();
   }
@@ -119,8 +127,10 @@ export default async function ({ addon, global, console }) {
 
     // position elements which closes flyout on load
     positionElements();
-    if (toggleSetting === "hover")
-      (placeHolderDiv.onmouseenter = onmouseenter), (blocklySvg.onmouseenter = onmouseleave);
+    if (toggleSetting === "hover") {
+      placeHolderDiv.onmouseenter = onmouseenter;
+      blocklySvg.onmouseenter = onmouseleave;
+    }
 
     if (toggleSetting === "cathover") onmouseleave(null, 0);
   }

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -60,7 +60,7 @@ export default async function ({ addon, global, console }) {
         case "scratch-gui/workspace-metrics/UPDATE_METRICS":
           positionElements();
           break;
-  
+
         // Event casted when you switch between tabs
         case "scratch-gui/navigation/ACTIVATE_TAB":
           // always 0, 1, 2
@@ -79,7 +79,7 @@ export default async function ({ addon, global, console }) {
           placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
           break;
       }
-    });  
+    });
     if (toggleSetting === "category" || toggleSetting === "cathover") {
       (async () => {
         while (true) {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -48,7 +48,7 @@ export default async function ({ addon, global, console }) {
 
   let startedCategoryLoop = false;
   function startCategoryLoop() {
-    if (toggleSetting === "category" || (toggleSetting === "cathover" && !startedCategoryLoop)) {
+    if ((toggleSetting === "category" || toggleSetting === "cathover") && !startedCategoryLoop) {
       startedCategoryLoop = true;
       (async () => {
         while (true) {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -1,124 +1,127 @@
 export default async function ({ addon, global, console }) {
-  var placeHolderDiv = null,
-    lockDisplay = null,
-    toggleSetting = addon.settings.get("toggle"),
-    flyoutLock = false;
-  while (true) {
-    let flyOut = await addon.tab.waitForElement(".blocklyFlyout", { markAsSeen: true });
-    let blocklySvg = await addon.tab.waitForElement(".blocklySvg", { markAsSeen: true });
+  let placeHolderDiv = null;
+  let lockDisplay = null;
+  let toggle = true;
+  let selectedCategory = null;
+  let toggleSetting = addon.settings.get("toggle");
+  let flyoutLock = false;
+
+  let flyOut;
+  let scrollBar;
+
+  function positionElements() {
+    placeHolderDiv.style.height = `${flyOut.getBoundingClientRect().height - 20}px`;
+    placeHolderDiv.style.width = `${flyOut.getBoundingClientRect().width}px`;
+    placeHolderDiv.style.top = `${flyOut.getBoundingClientRect().top}px`;
+    lockDisplay.style.top = `${flyOut.getBoundingClientRect().top}px`;
+  }
+  function getSpeedValue() {
+    let data = {
+      none: "0",
+      short: "0.25",
+      default: "0.5",
+      long: "1",
+    };
+    return data[addon.settings.get("speed")];
+  }
+  function onmouseenter(speed = {}) {
+    speed = typeof speed === "object" ? getSpeedValue() : speed;
+    flyOut.classList.remove("sa-flyoutClose");
+    flyOut.style.transitionDuration = `${speed}s`;
+    scrollBar.classList.remove("sa-flyoutClose");
+    scrollBar.style.transitionDuration = `${speed}s`;
+    lockDisplay.classList.remove("sa-flyoutClose");
+    lockDisplay.style.transitionDuration = `${speed}s`;
+    setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
+  }
+  function onmouseleave(e, speed = getSpeedValue()) {
+    // If we go behind the flyout or the user has locked it, let's return
+    if (
+      (toggleSetting !== "cathover" && e && e.clientX <= scrollBar.getBoundingClientRect().left) ||
+      flyoutLock
+    )
+      return;
+    flyOut.classList.add("sa-flyoutClose");
+    flyOut.style.transitionDuration = `${speed}s`;
+    scrollBar.classList.add("sa-flyoutClose");
+    scrollBar.style.transitionDuration = `${speed}s`;
+    lockDisplay.classList.add("sa-flyoutClose");
+    lockDisplay.style.transitionDuration = `${speed}s`;
+    setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
+  }
+
+  if (toggleSetting === "category" || toggleSetting === "cathover") {
     (async () => {
-      let scrollBar = document.querySelector(".blocklyFlyoutScrollbar");
-
-      // Placeholder Div
-      if (placeHolderDiv) placeHolderDiv.remove();
-      placeHolderDiv = document.createElement("div");
-      if (toggleSetting === "hover") document.body.appendChild(placeHolderDiv);
-      placeHolderDiv.className = "sa-flyout-placeHolder";
-
-      // Lock Img
-      if (lockDisplay) lockDisplay.remove();
-      lockDisplay = document.createElement("img");
-      lockDisplay.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
-      lockDisplay.className = "sa-lock-image";
-      lockDisplay.onclick = () => {
-        flyoutLock = !flyoutLock;
-        lockDisplay.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
-      };
-
-      function positionElements() {
-        placeHolderDiv.style.height = `${flyOut.getBoundingClientRect().height - 20}px`;
-        placeHolderDiv.style.width = `${flyOut.getBoundingClientRect().width}px`;
-        placeHolderDiv.style.top = `${flyOut.getBoundingClientRect().top}px`;
-        lockDisplay.style.top = `${flyOut.getBoundingClientRect().top}px`;
-      }
-
-      // Only append if we don't have "categoryclick" on
-      if (toggleSetting === "hover") document.body.appendChild(lockDisplay);
-
-      function getSpeedValue() {
-        let data = {
-          none: "0",
-          short: "0.25",
-          default: "0.5",
-          long: "1",
-        };
-        return data[addon.settings.get("speed")];
-      }
-
-      function onmouseenter(speed = {}) {
-        speed = typeof speed === "object" ? getSpeedValue() : speed;
-        flyOut.classList.remove("sa-flyoutClose");
-        flyOut.style.transitionDuration = `${speed}s`;
-        scrollBar.classList.remove("sa-flyoutClose");
-        scrollBar.style.transitionDuration = `${speed}s`;
-        lockDisplay.classList.remove("sa-flyoutClose");
-        lockDisplay.style.transitionDuration = `${speed}s`;
-        setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
-      }
-      function onmouseleave(e, speed = getSpeedValue()) {
-        // If we go behind the flyout or the user has locked it, let's return
-        if (
-          (toggleSetting !== "cathover" && e && e.clientX <= scrollBar.getBoundingClientRect().left) ||
-          flyoutLock
-        )
-          return;
-        flyOut.classList.add("sa-flyoutClose");
-        flyOut.style.transitionDuration = `${speed}s`;
-        scrollBar.classList.add("sa-flyoutClose");
-        scrollBar.style.transitionDuration = `${speed}s`;
-        lockDisplay.classList.add("sa-flyoutClose");
-        lockDisplay.style.transitionDuration = `${speed}s`;
-        setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
-      }
-
-      // position elements which closes flyout on load
-      positionElements();
-      let toggle = true,
-        selectedCat = null,
-        justStart = true;
-      if (toggleSetting === "hover")
-        (placeHolderDiv.onmouseenter = onmouseenter), (blocklySvg.onmouseenter = onmouseleave);
-
-      addon.tab.redux.initialize();
-      addon.tab.redux.addEventListener("statechanged", (e) => {
-        switch (e.detail.action.type) {
-          // Event casted when switch to small or normal size stage or when screen size changed.
-          case "scratch-gui/StageSize/SET_STAGE_SIZE":
-          case "scratch-gui/workspace-metrics/UPDATE_METRICS":
-            positionElements();
-            break;
-
-          // Event casted when you switch between tabs
-          case "scratch-gui/navigation/ACTIVATE_TAB":
-            // always 0, 1, 2
-            lockDisplay.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
-            placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
-            if (e.detail.action.activeTabIndex === 0)
-              onmouseenter(0), positionElements(), (toggle = true), (justStart = true);
-            break;
-          // Event casted when you switch between tabs
-          case "scratch-gui/mode/SET_PLAYER":
-            // always true or false
-            lockDisplay.style.display = e.detail.action.isPlayerOnly ? "none" : "block";
-            placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
-            break;
-        }
-      });
-
-      if (toggleSetting === "cathover") onmouseleave(null, 0);
-
       while (true) {
         let category = await addon.tab.waitForElement(".scratchCategoryMenuItem", { markAsSeen: true });
         category.onclick = (e) => {
-          if (toggle && selectedCat === category && toggleSetting === "category")
-            onmouseleave(), (selectedCat = category), (justStart = false);
-          else if (!toggle) onmouseenter(), (selectedCat = category), (justStart = false);
-          else return (selectedCat = category), (justStart = false);
+          if (toggle && selectedCategory === category && toggleSetting === "category")
+            onmouseleave(), (selectedCategory = category);
+          else if (!toggle) onmouseenter(), (selectedCategory = category);
+          else return (selectedCategory = category);
           if (toggleSetting === "category") toggle = !toggle;
         };
         if (toggleSetting === "cathover")
           (category.onmouseover = onmouseenter), (flyOut.onmouseleave = onmouseleave);
       }
     })();
+  }
+
+  addon.tab.redux.initialize();
+  addon.tab.redux.addEventListener("statechanged", (e) => {
+    switch (e.detail.action.type) {
+      // Event casted when switch to small or normal size stage or when screen size changed.
+      case "scratch-gui/StageSize/SET_STAGE_SIZE":
+      case "scratch-gui/workspace-metrics/UPDATE_METRICS":
+        positionElements();
+        break;
+
+      // Event casted when you switch between tabs
+      case "scratch-gui/navigation/ACTIVATE_TAB":
+        // always 0, 1, 2
+        lockDisplay.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
+        placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
+        if (e.detail.action.activeTabIndex === 0)
+          onmouseenter(0), positionElements(), (toggle = true);
+        break;
+      // Event casted when you switch between tabs
+      case "scratch-gui/mode/SET_PLAYER":
+        // always true or false
+        lockDisplay.style.display = e.detail.action.isPlayerOnly ? "none" : "block";
+        placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
+        break;
+    }
+  });
+
+  while (true) {
+    flyOut = await addon.tab.waitForElement(".blocklyFlyout", { markAsSeen: true });
+    let blocklySvg = await addon.tab.waitForElement(".blocklySvg", { markAsSeen: true });
+    scrollBar = document.querySelector(".blocklyFlyoutScrollbar");
+
+    // Placeholder Div
+    if (placeHolderDiv) placeHolderDiv.remove();
+    placeHolderDiv = document.createElement("div");
+    if (toggleSetting === "hover") document.body.appendChild(placeHolderDiv);
+    placeHolderDiv.className = "sa-flyout-placeHolder";
+
+    // Lock Img
+    if (lockDisplay) lockDisplay.remove();
+    lockDisplay = document.createElement("img");
+    lockDisplay.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
+    lockDisplay.className = "sa-lock-image";
+    lockDisplay.onclick = () => {
+      flyoutLock = !flyoutLock;
+      lockDisplay.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
+    };
+
+    // Only append if we don't have "categoryclick" on
+    if (toggleSetting === "hover") document.body.appendChild(lockDisplay);
+
+    // position elements which closes flyout on load
+    positionElements();
+    if (toggleSetting === "hover")
+      (placeHolderDiv.onmouseenter = onmouseenter), (blocklySvg.onmouseenter = onmouseleave);
+
+    if (toggleSetting === "cathover") onmouseleave(null, 0);
   }
 }

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -17,7 +17,7 @@ export default async function ({ addon, global, console }) {
       // Lock Img
       if (lockDisplay) lockDisplay.remove();
       lockDisplay = document.createElement("img");
-      lockDisplay.src = addon.self.dir + "/unlock.svg";
+      lockDisplay.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
       lockDisplay.className = "sa-lock-image";
       lockDisplay.onclick = () => {
         flyoutLock = !flyoutLock;


### PR DESCRIPTION
**Changes**

Fixes some bugs in the hide-flyout addon:

1. v1.12.0 regression: When `positionElements` was run while the flyout was in the middle of a transition, the lock image and the placeholder element would be displayed in the wrong position. This could make parts of the editor temporarily unusable. The easiest way to reproduce this is scrolling the workspace while the transition is happening https://user-images.githubusercontent.com/33787854/112885042-dd2a5d00-9095-11eb-9810-6c8dead50e5e.mp4 In general the positioning logic should be much better now as it's now entirely CSS.
4. Category click mode would break after leave editor -> go back into editor
5. Lock button would display the wrong icon when locked -> leave editor -> go back into editor
3. If the "Toggle On..." setting changed while the addon was running, you could get weird hybrids of modes that don't quite work properly. The addon will now always use the mode it started with instead of asking addon.settings every time.

I believe this has been very thoroughly tested. You can even toggle editor-stage-left while the addon is running and nothing seems to break.