### PR TITLE
css variables aren't being set bug

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -176,7 +176,7 @@ async function setCssVariables(addonSettings, addonsWithUserstyles) {
 
   // Set variables for settings
   for (const addonId of addonIds) {
-    for (const settingName of Object.keys(addonSettings[addonId] ?? {})) {
+    for (const settingName of Object.keys(addonSettings[addonId] || {})) {
       const value = addonSettings[addonId][settingName];
       if (typeof value === "string" || typeof value === "number") {
         setVar(addonId, hyphensToCamelCase(settingName), addonSettings[addonId][settingName]);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -176,7 +176,7 @@ async function setCssVariables(addonSettings, addonsWithUserstyles) {
 
   // Set variables for settings
   for (const addonId of addonIds) {
-    for (const settingName of Object.keys(addonSettings[addonId])) {
+    for (const settingName of Object.keys(addonSettings[addonId]) ?? {}) {
       const value = addonSettings[addonId][settingName];
       if (typeof value === "string" || typeof value === "number") {
         setVar(addonId, hyphensToCamelCase(settingName), addonSettings[addonId][settingName]);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -176,7 +176,7 @@ async function setCssVariables(addonSettings, addonsWithUserstyles) {
 
   // Set variables for settings
   for (const addonId of addonIds) {
-    for (const settingName of Object.keys(addonSettings[addonId]) ?? {}) {
+    for (const settingName of Object.keys(addonSettings[addonId] ?? {})) {
       const value = addonSettings[addonId][settingName];
       if (typeof value === "string" || typeof value === "number") {
         setVar(addonId, hyphensToCamelCase(settingName), addonSettings[addonId][settingName]);


### PR DESCRIPTION
**Resolves**

this bug
![image](https://user-images.githubusercontent.com/61329810/116458908-c90b8400-a82a-11eb-9f37-8ccfdca480e9.png)


**Changes**

added a fallback in case it's null

**Reason for changes**

i'm seeing this
![image](https://user-images.githubusercontent.com/61329810/116459693-c3626e00-a82b-11eb-9832-073688040111.png)
i want this
![image](https://user-images.githubusercontent.com/61329810/116460125-4d123b80-a82c-11eb-83c0-6590d64c9d4f.png)


**Tests**

<!-- Have you tested this pull request? If so, how? -->
yes