### PR TITLE
Lower addons.json conflicts

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -85,5 +85,6 @@
   "dango-rain",
   "custom-zoom",
   "wrap-lists",
-  "blocks2image"
+  "blocks2image",
+  "// This line is here as to lower conflicts"
 ]


### PR DESCRIPTION
In a sense, it allows a trailing comma, so conflicts will be way easier to resolve.