### PR TITLE
Disallow and remove use of Event.path

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,14 @@
     "no-unused-vars": 0,
     "no-useless-escape": 0,
     "no-inner-declarations": 0,
-    "no-constant-condition": [2, { "checkLoops": false }]
+    "no-constant-condition": [2, { "checkLoops": false }],
+    "no-restricted-syntax": [
+      2,
+      {
+        "selector": "MemberExpression[property.type=Identifier][property.name=path]:matches([object.name=e],[object.name=ev],[object.name=event])",
+        "message": "Event.path is incompatible with Firefox, use Event.composedPath()"
+      }
+    ]
   },
   "overrides": [
     {
@@ -70,7 +77,17 @@
     {
       "files": ["content-scripts/*.js"],
       "rules": {
-        "no-restricted-syntax": ["error", "ImportExpression"]
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "ImportExpression",
+            "message": "import() in content script is unsupported in Firefox, declare directly in manifest.json"
+          },
+          {
+            "selector": "MemberExpression[property.type=Identifier][property.name=path]:matches([object.name=e],[object.name=ev],[object.name=event])",
+            "message": "Event.path does not exist in Firefox, use Event.composedPath()"
+          }
+        ]
       }
     }
   ]

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -393,7 +393,7 @@ const showBanner = () => {
           /*
           Object.assign(document.createElement("b"), { textContent: chrome.i18n.getMessage("newFeature") }).outerHTML,
           Object.assign(document.createElement("b"), { textContent: chrome.i18n.getMessage("newFeatureName") })
-            .outerHTML, 
+            .outerHTML,
           */
           Object.assign(document.createElement("a"), {
             href: "https://scratch.mit.edu/scratch-addons-extension/settings",
@@ -517,13 +517,14 @@ if (isProfile || isStudioComments || isProject) {
     window.addEventListener(
       "click",
       (e) => {
+        const path = e.composedPath();
         if (
-          e.path[1] &&
-          e.path[1] !== document &&
-          e.path[1].getAttribute("data-control") === "post" &&
-          e.path[1].hasAttribute("data-commentee-id")
+          path[1] &&
+          path[1] !== document &&
+          path[1].getAttribute("data-control") === "post" &&
+          path[1].hasAttribute("data-commentee-id")
         ) {
-          const form = e.path[3];
+          const form = path[3];
           if (form.tagName !== "FORM") return;
           if (form.hasAttribute("data-sa-send-anyway")) {
             form.removeAttribute("data-sa-send-anyway");
@@ -588,13 +589,14 @@ if (isProfile || isStudioComments || isProject) {
       document.querySelector(".comments-container").addEventListener(
         "click",
         (e) => {
+          const path = e.composedPath();
           // When clicking the post button, e.path[0] might
           // be <span>Post</span> or the <button /> element
-          const possiblePostBtn = e.path[0].tagName === "SPAN" ? e.path[1] : e.path[0];
+          const possiblePostBtn = path[0].tagName === "SPAN" ? path[1] : path[0];
           if (!possiblePostBtn) return;
           if (possiblePostBtn.tagName !== "BUTTON") return;
           if (!possiblePostBtn.classList.contains("compose-post")) return;
-          const form = e.path[0].tagName === "SPAN" ? e.path[3] : e.path[2];
+          const form = path[0].tagName === "SPAN" ? path[3] : path[2];
           // Remove error when about to send comment anyway, if it exists
           form.parentNode.querySelector(".compose-error-row")?.remove();
           if (form.hasAttribute("data-sa-send-anyway")) {


### PR DESCRIPTION
Fixes a crash caused when clicking profile pages in Firefox.

New eslint rule disallows accessing `path` property of `e`, `ev` and `event`. This allows both false-negative and false-positive (e.g. SVG) but I expect people to follow conventions.