### PR TITLE
New addon: Editor sound effects

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -69,6 +69,7 @@
   "initialise-sprite-position",
   "custom-zoom",
   "blocks2image",
+  "editor-sounds",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/editor-sounds/addon.json
+++ b/addons/editor-sounds/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Editor sound effects",
+  "description": "Plays sound effects when you connect or delete blocks.",
+  "credits": [
+    {
+      "name": "GarboMuffin"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["editor"],
+  "enabledByDefault": false,
+  "l10n": true
+}

--- a/addons/editor-sounds/userscript.js
+++ b/addons/editor-sounds/userscript.js
@@ -1,0 +1,14 @@
+export default async function ({ addon, global, console }) {
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const workspace = Blockly.getMainWorkspace();
+  // Add sounds to the current workspace
+  const pathToMedia = workspace.options.pathToMedia;
+  ScratchBlocks.inject.loadSounds_(pathToMedia, workspace);
+  // Add sounds to all future workspaces
+  const originalInit = ScratchBlocks.init_;
+  ScratchBlocks.init_ = function (...args) {
+    const wksp = args[0];
+    wksp.options.hasSounds = true;
+    return originalInit.call(this, ...args);
+  };
+}


### PR DESCRIPTION
**Resolves**

Resolves #993

**Changes**

It adds sounds to the editor by enabling the disabled-by-default sound support in Blockly/scratch-blocks

Here's what they sound like: https://user-images.githubusercontent.com/33787854/115614282-22b40180-a2b3-11eb-93c6-9960109ace98.mp4

