### PR TITLE
Change "posts" to "comments"

### DIFF
--- a/addons-l10n/en/scratch-messaging.json
+++ b/addons-l10n/en/scratch-messaging.json
@@ -40,7 +40,7 @@
   "scratch-messaging/studio-promotions": "Studio promotions",
   "scratch-messaging/studio-promotion": "{actor} promoted you to manager for the studio {title}",
   "scratch-messaging/comment-error-empty": "You can't post an empty comment.",
-  "scratch-messaging/comment-error-ratelimit": "You are posting too quickly. Please wait longer between posts.",
+  "scratch-messaging/comment-error-ratelimit": "You are posting too quickly. Please wait longer between comments.",
   "scratch-messaging/comment-error-filterbot-generic": "Scratch's filterbot blocked your comment for violating the Community Guidelines.",
   "scratch-messaging/comment-error-filterbot-chat": "Scratch's filterbot blocked your comment for mentioning chat websites or social media.",
   "scratch-messaging/comment-error-filterbot-spam": "Scratch's filterbot blocked your comment for spamming.",


### PR DESCRIPTION
Resolves #2583 

Currently we use "post" as verb and "comment" as noun