### PR TITLE
Costume Editor Shape Opacity Addon

### DIFF
--- a/addons-l10n/en/shape-opacity.json
+++ b/addons-l10n/en/shape-opacity.json
@@ -1,0 +1,3 @@
+{
+  "shape-opacity/opacity": "Opacity"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -84,5 +84,6 @@
   "drag-drop",
   "dango-rain",
   "custom-zoom",
-  "wrap-lists"
+  "wrap-lists",
+  "shape-opacity"
 ]

--- a/addons/shape-opacity/addon.json
+++ b/addons/shape-opacity/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Costume Editor Shape Opacity",
+  "description": "Select a shape in the costume editor and a new input will apear to change the shape's opacity.",
+  "credits": [
+    {
+      "name": "TheColaber",
+      "link": "https://scratch.mit.edu/users/TheColaber"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["editor"],
+  "l10n": true
+}

--- a/addons/shape-opacity/userscript.js
+++ b/addons/shape-opacity/userscript.js
@@ -1,0 +1,61 @@
+export default async function ({ addon, global, console, msg }) {
+  let appended = false;
+  const clss = addon.tab.scratchClass;
+
+  const labelContainer = document.createElement("label");
+  labelContainer.className = clss("label_input-group");
+
+  const opacityText = document.createElement("span");
+  opacityText.className = clss("label_input-label");
+  opacityText.innerText = msg("opacity");
+
+  const opacityInput = document.createElement("input");
+  opacityInput.min = 0;
+  opacityInput.max = 100;
+  opacityInput.type = "number";
+
+  labelContainer.append(opacityText, opacityInput);
+
+  addon.tab.redux.initialize();
+  addon.tab.redux.addEventListener("statechanged", ({ detail }) => {
+    const { action } = detail;
+    if (action.type === "scratch-paint/select/CHANGE_SELECTED_ITEMS") {
+      if (action.selectedItems.length === 0) {
+        labelContainer.style.display = "none";
+      } else {
+        // Scratch returns undefined for bitmapMode when in bitmap mode...
+        if (action.bitmapMode !== false) return;
+        labelContainer.style.display = "";
+        if (!appended) {
+          appended = true;
+          const appendRow = document.querySelector("[class*=paint-editor_mod-mode-tools]");
+          appendRow.append(labelContainer);
+
+          // There appears to be 2 classes with the same name but with different discriminators.
+          // scratchClass gives us the wrong one, so in order to get the right one, we must use an element already appended.
+          opacityInput.className = document.querySelector(
+            "[class*=paint-editor_mod-labeled-icon-height] input"
+          ).className;
+        }
+        if (action.selectedItems.length === 1) {
+          opacityInput.value = action.selectedItems[0].opacity * 100;
+        } else {
+          const values = new Set();
+          for (const selected of action.selectedItems) {
+            values.add(selected.opacity);
+          }
+          if (values.size === 1) {
+            opacityInput.value = values.values().next().value * 100;
+          } else {
+            opacityInput.value = 0;
+          }
+        }
+        opacityInput.oninput = () => {
+          for (const selected of action.selectedItems) {
+            selected.opacity = opacityInput.value / 100;
+          }
+        };
+      }
+    }
+  });
+}


### PR DESCRIPTION
**Resolves**

Resolves #2129

**Changes**

Adds an input to the costume editor when a shape is selected. Also works with multiple selected shapes. Does not work with bitmap.

**Tests**

Works.