### PR TITLE
Fix unreadable ask prompts with editor-dark-mode

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -193,7 +193,6 @@ div.s3devDDOut.vis,
 .sound-editor_tool-button_2iNn9,
 .sound-editor_effect-button_2zuzT,
 .library-item_featured-extension-metadata_3D8E8,
-.question_question-label_1tRo2,
 .camera-modal_disabled-text_G3r68,
 .camera-modal_loading-text_e5804,
 .record-modal_help-text_Jevsk {


### PR DESCRIPTION
**Resolves**

Resolves #2433

**Changes**

Makes the text of questions asked by the stage visible.