### PR TITLE
Added disable-stage-drag-select addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -80,6 +80,7 @@
   "redirect-mobile-forums",
   "expanding-search-bar",
   "debugger",
+  "disable-stage-drag-select",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Disable sprite dragging in editor",
-  "description": "Makes dragging sprites in the project player behave exactly as in fullscreen while in the editor.",
+  "description": "Removes the ability to drag sprites around in the stage, except those explicitly set as draggable.",
   "credits": [
     {
       "name": "Chrome_Cat",

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -5,6 +5,9 @@
     {
       "name": "Chrome_Cat",
       "link": "https://scratch.mit.edu/users/Chrome_Cat"
+    },
+    {
+      "name": "GarboMuffin"
     }
   ],
   "userscripts": [

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Disable sprite dragging in editor",
+  "name": "Non-draggable sprites in editor",
   "description": "Removes the ability to drag sprites around in the stage, except those explicitly set as draggable.",
   "info": [
     {

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -1,18 +1,18 @@
 {
-    "name": "Disable sprite dragging in editor",
-    "description": "Makes dragging sprites in the project player behave exactly as in fullscreen while in the editor.",
-    "credits": [
-        {
-          "name": "Chrome_Cat",
-          "link": "https://scratch.mit.edu/users/Chrome_Cat"
-        }
-    ],
-    "userscripts": [
-        {
-          "url": "userscript.js",
-          "matches": ["https://scratch.mit.edu/projects/*"]
-        }
-    ],
-    "tags": ["editor"],
-    "enabledByDefault": false
+  "name": "Disable sprite dragging in editor",
+  "description": "Makes dragging sprites in the project player behave exactly as in fullscreen while in the editor.",
+  "credits": [
+    {
+      "name": "Chrome_Cat",
+      "link": "https://scratch.mit.edu/users/Chrome_Cat"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "tags": ["editor"],
+  "enabledByDefault": false
 }

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -14,5 +14,8 @@
     }
   ],
   "tags": ["editor"],
-  "enabledByDefault": false
+  "enabledByDefault": false,
+  "dynamicDisable": true,
+  "dynamicEnable": true,
+  "versionAdded": "1.17.0"
 }

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -20,7 +20,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor"],

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -1,6 +1,13 @@
 {
   "name": "Disable sprite dragging in editor",
   "description": "Removes the ability to drag sprites around in the stage, except those explicitly set as draggable.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "Hold Shift while dragging a sprite to move it normally, even if it's not set as draggable.",
+      "id": "shift"
+    }
+  ],
   "credits": [
     {
       "name": "Chrome_Cat",

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -1,6 +1,6 @@
 {
-    "name": "Disable stage drag/select",
-    "description": "Disables dragging or selecting sprites in the stage.",
+    "name": "Disable sprite dragging in editor",
+    "description": "Makes dragging sprites in the project player behave exactly as in fullscreen while in the editor.",
     "credits": [
         {
           "name": "Chrome_Cat",

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -1,0 +1,18 @@
+{
+    "name": "Disable stage drag/select",
+    "description": "Disables dragging or selecting sprites in the stage.",
+    "credits": [
+        {
+          "name": "Chrome_Cat",
+          "link": "https://scratch.mit.edu/users/Chrome_Cat"
+        }
+    ],
+    "userscripts": [
+        {
+          "url": "userscript.js",
+          "matches": ["https://scratch.mit.edu/projects/*"]
+        }
+    ],
+    "tags": ["editor"],
+    "enabledByDefault": false
+}

--- a/addons/disable-stage-drag-select/userscript.js
+++ b/addons/disable-stage-drag-select/userscript.js
@@ -1,0 +1,21 @@
+export default async ({addon}) => {
+    const vm = addon.tab.traps.vm;
+    //var oldFn = vm.setEditingTarget
+
+    vm.startDrag = function(x,y){
+        return;
+    }
+    vm.stopDrag = function (targetId) {
+        return;
+    }
+
+    /*vm.setEditingTarget = function(a){
+        //const rect = document.querySelector("canvas").getBoundingClientRect()
+        const mouse = vm.runtime.ioDevices.mouse;
+        const [x, y] = [mouse._x, mouse._y];
+        
+        if(rect.left<=x<=rect.right && rect.bottom<=y<=rect.top){
+            oldFn.call(this, a);
+        }
+    }*/
+};

--- a/addons/disable-stage-drag-select/userscript.js
+++ b/addons/disable-stage-drag-select/userscript.js
@@ -1,9 +1,21 @@
 export default async ({ addon, console }) => {
   const vm = addon.tab.traps.vm;
+  let shiftKeyPressed = false;
+
+  document.addEventListener("keydown", (event) => {
+    shiftKeyPressed = event.shiftKey;
+  });
+  document.addEventListener("keyup", (event) => {
+    shiftKeyPressed = event.shiftKey;
+  });
 
   // Do not focus sprite after dragging it
   const oldStopDrag = vm.stopDrag;
   vm.stopDrag = function (...args) {
+    if (shiftKeyPressed) {
+      const r = oldStopDrag.call(this, ...args);
+      return r;
+    }
     const setEditingTarget = this.setEditingTarget;
     this.setEditingTarget = () => {};
     const r = oldStopDrag.call(this, ...args);
@@ -15,6 +27,7 @@ export default async ({ addon, console }) => {
   const oldGetTargetIdForDrawableId = vm.getTargetIdForDrawableId;
   vm.getTargetIdForDrawableId = function (...args) {
     const targetId = oldGetTargetIdForDrawableId.call(this, ...args);
+    if (shiftKeyPressed) return targetId;
     if (targetId !== null) {
       const target = this.runtime.getTargetById(targetId);
       if (target && !target.draggable) {

--- a/addons/disable-stage-drag-select/userscript.js
+++ b/addons/disable-stage-drag-select/userscript.js
@@ -12,10 +12,7 @@ export default async ({ addon, console }) => {
   // Do not focus sprite after dragging it
   const oldStopDrag = vm.stopDrag;
   vm.stopDrag = function (...args) {
-    if (shiftKeyPressed) {
-      const r = oldStopDrag.call(this, ...args);
-      return r;
-    }
+    if (shiftKeyPressed || addon.self.disabled) return oldStopDrag.call(this, ...args);
     const setEditingTarget = this.setEditingTarget;
     this.setEditingTarget = () => {};
     const r = oldStopDrag.call(this, ...args);
@@ -27,7 +24,7 @@ export default async ({ addon, console }) => {
   const oldGetTargetIdForDrawableId = vm.getTargetIdForDrawableId;
   vm.getTargetIdForDrawableId = function (...args) {
     const targetId = oldGetTargetIdForDrawableId.call(this, ...args);
-    if (shiftKeyPressed) return targetId;
+    if (shiftKeyPressed || addon.self.disabled) return targetId;
     if (targetId !== null) {
       const target = this.runtime.getTargetById(targetId);
       if (target && !target.draggable) {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2709 

### Changes

I've added a new addon called disable-stage-drag-select. All it does is redefine the dragStart and dragStop functions to return instantly, essentially deleting them.

### Reason for changes

This adds the functionality to drag sprites in the editor and not select that sprite or call the dragStart or dragStop functions in the virtual machine.

### Tests

I tested it on one of my projects which I need it for: https://scratch.mit.edu/projects/524385137/. The result was that it did exactly what I needed it to do.

However, since I don't have access to the stage container and the methods contained within it, I couldn't remove the onDragStart or onDragStop methods, so the sprite will still go the top and be slightly offsetted when dragged. It will also still be selected on double click. This is only a minor inconvenience and most people wouldn't notice this is happening unless they know it's there.