### PR TITLE
Make block palette category icons not draggable

### DIFF
--- a/addons/block-palette-icons/userscript.js
+++ b/addons/block-palette-icons/userscript.js
@@ -27,6 +27,7 @@ export default async function ({ addon, global, console }) {
       //Position it relative so that absolute positioning will be relative to the bubble.
       item.style.position = "relative";
       let k = document.createElement("img");
+      k.draggable = false;
       k.src = `${addon.self.dir}/icons/${icons[i]}.svg`;
       Object.assign(k.style, {
         filter: "brightness(50000%)",


### PR DESCRIPTION
Block palette category icons should not be draggable.