### PR TITLE
Better handle key/mouse events in 60fps

### DIFF
--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -14,7 +14,10 @@ export default async function ({ addon, global, console }) {
       button.style.filter = mode ? "hue-rotate(90deg)" : "";
     };
     const flagListener = (e) => {
-      if (e.altKey && !addon.self.disabled) {
+      if (addon.self.disabled) return;
+      const isAltClick = e.type === "click" && e.altKey;
+      const isChromebookAltClick = navigator.userAgent.includes("CrOS") && e.type === "contextmenu";
+      if (isAltClick || isChromebookAltClick) {
         e.cancelBubble = true;
         e.preventDefault();
         changeMode();

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -4,18 +4,6 @@ export default async function ({ addon, global, console }) {
 
   let global_fps = 30;
   const vm = addon.tab.traps.vm;
-  let altPressesCount = 0;
-  let altPressedRecently = false;
-  window.addEventListener("keydown", (event) => {
-    if (event.key === "Alt") {
-      altPressesCount++;
-      const pressCount = altPressesCount;
-      altPressedRecently = true;
-      setTimeout(() => {
-        if (pressCount === altPressesCount) altPressedRecently = false;
-      }, 250);
-    }
-  });
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
     let mode = false;
@@ -26,14 +14,14 @@ export default async function ({ addon, global, console }) {
       button.style.filter = mode ? "hue-rotate(90deg)" : "";
     };
     const flagListener = (e) => {
-      if (altPressedRecently && !addon.self.disabled) {
+      if (e.altKey && !addon.self.disabled) {
         e.cancelBubble = true;
         e.preventDefault();
         changeMode();
       }
     };
-    button.addEventListener("click", (e) => flagListener(e));
-    button.addEventListener("contextmenu", (e) => flagListener(e));
+    button.addEventListener("click", flagListener);
+    button.addEventListener("contextmenu", flagListener);
 
     const setFPS = (fps) => {
       global_fps = addon.self.disabled ? 30 : fps;


### PR DESCRIPTION
Resolves #2153 properly
In most devices, it checks whether `e.altKey` is true when clicking the green flag
In chromebooks, it instead assumes a right click in the green flag is an alt+click