### PR TITLE
Bugfix - Event should have no default background color

### DIFF
--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -154,7 +154,6 @@ div.s3devDDOut.vis ul.s3devDD {
 }
 
 .event {
-  background-color: rgb(255, 213, 0);
   color: rgb(255, 191, 0);
 }
 .event:hover,


### PR DESCRIPTION
**Resolves**

Naughty background color on events in Find menu - should only have a background color when hovered over