### PR TITLE
Match userscripts/styles to scratch.mit.edu/[statusCode] if not 2xx

### DIFF
--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -69,6 +69,7 @@
         "https://scratch.mit.edu/403/",
         "https://scratch.mit.edu/404/",
         "https://scratch.mit.edu/500/",
+        "https://scratch.mit.edu/503/",
         "https://scratch.mit.edu/login",
         "https://scratch.mit.edu/login_retry",
         "https://scratch.mit.edu/news"
@@ -93,6 +94,7 @@
         "https://scratch.mit.edu/403/",
         "https://scratch.mit.edu/404/",
         "https://scratch.mit.edu/500/",
+        "https://scratch.mit.edu/503/",
         "https://scratch.mit.edu/news"
       ]
     },
@@ -207,6 +209,7 @@
         "https://scratch.mit.edu/403/",
         "https://scratch.mit.edu/404/",
         "https://scratch.mit.edu/500/",
+        "https://scratch.mit.edu/503/",
         "https://scratch.mit.edu/login",
         "https://scratch.mit.edu/login_retry",
         "https://scratch.mit.edu/news"

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -221,7 +221,7 @@ chrome.webRequest.onResponseStarted.addListener(
   },
   {
     urls: ["https://scratch.mit.edu/*"],
-    types: ["main_frame", "sub_frame"],
+    types: ["main_frame"],
   }
 );
 

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -130,6 +130,7 @@ async function getAddonData({ addonId, manifest, url }) {
 async function getContentScriptInfo(url) {
   const data = {
     url,
+    httpStatusCode: null, // Set by webRequest onResponseStarted listener
     l10njson: getL10NURLs(),
     globalState: {},
     addonsWithUserscripts: [],
@@ -209,6 +210,20 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     });
   }
 });
+
+chrome.webRequest.onResponseStarted.addListener(
+  (request) => {
+    const identity = createCsIdentity({ tabId: request.tabId, frameId: request.frameId, url: request.url });
+    const cacheEntry = csInfoCache.get(identity);
+    if (cacheEntry && cacheEntry.loading === false) {
+      cacheEntry.info.httpStatusCode = request.statusCode;
+    }
+  },
+  {
+    urls: ["https://scratch.mit.edu/*"],
+    types: ["main_frame", "sub_frame"],
+  }
+);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (!request.contentScriptReady) return;

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -4,9 +4,18 @@ try {
   throw "Scratch Addons: not first party iframe";
 }
 
-chrome.runtime.sendMessage({ contentScriptReady: { url: location.href } }, (res) => {
-  if (res) onInfoAvailable(res);
-});
+const onResponse = (res) => {
+  if (res) {
+    console.log("[Message from background]", res);
+    if (res.httpStatusCode === null || String(res.httpStatusCode)[0] === "2") onInfoAvailable(res);
+    else {
+      const newUrl = `https://scratch.mit.edu/${res.httpStatusCode}/`;
+      console.log(`Status code was not 2xx, replacing URL to ${newUrl}`);
+      chrome.runtime.sendMessage({ contentScriptReady: { url: newUrl } }, onResponse);
+    }
+  }
+};
+chrome.runtime.sendMessage({ contentScriptReady: { url: location.href } }, onResponse);
 
 const DOLLARS = ["$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"];
 

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -4,14 +4,15 @@ try {
   throw "Scratch Addons: not first party iframe";
 }
 
+let pseudoUrl; // Fake URL to use if response code isn't 2xx
 const onResponse = (res) => {
   if (res) {
     console.log("[Message from background]", res);
     if (res.httpStatusCode === null || String(res.httpStatusCode)[0] === "2") onInfoAvailable(res);
     else {
-      const newUrl = `https://scratch.mit.edu/${res.httpStatusCode}/`;
-      console.log(`Status code was not 2xx, replacing URL to ${newUrl}`);
-      chrome.runtime.sendMessage({ contentScriptReady: { url: newUrl } }, onResponse);
+      pseudoUrl = `https://scratch.mit.edu/${res.httpStatusCode}/`;
+      console.log(`Status code was not 2xx, replacing URL to ${pseudoUrl}`);
+      chrome.runtime.sendMessage({ contentScriptReady: { url: pseudoUrl } }, onResponse);
     }
   }
 };
@@ -111,7 +112,7 @@ if (path === "discuss/3/topic/add/") {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log("[Message from background]", request);
   if (request === "getInitialUrl") {
-    sendResponse(initialUrl);
+    sendResponse(pseudoUrl || initialUrl);
   }
 });
 


### PR DESCRIPTION
This is an easy implementation of #1976 (Resolves #1976)
If the status code of the page is not 2xx, instead of userscripts and userstyles being matched to the real url (e.g. `scratch.mit.edu/nope`) they are matched against slash + status code (`scratch.mit.edu/404`).

Some details about this implementation:
- Does not work on iframes to avoid complexity
- Addons aren't able to target specific URLs if they don't return 2xx. Not sure why an addon would want to do that, tho
- This implementation does not try its best to run the userscripts and userstyles as fast as if the page returned a 2xx status code, not because we need to wait to get the status code, but because **the content script is in charge** of requesting contentScriptInfo again if the original getContentScriptInfo request returned, along with other data, that the status code of the page was not 2xx. We could make the background page be in charge of this, but it would make the whole matching process more complex, since we don't know what status code the page will return in the moment we cache (onBeforeRequest). **So we're compromising a bit of potential flashing if the user has dark mode or 2.0→3.0, in exchange of way simpler logic and code.** The csInfoCache logic remains mostly unchanged, and we don't have to match against every potential status code. We don't have to maintain a cache of every potential status code and make sure to keep it up to date if addon settings changes. either
- dynamicEnable matches against the status code URL, not the real one

Some global details, independent of implementation:
- There are situations where we won't know the status code of the page. In these cases, we'll assume it returned 2xx
- I'd be OK changing the matching name to simply `404`
- I'd be OK restricting the status codes that can be matched against (403, 404, 503)
- scratch.mit.edu/500 returns 503 status :P