### PR TITLE
folders: performance improvements and bug fixes

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -490,6 +490,7 @@ export default async function ({ addon, global, console, msg }) {
           folderOccurences.set(folderName, occurence + 1);
           const baseUniqueId = getUniqueIdOfFolderItems(folderItems);
           const itemUniqueId = `${isOpen}&${occurence}&${folderName}&${baseUniqueId}&`;
+          const reactKey = `&__${occurence}_${folderName}`;
           const assetUniqueId = baseUniqueId;
 
           let folderItem;
@@ -500,11 +501,18 @@ export default async function ({ addon, global, console, msg }) {
           } else {
             folderItem = {
               // Can be used as a react key
-              toString() {
-                return itemUniqueId;
+              id: {
+                toString() {
+                  return reactKey;
+                },
               },
             };
-            folderData = {};
+            folderData = {
+              // Can be used as a react key
+              toString() {
+                return reactKey;
+              },
+            };
             folderItemCache.set(itemUniqueId, folderItem);
           }
 

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -489,9 +489,9 @@ export default async function ({ addon, global, console, msg }) {
 
           const occurence = folderOccurences.get(folderName) || 0;
           folderOccurences.set(folderName, occurence + 1);
-          const uniqueId = `${occurence}//${folderName}||${getUniqueIdOfFolderItems(folderItems)}`;
-          const itemUniqueId = `${isOpen}${uniqueId}`;
-          const assetUniqueId = uniqueId;
+          const baseUniqueId = getUniqueIdOfFolderItems(folderItems);
+          const itemUniqueId = `${isOpen}&${occurence}&${folderName}&${baseUniqueId}&`;
+          const assetUniqueId = baseUniqueId;
 
           let folderItem;
           let folderData;

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -416,7 +416,6 @@ export default async function ({ addon, global, console, msg }) {
           newItem = itemCache.get(itemId);
           itemData = newItem.name;
         } else {
-          console.log("Item cache miss", itemId);
           itemData = {
             toString() {
               return `_${item.name}`;
@@ -499,7 +498,6 @@ export default async function ({ addon, global, console, msg }) {
             folderItem = folderItemCache.get(itemUniqueId);
             folderData = folderItem.name;
           } else {
-            console.log("Folder cache miss", itemUniqueId);
             folderItem = {
               // Can be used as a react key
               toString() {
@@ -522,7 +520,6 @@ export default async function ({ addon, global, console, msg }) {
             if (folderAssetCache.has(assetUniqueId)) {
               folderAsset = folderAssetCache.get(assetUniqueId);
             } else {
-              console.log("Folder asset cache miss", assetUniqueId);
               folderAsset = {
                 assetId: assetUniqueId,
                 encodeDataURI() {

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -546,7 +546,7 @@ export default async function ({ addon, global, console, msg }) {
             // For sprite items, `id` is used as the drag payload and toString is used as a React key
             if (!folderItem.id) folderItem.id = {};
             folderItem.id.sa_folder_items = folderItems;
-            folderItem.id.toString = () => `&__${occurence}_${folderName}`;
+            folderItem.id.toString = () => reactKey;
           } else {
             folderItem.asset = folderAsset;
             if (!folderItem.dragPayload) folderItem.dragPayload = {};

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -201,7 +201,7 @@ export default async function ({ addon, global, console, msg }) {
       const className = `sa-folders-color-${id}`;
       folderColors[folderName] = className;
       folderColorStylesheet.textContent += `.${className}{background-color:${color} !important;}`;
-      folderColorStylesheet.textContent += `.${className}[class*="sprite-selector_raised"]:not([class*="sa-folder-folder"]){background-color:hsla(${hue}deg, 100%, 77%, 1) !important;}`;
+      folderColorStylesheet.textContent += `.${className}[class*="sprite-selector_raised"]:not([class*="sa-folders-folder"]){background-color:hsla(${hue}deg, 100%, 77%, 1) !important;}`;
     }
     return folderColors[folderName];
   };
@@ -976,7 +976,7 @@ export default async function ({ addon, global, console, msg }) {
           }
           this.props.selected = false;
           this.props.number = null;
-          this.props.className += ` ${getFolderColorClass(itemData.folder)} sa-folder-folder`;
+          this.props.className += ` ${getFolderColorClass(itemData.folder)} sa-folders-folder`;
         }
         if (typeof itemData.inFolder === "string") {
           this.props.className += ` ${getFolderColorClass(itemData.inFolder)}`;

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -533,7 +533,7 @@ export default async function ({ addon, global, console, msg }) {
             folderItem.id.toString = () => `&__${occurence}_${folderName}`;
           } else {
             folderItem.asset = folderAsset;
-            if (!folderItem.dragPayload) folderItem.dragPayload =  {};
+            if (!folderItem.dragPayload) folderItem.dragPayload = {};
             folderItem.dragPayload.sa_folder_items = folderItems;
           }
 

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -483,16 +483,19 @@ export default async function ({ addon, global, console, msg }) {
           i--;
 
           const uniqueId = `${i}||${getUniqueIdOfFolderItems(folderItems)}`;
+          const itemUniqueId = `${isOpen}${uniqueId}`;
+          const assetUniqueId = uniqueId;
+
           let folderItem;
           let folderData;
-          if (folderItemCache.has(uniqueId)) {
-            folderItem = folderItemCache.get(uniqueId);
+          if (folderItemCache.has(itemUniqueId)) {
+            folderItem = folderItemCache.get(itemUniqueId);
             folderData = folderItem.name;
           } else {
-            console.log("Folder cache miss", uniqueId);
+            console.log("Folder cache miss", itemUniqueId);
             folderItem = {};
             folderData = {};
-            folderItemCache.set(uniqueId, folderItem);
+            folderItemCache.set(itemUniqueId, folderItem);
           }
 
           folderData.folder = folderName;
@@ -504,17 +507,17 @@ export default async function ({ addon, global, console, msg }) {
           if (isOpen) {
             folderAsset = openFolderAsset;
           } else {
-            if (folderAssetCache.has(uniqueId)) {
-              folderAsset = folderAssetCache.get(uniqueId);
+            if (folderAssetCache.has(assetUniqueId)) {
+              folderAsset = folderAssetCache.get(assetUniqueId);
             } else {
-              console.log("Folder asset cache miss", uniqueId);
+              console.log("Folder asset cache miss", assetUniqueId);
               folderAsset = {
-                assetId: uniqueId,
+                assetId: assetUniqueId,
                 encodeDataURI() {
                   return createFolderPreview(folderItems);
                 },
               };
-              folderAssetCache.set(uniqueId, folderAsset);
+              folderAssetCache.set(assetUniqueId, folderAsset);
             }
           }
 

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -366,6 +366,13 @@ export default async function ({ addon, global, console, msg }) {
 
     const processItems = (openFolders, props) => {
       const processItem = (item) => {
+        if (item.sa_cachedItem) {
+          return {
+            newItem: item.sa_cachedItem,
+            itemData: item.sa_cachedItem.name
+          };
+        }
+
         const itemFolderName = getFolderFromName(item.name);
         const itemData = {
           realName: item.name,
@@ -386,6 +393,8 @@ export default async function ({ addon, global, console, msg }) {
             newItem.url = item.url;
           }
         }
+
+        item.sa_cachedItem = newItem;
 
         return {
           newItem,

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1244,7 +1244,7 @@ export default async function ({ addon, global, console, msg }) {
         let payload;
         let type;
         if (item.dragPayload) {
-          if (item.costumeURL) {
+          if (item.url) {
             type = "SOUND";
           } else {
             type = "COSTUME";

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -440,6 +440,7 @@ export default async function ({ addon, global, console, msg }) {
       folderItemCache.start();
       folderAssetCache.start();
 
+      const folderOccurences = new Map();
       const items = [];
       const result = {
         items,
@@ -482,7 +483,9 @@ export default async function ({ addon, global, console, msg }) {
           }
           i--;
 
-          const uniqueId = `${i}||${getUniqueIdOfFolderItems(folderItems)}`;
+          const occurence = folderOccurences.get(folderName) || 0;
+          folderOccurences.set(folderName, occurence + 1);
+          const uniqueId = `${occurence}//${folderName}||${getUniqueIdOfFolderItems(folderItems)}`;
           const itemUniqueId = `${isOpen}${uniqueId}`;
           const assetUniqueId = uniqueId;
 

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -514,26 +514,21 @@ export default async function ({ addon, global, console, msg }) {
                   return createFolderPreview(folderItems);
                 },
               };
-              if (type === TYPE_SPRITES) {
-                folderAsset = {
-                  asset: folderAsset,
-                };
-              }
               folderAssetCache.set(uniqueId, folderAsset);
             }
           }
 
           if (type === TYPE_SPRITES) {
-            folderItem.costume = folderAsset;
+            if (!folderItem.costume) folderItem.costume = {};
+            folderItem.costume.asset = folderAsset;
             // For sprite items, `id` is used as the drag payload and toString is used as a React key
             if (!folderItem.id) folderItem.id = {};
             folderItem.id.sa_folder_items = folderItems;
             folderItem.id.toString = () => `&__${folderName}`;
           } else {
             folderItem.asset = folderAsset;
-            folderItem.dragPayload = {
-              sa_folder_items: folderItems,
-            };
+            if (!folderItem.dragPayload) folderItem.dragPayload =  {};
+            folderItem.dragPayload.sa_folder_items = folderItems;
           }
 
           items.push(folderItem);

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -394,12 +394,14 @@ export default async function ({ addon, global, console, msg }) {
 
     const getUniqueIdOfFolderItems = (items) => {
       let id = "sa_folder&&";
-      for (let i = 0; i < items.length; i++) {
+      for (let i = 0; i < Math.min(PREVIEW_POSITIONS.length, items.length); i++) {
         const item = items[i];
         if (item.asset) {
           id += item.asset.assetId;
         } else if (item.costume && item.costume.asset) {
           id += item.costume.asset.assetId;
+        } else if (item.url) {
+          id += item.url;
         }
         id += "&&";
       }

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -530,7 +530,7 @@ export default async function ({ addon, global, console, msg }) {
             // For sprite items, `id` is used as the drag payload and toString is used as a React key
             if (!folderItem.id) folderItem.id = {};
             folderItem.id.sa_folder_items = folderItems;
-            folderItem.id.toString = () => `&__${folderName}`;
+            folderItem.id.toString = () => `&__${occurence}_${folderName}`;
           } else {
             folderItem.asset = folderAsset;
             if (!folderItem.dragPayload) folderItem.dragPayload =  {};

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1033,7 +1033,7 @@ export default async function ({ addon, global, console, msg }) {
     };
 
     const abstractReorder = (
-      { guiItems, getAll, set, rename, getVMItemFromGUIItem, zeroIndexed, end },
+      { guiItems, getAll, set, rename, getVMItemFromGUIItem, zeroIndexed, onFolderChanged },
       itemIndex,
       newIndex
     ) => {
@@ -1144,9 +1144,10 @@ export default async function ({ addon, global, console, msg }) {
           const name = asset.getName ? asset.getName() : asset.name;
           rename(asset, setFolderOfName(name, newFolder));
         }
+        if (onFolderChanged) {
+          onFolderChanged();
+        }
       }
-
-      end();
 
       return true;
     };
@@ -1167,8 +1168,7 @@ export default async function ({ addon, global, console, msg }) {
           getVMItemFromGUIItem: (item, targets) => {
             return targets.find((i) => i.id === item.id);
           },
-          end: () => {
-            // Emit a workspace update to update blocks if a sprite was renamed
+          onFolderChanged: () => {
             this.emitWorkspaceUpdate();
           },
           guiItems: currentSpriteItems,
@@ -1195,7 +1195,6 @@ export default async function ({ addon, global, console, msg }) {
             const itemData = getItemData(item);
             return costumes.find((c) => c.name === itemData.realName);
           },
-          end() {},
           guiItems: currentAssetItems,
           zeroIndexed: true,
         },
@@ -1220,7 +1219,6 @@ export default async function ({ addon, global, console, msg }) {
             const itemData = getItemData(item);
             return sounds.find((c) => c.name === itemData.realName);
           },
-          end() {},
           guiItems: currentAssetItems,
           zeroIndexed: true,
         },

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -200,8 +200,8 @@ export default async function ({ addon, global, console, msg }) {
       const id = Object.keys(folderColors).length;
       const className = `sa-folders-color-${id}`;
       folderColors[folderName] = className;
-      folderColorStylesheet.textContent += `.${className} { background-color: ${color} !important; }`;
-      folderColorStylesheet.textContent += `.${className}[class*="sprite-selector_raised"] { background-color: hsla(${hue}deg, 100%, 77%, 1) !important; }`;
+      folderColorStylesheet.textContent += `.${className}{background-color:${color} !important;}`;
+      folderColorStylesheet.textContent += `.${className}[class*="sprite-selector_raised"]:not([class*="sa-folder-folder"]){background-color:hsla(${hue}deg, 100%, 77%, 1) !important;}`;
     }
     return folderColors[folderName];
   };
@@ -976,7 +976,7 @@ export default async function ({ addon, global, console, msg }) {
           }
           this.props.selected = false;
           this.props.number = null;
-          this.props.className += ` ${getFolderColorClass(itemData.folder)}`;
+          this.props.className += ` ${getFolderColorClass(itemData.folder)} sa-folder-folder`;
         }
         if (typeof itemData.inFolder === "string") {
           this.props.className += ` ${getFolderColorClass(itemData.inFolder)}`;

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -417,7 +417,11 @@ export default async function ({ addon, global, console, msg }) {
           itemData = newItem.name;
         } else {
           console.log("Item cache miss", itemId);
-          itemData = {};
+          itemData = {
+            toString() {
+              return `_${item.name}`;
+            },
+          };
           newItem = {};
           itemCache.set(itemId, newItem);
         }
@@ -496,7 +500,12 @@ export default async function ({ addon, global, console, msg }) {
             folderData = folderItem.name;
           } else {
             console.log("Folder cache miss", itemUniqueId);
-            folderItem = {};
+            folderItem = {
+              // Can be used as a react key
+              toString() {
+                return itemUniqueId;
+              },
+            };
             folderData = {};
             folderItemCache.set(itemUniqueId, folderItem);
           }
@@ -865,10 +874,13 @@ export default async function ({ addon, global, console, msg }) {
         if (typeof this.props.id === "number") {
           const itemData = getItemData(this.props);
           if (itemData) {
-            const originalId = this.props.id;
-            this.props.id = itemData.realIndex;
+            const originalProps = this.props;
+            this.props = {
+              ...originalProps,
+              id: itemData.realIndex,
+            };
             const ret = original.call(this, ...args);
-            this.props.id = originalId;
+            this.props = originalProps;
             return ret;
           }
         }


### PR DESCRIPTION
**Changes**

 - Trick react into not rendering as much whenever something updates, fixes a performance regression caused by the addon
 - Don't emit unnecessary workspace update when reordering targets when nothing needs to be updated
 - Fix backpacking sound folders
