### PR TITLE
Update drag-and-drop addon description

### DIFF
--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Drag and drop files",
-  "description": "Lets you drag image, sound, and text files from your file explorer into the sprites pane, costume/sound list, ask and wait prompt, and list panes.",
+  "description": "Lets you drag images and sounds from your file explorer into the sprites pane or costume/sound list. You can also drag and drop text files into lists and \"ask and wait\" prompts.",
   "credits": [
     {
       "name": "Sheep_maker"

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Drag and drop files",
-  "description": "Lets you drag images and sounds from your file explorer into the sprites pane or costume/sound list. You can also drag and drop text files into lists and \"ask and wait\" prompts.",
+  "description": "Lets you drag images and sounds from your file explorer into the sprites pane or costume/sound list. You can also drag text files into lists or \"ask and wait\" prompts.",
   "credits": [
     {
       "name": "Sheep_maker"

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Drag and drop files",
-  "description": "Lets you drag images and sounds from your file explorer into the sprites pane or costume/sound list.",
+  "description": "Lets you drag image, sound, and text files from your file explorer into the sprites pane, costume/sound list, ask and wait prompt, and list panes.",
   "credits": [
     {
       "name": "Sheep_maker"


### PR DESCRIPTION
**Changes**

<!-- Please describe the changes you've made. -->
The addon is now properly described with the new 1.13.0 text file features.
New description:
> Lets you drag image, sound, and text files from your file explorer into the sprites pane, costume/sound list, ask and wait prompt, and list panes.

**Reason for changes**

<!-- Why should these changes be made? -->
Because nobody reads old changelogs and future users may miss out on this feature.

**Tests**

<!-- Have you tested this pull request? If so, how? -->
I just changed the text in a JSON string so that shouldn't break anything
