### PR TITLE
True YT link addon: stop using wildcard scratch.mit.edu/* match

### DIFF
--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/*"],
+      "matches": ["projects", "studioComments", "https://scratch.mit.edu/studios_www/*", "profiles", "forums"],
       "runAtComplete": false
     }
   ],

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects", "studioComments", "https://scratch.mit.edu/studios_www/*", "profiles", "forums"],
+      "matches": ["projects", "studios", "https://scratch.mit.edu/studios_www/*", "profiles", "forums"],
       "runAtComplete": false
     }
   ],


### PR DESCRIPTION
Changing `https://scratch.mit.edu/*` match to matching only places where users can provide links (comments, about me in profiles, project notes, studio description, forums)