### PR TITLE
Throw if addons.json has duplicated addon ID

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -69,7 +69,6 @@
   "wrap-lists",
   "initialise-sprite-position",
   "custom-zoom",
-  "wrap-lists",
   "blocks2image",
 
   "// NEW ADDONS ABOVE THIS ↑↑",

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -1,7 +1,7 @@
 (async function () {
   const folderNames = await (await fetch("/addons/addons.json")).json();
   folderNames.forEach((addonId, i) => {
-    if (folderNames.lastIndexOf(addonId) !== i) throw "Duplicated value in /addons/addons.json"
+    if (folderNames.lastIndexOf(addonId) !== i) throw "Duplicated value in /addons/addons.json";
   });
   await scratchAddons.l10n.load(folderNames);
   const useDefault = scratchAddons.l10n.locale.startsWith("en");

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -1,5 +1,8 @@
 (async function () {
   const folderNames = await (await fetch("/addons/addons.json")).json();
+  folderNames.forEach((addonId, i) => {
+    if (folderNames.lastIndexOf(addonId) !== i) throw "Duplicated value in /addons/addons.json"
+  });
   await scratchAddons.l10n.load(folderNames);
   const useDefault = scratchAddons.l10n.locale.startsWith("en");
   for (const folderName of folderNames) {


### PR DESCRIPTION
Whoops, while resolving conflicts `wrap-lists` ended up being twice, and the settings page listed the addon twice hehe
Easy fix to avoid problems, do not run extension if there's duplicates, good investment even tho it takes a few hundred CPU cycles :P