### PR TITLE
Fix Do not automatically run duplicated blocks edge cases

### DIFF
--- a/addons/fix-pasted-scripts/userscript.js
+++ b/addons/fix-pasted-scripts/userscript.js
@@ -7,15 +7,26 @@ export default async function ({ addon, global, console }) {
     vm.runtime.once("PROJECT_LOADED", resolve);
   });
   const BlocklyInstance = await addon.tab.traps.getBlockly();
-  const originalObject = BlocklyInstance.BlockSvg.prototype.onMouseDown_;
+  const originalBlockMouseDown = BlocklyInstance.BlockSvg.prototype.onMouseDown_;
+  const originalFieldMouseDown = BlocklyInstance.Field.prototype.onMouseDown_;
 
   // Fixes the duplicate/pasting bug, no matter the setting (@GarboMuffin's implementation)
   BlocklyInstance.BlockSvg.prototype.onMouseDown_ = function (e) {
     if (!addon.self.disabled && this.workspace && this.workspace.isDragging()) {
       return;
-    } else {
-      return originalObject.call(this, e);
     }
+    return originalBlockMouseDown.call(this, e);
+  };
+  BlocklyInstance.Field.prototype.onMouseDown_ = function (e) {
+    if (
+      !addon.self.disabled &&
+      this.sourceBlock_ &&
+      this.sourceBlock_.workspace &&
+      this.sourceBlock_.workspace.isDragging()
+    ) {
+      return;
+    }
+    return originalFieldMouseDown.call(this, e);
   };
 
   if (addon.self.enabledLate) vm.emitWorkspaceUpdate();

--- a/addons/fix-pasted-scripts/userscript.js
+++ b/addons/fix-pasted-scripts/userscript.js
@@ -1,16 +1,8 @@
-// This addon works by modifying the VM and Blockly to not react to clicking scripts.
-
 export default async function ({ addon, global, console }) {
-  const vm = addon.tab.traps.vm;
-  await new Promise((resolve, reject) => {
-    if (vm.editingTarget) return resolve();
-    vm.runtime.once("PROJECT_LOADED", resolve);
-  });
   const BlocklyInstance = await addon.tab.traps.getBlockly();
   const originalBlockMouseDown = BlocklyInstance.BlockSvg.prototype.onMouseDown_;
   const originalFieldMouseDown = BlocklyInstance.Field.prototype.onMouseDown_;
 
-  // Fixes the duplicate/pasting bug, no matter the setting (@GarboMuffin's implementation)
   BlocklyInstance.BlockSvg.prototype.onMouseDown_ = function (e) {
     if (!addon.self.disabled && this.workspace && this.workspace.isDragging()) {
       return;
@@ -29,5 +21,9 @@ export default async function ({ addon, global, console }) {
     return originalFieldMouseDown.call(this, e);
   };
 
-  if (addon.self.enabledLate) vm.emitWorkspaceUpdate();
+  // Because of how Scratch adds event listeners, we might have to redraw if the editor already has something
+  const vm = addon.tab.traps.vm;
+  if (vm.editingTarget) {
+    vm.emitWorkspaceUpdate();
+  }
 }


### PR DESCRIPTION
If a duplicated reporter was dropped onto a field, the script could still run sometimes

Also changed how the addon tries to inject, should be more reliable