### PR TITLE
Fix ocular reaction wrapping

### DIFF
--- a/addons/my-ocular/reactions.css
+++ b/addons/my-ocular/reactions.css
@@ -1,5 +1,6 @@
-.postfootright {
-  padding-bottom: 4px; /* so that the buttons have some space */
+.postfootright ul {
+  line-height: 28px; /* so that the buttons have some space */
+  padding-top: 5px;
 }
 
 .my-ocular-reaction-button {
@@ -8,6 +9,8 @@
   background-color: #f2f2f2;
   margin: 0 5px;
   padding: 4px;
+  display: inline-block; /* don't wrap in the middle of a reaction */
+  line-height: normal;
   border-radius: 6px;
   box-shadow: 0 0 2px #28a5da;
   opacity: 1;


### PR DESCRIPTION
**Resolves**

https://scratch.mit.edu/discuss/post/5199993/

**Changes**

Reactions are no longer overlapped or split into two when there are too many of them to fit on a single line.

**Tests**

Tested with this post: https://scratch.mit.edu/discuss/post/5199335/

Before:
![image](https://user-images.githubusercontent.com/51849865/117272769-d1337700-ae5b-11eb-872d-40f94f5a8dac.png)

Now:
![image](https://user-images.githubusercontent.com/51849865/117272911-ec9e8200-ae5b-11eb-897a-661829e9136a.png)