### PR TITLE
Revert "Change new-addon issue template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/--new-addon.md
+++ b/.github/ISSUE_TEMPLATE/--new-addon.md
@@ -2,7 +2,7 @@
 name: "➕ New addon"
 about: Suggest a new addon
 title: ''
-labels: 'type: enhancement, scope: new addon'
+labels: 'type: enhancement, new addon, scope: addon'
 assignees: ''
 
 ---


### PR DESCRIPTION
Reverts ScratchAddons/ScratchAddons#2022

Someone clearly didn't read my annoucement. The `new addon` is for backwards compability/general category for new addons. This is NOT a duplicate!