### PR TITLE
Fix profile statistics graph issues

### DIFF
--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -74,9 +74,10 @@ export default async function ({ addon, msg, console }) {
           msg("most-views")
         )
       );
-      fetch(`https://scratchdb.lefty.one/v3/user/graph/${username}/followers?range=365&segment=7`)
+      fetch(`https://scratchdb.lefty.one/v3/user/graph/${username}/followers?range=364&segment=6`)
         .then(async function (response) {
           const historyData = await response.json();
+          historyData.pop();
           await addon.tab.loadScript(addon.self.lib + "/Chart.min.js");
           const canvasContainer = document.createElement("div");
           stats.appendChild(canvasContainer);


### PR DESCRIPTION
**Resolves**

Resolves #2005

**Changes**

* Changes `segment` to 6 (for some reason 7 is actually 8 days) and `range` to 364 (so that it's a multiple of 7) in the call to the graph API
* Removes the last point from the graph so that there aren't two points for the same day

@WorldLanguages These changes should probably also be made on scratchstats.com.