### PR TITLE
New addon - Ctrl+Click to run scripts

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -75,6 +75,7 @@
   "gamepad",
   "remove-curved-stage-border",
   "fix-pasted-scripts",
+  "ctrl-click-run-scripts",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/ctrl-click-run-scripts/addon.json
+++ b/addons/ctrl-click-run-scripts/addon.json
@@ -6,6 +6,11 @@
       "type": "notice",
       "text": "If you just want to fix the bug where placing a duplicated block into a script runs the script, you should enable \"Do not automatically run duplicated blocks\" instead.",
       "id": "redirectToDuplicateFix"
+    },
+    {
+      "type": "notice",
+      "text": "If you're on macOS, use the Cmd key instead of the Ctrl key.",
+      "id": "macContextDisabled"
     }
   ],
   "credits": [

--- a/addons/ctrl-click-run-scripts/addon.json
+++ b/addons/ctrl-click-run-scripts/addon.json
@@ -1,0 +1,34 @@
+{
+    "name": "Ctrl+Click to run scripts",
+    "description": "Only run scripts when you click them while holding the Ctrl key.",
+    "info": [
+      {
+        "type": "notice",
+        "text": "If you just want to fix the bug where placing a duplicated block into a script runs the script, you should enable \"Do not automatically run duplicated blocks\" instead.",
+        "id": "redirectToDuplicateFix"
+      }
+    ],
+    "credits": [
+      {
+        "name": "lisa_wolfgang",
+        "link": "https://github.com/lisa-wolfgang"
+      },
+      {
+        "name": "apple502j",
+        "link": "https://github.com/apple502j"
+      }
+    ],
+    "dynamicEnable": true,
+    "dynamicDisable": true,
+    "userscripts": [
+      {
+        "url": "userscript.js",
+        "matches": ["projects"]
+      }
+    ],
+    "tags": ["editor", "codeEditor"],
+    "versionAdded": "1.15.0",
+    "enabledByDefault": false,
+    "l10n": true
+  }
+  

--- a/addons/ctrl-click-run-scripts/addon.json
+++ b/addons/ctrl-click-run-scripts/addon.json
@@ -1,15 +1,10 @@
 {
   "name": "Ctrl+Click to run scripts",
-  "description": "Only run scripts when you click them while holding the Ctrl key.",
+  "description": "Only run block stacks on click if also holding the Ctrl key.",
   "info": [
     {
       "type": "notice",
-      "text": "If you just want to fix the bug where placing a duplicated block into a script runs the script, you should enable \"Do not automatically run duplicated blocks\" instead.",
-      "id": "redirectToDuplicateFix"
-    },
-    {
-      "type": "notice",
-      "text": "If you're on macOS, use the Cmd key instead of the Ctrl key.",
+      "text": "On macOS, use the Cmd key instead of the Ctrl key.",
       "id": "macContextDisabled"
     }
   ],

--- a/addons/ctrl-click-run-scripts/addon.json
+++ b/addons/ctrl-click-run-scripts/addon.json
@@ -1,34 +1,33 @@
 {
-    "name": "Ctrl+Click to run scripts",
-    "description": "Only run scripts when you click them while holding the Ctrl key.",
-    "info": [
-      {
-        "type": "notice",
-        "text": "If you just want to fix the bug where placing a duplicated block into a script runs the script, you should enable \"Do not automatically run duplicated blocks\" instead.",
-        "id": "redirectToDuplicateFix"
-      }
-    ],
-    "credits": [
-      {
-        "name": "lisa_wolfgang",
-        "link": "https://github.com/lisa-wolfgang"
-      },
-      {
-        "name": "apple502j",
-        "link": "https://github.com/apple502j"
-      }
-    ],
-    "dynamicEnable": true,
-    "dynamicDisable": true,
-    "userscripts": [
-      {
-        "url": "userscript.js",
-        "matches": ["projects"]
-      }
-    ],
-    "tags": ["editor", "codeEditor"],
-    "versionAdded": "1.15.0",
-    "enabledByDefault": false,
-    "l10n": true
-  }
-  
+  "name": "Ctrl+Click to run scripts",
+  "description": "Only run scripts when you click them while holding the Ctrl key.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "If you just want to fix the bug where placing a duplicated block into a script runs the script, you should enable \"Do not automatically run duplicated blocks\" instead.",
+      "id": "redirectToDuplicateFix"
+    }
+  ],
+  "credits": [
+    {
+      "name": "lisa_wolfgang",
+      "link": "https://github.com/lisa-wolfgang"
+    },
+    {
+      "name": "apple502j",
+      "link": "https://github.com/apple502j"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "tags": ["editor", "codeEditor"],
+  "versionAdded": "1.15.0",
+  "enabledByDefault": false,
+  "l10n": true
+}

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -1,0 +1,36 @@
+export default async function ({ addon, global, console }) {
+
+    const vm = addon.tab.traps.vm;
+    await new Promise((resolve, reject) => {
+        if (vm.editingTarget) return resolve();
+        vm.runtime.once("PROJECT_LOADED", resolve);
+    });
+    const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
+  
+    // Necessary to detect the CTRL key
+    var ctrlKeyPressed = false;
+    document.addEventListener("keydown", function (e) {
+      if (e.ctrlKey) {
+        ctrlKeyPressed = true;
+      }
+    });
+    document.addEventListener("keyup", function (e) {
+      if (!e.ctrlKey) {
+        ctrlKeyPressed = false;
+      }
+    });
+  
+    // Limits all script running to CTRL + click
+    const newBlocklyListen = function (e) {
+      if (!addon.self.disabled && e.element === "stackclick" && !ctrlKeyPressed) {
+        return;
+      } else {
+        originalBlocklyListen.call(this, e);
+      }
+    };
+    vm.editingTarget.blocks.constructor.prototype.blocklyListen = newBlocklyListen;
+
+    if (addon.self.enabledLate) vm.emitWorkspaceUpdate();
+  
+  }
+  

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -1,36 +1,33 @@
 export default async function ({ addon, global, console }) {
+  const vm = addon.tab.traps.vm;
+  await new Promise((resolve, reject) => {
+    if (vm.editingTarget) return resolve();
+    vm.runtime.once("PROJECT_LOADED", resolve);
+  });
+  const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
 
-    const vm = addon.tab.traps.vm;
-    await new Promise((resolve, reject) => {
-        if (vm.editingTarget) return resolve();
-        vm.runtime.once("PROJECT_LOADED", resolve);
-    });
-    const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
-  
-    // Necessary to detect the CTRL key
-    var ctrlKeyPressed = false;
-    document.addEventListener("keydown", function (e) {
-      if (e.ctrlKey) {
-        ctrlKeyPressed = true;
-      }
-    });
-    document.addEventListener("keyup", function (e) {
-      if (!e.ctrlKey) {
-        ctrlKeyPressed = false;
-      }
-    });
-  
-    // Limits all script running to CTRL + click
-    const newBlocklyListen = function (e) {
-      if (!addon.self.disabled && e.element === "stackclick" && !ctrlKeyPressed) {
-        return;
-      } else {
-        originalBlocklyListen.call(this, e);
-      }
-    };
-    vm.editingTarget.blocks.constructor.prototype.blocklyListen = newBlocklyListen;
+  // Necessary to detect the CTRL key
+  var ctrlKeyPressed = false;
+  document.addEventListener("keydown", function (e) {
+    if (e.ctrlKey) {
+      ctrlKeyPressed = true;
+    }
+  });
+  document.addEventListener("keyup", function (e) {
+    if (!e.ctrlKey) {
+      ctrlKeyPressed = false;
+    }
+  });
 
-    if (addon.self.enabledLate) vm.emitWorkspaceUpdate();
-  
-  }
-  
+  // Limits all script running to CTRL + click
+  const newBlocklyListen = function (e) {
+    if (!addon.self.disabled && e.element === "stackclick" && !ctrlKeyPressed) {
+      return;
+    } else {
+      originalBlocklyListen.call(this, e);
+    }
+  };
+  vm.editingTarget.blocks.constructor.prototype.blocklyListen = newBlocklyListen;
+
+  if (addon.self.enabledLate) vm.emitWorkspaceUpdate();
+}

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -38,5 +38,4 @@ export default async function ({ addon, global, console }) {
     }
   };
   vm.editingTarget.blocks.constructor.prototype.blocklyListen = newBlocklyListen;
-
 }

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -28,6 +28,4 @@ export default async function ({ addon, global, console }) {
     }
   };
   vm.editingTarget.blocks.constructor.prototype.blocklyListen = newBlocklyListen;
-
-  if (addon.self.enabledLate) vm.emitWorkspaceUpdate();
 }

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -6,7 +6,7 @@ export default async function ({ addon, global, console }) {
   });
   const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
 
-  // Necessary to detect the CTRL key
+  // Necessary to detect the CTRL/CMD key
   var ctrlKeyPressed = false;
   document.addEventListener("keydown", function (e) {
     if (e.ctrlKey) {
@@ -15,6 +15,16 @@ export default async function ({ addon, global, console }) {
   });
   document.addEventListener("keyup", function (e) {
     if (!e.ctrlKey) {
+      ctrlKeyPressed = false;
+    }
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.metaKey) {
+      ctrlKeyPressed = true;
+    }
+  });
+  document.addEventListener("keyup", function (e) {
+    if (!e.metaKey) {
       ctrlKeyPressed = false;
     }
   });
@@ -28,4 +38,5 @@ export default async function ({ addon, global, console }) {
     }
   };
   vm.editingTarget.blocks.constructor.prototype.blocklyListen = newBlocklyListen;
+
 }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

This is a feature that was originally part of #2470.

### Changes

<!-- Please describe the changes you've made. -->
When the addon is enabled, scripts will only run when they are clicked while holding down the Ctrl key.

### Reason for changes

<!-- Why should these changes be made? -->
W_L approved

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Achieves its purpose without negative side effects.
Do your best to break it and let me know if you find anything.
