### PR TITLE
Modify last-edit-tooltip to avoid Scratch 404ing own unshared projects

### DIFF
--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -1,10 +1,8 @@
 export default async function ({ addon, global, console, msg }) {
+  const headers = new Headers();
+  if (addon.auth.xToken) headers.set("X-Token", addon.auth.xToken);
   const data = await (
-    await fetch("https://api.scratch.mit.edu" + location.pathname.match(/\/projects\/[0-9]+/g)[0], {
-      headers: {
-        "X-Token": addon.auth.xToken,
-      },
-    })
+    await fetch("https://api.scratch.mit.edu" + location.pathname.match(/\/projects\/[0-9]+/g)[0], { headers })
   ).json();
 
   if (!data.history) return;

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -2,8 +2,8 @@ export default async function ({ addon, global, console, msg }) {
   const data = await (
     await fetch("https://api.scratch.mit.edu" + location.pathname.match(/\/projects\/[0-9]+/g)[0], {
       headers: {
-        "X-Token": addon.auth.xToken
-      }
+        "X-Token": addon.auth.xToken,
+      },
     })
   ).json();
 

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -1,6 +1,10 @@
 export default async function ({ addon, global, console, msg }) {
   const data = await (
-    await fetch("https://api.scratch.mit.edu" + location.pathname.match(/\/projects\/[0-9]+/g)[0])
+    await fetch("https://api.scratch.mit.edu" + location.pathname.match(/\/projects\/[0-9]+/g)[0], {
+      headers: {
+        "X-Token": addon.auth.xToken
+      }
+    })
   ).json();
 
   if (!data.history) return;


### PR DESCRIPTION
Resolves own unshared projects 404ing
Weird timing & cache issue in Scratch's side. We request API info without x-token, which will 404 for unshared projects because we're not authorized. Real request by Scratch to get project info will hit the cache and also get 404, even tho that request does have valid x-token header.
To solve this issue, we simply make sure to send x-token header from the addon as well. This fixes the issue and also makes the addon work in unshared projects.