### PR TITLE
custom-block-shape: fix #2033

### DIFF
--- a/addons/custom-block-shape/userscript.js
+++ b/addons/custom-block-shape/userscript.js
@@ -158,13 +158,9 @@ export default async function ({ addon, global, console }) {
       BlockSvg.INPUT_SHAPE_ROUND_WIDTH = 12 * GRID_UNIT * multiplier;
       BlockSvg.INPUT_SHAPE_HEIGHT = 8 * GRID_UNIT * multiplier;
       BlockSvg.FIELD_HEIGHT = 8 * GRID_UNIT * multiplier; // NOTE: Determines string input heights
-      if (multiplier >= 1.5) {
-        BlockSvg.FIELD_WIDTH = 8 * GRID_UNIT * multiplier;
-      } else if (multiplier > 1) {
-        BlockSvg.FIELD_WIDTH = 7 * GRID_UNIT * multiplier;
-      } else {
-        BlockSvg.FIELD_WIDTH = 6 * GRID_UNIT * multiplier;
-      }
+      BlockSvg.FIELD_WIDTH =
+        6 * GRID_UNIT * Math.min(multiplier, 1) +
+        10 * GRID_UNIT * Math.max(multiplier - 1, 0);
       BlockSvg.FIELD_DEFAULT_CORNER_RADIUS = 4 * GRID_UNIT * multiplier;
       BlockSvg.EDITABLE_FIELD_PADDING = 1.5 * GRID_UNIT * multiplier;
       BlockSvg.BOX_FIELD_PADDING = 2 * GRID_UNIT * multiplier;

--- a/addons/custom-block-shape/userscript.js
+++ b/addons/custom-block-shape/userscript.js
@@ -158,7 +158,13 @@ export default async function ({ addon, global, console }) {
       BlockSvg.INPUT_SHAPE_ROUND_WIDTH = 12 * GRID_UNIT * multiplier;
       BlockSvg.INPUT_SHAPE_HEIGHT = 8 * GRID_UNIT * multiplier;
       BlockSvg.FIELD_HEIGHT = 8 * GRID_UNIT * multiplier; // NOTE: Determines string input heights
-      BlockSvg.FIELD_WIDTH = 0 * GRID_UNIT * multiplier;
+      if (multiplier >= 1.5) {
+        BlockSvg.FIELD_WIDTH = 8 * GRID_UNIT * multiplier;
+      } else if (multiplier > 1) {
+        BlockSvg.FIELD_WIDTH = 7 * GRID_UNIT * multiplier;
+      } else {
+        BlockSvg.FIELD_WIDTH = 6 * GRID_UNIT * multiplier;
+      }
       BlockSvg.FIELD_DEFAULT_CORNER_RADIUS = 4 * GRID_UNIT * multiplier;
       BlockSvg.EDITABLE_FIELD_PADDING = 1.5 * GRID_UNIT * multiplier;
       BlockSvg.BOX_FIELD_PADDING = 2 * GRID_UNIT * multiplier;

--- a/addons/custom-block-shape/userscript.js
+++ b/addons/custom-block-shape/userscript.js
@@ -158,9 +158,7 @@ export default async function ({ addon, global, console }) {
       BlockSvg.INPUT_SHAPE_ROUND_WIDTH = 12 * GRID_UNIT * multiplier;
       BlockSvg.INPUT_SHAPE_HEIGHT = 8 * GRID_UNIT * multiplier;
       BlockSvg.FIELD_HEIGHT = 8 * GRID_UNIT * multiplier; // NOTE: Determines string input heights
-      BlockSvg.FIELD_WIDTH =
-        6 * GRID_UNIT * Math.min(multiplier, 1) +
-        10 * GRID_UNIT * Math.max(multiplier - 1, 0);
+      BlockSvg.FIELD_WIDTH = 6 * GRID_UNIT * Math.min(multiplier, 1) + 10 * GRID_UNIT * Math.max(multiplier - 1, 0);
       BlockSvg.FIELD_DEFAULT_CORNER_RADIUS = 4 * GRID_UNIT * multiplier;
       BlockSvg.EDITABLE_FIELD_PADDING = 1.5 * GRID_UNIT * multiplier;
       BlockSvg.BOX_FIELD_PADDING = 2 * GRID_UNIT * multiplier;


### PR DESCRIPTION
Fixes #2033

Tested on padding sizes ranging from 50-200. Text is centered (within a couple pixels) at all sizes

I've only tested on a strange Linux system. I see no reason why it wouldn't work on Windows, but do make a brief check (surely you do that anyways, right?)