### PR TITLE
Fix unreadable email confirmation modal

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -158,6 +158,14 @@
       }
     },
     {
+      "url": "experimental_confirm_email_modal.css",
+      "matches": ["https://scratch.mit.edu/accounts/email_resend_standalone/"],
+      "settingMatch": {
+        "id": "selectedMode",
+        "value": "experimental-dark"
+      }
+    },
+    {
       "url": "experimental_statistics.css",
       "matches": ["https://scratch.mit.edu/statistics/"],
       "settingMatch": {

--- a/addons/dark-www/experimental_confirm_email_modal.css
+++ b/addons/dark-www/experimental_confirm_email_modal.css
@@ -1,0 +1,15 @@
+#email-resend-box {
+  border: none;
+}
+.modal-header {
+  border-color: #606060;
+}
+#email-resend-box .email-resend-subsection {
+  color: white;
+}
+#email-resend-box a {
+  color: var(--scratchr2-linkColor);
+}
+#email-resend-box button.button {
+  padding: 0 4px;
+}

--- a/addons/scratchr2/scratchwww.css
+++ b/addons/scratchr2/scratchwww.css
@@ -15,6 +15,9 @@ a:hover,
 .news li:hover h4 {
   color: var(--scratchr2-activeColor);
 }
+.banner a {
+  color: white;
+}
 .studio-info .studio-info-footer-report button:hover {
   background-color: var(--scratchr2-activeColor);
 }


### PR DESCRIPTION
Resolves #2170 although I don't think this is actually what the issue was originally about

### Changes

Makes the links in the confirm email banner and the modal opened by one of those links styled correctly.