### PR TITLE
Fix wrong addons being listed as dynamically disabled

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -268,9 +268,9 @@ async function onInfoAvailable({ globalState: globalStateMsg, l10njson, addonsWi
       disabledDynamicAddons.push(addonId);
 
       let addonIndex = addonsWithUserscripts.findIndex((a) => a.addonId === addonId);
-      addonsWithUserscripts.splice(addonIndex, 1);
+      if (addonIndex !== -1) addonsWithUserscripts.splice(addonIndex, 1);
       addonIndex = addonsWithUserstyles.findIndex((a) => a.addonId === addonId);
-      addonsWithUserstyles.splice(addonIndex, 1);
+      if (addonIndex !== -1) addonsWithUserstyles.splice(addonIndex, 1);
 
       removeAddonStyles(addonId);
       _page_.fireEvent({ name: "disabled", addonId, target: "self" });


### PR DESCRIPTION
To repro, disable an addon without userscripts (e.g. website dark mode), and see how another addon disappeared from the "currently running list"
Dumb bug, easy fix