### PR TITLE
debugger: fix #2771 and some other bugs

### DIFF
--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -408,7 +408,12 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     const stageHeaderSizeControls = await addon.tab.waitForElement('[class*="stage-header_stage-size-row"]', {
       markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "scratch-gui/mode/SET_FULL_SCREEN", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      reduxEvents: [
+        "scratch-gui/mode/SET_PLAYER",
+        "scratch-gui/mode/SET_FULL_SCREEN",
+        "fontsLoaded/SET_FONTS_LOADED",
+        "scratch-gui/locales/SELECT_LOCALE",
+      ],
     });
     if (addon.tab.editorMode === "editor") {
       stageHeaderSizeControls.insertBefore(container, stageHeaderSizeControls.firstChild);

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -69,7 +69,7 @@ export default async function ({ addon, global, console, msg }) {
     if (!block) return;
 
     // Don't scroll to blocks in the flyout
-    if (block.workspace !== workspace) return;
+    if (block.workspace.isFlyout) return;
 
     // Copied from devtools. If it's code gets improved for this function, bring those changes here too.
     let root = block.getRootBlock();

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -408,7 +408,7 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     const stageHeaderSizeControls = await addon.tab.waitForElement('[class*="stage-header_stage-size-row"]', {
       markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "scratch-gui/mode/SET_FULL_SCREEN", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
     if (addon.tab.editorMode === "editor") {
       stageHeaderSizeControls.insertBefore(container, stageHeaderSizeControls.firstChild);

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -68,6 +68,9 @@ export default async function ({ addon, global, console, msg }) {
     const block = workspace.getBlockById(blockId);
     if (!block) return;
 
+    // Don't scroll to blocks in the flyout
+    if (block.workspace !== workspace) return;
+
     // Copied from devtools. If it's code gets improved for this function, bring those changes here too.
     let root = block.getRootBlock();
 

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -315,22 +315,24 @@ export default async function ({ addon, global, console, msg }) {
 
     const blockId = thread.peekStack();
     const block = workspace.getBlockById(blockId);
-    const inputBlock = block.getChildren().find((b) => b.parentBlock_.id === blockId);
-    if (inputBlock.type !== "text") {
-      if (inputBlock.inputList.filter((i) => i.name).length === 0) {
-        const inputSpan = document.createElement("span");
-        const svgPathStyle = getComputedStyle(inputBlock.svgPath_);
-        const inputBlockFill = svgPathStyle.fill;
-        const inputBlockStroke = svgPathStyle.stroke;
-        // for compatibility with custom block colors
-        const inputBlockColor =
-          inputBlockFill === "rgb(40, 40, 40)" || inputBlockFill === "rgb(255, 255, 255)"
-            ? inputBlockStroke
-            : inputBlockFill;
-        inputSpan.innerText = inputBlock.toString();
-        inputSpan.className = "console-variable";
-        inputSpan.style.background = inputBlockColor;
-        wrapper.append(inputSpan);
+    if (block) {
+      const inputBlock = block.getChildren().find((b) => b.parentBlock_.id === blockId);
+      if (inputBlock.type !== "text") {
+        if (inputBlock.inputList.filter((i) => i.name).length === 0) {
+          const inputSpan = document.createElement("span");
+          const svgPathStyle = getComputedStyle(inputBlock.svgPath_);
+          const inputBlockFill = svgPathStyle.fill;
+          const inputBlockStroke = svgPathStyle.stroke;
+          // for compatibility with custom block colors
+          const inputBlockColor =
+            inputBlockFill === "rgb(40, 40, 40)" || inputBlockFill === "rgb(255, 255, 255)"
+              ? inputBlockStroke
+              : inputBlockFill;
+          inputSpan.innerText = inputBlock.toString();
+          inputSpan.className = "console-variable";
+          inputSpan.style.background = inputBlockColor;
+          wrapper.append(inputSpan);
+        }
       }
     }
     logs.push({

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -330,14 +330,18 @@ export default async function ({ addon, global, console, msg }) {
           // Try to call things like https://github.com/LLK/scratch-blocks/blob/develop/blocks_vertical/operators.js
           let jsonData;
           const fakeBlock = {
-            jsonInit (data) {
+            jsonInit(data) {
               jsonData = data;
-            }
+            },
           };
           const blockConstructor = ScratchBlocks.Blocks[inputBlock.opcode];
           if (blockConstructor) {
-            blockConstructor.init.call(fakeBlock);
-          }  
+            try {
+              blockConstructor.init.call(fakeBlock);
+            } catch (e) {
+              // ignore
+            }
+          }
           if (jsonData && jsonData.message0 && !jsonData.args0) {
             text = jsonData.message0;
             category = jsonData.category;
@@ -348,7 +352,8 @@ export default async function ({ addon, global, console, msg }) {
           inputSpan.textContent = text;
           inputSpan.className = "console-variable";
           inputSpan.dataset.category = category === "list" ? "data-lists" : category;
-          inputSpan.style.backgroundColor = ScratchBlocks.Colours[category === "list" ? "data_lists" : category].primary;
+          inputSpan.style.backgroundColor =
+            ScratchBlocks.Colours[category === "list" ? "data_lists" : category].primary;
           wrapper.append(inputSpan);
         }
       }

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -88,7 +88,11 @@ function updateSettings(addon, newStyle) {
       }
       #s3devIDD > li.${prop} {
         background-color: var(--editorTheme3-${settingName}Color);
-      }`;
+      }
+      .console-variable[data-category="${prop}"] {
+        background-color: var(--editorTheme3-${settingName}Color) !important;
+      }
+      `;
       if (prop === "custom") {
         stylesheet += `path.blocklyBlockBackground[fill="#FF6680"] {
           fill: var(--editorTheme3-${prop}Color);


### PR DESCRIPTION
 - Changes how the block "previews" are generated to not rely on an actual Blockly block existing.
 - don't try to scroll a block in a flyout into view.
 - make the button not disappear when entering and leaving fullscreen.