### PR TITLE
Disable scrolling

### DIFF
--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -16,7 +16,7 @@ export default async function ({ addon, msg }) {
   iframeElement.setAttribute("frameborder", "0");
   iframeElement.setAttribute("allowfullscreen", "");
   iframeElement.setAttribute("scrolling", "no");
-  
+
   const wrapperElement = document.createElement("div");
   wrapperElement.id = "lfp-embed";
 

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -15,7 +15,8 @@ export default async function ({ addon, msg }) {
   iframeElement.setAttribute("height", "210");
   iframeElement.setAttribute("frameborder", "0");
   iframeElement.setAttribute("allowfullscreen", "");
-
+  iframeElement.setAttribute("scrolling", "no");
+  
   const wrapperElement = document.createElement("div");
   wrapperElement.id = "lfp-embed";
 


### PR DESCRIPTION
**Resolves**
Resolves an issue where the live featured project embed scrolls when it's not supposed to.

**Changes**
I added a single line of code. It adds the "scrolling, no" attributes to the iframe.

**Reason for changes**
Scrolling is not supposed to happen, according to TheColaber.
![image](https://user-images.githubusercontent.com/75950907/114214327-cacbe100-9929-11eb-9965-7e21a7763a19.png)

**Tests**
Yes, I tested it by simply reloading the page when I make a new change.
