### PR TITLE
Add two new settings to editor dark mode

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -614,6 +614,19 @@
       }
     },
     {
+      "url": "stage.css",
+      "matches": [
+        "https://scratch.mit.edu/projects/*/",
+        "https://scratch.mit.edu/projects/*/editor",
+        "https://scratch.mit.edu/projects/*/fullscreen",
+        "https://scratch.mit.edu/projects/editor"
+      ],
+      "settingMatch": {
+        "id": "affectStage",
+        "value": true
+      }
+    },
+    {
       "url": "dark_comments.css",
       "matches": [
         "https://scratch.mit.edu/projects/*/",
@@ -747,6 +760,12 @@
     {
       "name": "Text shadow on blocks",
       "id": "textShadow",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "name": "Change the colors of variables, lists, and answer inputs on the stage",
+      "id": "affectStage",
       "type": "boolean",
       "default": false
     },

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -85,6 +85,16 @@
       }
     },
     {
+      "name": "primary-iconFilter",
+      "value": {
+        "type": "recolorFilter",
+        "source": {
+          "type": "settingValue",
+          "settingId": "primary"
+        }
+      }
+    },
+    {
       "name": "primary-transparent35",
       "value": {
         "type": "multiply",
@@ -168,6 +178,16 @@
           "b": 0.75
         },
         "threshold": 60
+      }
+    },
+    {
+      "name": "highlightText-iconFilter",
+      "value": {
+        "type": "recolorFilter",
+        "source": {
+          "type": "settingValue",
+          "settingId": "highlightText"
+        }
       }
     },
     {
@@ -667,6 +687,12 @@
       "default": "#4d97ff"
     },
     {
+      "name": "Text and icon highlight color",
+      "id": "highlightText",
+      "type": "color",
+      "default": "#4d97ff"
+    },
+    {
       "name": "Menu bar background",
       "id": "menuBar",
       "type": "color",
@@ -790,6 +816,7 @@
       "values": {
         "page": "#111111",
         "primary": "#4d97ff",
+        "highlightText": "#4d97ff",
         "menuBar": "#202020",
         "activeTab": "#202020",
         "tab": "#151515",
@@ -817,6 +844,7 @@
       "values": {
         "page": "#051638",
         "primary": "#4d97ff",
+        "highlightText": "#4d97ff",
         "menuBar": "#2f4066",
         "activeTab": "#2f4066",
         "tab": "#273552",
@@ -844,6 +872,7 @@
       "values": {
         "page": "#2e2e2e",
         "primary": "#47566b",
+        "highlightText": "#4d97ff",
         "menuBar": "#47566b",
         "activeTab": "#555555",
         "tab": "#444444",
@@ -871,6 +900,7 @@
       "values": {
         "page": "#001533",
         "primary": "#4d97ff",
+        "highlightText": "#4d97ff",
         "menuBar": "#4d97ff",
         "activeTab": "#282828",
         "tab": "#192f4d",
@@ -898,6 +928,7 @@
       "values": {
         "page": "#e5f0ff",
         "primary": "#4d97ff",
+        "highlightText": "#4d97ff",
         "menuBar": "#4d97ff",
         "activeTab": "#ffffff",
         "tab": "#d9e3f2",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -153,7 +153,6 @@ div.s3devDDOut.vis,
 .mediaRecorderPopupContent,
 .mediaRecorderPopupContent p,
 .slider-prompt_body_2ZkXL,
-.camera-modal_body_3GKi0,
 .record-modal_body_2VO4l {
   background-color: var(--editorDarkMode-accent);
   color: var(--editorDarkMode-accent-text);
@@ -165,13 +164,8 @@ div.s3devDDOut.vis,
 .sound-editor_tool-button_2iNn9,
 .sound-editor_effect-button_2zuzT,
 .library-item_featured-extension-metadata_3D8E8,
-.camera-modal_disabled-text_G3r68,
-.camera-modal_loading-text_e5804,
 .record-modal_help-text_Jevsk {
   color: var(--editorDarkMode-accent-text);
-}
-.camera-modal_main-button_1G6x1:disabled {
-  background-color: var(--editorDarkMode-accent-text);
 }
 .blocklyFlyoutButton:hover {
   fill: var(--editorDarkMode-accent);
@@ -198,10 +192,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .library-item_featured-extension-metadata-detail_1M9BV img {
   filter: var(--editorDarkMode-accent-filter);
 }
-.sa-body-editor
-  .stage-header_stage-size-toggle-group_17LtK
-  .stage-header_stage-button_hkl9B:not(.stage-header_stage-button-toggled-off_AJ8yG)
-  .stage-header_stage-button-icon_3zzFK,
 .sa-body-editor .stage-header_stage-button-toggled-off_AJ8yG,
 .sprite-info_radio_v-fgn:not(.sprite-info_is-active_ewF6e) {
   filter: none;
@@ -337,13 +327,13 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .paint-editor_bitmap-button_keW7B,
 .sa-onion-button[data-enabled="true"],
 .sound-editor_round-button_3NLcW,
+.audio-trimmer_selection-background_3LBuB,
 .tag-button_tag-button_nBLRM:not(.tag-button_active_2stEz),
 .action-menu_button_1qbot,
 .context-menu_menu-item_3cioN:not(.context-menu_menu-item-danger_1tJg0):hover,
 .blocklyWidgetDiv .goog-menuitem-highlight,
 .blocklyWidgetDiv .goog-menuitem-hover,
-.s3dev-mi:hover,
-.camera-modal_main-button_1G6x1 {
+.s3dev-mi:hover {
   background-color: var(--editorDarkMode-primary);
   color: var(--editorDarkMode-primary-text);
 }
@@ -364,7 +354,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .stop-all_stop-all_1Y8P9:hover,
 .pause-btn:hover,
 .icon-button_container_278u5:not(.tool-select-base_is-selected_3x4kL):active,
-.camera-modal_camera-feed-container_-La7q,
 .record-modal_waveform-container__ay3Q {
   background-color: var(--editorDarkMode-primary-transparent15);
 }
@@ -391,8 +380,7 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
   border-color: var(--editorDarkMode-primary);
   box-shadow: 0 0 0 3px var(--editorDarkMode-primary-transparent35);
 }
-.action-menu_main-button_3ccfy,
-.camera-modal_main-button_1G6x1 {
+.action-menu_main-button_3ccfy {
   box-shadow: 0 0 0 4px var(--editorDarkMode-primary-transparent35);
 }
 .input_input-form_l9eYg:not(.project-title-input_title-field_en5Gd):not(.s3devInp):focus,
@@ -403,8 +391,7 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
   border-color: var(--editorDarkMode-primary);
   box-shadow: 0 0 0 4px var(--editorDarkMode-primary-transparent35);
 }
-.action-menu_main-button_3ccfy:hover,
-.camera-modal_main-button_1G6x1:not(:disabled):hover {
+.action-menu_main-button_3ccfy:hover {
   box-shadow: 0 0 0 6px var(--editorDarkMode-primary-transparent35);
 }
 .stage-selector_stage-selector_3oWOr.stage-selector_is-selected_2x2r_ .stage-selector_header-title_33xCt,
@@ -429,9 +416,15 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .sa-onion-button[data-enabled="true"] .sa-onion-image {
   filter: var(--editorDarkMode-primary-filter2);
 }
+.audio-trimmer_trim-handle_1Obhp img {
+  filter: var(--editorDarkMode-primary-iconFilter);
+}
 .action-menu_more-buttons-outer_3J9yZ,
 .action-menu_more-button_1fMGZ {
   background-color: var(--editorDarkMode-primary-variant);
+}
+.audio-trimmer_selector_DDQ2- .audio-trimmer_trim-line_2cpoE {
+  border-color: var(--editorDarkMode-primary-variant);
 }
 .checked > .blocklyFlyoutCheckbox {
   stroke: var(--editorDarkMode-primary-variant);
@@ -443,6 +436,32 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 }
 .question_question-container_OuJwy /* <-- specificity */ .question_question-input_1oAB7 .input_input-form_l9eYg:focus {
   box-shadow: 0 0 0 4px rgba(77, 151, 255, 0.35);
+}
+
+/* Text and icon highlight color */
+.gui_tab_27Unf.gui_is-selected_sHAiu,
+.record-modal_playing-text_1tknI,
+.record-modal_button-row_1hdGe button {
+  color: var(--editorDarkMode-highlightText);
+}
+.scratchCategoryMenuItem:hover {
+  color: var(--editorDarkMode-highlightText) !important;
+}
+.gui_tab_27Unf.gui_is-selected_sHAiu img,
+.sa-body-editor
+  .stage-header_stage-size-toggle-group_17LtK
+  .stage-header_stage-button_hkl9B:not(.stage-header_stage-button-toggled-off_AJ8yG)
+  .stage-header_stage-button-icon_3zzFK,
+.sprite-info_is-active_ewF6e .sprite-info_icon_1iZ_9,
+.fixed-tools_button-group-button-icon_1cr4a,
+.sound-editor_undo-icon_So0sO,
+.sound-editor_redo-icon_XGcr5,
+.sound-editor_tool-button_2iNn9 img,
+.filter_filter-icon_3Pfaw,
+img[src="/static/assets/d889a872f3b0985b28fa872764172ef1.svg"] /* record modal play */,
+img[src="/static/assets/26255153f92ea41df149a58d3c3fe2cf.svg"] /* record modal stop */,
+.record-modal_rerecord-button_jgsi_ img {
+  filter: var(--editorDarkMode-highlightText-iconFilter);
 }
 
 /* Border color */
@@ -503,7 +522,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .slider-prompt_min-input_1IxXX,
 .slider-prompt_max-input_1Nwbv,
 .slider-prompt_button-row_32aCX button,
-.camera-modal_camera-feed-container_-La7q,
 .record-modal_waveform-container__ay3Q,
 .record-modal_button-row_1hdGe button {
   border-color: var(--editorDarkMode-border);

--- a/addons/editor-dark-mode/stage.css
+++ b/addons/editor-dark-mode/stage.css
@@ -1,0 +1,47 @@
+.monitor_monitor-container_2J9gl,
+.monitor_list-body_2OFZ6 {
+  background-color: var(--editorDarkMode-page);
+  color: var(--editorDarkMode-page-text);
+}
+.monitor_list-index_7tKdl {
+  color: var(--editorDarkMode-page-text);
+}
+.monitor_label_ci1ok,
+.monitor_list-empty_1UKsB {
+  color: var(--editorDarkMode-page-text) !important;
+}
+
+.monitor_list-header_-cp0o,
+.monitor_list-footer_2HyG8,
+.question_question-container_OuJwy {
+  background-color: var(--editorDarkMode-accent);
+  color: var(--editorDarkMode-accent-text);
+}
+.question_question-label_1tRo2 {
+  color: var(--editorDarkMode-accent-text);
+}
+
+.question_question-input_1oAB7 .input_input-form_l9eYg {
+  background-color: var(--editorDarkMode-input);
+  border-color: var(--editorDarkMode-border);
+  color: var(--editorDarkMode-input-text);
+}
+
+.question_question-submit-button_3nYah {
+  background-color: var(--editorDarkMode-primary);
+}
+.question_question-submit-button-icon_upm57 {
+  filter: var(--editorDarkMode-primary-filter);
+}
+.question_question-input_1oAB7 .input_input-form_l9eYg:hover,
+.question_question-container_OuJwy /* <-- specificity */ .question_question-input_1oAB7 .input_input-form_l9eYg:focus {
+  border-color: var(--editorDarkMode-primary);
+}
+.question_question-container_OuJwy /* <-- specificity */ .question_question-input_1oAB7 .input_input-form_l9eYg:focus {
+  box-shadow: 0 0 0 4px var(--editorDarkMode-primary-transparent35);
+}
+
+.monitor_list-header_-cp0o,
+.question_question-container_OuJwy {
+  border-color: var(--editorDarkMode-border);
+} 

--- a/addons/editor-dark-mode/stage.css
+++ b/addons/editor-dark-mode/stage.css
@@ -44,4 +44,4 @@
 .monitor_list-header_-cp0o,
 .question_question-container_OuJwy {
   border-color: var(--editorDarkMode-border);
-} 
+}

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -229,6 +229,9 @@ function setCssVariables(addonSettings, addonsWithUserstyles) {
         let opaqueHex = getColor(addonId, obj.opaqueSource);
         let transparentHex = getColor(addonId, obj.transparentSource);
         return textColorLib.alphaBlend(opaqueHex, transparentHex);
+      case "recolorFilter":
+        hex = getColor(addonId, obj.source);
+        return textColorLib.recolorFilter(hex);
     }
   };
 

--- a/libraries/common/cs/text-color.esm.js
+++ b/libraries/common/cs/text-color.esm.js
@@ -1,3 +1,3 @@
 import * as _textColor from "./text-color.js";
-const { textColor, multiply, brighten, alphaBlend } = globalThis.__scratchAddonsTextColor;
-export { textColor, multiply, brighten, alphaBlend };
+const { textColor, multiply, brighten, alphaBlend, recolorFilter } = globalThis.__scratchAddonsTextColor;
+export { textColor, multiply, brighten, alphaBlend, recolorFilter };

--- a/libraries/common/cs/text-color.js
+++ b/libraries/common/cs/text-color.js
@@ -65,9 +65,26 @@ function alphaBlend(opaqueHex, transparentHex) {
   });
 }
 
+function recolorFilter(hex) {
+  const { r, g, b } = parseHex(hex);
+  return `url("data:image/svg+xml,
+    <svg xmlns='http://www.w3.org/2000/svg'>
+      <filter id='recolor'>
+        <feColorMatrix values='
+          0 0 0 0 ${r/255}
+          0 0 0 0 ${g/255}
+          0 0 0 0 ${b/255}
+          0 0 0 1 0
+        '/>
+      </filter>
+    </svg>#recolor
+  ")`.split("\n").join("");
+}
+
 globalThis.__scratchAddonsTextColor = {
   textColor,
   multiply,
   brighten,
   alphaBlend,
+  recolorFilter,
 };

--- a/libraries/common/cs/text-color.js
+++ b/libraries/common/cs/text-color.js
@@ -71,14 +71,16 @@ function recolorFilter(hex) {
     <svg xmlns='http://www.w3.org/2000/svg'>
       <filter id='recolor'>
         <feColorMatrix values='
-          0 0 0 0 ${r/255}
-          0 0 0 0 ${g/255}
-          0 0 0 0 ${b/255}
+          0 0 0 0 ${r / 255}
+          0 0 0 0 ${g / 255}
+          0 0 0 0 ${b / 255}
           0 0 0 1 0
         '/>
       </filter>
     </svg>#recolor
-  ")`.split("\n").join("");
+  ")`
+    .split("\n")
+    .join("");
 }
 
 globalThis.__scratchAddonsTextColor = {


### PR DESCRIPTION
Resolves #2415
Adds a feature described in https://github.com/ScratchAddons/ScratchAddons/pull/1805#issuecomment-827611354

### Changes

* Adds the Boolean setting described in #2415
* Adds a setting to change the color of blue text and icons (ideally the tool buttons in the paint editor would also be affected but those icons also use other colors and I'm not sure if there is an SVG filter that would only affect a specific color)
* Makes the selection background and handles in the sound editor affected by the highlight color setting
* Removes now unused camera modal styles

### `addon.json` change

There is a new type for custom CSS variables, `"recolorFilter"`, which returns a filter function that can be used to change the color of monochrome icons.

### Reason for changes

To allow more customization.

### Tests

Tested with different values of both settings.