### PR TITLE
Update ocular reactions UI

### DIFF
--- a/addons-l10n/en/my-ocular.json
+++ b/addons-l10n/en/my-ocular.json
@@ -1,4 +1,5 @@
 {
   "my-ocular/status-hover": "This is a customized status from ocular, displayed by Scratch Addons. You can set your own at https://ocular.jeffalo.net/dashboard.",
-  "my-ocular/view-on-ocular": "View this post on ocular"
+  "my-ocular/view-on-ocular": "View this post on ocular",
+  "my-ocular/add-reaction": "React to this post using ocular"
 }

--- a/addons/dark-www/experimental_forums.css
+++ b/addons/dark-www/experimental_forums.css
@@ -99,3 +99,14 @@
 .my-ocular-reaction-button.selected {
   background-color: #075e46;
 }
+.my-ocular-popup {
+  background-color: #202020;
+  border-color: #606060;
+  color: white;
+}
+.my-ocular-popup::before {
+  border-top-color: #606060;
+}
+.my-ocular-popup::after {
+  border-top-color: #202020;
+}

--- a/addons/my-ocular/reactions.css
+++ b/addons/my-ocular/reactions.css
@@ -9,14 +9,78 @@
   background-color: #f2f2f2;
   margin: 0 5px;
   padding: 4px;
+  vertical-align: middle;
   display: inline-block; /* don't wrap in the middle of a reaction */
-  line-height: normal;
+  line-height: 16px;
   border-radius: 6px;
   box-shadow: 0 0 2px #28a5da;
+  text-shadow: none;
   opacity: 1;
   /* transition: opacity .5s; */ /* due to the way the list is rerendered, css transitions wont do anything */
+  position: relative;
 }
 .my-ocular-reaction-button.selected {
   color: #fff;
   background-color: #28a5da;
+}
+
+.my-ocular-reaction-button > .my-ocular-popup {
+  display: none;
+}
+.my-ocular-reaction-button:hover > .my-ocular-popup {
+  display: block;
+}
+
+.my-ocular-popup {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  padding: 6px;
+  background-color: #fafafa;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  color: #322f31;
+}
+.my-ocular-popup::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: calc(100% + 1px);
+  left: calc(50% - 6px);
+  width: 0;
+  height: 0;
+  border: 6px solid transparent;
+  border-top-color: #d9d9d9;
+}
+.my-ocular-popup::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 100%;
+  left: calc(50% - 5px);
+  width: 0;
+  height: 0;
+  border: 5px solid transparent;
+  border-top-color: #fafafa;
+}
+
+.my-ocular-reaction-menu-button {
+  cursor: pointer;
+  filter: grayscale(100%);
+  transition: filter 0.2s ease;
+}
+.my-ocular-reaction-menu.open .my-ocular-reaction-menu-button {
+  filter: none;
+}
+
+.my-ocular-reaction-menu {
+  position: relative;
+}
+.my-ocular-reaction-menu > .my-ocular-popup {
+  display: none;
+}
+.my-ocular-reaction-menu.open > .my-ocular-popup {
+  display: block;
 }

--- a/addons/my-ocular/reactions.js
+++ b/addons/my-ocular/reactions.js
@@ -26,7 +26,7 @@ export default async function ({ addon, global, console, msg }) {
       reactionMenuContainer.appendChild(document.createTextNode(" "));
       reactionMenuContainer.appendChild(reactionMenuButton);
       reactionMenuContainer.appendChild(document.createTextNode(" "));
-      
+
       let reactionMenu = document.createElement("span");
       reactionMenu.className = "my-ocular-popup";
       reactionMenuContainer.appendChild(reactionMenu);
@@ -40,7 +40,7 @@ export default async function ({ addon, global, console, msg }) {
       });
       document.body.addEventListener("click", () => reactionMenuContainer.classList.remove("open"));
       reactionMenu.addEventListener("click", (e) => e.stopPropagation()); /* don't close the menu when it's clicked */
-      
+
       let reactionList = document.createElement("li"); // it's a list item, because its inside the postfootright list. so it's basically a nested list
       async function makeReactionList() {
         const reactions = await fetchReactions(postID);
@@ -51,21 +51,27 @@ export default async function ({ addon, global, console, msg }) {
           let reactionButton = reaction.reactions.length !== 0 ? document.createElement("span") : null;
           if (reactionButton) reactionButton.className = "my-ocular-reaction-button";
           if (reactionButton) reactionButton.innerText = `${reaction.emoji} ${reaction.reactions.length}`;
-          
+
           let reactionMenuItem = document.createElement("span");
           reactionMenuItem.className = "my-ocular-reaction-button";
           reactionMenuItem.innerText = reaction.emoji;
-          
+
           if (reaction.reactions.find((r) => r.user === addon.auth.username)) {
             if (reactionButton) reactionButton.classList.add("selected");
             reactionMenuItem.classList.add("selected");
           }
-          
+
           if (reactionButton) {
             let tooltip = document.createElement("span");
             tooltip.className = "my-ocular-popup";
-            if (reaction.reactions.length <= 5) tooltip.innerText = reaction.reactions.map(user => user.user).join(", ");
-            else tooltip.innerText = reaction.reactions.slice(0, 5).map(user => user.user).join(", ") + " and others";
+            if (reaction.reactions.length <= 5)
+              tooltip.innerText = reaction.reactions.map((user) => user.user).join(", ");
+            else
+              tooltip.innerText =
+                reaction.reactions
+                  .slice(0, 5)
+                  .map((user) => user.user)
+                  .join(", ") + " and others";
             reactionButton.appendChild(tooltip);
           }
 

--- a/addons/my-ocular/reactions.js
+++ b/addons/my-ocular/reactions.js
@@ -17,22 +17,59 @@ export default async function ({ addon, global, console, msg }) {
     footer.insertAdjacentElement("afterbegin", viewOnOcularContainer);
 
     if (addon.auth.isLoggedIn) {
+      let reactionMenuContainer = document.createElement("li");
+      reactionMenuContainer.className = "my-ocular-reaction-menu";
+      let reactionMenuButton = document.createElement("span");
+      reactionMenuButton.className = "my-ocular-reaction-menu-button";
+      reactionMenuButton.innerText = "😀";
+      reactionMenuButton.title = msg("add-reaction");
+      reactionMenuContainer.appendChild(document.createTextNode(" "));
+      reactionMenuContainer.appendChild(reactionMenuButton);
+      reactionMenuContainer.appendChild(document.createTextNode(" "));
+      
+      let reactionMenu = document.createElement("span");
+      reactionMenu.className = "my-ocular-popup";
+      reactionMenuContainer.appendChild(reactionMenu);
+      reactionMenuButton.addEventListener("click", (e) => {
+        e.stopPropagation();
+        reactionMenuContainer.classList.toggle("open");
+        for (let otherMenuContainer of document.querySelectorAll(".my-ocular-reaction-menu")) {
+          if (otherMenuContainer == reactionMenuContainer) continue;
+          otherMenuContainer.classList.remove("open");
+        }
+      });
+      document.body.addEventListener("click", () => reactionMenuContainer.classList.remove("open"));
+      reactionMenu.addEventListener("click", (e) => e.stopPropagation()); /* don't close the menu when it's clicked */
+      
       let reactionList = document.createElement("li"); // it's a list item, because its inside the postfootright list. so it's basically a nested list
       async function makeReactionList() {
         const reactions = await fetchReactions(postID);
 
         reactionList.innerHTML = "";
+        reactionMenu.innerHTML = "";
         reactions.forEach((reaction) => {
-          let reactionButton = document.createElement("span");
-          reactionButton.innerText = `${reaction.emoji} ${reaction.reactions.length}`;
-
-          reactionButton.className = "my-ocular-reaction-button";
+          let reactionButton = reaction.reactions.length !== 0 ? document.createElement("span") : null;
+          if (reactionButton) reactionButton.className = "my-ocular-reaction-button";
+          if (reactionButton) reactionButton.innerText = `${reaction.emoji} ${reaction.reactions.length}`;
+          
+          let reactionMenuItem = document.createElement("span");
+          reactionMenuItem.className = "my-ocular-reaction-button";
+          reactionMenuItem.innerText = reaction.emoji;
+          
           if (reaction.reactions.find((r) => r.user === addon.auth.username)) {
-            reactionButton.classList.add("selected");
+            if (reactionButton) reactionButton.classList.add("selected");
+            reactionMenuItem.classList.add("selected");
+          }
+          
+          if (reactionButton) {
+            let tooltip = document.createElement("span");
+            tooltip.className = "my-ocular-popup";
+            if (reaction.reactions.length <= 5) tooltip.innerText = reaction.reactions.map(user => user.user).join(", ");
+            else tooltip.innerText = reaction.reactions.slice(0, 5).map(user => user.user).join(", ") + " and others";
+            reactionButton.appendChild(tooltip);
           }
 
-          reactionButton.addEventListener("click", (e) => {
-            e.preventDefault();
+          function react() {
             let ocular = window.open(
               `https://ocular.jeffalo.net/react/${postID}?emoji=${reaction.emoji}`,
               "ocular",
@@ -46,11 +83,18 @@ export default async function ({ addon, global, console, msg }) {
                 makeReactionList();
               }
             }
-          });
+          }
+          if (reactionButton) reactionButton.addEventListener("click", react);
+          reactionMenuItem.addEventListener("click", react);
 
-          reactionList.appendChild(reactionButton);
+          if (reactionButton) reactionList.appendChild(reactionButton);
+          reactionMenu.appendChild(reactionMenuItem);
         });
+        if (reactions.some((reaction) => reaction.reactions.length !== 0)) {
+          reactionList.appendChild(document.createTextNode("|"));
+        }
       }
+      footer.insertAdjacentElement("afterbegin", reactionMenuContainer);
       footer.insertAdjacentElement("afterbegin", reactionList);
 
       makeReactionList();

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -138,3 +138,6 @@
 .my-ocular-reaction-button.selected {
   background-color: #0fbd8c;
 }
+.my-ocular-popup {
+  color: #575e75;
+}


### PR DESCRIPTION
### Reason for changes

Jeffalo recently updated the ocular UI for reactions to initially only show reactions with a non-zero reaction count and added a tooltip that lists the users who reacted.

### Changes

Adds these changes to the ocular addon. The tooltips are limited to 5 usernames because the post container has `overflow: hidden` so part of the list could otherwise be cut off.

### Screenshots

![image](https://user-images.githubusercontent.com/51849865/121020179-6948b700-c7a0-11eb-93b9-cc650ca42bae.png)
![image](https://user-images.githubusercontent.com/51849865/121020183-6b127a80-c7a0-11eb-898a-ba6652017285.png)