### PR TITLE
Use JSON API for retrieving/replying/deleting comments in projects and studios (scratch-messaging)

### DIFF
--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -108,7 +108,10 @@ export default async function ({ addon, global, console, setTimeout, setInterval
       const { resourceType, resourceId, commentIds } = popupRequest.retrieveComments;
       retrieveComments(resourceType, resourceId, commentIds)
         .then((comments) => sendResponse(comments))
-        .catch((err) => sendResponse(err));
+        .catch((err) => {
+          console.error(err);
+          sendResponse(err);
+        });
       return true;
     } else if (popupRequest === "markAsRead") {
       addon.account.clearMessages();
@@ -127,6 +130,104 @@ export default async function ({ addon, global, console, setTimeout, setInterval
   });
 
   async function retrieveComments(resourceType, resourceId, commentIds, page = 1, commentsObj = {}) {
+    if (resourceType === "project" || resourceType === "gallery") {
+      let projectAuthor;
+      if (resourceType === "project") {
+        const projectRes = await fetch(`https://api.scratch.mit.edu/projects/${resourceId}`);
+        if (!projectRes.ok) return commentsObj; // empty
+        const projectJson = await projectRes.json();
+        projectAuthor = projectJson.author.username;
+      }
+
+      const getCommentUrl = (commId) =>
+        resourceType === "project"
+          ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}`
+          : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}`;
+      const getRepliesUrl = (commId, offset) =>
+        resourceType === "project"
+          ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}`
+          : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}`;
+
+      for (const commentId of commentIds) {
+        if (commentsObj[`${resourceType[0]}_${commentId}`]) continue;
+
+        const res = await fetch(getCommentUrl(commentId));
+
+        if (!res.ok) continue;
+        const json = await res.json();
+
+        const parentId = json.parent_id || commentId;
+        const childrenComments = {};
+
+        let parentComment;
+
+        if (json.parent_id) {
+          const resParent = await fetch(getCommentUrl(parentId));
+          if (!resParent.ok) continue;
+          const jsonParent = await resParent.json();
+          parentComment = jsonParent;
+        } else {
+          parentComment = json;
+        }
+
+        // If originally requested comment was not a parent comment, we do not use
+        // "json" variable at all. We'll get info for the same comment when fetching
+        // all of the parent's child comments anyway
+        // Note: we need to check replies for all parent comments, reply_count doesn't work properly
+
+        const getReplies = async (offset) => {
+          const repliesRes = await fetch(getRepliesUrl(parentId, offset));
+          if (!repliesRes.ok) return [];
+          const repliesJson = await repliesRes.json();
+          return repliesJson;
+        };
+
+        const replies = [];
+        let lastRepliesLength = 40;
+        let offset = 0;
+        while (lastRepliesLength === 40) {
+          const newReplies = await getReplies(offset);
+          newReplies.forEach((c) => replies.push(c));
+          lastRepliesLength = newReplies.length;
+          offset += 40;
+        }
+
+        if (json.parent_id && replies.length === 0) {
+          // Something went wrong, we didn't get the replies
+          continue;
+        }
+
+        for (const reply of replies) {
+          const commenteeReply = replies.find((c) => c.author.id === reply.commentee_id);
+          const replyingTo = commenteeReply ? commenteeReply.author.username : parentComment.author.username;
+          const mention = `<a href=\"https://scratch.mit.edu/users/${replyingTo}\">@${replyingTo}</a>`;
+          childrenComments[`${resourceType[0]}_${reply.id}`] = {
+            author: reply.author.username,
+            authorId: reply.author.id,
+            content: `${mention} ${fixCommentContent(reply.content)}`,
+            date: reply.datetime_created,
+            children: null,
+            childOf: `${resourceType[0]}_${parentId}`,
+            scratchTeam: reply.author.scratchteam,
+          };
+        }
+        for (const childCommentId of Object.keys(childrenComments)) {
+          commentsObj[childCommentId] = childrenComments[childCommentId];
+        }
+
+        commentsObj[`${resourceType[0]}_${parentId}`] = {
+          author: parentComment.author.username,
+          authorId: parentComment.author.id,
+          content: fixCommentContent(parentComment.content),
+          date: parentComment.datetime_created,
+          children: Object.keys(childrenComments),
+          childOf: null,
+          scratchTeam: parentComment.author.scratchteam,
+        };
+      }
+      return commentsObj;
+    }
+
     const res = await fetch(
       `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/?page=${page}&nocache=${Date.now()}`
     );

--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -337,6 +337,7 @@ export default async function ({ addon, global, console, setTimeout, setInterval
       });
       if (res.ok) {
         const json = await res.json();
+        if (json.rejected) return { error: json.rejected };
         const mention = `<a href=\"https://scratch.mit.edu/users/${commenteeUsername}\">@${commenteeUsername}</a>`;
         return {
           commentId: json.id,

--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -155,7 +155,8 @@ export default async function ({ addon, global, console, setTimeout, setInterval
 
         if (!res.ok) continue;
         const json = await res.json();
-
+        // This is sometimes null for deleted comments
+        if (json === null) continue;
         const parentId = json.parent_id || commentId;
         const childrenComments = {};
 

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -401,16 +401,21 @@ import { escapeHTML } from "../../libraries/common/cs/autoescaper.js";
               for (const commentId of Object.keys(comments)) {
                 const commentObject = comments[commentId];
                 Vue.set(this.comments, commentId, commentObject);
-                const chainId = commentObject.childOf || commentId;
-                const resourceGetFunction =
-                  resourceType === "project"
-                    ? "getProjectObject"
-                    : resourceType === "user"
-                    ? "getProfileObject"
-                    : "getStudioObject";
-                const resourceObject = this[resourceGetFunction](resourceId);
-                if (!resourceObject.commentChains.includes(chainId)) resourceObject.commentChains.push(chainId);
               }
+
+              // Preserve chronological sort when using JSON API
+              const parentComments = Object.entries(comments).filter((c) => c[1].childOf === null);
+              const sortedParentComments = parentComments.sort((a, b) => new Date(b[1].date) - new Date(a[1].date));
+              const sortedIds = sortedParentComments.map((arr) => arr[0]);
+              const resourceGetFunction =
+                resourceType === "project"
+                  ? "getProjectObject"
+                  : resourceType === "user"
+                  ? "getProfileObject"
+                  : "getStudioObject";
+              const resourceObject = this[resourceGetFunction](resourceId);
+              for (const sortedId of sortedIds) resourceObject.commentChains.push(sortedId);
+
               elementObject.loadedComments = true;
               resolve();
             }

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -89,6 +89,7 @@ import { escapeHTML } from "../../libraries/common/cs/autoescaper.js";
                 content: this.replyBoxValue,
                 parent_id,
                 commentee_id: this.thisComment.authorId,
+                commenteeUsername: this.thisComment.author,
               },
             },
           },


### PR DESCRIPTION
Resolves #2046 
- [x] Show project and gallery comments using JSON API
- [x] Send and delete comments using JSON API
- [x] Test everything works the same as before in both Chrome and Firefox

Caveats:
- Links aren't supported yet. No links will be clickeable, including scratch.mit.edu links