### PR TITLE
Fix waitForElement MutationObserver options

### DIFF
--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -104,7 +104,6 @@ class SharedObserver {
       this.observer.observe(document.documentElement, {
         subtree: true,
         childList: true,
-        attributes: true,
       });
     }
     return new Promise((resolve) =>


### PR DESCRIPTION
The waitForElement MutationObserver used to specify `attributes: false`, but it seems it was accidentally changed to `attributes: true` in #2061 which is *very bad* for performance, especially in the editor.

This shouldn't cause any addons to misbehave as this was the old behavior.