### PR TITLE
Use console.debug instead of console.log

### DIFF
--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -6,7 +6,7 @@ export default async function runAddonUserscripts({ addonId, scripts, enabledLat
   for (const scriptInfo of scripts) {
     const { url: scriptPath, runAtComplete } = scriptInfo;
     const scriptUrl = `${new URL(import.meta.url).origin}/addons/${addonId}/${scriptPath}`;
-    console.log(
+    console.debug(
       `%cDebug addons/${addonId}/${scriptPath}: ${scriptUrl}, runAtComplete: ${runAtComplete}`,
       "color:red; font-weight: bold; font-size: 1.2em;"
     );


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

This PR doesn't resolve any issues.

### Changes

Replaced console.log in userscript loader with console.debug.

### Reason for changes

The userscript loader output is verbose, so it will fit better in "debug" tab.

### Tests

I went to the Scratch website and opened console. Everything works.