### PR TITLE
Fix project page crash in edge cases (caused by "avoid commenting SA" code)

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -617,7 +617,6 @@ if (isProfile || isStudio || isProject) {
         document.querySelector(".comments-container, .studio-compose-container").addEventListener(
           "click",
           (e) => {
-            console.log(e);
             const path = e.composedPath();
             // When clicking the post button, e.path[0] might
             // be <span>Post</span> or the <button /> element

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -625,6 +625,9 @@ if (isProfile || isStudio || isProject) {
             if (possiblePostBtn.tagName !== "BUTTON") return;
             if (!possiblePostBtn.classList.contains("compose-post")) return;
             const form = path[0].tagName === "SPAN" ? path[3] : path[2];
+            if (!form) return;
+            if (form.tagName !== "FORM") return;
+            if (!form.classList.contains("full-width-form")) return;
             // Remove error when about to send comment anyway, if it exists
             form.parentNode.querySelector(".sa-compose-error-row")?.remove();
             if (form.hasAttribute("data-sa-send-anyway")) {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -627,7 +627,7 @@ if (isProfile || isStudio || isProject) {
             if (!possiblePostBtn.classList.contains("compose-post")) return;
             const form = path[0].tagName === "SPAN" ? path[3] : path[2];
             // Remove error when about to send comment anyway, if it exists
-            form.parentNode.querySelector(".compose-error-row")?.remove();
+            form.parentNode.querySelector(".sa-compose-error-row")?.remove();
             if (form.hasAttribute("data-sa-send-anyway")) {
               form.removeAttribute("data-sa-send-anyway");
               return;
@@ -637,7 +637,7 @@ if (isProfile || isStudio || isProject) {
             if (shouldCaptureComment(textarea.value)) {
               e.stopPropagation();
               const errorRow = document.createElement("div");
-              errorRow.className = "flex-row compose-error-row";
+              errorRow.className = "flex-row compose-error-row sa-compose-error-row";
               const errorTip = document.createElement("div");
               errorTip.className = "compose-error-tip";
               const span = document.createElement("span");


### PR DESCRIPTION
From feedback:
> issue: even with no addons well, on. for some reason posting blank it says. You can't post an empty comment, like usual, then try to post it again it crashes scratch. without the extension, it just says You can't post an empty comment

Apparently React doesn't like when you remove an element it owns from the DOM
So now, it only removes elements owned (created) by cs.js
Could also be workarounded with `display: none`, but the original code never intended to remove/hide vanilla Scratch comment warnings.
`try {} catch {}` wouldn't have avoided this issue, since its not our code throwing, but React's, after it not expecting the element to have been removed by us.

Also, added some safer code in last commit just in case Scratch changes the comment component