### PR TITLE
Dark embedded projects

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -148,8 +148,8 @@
       }
     },
     {
-      "url": "experimental_contact.css",
-      "matches": ["https://scratch.mit.edu/contact-us/"],
+      "url": "experimental_project_embed.css",
+      "matches": ["https://scratch.mit.edu/projects/*/embed"],
       "settingMatch": {
         "id": "selectedMode",
         "value": "experimental-dark"

--- a/addons/dark-www/experimental_contact.css
+++ b/addons/dark-www/experimental_contact.css
@@ -1,5 +1,0 @@
-.elements__SearchTitle-sc-8yny41-3,
-.elements__ArticleContent-sc-1lq865d-7 *,
-.elements__AttachFiles-sc-1ku14sw-2 * {
-  color: #575e75;
-}

--- a/addons/dark-www/experimental_project_embed.css
+++ b/addons/dark-www/experimental_project_embed.css
@@ -1,0 +1,10 @@
+.loader_background_2DPrW {
+  background-color: #282828;
+}
+.stage-wrapper_stage-wrapper_2bejr.stage-wrapper_full-screen_2hjMb,
+.stage-header_stage-header-wrapper-overlay_5vfJa {
+  background-color: #202020;
+}
+.stage_stage_1fD7k.stage_full-screen_ZO7xi {
+  border-color: #606060;
+}


### PR DESCRIPTION
**Resolves**

Resolves #2039

**Changes**

Adds dark mode to embedded projects. This is intentionally part of website dark mode, not editor dark mode, because the place where most users see embeds are profile pages (live featured project).

Also removes a few lines of unused CSS.