### PR TITLE
editor-devtools: fix some bugs

### DIFF
--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1639,6 +1639,14 @@ export default class DevTools {
     }
   }
 
+  eventMouseUp(e) {
+    if (e.button === 1 && e.target.closest("svg.blocklySvg")) {
+      // On Linux systems, middle click is often treated as a paste.
+      // We do not want this as we assign our own functionality to middle mouse.
+      e.preventDefault();
+    }
+  }
+
   middleClickWorkspace(e) {
     if (!this.isScriptEditor()) {
       return;
@@ -2261,6 +2269,7 @@ export default class DevTools {
 
     this.domHelpers.bindOnce(document, "mousemove", (...e) => this.eventMouseMove(...e), true);
     this.domHelpers.bindOnce(document, "mousedown", (...e) => this.eventMouseDown(...e), true); // true to capture all mouse downs 'before' the dom events handle them
+    this.domHelpers.bindOnce(document, "mouseup", (...e) => this.eventMouseUp(...e), true);
     // bindOnce(document.getElementById("s3devDeep"), "click", deepSearch);
     // bindOnce(document.getElementById('s3devCleanUp'),'click', clickCleanUp);
     // bindOnce(document.getElementById("s3devInject"), "click", clickInject);

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -2056,6 +2056,10 @@ export default class DevTools {
    * @param e
    */
   dropDownFloatClick(e) {
+    if (e.target.closest("input")) {
+      return;
+    }
+
     e.cancelBubble = true;
     e.preventDefault();
 

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1830,7 +1830,7 @@ export default class DevTools {
 
     let options = [];
 
-    let t = Blockly.getMainWorkspace().getToolbox();
+    let t = this.utils.getWorkspace().getToolbox();
 
     let blocks = t.flyout_.getWorkspace().getTopBlocks();
     // 107 blocks, not in order... but we can sort by y value or description right :)

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1255,9 +1255,13 @@ export default class DevTools {
     }
   }
 
-  eventMouseMove(e) {
+  updateMousePosition(e) {
     this.mouseXY.x = e.clientX;
     this.mouseXY.y = e.clientY;
+  }
+
+  eventMouseMove(e) {
+    this.updateMousePosition(e);
   }
 
   eventKeyDown(e) {
@@ -1351,6 +1355,8 @@ export default class DevTools {
   }
 
   eventMouseDown(e) {
+    this.updateMousePosition(e);
+
     if (this.ddOut && this.ddOut.classList.contains("vis") && !e.target.closest("#s3devDDOut")) {
       // If we click outside the dropdown, then instigate the hide code...
       this.hideDropDown();
@@ -1640,6 +1646,8 @@ export default class DevTools {
   }
 
   eventMouseUp(e) {
+    this.updateMousePosition(e);
+
     if (e.button === 1 && e.target.closest("svg.blocklySvg")) {
       // On Linux systems, middle click is often treated as a paste.
       // We do not want this as we assign our own functionality to middle mouse.

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -2056,12 +2056,10 @@ export default class DevTools {
    * @param e
    */
   dropDownFloatClick(e) {
-    if (e.target.closest("input")) {
-      return;
-    }
-
     e.cancelBubble = true;
-    e.preventDefault();
+    if (!e.target.closest("input")) {
+      e.preventDefault();
+    }
 
     let wksp = this.utils.getWorkspace();
 

--- a/addons/editor-devtools/blockly/BlockFlasher.js
+++ b/addons/editor-devtools/blockly/BlockFlasher.js
@@ -9,7 +9,9 @@ export default class BlockFlasher {
   static flash(block) {
     if (myFlash.timerID > 0) {
       clearTimeout(myFlash.timerID);
-      myFlash.block.svgPath_.style.fill = "";
+      if (myFlash.block.svgPath_) {
+        myFlash.block.svgPath_.style.fill = "";
+      }
     }
 
     let count = 4;
@@ -21,13 +23,16 @@ export default class BlockFlasher {
      * @private
      */
     function _flash() {
-      myFlash.block.svgPath_.style.fill = flashOn ? "#ffff80" : "";
+      if (myFlash.block.svgPath_) {
+        myFlash.block.svgPath_.style.fill = flashOn ? "#ffff80" : "";
+      }
       flashOn = !flashOn;
       count--;
       if (count > 0) {
         myFlash.timerID = setTimeout(_flash, 200);
       } else {
         myFlash.timerID = 0;
+        myFlash.block = null;
       }
     }
 
@@ -35,4 +40,4 @@ export default class BlockFlasher {
   }
 }
 
-const myFlash = { block: null, timerID: null, colour: null };
+const myFlash = { block: null, timerID: null };


### PR DESCRIPTION
Most of these are minor nitpicks that no one will notice, except the first one

1. Use the find bar to switch between broadcast receivers across sprites was not very reliable: https://user-images.githubusercontent.com/33787854/117884225-fa943e80-b271-11eb-9d3f-5e9fc372e9b9.mp4

2. On Linux systems, middle click is usually assigned to paste for some reason, which caused issues when middle click was used to open the floating block palette

3. Floating block palette would appear in wrong spot if user middle mouse clicked without first moving the mouse

4. Floating block palette did not work properly when opened immediately after leaving custom block menu sometimes

5. Floating block palette text input could not be interacted with using the mouse
