### PR TITLE
Fix addon body CSS

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -82,10 +82,12 @@
   .addon-description {
     margin-inline: 10px;
     color: gray;
-    max-width: 35vw;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    width: 0; /* don't include the description
+                 when calculating addon-body size */
+    flex-grow: 1;
   }
 
   .addon-warn {

--- a/webpages/styles/components/badges.css
+++ b/webpages/styles/components/badges.css
@@ -6,6 +6,7 @@
   font-size: 12px;
   margin-inline-start: 10px;
   border-bottom: 2px solid #111;
+  white-space: nowrap;
 }
 
 .badge.blue {


### PR DESCRIPTION
Resolves #2681

### Changes

* Removes `max-width` from collapsed addon descriptions
* Tags no longer wrap
* Addon names no longer wrap until the window is so small that the description becomes invisible