### PR TITLE
Fix loading presets for colors & allowTransparency:false not working

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -42,7 +42,7 @@
               v-show="isOpen"
               v-el:pickr
               :formats="formats"
-              :no_alpha="no_alpha"
+              :no_alpha="noAlphaString"
             ></color-picker>
           </template>
         </button>

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -49,6 +49,11 @@ const ColorInput = Vue.extend({
       }
     });
   },
+  computed: {
+    noAlphaString() {
+      return String(this.no_alpha);
+    }
+  },
   methods: {
     toggle(addon, setting, value = !this.isOpen) {
       if (!this.loadColorPicker) return;
@@ -79,7 +84,7 @@ const ColorInput = Vue.extend({
       this.$els.pickr?._valueChanged();
     },
     loadColorPicker() {
-      this.$options.ready[0]();
+      this.$options.ready[0].call(this);
     },
   },
 });

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -52,7 +52,7 @@ const ColorInput = Vue.extend({
   computed: {
     noAlphaString() {
       return String(this.no_alpha);
-    }
+    },
   },
   methods: {
     toggle(addon, setting, value = !this.isOpen) {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -72,10 +72,11 @@ const ColorInput = Vue.extend({
   watch: {
     value() {
       this.color = this.value;
-      this.$els.pickr._valueChanged();
+      // ?. is #2090 tempfix, 4 lines below as well
+      this.$els.pickr?._valueChanged();
     },
     isOpen() {
-      this.$els.pickr._valueChanged();
+      this.$els.pickr?._valueChanged();
     },
     loadColorPicker() {
       this.$options.ready[0]();


### PR DESCRIPTION
Resolves #2196 
Resolves #2097

Do not call `._valueChanged()` in the color picker if it doesn't exist
Doesn't cause any bugs because when created, the color picker will grab the updated color from `this.value` through the `v-bind:value` HTML attribute