### PR TITLE
Fix edge case TypeError in get-userscripts.js

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -239,6 +239,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       if (cacheEntry.loading) {
         scratchAddons.localEvents.addEventListener("csInfoCacheUpdated", function thisFunction() {
           cacheEntry = getCacheEntry();
+          if (!cacheEntry) {
+            scratchAddons.localEvents.removeEventListener("csInfoCacheUpdated", thisFunction);
+          }
           if (!cacheEntry.loading) {
             sendResponse(cacheEntry.info);
             csInfoCache.delete(identity);

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -241,8 +241,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           cacheEntry = getCacheEntry();
           if (!cacheEntry) {
             scratchAddons.localEvents.removeEventListener("csInfoCacheUpdated", thisFunction);
-          }
-          if (!cacheEntry.loading) {
+          } else if (!cacheEntry.loading) {
             sendResponse(cacheEntry.info);
             csInfoCache.delete(identity);
             scratchAddons.localEvents.removeEventListener("csInfoCacheUpdated", thisFunction);


### PR DESCRIPTION
Doesn't actually fix any bugs
Not sure how it happened, but making sure we're not causing an memory leak by checking if `cacheEntry` is undefined and unregistering the event

![image](https://user-images.githubusercontent.com/17484114/119274120-c95a2d80-bbe4-11eb-8b9b-cbf9976f6115.png)
