### PR TITLE
Add improved userscript matching

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -259,7 +259,7 @@ const WELL_KNOWN_PATTERNS = {
   profiles: /^\/users\/[\w-]+\/?$/,
   topics: /^\/discuss\/topic\/\d+\/?$/,
   newPostScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add)\/?$/,
-  editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|settings\/[\w-]+)\/?$/,
+  editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/,
   forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
 };
 

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -261,6 +261,14 @@ const WELL_KNOWN_PATTERNS = {
   newPostScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add)\/?$/,
   editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/,
   forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
+  scratchWWWNoEditor: /^\/(?:about|annual-report|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|credits|developers|dmca|download(?:\/scratch2)?|educators(?:\/faq|register|waiting)?|explore\/(?:project|studio)s\/\w+|info\/faq|community_guidelines|ideas|join|messages|parents|privacy_policy|research|scratch_1\.4|search\/(?:project|studio)s|sec|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost)\/?$/,
+};
+
+const WELL_KNOWN_MATCHERS = {
+  isNotScratchWWW: (match) => {
+    const {projects, projectEmbeds, scratchWWWNoEditor} = WELL_KNOWN_PATTERNS;
+    return !(projects.test(match) || projectEmbeds.test(match) || scratchWWWNoEditor.test(match));
+  }
 };
 
 // regexPattern = "^https:(absolute-regex)" | "^(relative-regex)"
@@ -295,6 +303,8 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
       }
     } else if (Object.prototype.hasOwnProperty.call(WELL_KNOWN_PATTERNS, match)) {
       if (isScratchOrigin && WELL_KNOWN_PATTERNS[match].test(parsedPathname)) return true;
+    } else if (Object.prototype.hasOwnProperty.call(WELL_KNOWN_MATCHERS, match)) {
+      if (isScratchOrigin && WELL_KNOWN_MATCHERS[match](parsedPathname)) return true;
     } else if (urlMatchesLegacyPattern(match, parsedURL)) return true;
   }
   return false;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -249,21 +249,59 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
+// Pathname patterns. Make sure NOT to set global flag!
+// Don't forget ^ and $
+const WELL_KNOWN_PATTERNS = {
+  projects: /^\/projects\/(?:editor|\d+(?:\/(?:fullscreen|editor))?)\/?$/,
+  projectEmbeds: /^\/projects\/\d+\/embed\/?$/,
+  studios: /^\/studios\/\d+(?:\/(?:projects|comments|curators|activity))?\/?$/,
+  studioComments: /^\/studios\/\d+\/comments\/?$/,
+  profiles: /^\/users\/[\w-]+\/?$/,
+  topics: /^\/discuss\/topic\/\d+\/?$/,
+  newPostScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add)\/?$/,
+  editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|settings\/[\w-]+)\/?$/,
+  forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
+};
+
+// regexPattern = "^https:(absolute-regex)" | "^(relative-regex)"
+// matchesPattern = "*" | regexPattern | Array<wellKnownName | regexPattern | legacyPattern>
 function userscriptMatches(data, scriptOrStyle, addonId) {
   if (scriptOrStyle.settingMatch) {
     const { id, value } = scriptOrStyle.settingMatch;
     if (scratchAddons.globalState.addonSettings[addonId][id] !== value) return false;
   }
   const url = data.url;
-  for (const match of scriptOrStyle.matches) {
-    if (urlMatchesPattern(match, url)) return true;
+  const parsedURL = new URL(url);
+  const { matches, _scratchDomainImplied } = scriptOrStyle;
+  const parsedPathname = parsedURL.pathname;
+  const parsedOrigin = parsedURL.origin;
+  const originPath = parsedOrigin + parsedPathname;
+  const matchURL = _scratchDomainImplied ? parsedPathname : originPath;
+  const scratchOrigin = "https://scratch.mit.edu";
+  const isScratchOrigin = parsedOrigin === scratchOrigin;
+  // "*" is used for any URL on Scratch origin
+  if (matches === "*") return isScratchOrigin;
+  // matches becomes RegExp if it is a string that starts with ^
+  // See load-addon-manifests.js
+  if (matches instanceof RegExp) {
+    if (_scratchDomainImplied && !isScratchOrigin) return false;
+    return matches.test(matchURL);
+  }
+  for (const match of matches) {
+    if (match instanceof RegExp) {
+      if (match._scratchDomainImplied && !isScratchOrigin) continue;
+      if (match.test(match._scratchDomainImplied ? parsedPathname : originPath)) {
+        return true;
+      }
+    } else if (Object.prototype.hasOwnProperty.call(WELL_KNOWN_PATTERNS, match)) {
+      if (isScratchOrigin && WELL_KNOWN_PATTERNS[match].test(parsedPathname)) return true;
+    } else if (urlMatchesLegacyPattern(match, parsedURL)) return true;
   }
   return false;
 }
 
-function urlMatchesPattern(pattern, url) {
+function urlMatchesLegacyPattern(pattern, urlUrl) {
   const patternUrl = new URL(pattern);
-  const urlUrl = new URL(url);
   // We assume both URLs start with https://scratch.mit.edu
 
   const patternPath = patternUrl.pathname.split("/");

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -266,9 +266,9 @@ const WELL_KNOWN_PATTERNS = {
 
 const WELL_KNOWN_MATCHERS = {
   isNotScratchWWW: (match) => {
-    const {projects, projectEmbeds, scratchWWWNoEditor} = WELL_KNOWN_PATTERNS;
+    const { projects, projectEmbeds, scratchWWWNoEditor } = WELL_KNOWN_PATTERNS;
     return !(projects.test(match) || projectEmbeds.test(match) || scratchWWWNoEditor.test(match));
-  }
+  },
 };
 
 // regexPattern = "^https:(absolute-regex)" | "^(relative-regex)"

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -261,13 +261,13 @@ const WELL_KNOWN_PATTERNS = {
   newPostScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add)\/?$/,
   editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/,
   forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
-  scratchWWWNoEditor: /^\/(?:about|annual-report|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|credits|developers|dmca|download(?:\/scratch2)?|educators(?:\/faq|register|waiting)?|explore\/(?:project|studio)s\/\w+|info\/faq|community_guidelines|ideas|join|messages|parents|privacy_policy|research|scratch_1\.4|search\/(?:project|studio)s|sec|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost)\/?$/,
+  scratchWWWNoProject: /^\/(?:about|annual-report|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|credits|developers|dmca|download(?:\/scratch2)?|educators(?:\/faq|register|waiting)?|explore\/(?:project|studio)s\/\w+|info\/faq|community_guidelines|ideas|join|messages|parents|privacy_policy|research|scratch_1\.4|search\/(?:project|studio)s|sec|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost)\/?$/,
 };
 
 const WELL_KNOWN_MATCHERS = {
   isNotScratchWWW: (match) => {
-    const { projects, projectEmbeds, scratchWWWNoEditor } = WELL_KNOWN_PATTERNS;
-    return !(projects.test(match) || projectEmbeds.test(match) || scratchWWWNoEditor.test(match));
+    const { projects, projectEmbeds, scratchWWWNoProject } = WELL_KNOWN_PATTERNS;
+    return !(projects.test(match) || projectEmbeds.test(match) || scratchWWWNoProject.test(match));
   },
 };
 

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -272,7 +272,7 @@ const WELL_KNOWN_MATCHERS = {
 };
 
 // regexPattern = "^https:(absolute-regex)" | "^(relative-regex)"
-// matchesPattern = "*" | regexPattern | Array<wellKnownName | regexPattern | legacyPattern>
+// matchesPattern = "*" | regexPattern | Array<wellKnownName | wellKnownMatcher | regexPattern | legacyPattern>
 function userscriptMatches(data, scriptOrStyle, addonId) {
   if (scriptOrStyle.settingMatch) {
     const { id, value } = scriptOrStyle.settingMatch;

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -21,6 +21,23 @@
         manifest.popup.name = scratchAddons.l10n.get(`${folderName}/@popup-name`, {}, manifest.popup.name);
       }
     }
+    for (const propName of ["userscripts", "userstyles"]) {
+      for (const injectable of (manifest[propName] || [])) {
+        const { matches } = injectable;
+        if (typeof matches === "string" && matches.startsWith("^")) {
+          injectable._scratchDomainImplied = !matches.startsWith("^https:");
+          injectable.matches = new RegExp(matches, "u");
+        } else if (Array.isArray(matches)) {
+          for (let i = matches.length; i--;) {
+            const match = matches[i];
+            if (typeof match === "string" && match.startsWith("^")) {
+              matches[i] = new RegExp(match, "u");
+              matches[i]._scratchDomainImplied = !match.startsWith("^https:");
+            }
+          }
+        }
+      }
+    }
 
     for (const preset of manifest.presets || []) {
       for (const prop of ["name", "description"]) {

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -22,13 +22,13 @@
       }
     }
     for (const propName of ["userscripts", "userstyles"]) {
-      for (const injectable of (manifest[propName] || [])) {
+      for (const injectable of manifest[propName] || []) {
         const { matches } = injectable;
         if (typeof matches === "string" && matches.startsWith("^")) {
           injectable._scratchDomainImplied = !matches.startsWith("^https:");
           injectable.matches = new RegExp(matches, "u");
         } else if (Array.isArray(matches)) {
-          for (let i = matches.length; i--;) {
+          for (let i = matches.length; i--; ) {
             const match = matches[i];
             if (typeof match === "string" && match.startsWith("^")) {
               matches[i] = new RegExp(match, "u");


### PR DESCRIPTION
Resolves #23 
Resolves #646
Closes #2257 

New syntax is:

- `*`: allow any URL on Scratch origin.
- string starting with `^https:`: treat as regex that matches origin+pathname, aka absolute regex
- string starting with `^` but not `^https:`: treat as regex that matches pathname, aka relative regex
- Array of:
  - absolute or relative regexes (mentioned above)
  - shortcut: `projects` (excl. embeds), `projectEmbeds`, `studios`, `studioComments`, `profiles`, `topics`, `newPostScreens` (topics + new topic), `editingScreens` (newPostScreens + signature setting), `forums` (excl. mobile forums)), `scratchWWWNoProject` (all scratch-www pages, except project page and embeds)
  - shortcut matchers: `isNotScratchWWW`, which can be used like "is scratchr2?"
  - legacy match (aka current match) is kept untouched

NOTE: To use origin-less URL, regex must be used (not current glob-style match.) Legacy matching style should no longer be used.