### PR TITLE
Make Transparent orphan blocks support more blocks

### DIFF
--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -29,7 +29,7 @@
       "type": "integer",
       "min": 0,
       "max": 100,
-      "default": 0
+      "default": 25
     },
     {
       "name": "Dragged transparency (%)",
@@ -37,7 +37,7 @@
       "type": "integer",
       "min": 0,
       "max": 100,
-      "default": 0
+      "default": 25
     }
   ],
   "userstyles": [

--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Transparent orphan blocks",
-  "description": "Makes block stacks without a hat block at the top of them transparent.",
+  "name": "Block transparency",
+  "description": "Adjust the transparency for stacks without a hat block, dragged blocks, and all blocks in general.",
   "tags": ["editor", "codeEditor"],
   "versionAdded": "1.15.0",
   "dynamicDisable": true,
@@ -16,12 +16,28 @@
   ],
   "settings": [
     {
-      "name": "Transparency (%)",
-      "id": "transparency",
+      "name": "Block transparency (%)",
+      "id": "block",
       "type": "integer",
       "min": 0,
       "max": 100,
-      "default": 50
+      "default": 0
+    },
+    {
+      "name": "Orphaned transparency (%)",
+      "id": "orphan",
+      "type": "integer",
+      "min": 0,
+      "max": 100,
+      "default": 0
+    },
+    {
+      "name": "Dragged transparency (%)",
+      "id": "dragged",
+      "type": "integer",
+      "min": 0,
+      "max": 100,
+      "default": 0
     }
   ],
   "userstyles": [

--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Block transparency",
-  "description": "Adjust the transparency for stacks without a hat block, dragged blocks, and all blocks in general.",
+  "description": "Adjust the transparency for all blocks in general, orphaned blocks (those without a hat block at the top) and blocks that are being dragged.",
   "tags": ["editor", "codeEditor"],
   "versionAdded": "1.15.0",
   "dynamicDisable": true,

--- a/addons/transparent-orphans/userstyle.css
+++ b/addons/transparent-orphans/userstyle.css
@@ -1,6 +1,18 @@
+.blocklySvg > .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable[data-shapes*="hat"],
+.blocklyFlyout > .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable {
+  opacity: calc(1 - var(--transparentOrphans-block) / 100);
+}
+.blocklyWsDragSurface > .blocklyBlockCanvas > .blocklyDraggable[data-shapes*="hat"] {
+  opacity: calc(1 - var(--transparentOrphans-block) / 100);
+}
+
 .blocklySvg > .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable:not([data-shapes*="hat"]) {
-  opacity: calc(1 - var(--transparentOrphans-transparency) / 100);
+  opacity: calc(1 - var(--transparentOrphans-orphan) / 100);
 }
 .blocklyWsDragSurface > .blocklyBlockCanvas > .blocklyDraggable:not([data-shapes*="hat"]) {
-  opacity: calc(1 - var(--transparentOrphans-transparency) / 100);
+  opacity: calc(1 - var(--transparentOrphans-orphan) / 100);
+}
+
+.blocklyBlockDragSurface {
+  opacity: calc(1 - var(--transparentOrphans-dragged) / 100);
 }


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/discussions/2551#discussioncomment-767955

### Changes

Adds 2 new setting options, plus the name change to support dragged blocks, and all other blocks in general.

<!-- Please describe the changes you've made. -->

### Reason for changes

> Snap (snap.berkeley.edu) solved on[e] of the more annoying Scratch problems, that is dragging a reporter block in the right argument, making the dragged block semitransparent.

### Tests

I have tested it, it works great.