### PR TITLE
Fix crash when dragging folder into empty backpack

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1214,7 +1214,7 @@ export default async function ({ addon, global, console, msg }) {
 
   // Backpack
   (async () => {
-    const backpackContainer = await addon.tab.waitForElement("[class*='backpack_backpack-list-inner']");
+    const backpackContainer = await addon.tab.waitForElement("[class*='backpack_backpack-list_']");
     const backpackInstance = getBackpackFromElement(backpackContainer);
     verifyBackpack(backpackInstance);
     patchBackpack(backpackInstance);


### PR DESCRIPTION
Fixes folders still causing crashes when trying to backpack a folder specifically when the backpack is empty
