### PR TITLE
Make clipboardWrite a Firefox-only browserLevelPermission

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -459,7 +459,8 @@ const CategorySelector = Vue.extend({
 });
 Vue.component("category-selector", CategorySelector);
 
-const browserLevelPermissions = ["notifications", "clipboardWrite"];
+const browserLevelPermissions = ["notifications"];
+if (typeof browser !== "undefined") browserLevelPermissions.push("clipboardWrite");
 let grantedOptionalPermissions = [];
 const updateGrantedPermissions = () =>
   chrome.permissions.getAll(({ permissions }) => {


### PR DESCRIPTION
Better alternative to #2439. However requires one zip for Chrome and another for Firefox, since manifest.json is going to be different
Note that the builds released in stores do have different manifest.json contents anyway, since each store adds their own unique update_url URL