### PR TITLE
Do not send dynamicAddonEnabled message with no userscripts/styles

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -25,20 +25,22 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
           if (res) {
             (async () => {
               const { userscripts, userstyles, cssVariables } = await getAddonData({ addonId, url: res, manifest });
-              chrome.tabs.sendMessage(
-                tab.id,
-                {
-                  dynamicAddonEnabled: {
-                    scripts: userscripts,
-                    userstyles,
-                    cssVariables,
-                    addonId,
-                    injectAsStyleElt: !!manifest.injectAsStyleElt,
-                    index: scratchAddons.manifests.findIndex((addon) => addon.addonId === addonId),
+              if (userscripts.length || userstyles.length) {
+                chrome.tabs.sendMessage(
+                  tab.id,
+                  {
+                    dynamicAddonEnabled: {
+                      scripts: userscripts,
+                      userstyles,
+                      cssVariables,
+                      addonId,
+                      injectAsStyleElt: !!manifest.injectAsStyleElt,
+                      index: scratchAddons.manifests.findIndex((addon) => addon.addonId === addonId),
+                    },
                   },
-                },
-                { frameId: 0 }
-              );
+                  { frameId: 0 }
+                );
+              }
             })();
           }
         });


### PR DESCRIPTION
Resolves bug with no issue number. Repro:
1. Open anything else but a project
2. Go to settings page
3. Enable 60fps addon (or any other project addon)
4. Come back to tab you opened in step 1
5. Open addons popup
6. It says 60fps is running on tab, when it has no userscripts nor userstyles running on the page