### PR TITLE
Move waitForElement logic from addon-api to core

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -54,22 +54,10 @@ export default class Tab extends Listenable {
       if (markAsSeen) this._waitForElementSet.add(element);
       return Promise.resolve(element);
     }
-    return new Promise((resolve) =>
-      new MutationObserver((mutationsList, observer) => {
-        const elements = document.querySelectorAll(selector);
-        for (const element of elements) {
-          if (this._waitForElementSet.has(element)) continue;
-          observer.disconnect();
-          resolve(element);
-          if (markAsSeen) this._waitForElementSet.add(element);
-          break;
-        }
-      }).observe(document.documentElement, {
-        attributes: false,
-        childList: true,
-        subtree: true,
-      })
-    );
+    return scratchAddons.sharedObserver.watch({
+      query: selector,
+      seen: markAsSeen ? this._waitForElementSet : null,
+    });
   }
   /**
    * editor mode (or null for non-editors).

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -77,7 +77,7 @@ class SharedObserver {
       }
     });
   }
-  
+
   /**
    * Watches an element.
    * @param {object} opts - options
@@ -94,10 +94,12 @@ class SharedObserver {
         attributes: true,
       });
     }
-    return new Promise((resolve) => this.pending.add({
-      resolve,
-      ...opts,
-    }));
+    return new Promise((resolve) =>
+      this.pending.add({
+        resolve,
+        ...opts,
+      })
+    );
   }
 }
 
@@ -123,7 +125,7 @@ function onDataReady() {
   scratchAddons.methods.copyImage = async (dataURL) => {
     return _cs_.copyImage(dataURL);
   };
-  
+
   scratchAddons.sharedObserver = new SharedObserver();
 
   const runUserscripts = () => {

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -55,6 +55,52 @@ const page = {
 };
 Comlink.expose(page, Comlink.windowEndpoint(comlinkIframe4.contentWindow, comlinkIframe3.contentWindow));
 
+class SharedObserver {
+  constructor() {
+    this.inactive = true;
+    this.pending = new Set();
+    this.observer = new MutationObserver((mutation, observer) => {
+      for (const item of this.pending) {
+        for (const match of document.querySelectorAll(item.query)) {
+          if (item.seen) {
+            if (item.seen.has(match)) continue;
+            item.seen.add(match);
+          }
+          this.pending.delete(item);
+          item.resolve(match);
+          break;
+        }
+      }
+      if (this.pending.size === 0) {
+        this.inactive = true;
+        this.observer.disconnect();
+      }
+    });
+  }
+  
+  /**
+   * Watches an element.
+   * @param {object} opts - options
+   * @param {string} opts.query - query.
+   * @param {WeakSet=} opts.seen - a WeakSet that tracks whether an element has alreay been seen.
+   * @returns {Promise<Node>} Promise that is resolved with modified element.
+   */
+  watch(opts) {
+    if (this.inactive) {
+      this.inactive = false;
+      this.observer.observe(document.documentElement, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+      });
+    }
+    return new Promise((resolve) => this.pending.add({
+      resolve,
+      ...opts,
+    }));
+  }
+}
+
 function onDataReady() {
   const addons = page.addonsWithUserscripts;
 
@@ -77,6 +123,8 @@ function onDataReady() {
   scratchAddons.methods.copyImage = async (dataURL) => {
     return _cs_.copyImage(dataURL);
   };
+  
+  scratchAddons.sharedObserver = new SharedObserver();
 
   const runUserscripts = () => {
     for (const addon of addons) {


### PR DESCRIPTION
Most of waitForElement logic is now moved to core, and one MutationObserver is reused for all calls of waitForElement.