### PR TITLE
Fix addons not running on browser startup

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -268,6 +268,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 });
+// In case a tab messaged us before we registered the event above,
+// we notify them they can resend the contentScriptInfo message
+chrome.tabs.query({}, (tabs) =>
+  tabs.forEach((tab) => {
+    if (tab.url || (!tab.url && typeof browser !== "undefined")) {
+      chrome.tabs.sendMessage(tab.id, "backgroundListenerReady");
+    }
+  })
+);
 
 // Pathname patterns. Make sure NOT to set global flag!
 // Don't forget ^ and $

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -5,7 +5,15 @@ try {
 }
 
 let pseudoUrl; // Fake URL to use if response code isn't 2xx
+
+let tries = 0;
 const onResponse = (res) => {
+  if (!res) {
+    // chrome.runtime.onMessage listener might not be available yet
+    tries++;
+    if (tries > 60) return; // Up to ~15 seconds waiting
+    setTimeout(() => chrome.runtime.sendMessage({ contentScriptReady: { url: location.href } }, onResponse), 250);
+  }
   if (res) {
     console.log("[Message from background]", res);
     if (res.httpStatusCode === null || String(res.httpStatusCode)[0] === "2") onInfoAvailable(res);


### PR DESCRIPTION
Surprisingly, my usual test case of opening a Scratch tab on startup with focus by default stopped working.
It looks like the tab is loading before we register `chrome.runtime.onMessage`, which is weird, one would expect extensions would be able to run sync operations before any tabs loading but whatever :P
Fix is ugly but lets us avoid edge cases like opening "a Scratch tab with an iframe on it on startup with focus". (edit: redid properly, tested succesfully in edgecase)
@mxmou Maybe this is what was causing `Unchecked runtime.lastError: The message port closed before a response was received.` for you?