### PR TITLE
Switch my-ocular to ocular

### DIFF
--- a/addons-l10n/en/my-ocular.json
+++ b/addons-l10n/en/my-ocular.json
@@ -1,4 +1,4 @@
 {
-  "my-ocular/status-hover": "This is a customized status from Ocular, displayed by Scratch Addons. You can set your own at https://ocular.jeffalo.net/dashboard.",
+  "my-ocular/status-hover": "This is a customized status from ocular, displayed by Scratch Addons. You can set your own at https://ocular.jeffalo.net/dashboard.",
   "my-ocular/view-on-ocular": "View this post on ocular"
 }

--- a/addons-l10n/en/my-ocular.json
+++ b/addons-l10n/en/my-ocular.json
@@ -1,4 +1,4 @@
 {
-  "my-ocular/status-hover": "This is a customized status from my-ocular, displayed with Scratch Addons. You can set your own at https://my-ocular.jeffalo.net.",
+  "my-ocular/status-hover": "This is a customized status from Ocular, displayed by Scratch Addons. You can set your own at https://ocular.jeffalo.net/dashboard.",
   "my-ocular/view-on-ocular": "View this post on ocular"
 }


### PR DESCRIPTION
swaps the link from my-ocular.jeffalo.net to ocular.jeffalo.net in the l10n

**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2404

**Changes**

Switches the link from my-ocular.jeffalo.net to ocular.jeffalo.net/dashboard

**Reason for changes**

everything from my-ocular.jeffalo.net is now in ocular.jeffalo.net
