### PR TITLE
Migrate `exact-count` to scratch-www

### DIFF
--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -45,7 +45,7 @@
     },
     {
       "url": "studio.js",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": ["https://scratch.mit.edu/studios/*","https://scratch.mit.edu/studios_www/*"],
       "settingMatch": {
         "id": "studio",
         "value": true

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -45,7 +45,7 @@
     },
     {
       "url": "studio.js",
-      "matches": ["https://scratch.mit.edu/studios/*","https://scratch.mit.edu/studios_www/*"],
+      "matches": ["https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/studios_www/*"],
       "settingMatch": {
         "id": "studio",
         "value": true

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, global, console }) {
+export default async function ({ addon }) {
   function countProjects(url, page, delta, callback) {
     const request = new XMLHttpRequest();
     request.open("GET", url + 40 * page);
@@ -10,6 +10,8 @@ export default async function ({ addon, global, console }) {
         } else if (pageLen > 0) {
           let count = 40 * page + pageLen;
           callback(count);
+        } else if (pageLen === 0 && page === 0) {
+          callback(0);
         } else {
           page -= delta;
           delta /= 10;
@@ -19,12 +21,16 @@ export default async function ({ addon, global, console }) {
     };
     request.send();
   }
-
-  if (document.querySelector("[data-count=projects]").innerText === "100+") {
+  if (
+    addon.tab.clientVersion === "scratch-www" ||
+    document.querySelector("[data-count=projects]").innerText === "100+"
+  ) {
     const apiUrlPrefix =
       "https://api.scratch.mit.edu/studios/" + /[0-9]+/.exec(location.pathname)[0] + "/projects/?limit=40&offset=";
     countProjects(apiUrlPrefix, 0, 100, function (count) {
-      document.querySelector("[data-count=projects]").innerText = count;
+      if (addon.tab.clientVersion === "scratch-www")
+        document.querySelector(".studio-tab-nav span").innerText += ` (${count})`;
+      else document.querySelector("[data-count=projects]").innerText === count;
     });
   }
 }


### PR DESCRIPTION
**Resolves**

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2491 

**Changes**

make it compatible with 3.0 studios and with 2.0 studios

**Reason for changes**

because
also we should keep the count even tho it's not in vanilla scratch anymore because
1. we shouldn't remove features if we dont need to
2. we already have the code
3. it's a nice feature

**Tests**

on local scratch-www