### PR TITLE
mute-project: fix control key detection

### DIFF
--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -4,39 +4,25 @@ export default async function ({ addon, global, console }) {
   let icon = document.createElement("img");
   icon.src = "/static/assets/e21225ab4b675bc61eed30cfb510c288.svg";
   icon.style.display = "none";
-  let ctrlPressesCount = 0;
-  let ctrlPressedRecently = false;
-
-  window.addEventListener("keydown", (event) => {
-    if (event.ctrlKey) {
-      ctrlPressesCount++;
-      const pressCount = ctrlPressesCount;
-      ctrlPressedRecently = true;
-      setTimeout(() => {
-        if (pressCount === ctrlPressesCount) ctrlPressedRecently = false;
-      }, 2500);
+  const toggleMute = (e) => {
+    if (e.ctrlKey) {
+      e.cancelBubble = true;
+      e.preventDefault();
+      muted = !muted;
+      if (muted) {
+        vm.runtime.audioEngine.inputNode.gain.value = 0;
+        icon.style.display = "block";
+      } else {
+        vm.runtime.audioEngine.inputNode.gain.value = 1;
+        icon.style.display = "none";
+      }
     }
-  });
-
+  };
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
     let container = button.parentElement;
     container.appendChild(icon);
-    const clickListener = (e) => {
-      if (ctrlPressedRecently) {
-        e.cancelBubble = true;
-        e.preventDefault();
-        muted = !muted;
-        if (muted) {
-          vm.runtime.audioEngine.inputNode.gain.value = 0;
-          icon.style.display = "block";
-        } else {
-          vm.runtime.audioEngine.inputNode.gain.value = 1;
-          icon.style.display = "none";
-        }
-      }
-    };
-    button.addEventListener("click", clickListener);
-    button.addEventListener("contextmenu", clickListener);
+    button.addEventListener("click", toggleMute);
+    button.addEventListener("contextmenu", toggleMute);
   }
 }


### PR DESCRIPTION
**Changes**

Previously, whenever you pressed and released the control key, *all* clicks on the green flag for the next couple seconds would toggle mute instead of clicking on the flag. Also, on macOS, if you were to hold the control key down for several seconds before clicking the green flag, it would open the context menu instead of muting.

This fixes all of that. Tested in Firefox on Windows and macOS.