### PR TITLE
forum-time-zones: use days since epoch instead of day of month

### DIFF
--- a/addons/forum-time-zones/userscript.js
+++ b/addons/forum-time-zones/userscript.js
@@ -18,7 +18,7 @@ export default async function ({ addon, _global, _console }) {
     const localTimeRepr = new Date(instantTimeRepr.toLocaleString("en-US", { timeZone }));
     // Due to daytime saving, diff between two Date is inaccurate unless we both use timezoned Date
     // Math.min makes sure nobody gets posts from tomorrow
-    const localDateDiff = Math.min(localTimeRepr.getDate() - localCurrentTimeRepr.getDate(), 0);
+    const localDateDiff = Math.min(Math.floor(localTimeRepr/8.64e7) - Math.floor(localCurrentTimeRepr/8.64e7), 0);
     const timePart = localTimeRepr.toLocaleTimeString("en-GB");
     switch (localDateDiff) {
       case 0:

--- a/addons/forum-time-zones/userscript.js
+++ b/addons/forum-time-zones/userscript.js
@@ -18,7 +18,7 @@ export default async function ({ addon, _global, _console }) {
     const localTimeRepr = new Date(instantTimeRepr.toLocaleString("en-US", { timeZone }));
     // Due to daytime saving, diff between two Date is inaccurate unless we both use timezoned Date
     // Math.min makes sure nobody gets posts from tomorrow
-    const localDateDiff = Math.min(Math.floor(localTimeRepr/8.64e7) - Math.floor(localCurrentTimeRepr/8.64e7), 0);
+    const localDateDiff = Math.min(Math.floor(localTimeRepr / 8.64e7) - Math.floor(localCurrentTimeRepr / 8.64e7), 0);
     const timePart = localTimeRepr.toLocaleTimeString("en-GB");
     switch (localDateDiff) {
       case 0:


### PR DESCRIPTION
`getDate()` in the code clearly was intended to be used in the code of this addon to calculate how many days have have happened since the post, but that method only returns the day of the month, not number of days since a specific date.
Fixes wrong dates when posts were older than a month. Example: https://scratch.mit.edu/discuss/topic/217432/ (showed "today", was posted in 2016)