### PR TITLE
Use the new waitForElement spec and remove unnecesary waitForElement calls to improve performance

### DIFF
--- a/addons/2d-color-picker/paint-editor.js
+++ b/addons/2d-color-picker/paint-editor.js
@@ -62,7 +62,12 @@ export default async ({ addon, console, msg }) => {
   // le loop
   while (true) {
     // wait for color dialog box appearance
-    const element = await addon.tab.waitForElement('div[class*="color-picker_swatch-row"]', { markAsSeen: true });
+    const element = await addon.tab.waitForElement('div[class*="color-picker_swatch-row"]', {
+      markAsSeen: true,
+      condition: () =>
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 1 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     rateLimiter.abort(false);
 
     // update the bg color of the picker

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -5,7 +5,10 @@ export default async function ({ addon, global, console }) {
   let global_fps = 30;
   const vm = addon.tab.traps.vm;
   while (true) {
-    let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
+    let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+    });
     let mode = false;
     const changeMode = (_mode = !mode) => {
       mode = _mode;

--- a/addons/animated-thumb/userscript.js
+++ b/addons/animated-thumb/userscript.js
@@ -4,6 +4,8 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     let nav = await addon.tab.waitForElement("[class^='menu-bar_main-menu']", {
       markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
     });
     if (!document.querySelector("[class^='author-info_username-line']")) {
       let setthumb = document.createElement("div");

--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -68,14 +68,15 @@ export default async function ({ addon, global, console, msg }) {
     }
   }
 
-  while (true) {
-    let blocklyWorkspace = await addon.tab.waitForElement("g.blocklyWorkspace", {
-      markAsSeen: true,
-    });
-
-    // insert contextmenu
-    blocklyWorkspace.addEventListener("mousedown", (e) => eventMouseDown(e));
-  }
+  document.addEventListener(
+    "mousedown",
+    (e) => {
+      if (e.target.closest("g.blocklyWorkspace")) {
+        eventMouseDown(e);
+      }
+    },
+    true
+  );
 
   function exportBlock(request, sender, sendMessage) {
     // console.log(request)

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -56,7 +56,11 @@ export default async function ({ addon, global, console, msg }) {
 
 async function hideInSmallStageMode({ addon }) {
   while (true) {
-    await addon.tab.waitForElement("[class*='stage-header_stage-size-toggle-group']", { markAsSeen: true });
+    await addon.tab.waitForElement("[class*='stage-header_stage-size-toggle-group']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
 
     document.querySelector("[class*='stage-header_stage-button-first']").addEventListener("click", () => {
       document.querySelector(".clone-container-container").style.display = "none";

--- a/addons/color-picker/code-editor.js
+++ b/addons/color-picker/code-editor.js
@@ -43,7 +43,12 @@ export default async ({ addon, console, msg }) => {
     element.click();
   };
   while (true) {
-    const element = await addon.tab.waitForElement("button.scratchEyedropper", { markAsSeen: true });
+    const element = await addon.tab.waitForElement("button.scratchEyedropper", {
+      markAsSeen: true,
+      condition: () =>
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 0 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     rateLimiter.abort(false);
     if (addon.tab.editorMode !== "editor") continue;
     addon.tab.redux.initialize();

--- a/addons/color-picker/code-editor.js
+++ b/addons/color-picker/code-editor.js
@@ -42,15 +42,9 @@ export default async ({ addon, console, msg }) => {
     document.body.classList.add("sa-hide-eye-dropper-background");
     element.click();
   };
-  while (true) {
-    const element = await addon.tab.waitForElement("button.scratchEyedropper", {
-      markAsSeen: true,
-      condition: () =>
-        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 0 &&
-        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
-    });
+  const addColorPicker = () => {
+    const element = document.querySelector("button.scratchEyedropper");
     rateLimiter.abort(false);
-    if (addon.tab.editorMode !== "editor") continue;
     addon.tab.redux.initialize();
     const defaultColor = getColor(element);
     const saColorPicker = Object.assign(document.createElement("div"), {
@@ -81,5 +75,12 @@ export default async ({ addon, console, msg }) => {
     saColorPicker.appendChild(saColorPickerColor);
     saColorPicker.appendChild(saColorPickerText);
     element.parentElement.insertBefore(saColorPicker, element);
-  }
+  };
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const originalShowEditor = ScratchBlocks.FieldColourSlider.prototype.showEditor_;
+  ScratchBlocks.FieldColourSlider.prototype.showEditor_ = function (...args) {
+    const r = originalShowEditor.call(this, ...args);
+    addColorPicker();
+    return r;
+  };
 };

--- a/addons/color-picker/paint-editor.js
+++ b/addons/color-picker/paint-editor.js
@@ -45,7 +45,12 @@ export default async ({ addon, console, msg }) => {
     element.children[1].children[0].click();
   };
   while (true) {
-    const element = await addon.tab.waitForElement('div[class*="color-picker_swatch-row"]', { markAsSeen: true });
+    const element = await addon.tab.waitForElement('div[class*="color-picker_swatch-row"]', {
+      markAsSeen: true,
+      condition: () =>
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 1 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     rateLimiter.abort(false);
     addon.tab.redux.initialize();
     if (addon.tab.redux && typeof prevEventHandler === "function") {

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -1,22 +1,25 @@
 export default async function ({ addon, console, msg }) {
-  actionAlert("projectsharing", "[class*='share-button_share-button'], .banner-button", msg("share"));
-  actionAlert("followinguser", "#profile-data .follow-button", msg("follow"));
-  actionAlert("joiningstudio", "a.accept", msg("joinstudio"));
-  async function actionAlert(setting, queryButton, res) {
-    while (true) {
-      let button = await addon.tab.waitForElement(queryButton, { markAsSeen: true });
-      let canAction = false;
-      button.addEventListener("click", function (e) {
-        if (addon.self.disabled || !addon.settings.get(setting)) return;
-        if (!canAction) {
-          e.cancelBubble = true;
+  document.addEventListener(
+    "click",
+    (e) => {
+      let cancelMessage = null;
+      if (
+        addon.settings.get("projectsharing") &&
+        e.target.closest("[class*='share-button_share-button'], .banner-button")
+      ) {
+        cancelMessage = msg("share");
+      } else if (addon.settings.get("followinguser") && e.target.closest("#profile-data .follow-button")) {
+        cancelMessage = msg("follow");
+      } else if (addon.settings.get("joiningstudio") && e.target.closest("#profile-data .follow-button")) {
+        cancelMessage = msg("joinstudio");
+      }
+      if (cancelMessage !== null) {
+        if (!confirm(cancelMessage)) {
           e.preventDefault();
-          if (confirm(res)) {
-            canAction = true;
-            button.click();
-          }
-        } else canAction = false;
-      });
-    }
-  }
+          e.stopPropagation();
+        }
+      }
+    },
+    true
+  );
 }

--- a/addons/copy-message-link/project.js
+++ b/addons/copy-message-link/project.js
@@ -2,6 +2,7 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     const comment = await addon.tab.waitForElement("div.comment", {
       markAsSeen: true,
+      condition: () => addon.tab.redux.state && addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
     });
     if (comment.querySelector("form")) continue; // Comment input
     const newElem = document.createElement("span");

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -6,7 +6,11 @@ export default async ({ addon, console, msg }) => {
     console.log("Pending autosave prevented.");
   });
   while (true) {
-    const btn = await addon.tab.waitForElement('[class*="community-button_community-button_"]', { markAsSeen: true });
+    const btn = await addon.tab.waitForElement('[class*="community-button_community-button_"]', {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     btn.addEventListener(
       "click",
       (e) => {

--- a/addons/discuss-button/userscript.js
+++ b/addons/discuss-button/userscript.js
@@ -15,7 +15,7 @@ export default async function ({ addon, global, console }) {
         markAsSeen: true,
         condition: () => {
           if (!addon.tab.redux.state) return false;
-          if (!addon.tab.redux.state.scratchGui) return false;
+          if (!addon.tab.redux.state.scratchGui) return true;
           return addon.tab.redux.state.scratchGui.mode.isPlayerOnly;
         },
       });

--- a/addons/discuss-button/userscript.js
+++ b/addons/discuss-button/userscript.js
@@ -11,7 +11,14 @@ export default async function ({ addon, global, console }) {
 
   if (addon.tab.clientVersion === "scratch-www") {
     while (true) {
-      const el = await addon.tab.waitForElement("div#navigation div.inner ul:not(.production)", { markAsSeen: true });
+      const el = await addon.tab.waitForElement("div#navigation div.inner ul:not(.production)", {
+        markAsSeen: true,
+        condition: () => {
+          if (!addon.tab.redux.state) return false;
+          if (!addon.tab.redux.state.scratchGui) return false;
+          return addon.tab.redux.state.scratchGui.mode.isPlayerOnly;
+        },
+      });
       if (addon.settings.get("removeIdeasBtn")) el.getElementsByTagName("li")[3].remove();
       el.insertBefore(link, el.getElementsByTagName("li")[3]);
     }

--- a/addons/drag-drop/dragged-over.css
+++ b/addons/drag-drop/dragged-over.css
@@ -1,8 +1,8 @@
 /* Based on the `stage-selector_raised` class */
-.sa-drag-area,
-.sa-drag-area div[class*="stage-selector_header_"],
-.sa-drag-area div[class*="sprite-info_sprite-info"],
-.sa-drag-area div[class*="monitor_list-body"] {
+div[class*="stage-selector_header_"],
+div[class*="sprite-selector_sprite-selector"],
+div[class*="sprite-info_sprite-info"],
+div[class*="monitor_list-body"] {
   -webkit-transition: background-color 0.25s ease;
   -o-transition: background-color 0.25s ease;
   transition: background-color 0.25s ease;

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -1,87 +1,37 @@
 export default async function ({ addon, global, console }) {
-  const DRAG_AREA_CLASS = "sa-drag-area";
   const DRAG_OVER_CLASS = "sa-dragged-over";
 
-  function droppable(dropArea, onDrop, allowDrop = () => true) {
-    dropArea.classList.add(DRAG_AREA_CLASS);
-    dropArea.addEventListener("drop", (e) => {
-      if (e.dataTransfer.types.includes("Files") && allowDrop()) {
-        if (e.dataTransfer.files.length > 0) {
-          onDrop(e.dataTransfer.files);
-        }
-        e.preventDefault();
-      }
-      dropArea.classList.remove(DRAG_OVER_CLASS);
-    });
-    dropArea.addEventListener("dragover", (e) => {
-      // Ignore dragged text, for example
-      if (!e.dataTransfer.types.includes("Files") || !allowDrop()) {
-        return;
-      }
-      dropArea.classList.add(DRAG_OVER_CLASS);
-      e.preventDefault();
-    });
-    dropArea.addEventListener("dragleave", () => {
-      dropArea.classList.remove(DRAG_OVER_CLASS);
-    });
-  }
+  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+  const reactAwareSetValue = (el, value) => {
+    nativeInputValueSetter.call(el, value);
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  };
 
-  async function foreverDroppable(dropAreaSelector, fileInputSelector, waitForElementOptions) {
-    while (true) {
-      const dropArea = await addon.tab.waitForElement(dropAreaSelector, {
-        markAsSeen: true,
-        ...waitForElementOptions,
-      });
-      const fileInput = document.querySelector(fileInputSelector);
-      droppable(dropArea, (files) => {
+  const globalHandleDragOver = (e) => {
+    if (!e.dataTransfer.types.includes("Files")) {
+      return;
+    }
+
+    let el;
+    let callback;
+    if (
+      (el = e.target.closest('div[class*="sprite-selector_sprite-selector"]')) ||
+      (el = e.target.closest('div[class*="stage-selector_stage-selector"]')) ||
+      (el = e.target.closest('div[class*="selector_wrapper"]'))
+    ) {
+      callback = (files) => {
+        const fileInput = el.querySelector('input[class*="action-menu_file-input"]');
         fileInput.files = files;
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
-      });
-    }
-  }
-
-  // Sprite selector
-  foreverDroppable(
-    'div[class*="sprite-selector_sprite-selector"]',
-    'div[class*="sprite-selector_sprite-selector"] input[class*="action-menu_file-input"]',
-    {
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
-      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
-    }
-  );
-
-  // Stage selector
-  foreverDroppable(
-    'div[class*="stage-selector_stage-selector"]',
-    'div[class*="stage-selector_stage-selector"] input[class*="action-menu_file-input"]',
-    {
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
-      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
-    }
-  );
-
-  // Costume/sound asset list
-  foreverDroppable(
-    'div[class*="selector_wrapper"]',
-    'div[class*="selector_wrapper"] input[class*="action-menu_file-input"]',
-    {
-      condition: () =>
-        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex !== 0 &&
-        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
-    }
-  );
-
-  async function listMonitorsDroppable() {
-    while (true) {
-      const listMonitor = await addon.tab.waitForElement('div[class*="monitor_list-monitor"]', { markAsSeen: true });
-      const canDrop = () => {
-        // Don't show drop indicator if in fullscreen/player mode
-        return !listMonitor.closest('div[class*="stage_full-screen"], .guiPlayer');
       };
-      const handleDrop = async (files) => {
+    } else if (
+      !addon.tab.redux.state.scratchGui.mode.isPlayerOnly &&
+      (el = e.target.closest('div[class*="monitor_list-monitor"]'))
+    ) {
+      callback = (files) => {
         const contextMenuBefore = document.querySelector("body > .react-contextmenu.react-contextmenu--visible");
         // Simulate a right click on the list monitor
-        listMonitor.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+        el.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
         // Get the right click menu that opened (monitor context menus are
         // children of <body>)
         const contextMenuAfter = document.querySelector("body > .react-contextmenu.react-contextmenu--visible");
@@ -121,35 +71,59 @@ export default async function ({ addon, global, console }) {
         // Simulate clicking on the "Import" option
         contextMenu.children[0].click();
       };
-      droppable(listMonitor, handleDrop, canDrop);
-    }
-  }
-  listMonitorsDroppable();
-
-  // For setting .value and letting React know about it
-  // https://stackoverflow.com/a/60378508
-  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-  async function askAnswerDroppable() {
-    while (true) {
-      const answerField = await addon.tab.waitForElement(
-        'div[class*="question_question-input"] > input[class*="input_input-form_l9eYg"]',
-        { markAsSeen: true }
-      );
-      droppable(answerField, async (files) => {
+    } else if (
+      (el = e.target.closest('div[class*="question_question-input"] > input[class*="input_input-form_l9eYg"]'))
+    ) {
+      callback = async (files) => {
         const text = (await Promise.all(Array.from(files, (file) => file.text())))
           .join("")
           // Match pasting behaviour: remove all newline characters at the end
           .replace(/[\r\n]+$/, "")
           .replace(/\r?\n|\r/g, " ");
-        const selectionStart = answerField.selectionStart;
-        nativeInputValueSetter.call(
-          answerField,
-          answerField.value.slice(0, selectionStart) + text + answerField.value.slice(answerField.selectionEnd)
-        );
-        answerField.dispatchEvent(new Event("change", { bubbles: true }));
-        answerField.setSelectionRange(selectionStart, selectionStart + text.length);
-      });
+        const selectionStart = el.selectionStart;
+        reactAwareSetValue(el, el.value.slice(0, selectionStart) + text + el.value.slice(el.selectionEnd));
+        el.setSelectionRange(selectionStart, selectionStart + text.length);
+      };
     }
-  }
-  askAnswerDroppable();
+    if (!el) {
+      return;
+    }
+
+    e.preventDefault();
+
+    if (el.classList.contains(DRAG_OVER_CLASS)) {
+      return;
+    }
+    el.classList.add(DRAG_OVER_CLASS);
+
+    const handleDrop = (e) => {
+      e.preventDefault();
+      cleanup();
+      if (e.dataTransfer.types.includes("Files") && e.dataTransfer.files.length > 0) {
+        callback(e.dataTransfer.files);
+      }
+    };
+
+    const handleDragOver = (e) => {
+      e.preventDefault();
+    };
+
+    const handleDragLeave = (e) => {
+      e.preventDefault();
+      cleanup();
+    };
+
+    const cleanup = () => {
+      el.classList.remove(DRAG_OVER_CLASS);
+      el.removeEventListener("dragover", handleDragOver);
+      el.removeEventListener("dragleave", handleDragLeave);
+      el.removeEventListener("drop", handleDrop);
+    };
+
+    el.addEventListener("dragover", handleDragOver);
+    el.addEventListener("dragleave", handleDragLeave);
+    el.addEventListener("drop", handleDrop);
+  };
+
+  document.addEventListener("dragover", globalHandleDragOver, true);
 }

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -26,12 +26,13 @@ export default async function ({ addon, global, console }) {
     });
   }
 
-  async function foreverDroppable(dropAreaSelector, fileInputSelector) {
+  async function foreverDroppable(dropAreaSelector, fileInputSelector, waitForElementOptions) {
     while (true) {
-      const dropArea = await addon.tab.waitForElement(dropAreaSelector, { markAsSeen: true });
-      const fileInput = await addon.tab.waitForElement(fileInputSelector, {
+      const dropArea = await addon.tab.waitForElement(dropAreaSelector, {
         markAsSeen: true,
+        ...waitForElementOptions,
       });
+      const fileInput = document.querySelector(fileInputSelector);
       droppable(dropArea, (files) => {
         fileInput.files = files;
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
@@ -42,19 +43,32 @@ export default async function ({ addon, global, console }) {
   // Sprite selector
   foreverDroppable(
     'div[class*="sprite-selector_sprite-selector"]',
-    'div[class*="sprite-selector_sprite-selector"] input[class*="action-menu_file-input"]'
+    'div[class*="sprite-selector_sprite-selector"] input[class*="action-menu_file-input"]',
+    {
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    }
   );
 
   // Stage selector
   foreverDroppable(
     'div[class*="stage-selector_stage-selector"]',
-    'div[class*="stage-selector_stage-selector"] input[class*="action-menu_file-input"]'
+    'div[class*="stage-selector_stage-selector"] input[class*="action-menu_file-input"]',
+    {
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    }
   );
 
   // Costume/sound asset list
   foreverDroppable(
     'div[class*="selector_wrapper"]',
-    'div[class*="selector_wrapper"] input[class*="action-menu_file-input"]'
+    'div[class*="selector_wrapper"] input[class*="action-menu_file-input"]',
+    {
+      condition: () =>
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex !== 0 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    }
   );
 
   async function listMonitorsDroppable() {

--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -33,6 +33,8 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     let nav = await addon.tab.waitForElement("[class^='menu-bar_account-info-group'] > [href^='/my']", {
       markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
     });
     document.querySelector("[class^='menu-bar_account-info-group']").insertBefore(messages, nav);
   }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -173,7 +173,11 @@ export default async function ({ addon, global, console }) {
   }
 
   function findBlocklyDropDownDiv() {
-    return addon.tab.waitForElement(".blocklyDropDownDiv").then(() => document.querySelector(".blocklyDropDownDiv"));
+    return addon.tab.waitForElement(".blocklyDropDownDiv", {
+      condition: () =>
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 0 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
   }
 
   blocklyDropDownDiv = await findBlocklyDropDownDiv();

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1293,9 +1293,7 @@ export default async function ({ addon, global, console, msg }) {
     const spriteSelectorItemElement = await addon.tab.waitForElement("[class^='sprite-selector_sprite-wrapper']", {
       condition: () =>
         // We can run before redux state is ready
-        addon.tab.redux.state &&
-        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 0 &&
-        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+        addon.tab.redux.state && !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
     });
     vm = addon.tab.traps.vm;
     reactInternalKey = Object.keys(spriteSelectorItemElement).find((i) => i.startsWith(REACT_INTERNAL_PREFIX));

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1288,6 +1288,26 @@ export default async function ({ addon, global, console, msg }) {
 
   await untilInEditor();
 
+  // Backpack
+  {
+    const clickListener = (e) => {
+      if (!e.target.closest('[class*="backpack_backpack-header_"]')) {
+        return;
+      }
+      setTimeout(() => {
+        const backpackContainer = document.querySelector("[class^='backpack_backpack-list_']");
+        if (!backpackContainer) {
+          return;
+        }
+        document.removeEventListener("click", clickListener);
+        const backpackInstance = getBackpackFromElement(backpackContainer);
+        verifyBackpack(backpackInstance);
+        patchBackpack(backpackInstance);
+      });
+    };
+    document.addEventListener("click", clickListener, true);
+  }
+
   // Sprite list
   {
     const spriteSelectorItemElement = await addon.tab.waitForElement("[class^='sprite-selector_sprite-wrapper']", {
@@ -1307,16 +1327,6 @@ export default async function ({ addon, global, console, msg }) {
     sortableHOCInstance.saInitialSetup();
     patchVM();
   }
-
-  // Backpack
-  (async () => {
-    const backpackContainer = await addon.tab.waitForElement("[class^='backpack_backpack-list_']", {
-      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
-    });
-    const backpackInstance = getBackpackFromElement(backpackContainer);
-    verifyBackpack(backpackInstance);
-    patchBackpack(backpackInstance);
-  })();
 
   // Costume and sound list
   {

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1290,7 +1290,13 @@ export default async function ({ addon, global, console, msg }) {
 
   // Sprite list
   {
-    const spriteSelectorItemElement = await addon.tab.waitForElement("[class*='sprite-selector_sprite-wrapper']");
+    const spriteSelectorItemElement = await addon.tab.waitForElement("[class^='sprite-selector_sprite-wrapper']", {
+      condition: () =>
+        // We can run before redux state is ready
+        addon.tab.redux.state &&
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 0 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     vm = addon.tab.traps.vm;
     reactInternalKey = Object.keys(spriteSelectorItemElement).find((i) => i.startsWith(REACT_INTERNAL_PREFIX));
     const sortableHOCInstance = getSortableHOCFromElement(spriteSelectorItemElement);
@@ -1306,7 +1312,9 @@ export default async function ({ addon, global, console, msg }) {
 
   // Backpack
   (async () => {
-    const backpackContainer = await addon.tab.waitForElement("[class*='backpack_backpack-list_']");
+    const backpackContainer = await addon.tab.waitForElement("[class^='backpack_backpack-list_']", {
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     const backpackInstance = getBackpackFromElement(backpackContainer);
     verifyBackpack(backpackInstance);
     patchBackpack(backpackInstance);
@@ -1314,7 +1322,11 @@ export default async function ({ addon, global, console, msg }) {
 
   // Costume and sound list
   {
-    const selectorListItem = await addon.tab.waitForElement("[class*='selector_list-item']");
+    const selectorListItem = await addon.tab.waitForElement("[class*='selector_list-item']", {
+      condition: () =>
+        addon.tab.redux.state.scratchGui.editorTab.activeTabIndex !== 0 &&
+        !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
     const sortableHOCInstance = getSortableHOCFromElement(selectorListItem);
     verifySortableHOC(sortableHOCInstance);
     patchSortableHOC(sortableHOCInstance.constructor, TYPE_ASSETS);

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -94,8 +94,12 @@ export default async function ({ addon, global, console }) {
   }
 
   while (true) {
-    flyOut = await addon.tab.waitForElement(".blocklyFlyout", { markAsSeen: true });
-    let blocklySvg = await addon.tab.waitForElement(".blocklySvg", { markAsSeen: true });
+    flyOut = await addon.tab.waitForElement(".blocklyFlyout", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
+    let blocklySvg = document.querySelector(".blocklySvg");
     scrollBar = document.querySelector(".blocklyFlyoutScrollbar");
     const tabs = document.querySelector('[class^="gui_tabs"]');
 

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -3,10 +3,14 @@ export default async function ({ addon, global, console, msg }) {
     await fetch("https://api.scratch.mit.edu" + location.pathname.match(/\/projects\/[0-9]+/g)[0])
   ).json();
 
-  while (true) {
-    const element = await addon.tab.waitForElement(".share-date", { markAsSeen: true });
+  if (!data.history) return;
 
-    if (!data.history) return;
+  while (true) {
+    const element = await addon.tab.waitForElement(".share-date", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
 
     // Using this instead of scratchAddons.l10n.locales
     // to avoid confusion between DD/MM/YYYY and MM/DD/YYYY.

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -13,6 +13,7 @@ export default async ({ addon, console, msg }) => {
   while (true) {
     const elem = await addon.tab.waitForElement('div[class*="menu-bar_file-group"] > div:last-child:not(.sa-record)', {
       markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
     });
     const getOptions = () => {
       const recordOption = Object.assign(document.createElement("div"), {

--- a/addons/mouse-pos/userscript.js
+++ b/addons/mouse-pos/userscript.js
@@ -36,7 +36,10 @@ export default async function ({ addon, global, console }) {
   hideInSmallStageMode({ addon });
 
   while (true) {
-    let bar = await addon.tab.waitForElement('[class*="controls_controls-container"]', { markAsSeen: true });
+    let bar = await addon.tab.waitForElement('[class*="controls_controls-container"]', {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+    });
 
     if (addon.tab.editorMode === "editor") {
       // my attempt at detecting if they're in the editor?
@@ -61,7 +64,10 @@ export default async function ({ addon, global, console }) {
 
 async function hideInSmallStageMode({ addon }) {
   while (true) {
-    await addon.tab.waitForElement("[class*='stage-header_stage-size-toggle-group']", { markAsSeen: true });
+    await addon.tab.waitForElement("[class*='stage-header_stage-size-toggle-group']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+    });
 
     document.querySelector("[class*='stage-header_stage-button-first']").addEventListener("click", () => {
       document.querySelector(".pos-container-container").style.display = "none";

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -19,7 +19,10 @@ export default async function ({ addon, global, console }) {
     }
   };
   while (true) {
-    let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", { markAsSeen: true });
+    let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+    });
     let container = button.parentElement;
     container.appendChild(icon);
     button.addEventListener("click", toggleMute);

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -723,6 +723,10 @@ export default async function ({ addon, global, console, msg }) {
     while (true) {
       const canvasControls = await addon.tab.waitForElement("[class^='paint-editor_canvas-controls']", {
         markAsSeen: true,
+        condition: () =>
+          addon.tab.redux.state &&
+          addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 1 &&
+          !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
       });
       const zoomControlsContainer = canvasControls.querySelector("[class^='paint-editor_zoom-controls']");
       const canvasContainer = document.querySelector("[class^='paint-editor_canvas-container']");

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -118,7 +118,10 @@ export default async function ({ addon, global, console, msg }) {
   };
 
   while (true) {
-    const flag = await addon.tab.waitForElement("[class^='green-flag']", { markAsSeen: true });
+    const flag = await addon.tab.waitForElement("[class^='green-flag']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+    });
     flag.insertAdjacentElement("afterend", img);
   }
 }

--- a/addons/project-info/blockcount.js
+++ b/addons/project-info/blockcount.js
@@ -19,7 +19,11 @@ export default async function ({ addon, console, msg }) {
   const addLiveBlockCount = async () => {
     if (vm.editingTarget) {
       while (true) {
-        const topBar = await addon.tab.waitForElement("[class^='menu-bar_main-menu']", { markAsSeen: true });
+        const topBar = await addon.tab.waitForElement("[class^='menu-bar_main-menu']", {
+          markAsSeen: true,
+          reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+          condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+        });
         let display = topBar.appendChild(document.createElement("span"));
         display.style.order = 1;
         display.style.padding = "9px";

--- a/addons/project-info/projectstats.js
+++ b/addons/project-info/projectstats.js
@@ -18,7 +18,11 @@ export default async function ({ addon, console, msg }) {
 
   const addProjectPageStats = async () => {
     while (true) {
-      const buttons = await addon.tab.waitForElement(".preview .project-buttons", { markAsSeen: true });
+      const buttons = await addon.tab.waitForElement(".preview .project-buttons", {
+        markAsSeen: true,
+        reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+        condition: () => addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+      });
       const container = document.createElement("div");
       container.className = "sa-project-info";
       buttons.insertBefore(container, buttons.firstChild);

--- a/addons/project-notes-tabs/userscript.js
+++ b/addons/project-notes-tabs/userscript.js
@@ -1,7 +1,10 @@
 export default async function ({ addon, global, console }) {
   async function remixHandler() {
     while (true) {
-      await addon.tab.waitForElement(".remix-credit", { markAsSeen: true });
+      await addon.tab.waitForElement(".remix-credit", {
+        markAsSeen: true,
+        condition: () => addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+      });
       projectNotes.insertBefore(tabs, projectNotes.querySelector(".description-block"));
     }
   }
@@ -10,7 +13,10 @@ export default async function ({ addon, global, console }) {
   let tabs;
 
   while (true) {
-    projectNotes = await addon.tab.waitForElement(".project-notes", { markAsSeen: true });
+    projectNotes = await addon.tab.waitForElement(".project-notes", {
+      markAsSeen: true,
+      condition: () => addon.tab.redux.state && addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
+    });
 
     const labels = document.querySelectorAll(".project-textlabel");
     const descriptions = document.querySelectorAll(".description-block");

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -338,6 +338,8 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     const tabs = await addon.tab.waitForElement("[class^='react-tabs_react-tabs__tab-list']", {
       markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER"],
+      condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
     });
     const soundTab = tabs.children[2];
     soundTab.insertAdjacentElement("afterend", varTab);


### PR DESCRIPTION
 - Makes a lot of addons use the new waitForElement spec (#2182) to reduce the amount of querySelectorAlls that are run in response to any DOM change. This can significantly reduce Scratch Addons' impact on performance in large projects.
 - Removes unnecessary waitForElement usages

I did a test where I dragged some blocks around in the player sprite of https://scratch.mit.edu/projects/60917032/editor/ with a bunch of addons enabled:

Before: 30+ querySelectorAll / 134ms per DOM change (https://share.firefox.dev/3ayMSgu)
After: 2 querySelectorAll / 10ms per DOM change (https://share.firefox.dev/2QHjgXx)

The difference is immediately noticeable. The remaining two querySelectorAlls are in hide-flyout (only when mode is category click or category hover) and addon.tab.scratchClass.

The likelihood of some bugs sneaking into this PR is **very high**. Consider testing it out and especially making sure that addons work after doing things like entering/leaving the editor, fullscreen, etc.