### PR TITLE
Move `handleKeySettings` to addon-settings component

### DIFF
--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -55,9 +55,11 @@
     <template v-if="setting.type === 'key'">
       <input
         type="text"
-        class="setting-input key"
+        class="setting-input"
         v-model="addonSettings[addon._addonId][setting.id]"
         @input="updateSettings()"
+        @keydown="keySettingKeyDown"
+        @keyup="keySettingKeyUp"
         :disabled="!addon._enabled"
         :placeholder="setting.default"
         maxlength="100"

--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -39,6 +39,26 @@ export default async function ({ template }) {
           ? input.value
           : this.setting.default;
       },
+      keySettingKeyDown(e) {
+        e.preventDefault();
+        e.target.value = e.ctrlKey
+          ? "Ctrl" +
+            (e.shiftKey ? " + Shift" : "") +
+            (e.key === "Control" || e.key === "Shift"
+              ? ""
+              : (e.ctrlKey ? " + " : "") +
+                (e.key.toUpperCase() === e.key
+                  ? e.code.includes("Digit")
+                    ? e.code.substring(5, e.code.length)
+                    : e.key
+                  : e.key.toUpperCase()))
+          : "";
+      },
+      keySettingKeyUp(e) {
+        // Ctrl by itself isn't a hotkey
+        if (e.target.value === "Ctrl") e.target.value = "";
+        this.updateOption(e.target.value);
+      },
       msg(...params) {
         return this.$root.msg(...params);
       },
@@ -47,7 +67,8 @@ export default async function ({ template }) {
         this.$root.updateSettings(...params);
       },
       updateOption(newValue) {
-        this.$root.updateOption(this.setting.id, newValue, this.addon);
+        this.addonSettings[this.addon._addonId][this.setting.id] = newValue;
+        this.updateSettings();
       },
     },
     events: {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -81,7 +81,10 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
   chrome.permissions.onAdded?.addListener(updateGrantedPermissions);
   chrome.permissions.onRemoved?.addListener(updateGrantedPermissions);
 
-  const promisify = (callbackFn) => (...args) => new Promise((resolve) => callbackFn(...args, resolve));
+  const promisify =
+    (callbackFn) =>
+    (...args) =>
+      new Promise((resolve) => callbackFn(...args, resolve));
 
   let handleConfirmClicked = null;
 

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -81,10 +81,7 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
   chrome.permissions.onAdded?.addListener(updateGrantedPermissions);
   chrome.permissions.onRemoved?.addListener(updateGrantedPermissions);
 
-  const promisify =
-    (callbackFn) =>
-    (...args) =>
-      new Promise((resolve) => callbackFn(...args, resolve));
+  const promisify = (callbackFn) => (...args) => new Promise((resolve) => callbackFn(...args, resolve));
 
   let handleConfirmClicked = null;
 
@@ -272,10 +269,6 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
       },
       stopPropagation(e) {
         e.stopPropagation();
-      },
-      updateOption(id, newValue, addon) {
-        this.addonSettings[addon._addonId][id] = newValue;
-        this.updateSettings(addon);
       },
       updateSettings(addon, { wait = 0, settingId = null } = {}) {
         const value = settingId && this.addonSettings[addon._addonId][settingId];
@@ -598,7 +591,6 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
     vue.addonListObjs = vue.addonListObjs.filter((o) => o.manifest._addonId !== "example");
 
     vue.loaded = true;
-    setTimeout(handleKeySettings, 0);
     setTimeout(() => {
       // Set hash again after loading addons, to force scroll to addon
       let hash = window.location.hash;
@@ -618,36 +610,6 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
       }
     }, 0);
   });
-
-  function handleKeySettings() {
-    let keyInputs = document.querySelectorAll(".key");
-    for (const input of keyInputs) {
-      input.addEventListener("keydown", function (e) {
-        e.preventDefault();
-        e.target.value = e.ctrlKey
-          ? "Ctrl" +
-            (e.shiftKey ? " + Shift" : "") +
-            (e.key === "Control" || e.key === "Shift"
-              ? ""
-              : (e.ctrlKey ? " + " : "") +
-                (e.key.toUpperCase() === e.key
-                  ? e.code.includes("Digit")
-                    ? e.code.substring(5, e.code.length)
-                    : e.key
-                  : e.key.toUpperCase()))
-          : "";
-        vue.updateOption(
-          e.target.getAttribute("data-setting-id"),
-          e.target.value,
-          vue.manifests.find((manifest) => manifest._addonId === e.target.getAttribute("data-addon-id"))
-        );
-      });
-      input.addEventListener("keyup", function (e) {
-        // Ctrl by itself isn't a hotkey
-        if (e.target.value === "Ctrl") e.target.value = "";
-      });
-    }
-  }
 
   window.addEventListener("keydown", function (e) {
     if (e.ctrlKey && e.key === "f") {


### PR DESCRIPTION
This improves speed of key inputs (when they are actually used) but also removes the querySelectorAll which can remove up to 0.5 seconds of load time!!

This should not change any functionality.

This also moves `updateOption` to the addon-settings component.