### PR TITLE
Update description for the "Block transparency" addon

### DIFF
--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Block transparency",
-  "description": "Adjust the transparency for all blocks in general, orphaned blocks (those without a hat block at the top) and blocks that are being dragged.",
+  "description": "Adjust the transparency for blocks in the editor, with separate options for orphaned blocks (those without a hat block at the top) and blocks that are being dragged.",
   "tags": ["editor", "codeEditor"],
   "versionAdded": "1.15.0",
   "dynamicDisable": true,


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

~~Resolves W_L's issues~~

### Changes

<!-- Please describe the changes you've made. -->
Old:
> Adjust the transparency for all blocks in general, orphaned blocks (those without a hat block at the top) and blocks that are being dragged.

New:
> Adjust the transparency for blocks in the editor, with separate options for orphaned blocks (those without a hat block at the top) and blocks that are being dragged.

### Reason for changes

<!-- Why should these changes be made? -->
It's now more clear that there are separate color options for each of the three block "types" described.