### PR TITLE
reduxCondition regression: missing !

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1311,7 +1311,7 @@ export default async function ({ addon, global, console, msg }) {
   // Sprite list
   {
     const spriteSelectorItemElement = await addon.tab.waitForElement("[class^='sprite-selector_sprite-wrapper']", {
-      reduxCondition: (state) => state.scratchGui.mode.isPlayerOnly,
+      reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     vm = addon.tab.traps.vm;
     reactInternalKey = Object.keys(spriteSelectorItemElement).find((i) => i.startsWith(REACT_INTERNAL_PREFIX));


### PR DESCRIPTION
PR #2420 switched `condition` functions that only consisted of Redux state to `reduxCondition`s. All changes kept the same behavior, except this one, where a `!` was forgotten.

See https://github.com/ScratchAddons/ScratchAddons/pull/2420/files#r628910519