### PR TITLE
Fix addon descriptions in light mode

### DIFF
--- a/webpages/settings/light.css
+++ b/webpages/settings/light.css
@@ -83,7 +83,7 @@ body {
 }
 
 .addon-description {
-  color: #000;
+  color: #a1a1a1;
 }
 
 .addon-description-full,


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2530

### Changes

<!-- Please describe the changes you've made. -->
![image](https://user-images.githubusercontent.com/43426138/119211296-df49e000-ba76-11eb-8f9a-cc51946117b5.png)

Faded the description color in light mode to match the contrast level with the background in dark mode.

### Reason for changes

<!-- Why should these changes be made? -->
Because readability before was bad:

![image](https://user-images.githubusercontent.com/43426138/119211235-88dca180-ba76-11eb-97b1-2d65e1c0cb49.png)

And also consistency with dark mode:

![image](https://user-images.githubusercontent.com/43426138/119211244-9abe4480-ba76-11eb-838d-705a9f21f291.png)

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Doesn't appear to recolor anything else unintentionally.