### PR TITLE
Remove unnecessary typecasting in onion skinning

### DIFF
--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -23,10 +23,10 @@ export default async function ({ addon, global, console, msg }) {
 
   const settings = {
     enabled: addon.settings.get("default"),
-    previous: +addon.settings.get("previous"),
-    next: +addon.settings.get("next"),
-    opacity: +addon.settings.get("opacity"),
-    opacityStep: +addon.settings.get("opacityStep"),
+    previous: addon.settings.get("previous"),
+    next: addon.settings.get("next"),
+    opacity: addon.settings.get("opacity"),
+    opacityStep: addon.settings.get("opacityStep"),
     layering: addon.settings.get("layering"),
     mode: addon.settings.get("mode"),
     beforeTint: parseHexColor(addon.settings.get("beforeTint")),


### PR DESCRIPTION
**Resolves**

none

**Changes**

Removes unnecessary typecasting from onion skinning

**Reason for changes**

#2142 means these typecasts are not needed, and no me gusta nada unneeded code.

**Tests**

Works in chrome