### PR TITLE
Settings: ignore patch when checking if addon is new

### DIFF
--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -32,7 +32,7 @@
     }
   ],
   "tags": ["editor", "codeEditor"],
-  "versionAdded": "1.14.0",  
+  "versionAdded": "1.14.0",
   "enabledByDefault": false,
   "libraries": ["scratch-blocks"],
   "l10n": true

--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -32,6 +32,7 @@
     }
   ],
   "tags": ["editor", "codeEditor"],
+  "versionAdded": "1.14.0",  
   "enabledByDefault": false,
   "libraries": ["scratch-blocks"],
   "l10n": true

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -974,9 +974,13 @@ chrome.runtime.sendMessage("getSettingsInfo", async ({ manifests, addonsEnabled,
     manifest._addonId = addonId;
     manifest._groups = [];
 
-    if (manifest.versionAdded === vue.version) {
-      manifest.tags.push("new");
-      manifest._groups.push("new");
+    if (manifest.versionAdded) {
+      const [extMajor, extMinor, _] = vue.version.split(".");
+      const [addonMajor, addonMinor, __] = manifest.versionAdded.split(".");
+      if (extMajor === addonMajor && extMinor === addonMinor) {
+        manifest.tags.push("new");
+        manifest._groups.push("new");
+      }
     }
 
     // Sort tags to preserve consistent order


### PR DESCRIPTION
This also makes cat-blocks a new addon, which is kinda a lie, but worth doing :P