### PR TITLE
scratch-messaging: fix stMessages being null when error:notReady

### DIFF
--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -326,14 +326,9 @@ import { escapeHTML } from "../../libraries/common/cs/autoescaper.js";
     methods: {
       getData() {
         return new Promise((resolve) => {
-          const timeout = setTimeout(() => {
-            this.error = "addonDisabled";
-            resolve(undefined);
-          }, 500);
           chrome.runtime.sendMessage({ scratchMessaging: "getData" }, (res) => {
             if (res) {
-              clearTimeout(timeout);
-              this.stMessages = res.stMessages.map((alert) => ({
+              this.stMessages = (res.stMessages || []).map((alert) => ({
                 ...alert,
                 datetime_created: new Date(alert.datetime_created).toDateString(),
               }));


### PR DESCRIPTION
Title, it would throw "cannot get property map of undefined" if res was `{"error": "notReady"}` for obvious reasons
Also removed a timeout from the days you could not remove popups, unused now
Bug introduced by #2431 when adding alerts feature