### PR TITLE
Fix white profile placeholders and inconsistent gray text colors

### DIFF
--- a/addons/dark-www/experimental_mystuff.css
+++ b/addons/dark-www/experimental_mystuff.css
@@ -40,3 +40,7 @@
   background: #282828;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
+.media-info-item.date,
+.media-item-content .media-stats .stat {
+  color: rgba(255, 255, 255, 0.4);
+}

--- a/addons/dark-www/experimental_profile.css
+++ b/addons/dark-www/experimental_profile.css
@@ -9,6 +9,18 @@
 .header-text .profile-details .group {
   border-color: #fff;
 }
+.editable-empty {
+  background-color: transparent;
+  border-color: #606060;
+}
+.editable-empty [data-content="prompt"],
+.activity-stream .time,
+.slider-carousel .thumb span.owner {
+  color: rgba(255, 255, 255, 0.4);
+}
+.editable textarea {
+  border-radius: 0;
+}
 #profile-box .player,
 #profile-box .doing,
 #profile-data .footer,

--- a/addons/dark-www/experimental_profile.css
+++ b/addons/dark-www/experimental_profile.css
@@ -9,17 +9,9 @@
 .header-text .profile-details .group {
   border-color: #fff;
 }
-.editable-empty {
-  background-color: transparent;
-  border-color: #606060;
-}
-.editable-empty [data-content="prompt"],
 .activity-stream .time,
 .slider-carousel .thumb span.owner {
   color: rgba(255, 255, 255, 0.4);
-}
-.editable textarea {
-  border-radius: 0;
 }
 #profile-box .player,
 #profile-box .doing,

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -13,6 +13,9 @@ a.black:visited,
 input.link.black {
   color: #fff;
 }
+span.small-text {
+  color: rgba(255, 255, 255, 0.4);
+}
 html > body:not(.sa-body-editor) input,
 html > body:not(.sa-body-editor) textarea,
 html > body:not(.sa-body-editor) select,
@@ -23,7 +26,7 @@ html > body:not(.sa-body-editor) select,
 }
 input,
 textarea {
-  border: 2px solid rgba(255, 255, 255, 0.2);
+  border: 2px solid #606060;
 }
 .button,
 html > body:not(.sa-body-editor) button,

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -19,6 +19,8 @@ span.small-text {
 html > body:not(.sa-body-editor) input,
 html > body:not(.sa-body-editor) textarea,
 html > body:not(.sa-body-editor) select,
+.editable-empty,
+.editable.read,
 .editable.write,
 .editable:hover {
   background-color: #282828;
@@ -27,6 +29,9 @@ html > body:not(.sa-body-editor) select,
 input,
 textarea {
   border: 2px solid #606060;
+}
+.editable-empty [data-content="prompt"] {
+  color: rgba(255, 255, 255, 0.4);
 }
 .button,
 html > body:not(.sa-body-editor) button,

--- a/addons/dark-www/experimental_scratchr2_comments.css
+++ b/addons/dark-www/experimental_scratchr2_comments.css
@@ -27,6 +27,9 @@
 #comments .comment .info .name a {
   color: #fff;
 }
+#comments .comment .info .time {
+  color: rgba(255, 255, 255, 0.4);
+}
 #comments #comments-loading {
   background-color: transparent;
 }

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -61,6 +61,9 @@ img.tips-icon,
 .project-favorites.favorited::before {
   filter: none;
 }
+.comment .comment-body .comment-bottom-row .comment-time {
+  color: rgba(255, 255, 255, 0.4);
+}
 .credits .logo-grid {
   /* Some logos don't look well on dark background */
   background: #f7f6f8;

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -86,9 +86,11 @@
 #status-readonly,
 #profile-box #bio textarea,
 #profile-box #status textarea {
-  border: 2px solid transparent;
-  box-shadow: none;
   color: #575e75;
+}
+#profile-box #bio textarea,
+#profile-box #status textarea {
+  border-radius: 6px;
 }
 #profile-box .player {
   border-radius: 4px;

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -45,6 +45,7 @@ input,
 textarea {
   box-shadow: none;
   border-radius: 8px;
+  background-color: #fafafa;
   border: 2px solid rgba(0, 0, 0, 0.2);
   resize: none;
 }
@@ -55,6 +56,28 @@ input:focus {
 textarea:focus {
   box-shadow: 0 0 0 4px rgba(77, 151, 255, 0.25);
   border: 2px solid var(--scratchr2-primaryColor);
+}
+.editable-empty,
+.editable.read,
+.editable.write,
+.editable:hover {
+  background-color: #fafafa;
+  border: 2px dashed rgba(77, 151, 255, 0.25) !important;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+}
+.editable.write,
+.editable-empty.write {
+  border-style: solid !important;
+  border-color: #4d97ff !important;
+  box-shadow: 0 0 0 4px rgba(77, 151, 255, 0.25);
+}
+.editable textarea,
+.editable-empty textarea,
+.editable input,
+.editable-empty input {
+  border-color: transparent;
+  box-shadow: none;
 }
 .button,
 button,

--- a/addons/scratchr2/studio.css
+++ b/addons/scratchr2/studio.css
@@ -9,6 +9,7 @@
   transform: translateX(-50%) /* Center horizontally */;
   width: 942px;
   padding: 0;
+  overflow: visible;
 }
 .box .box-head h2 {
   font-size: 28px;


### PR DESCRIPTION
**Resolves**

Resolves #2049

**Changes**

Multiple changes to website dark mode:
* Fixes white textarea placeholders on profile pages (unfinished)
* Now a consistent color, `rgba(255, 255, 255, 0.4)`, is used for all gray text (preparation for #645)
* Fixes the border color of textareas on scratchr2 pages being different from other borders