### PR TITLE
Fix deleting procedures when debugger blocks exist and don't show "Edit" context menu item

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -88,6 +88,7 @@ const injectWorkspace = (ScratchBlocks) => {
         this.colour_ = block.color;
         this.colourSecondary_ = block.secondaryColor;
         this.colourTertiary_ = block.tertiaryColor;
+        this.customContextMenu = null;
       }
     }
     return oldUpdateColour.call(this, ...args);
@@ -135,11 +136,11 @@ const injectWorkspace = (ScratchBlocks) => {
             connection: {
               targetBlock() {
                 return null;
-              }
-            }
-          }
-        }
-      }
+              },
+            },
+          };
+        },
+      };
     }
     return result;
   };


### PR DESCRIPTION
 - Fixes https://scratch.mit.edu/users/GarboMuffin/#comments-146974453 or "can't delete procedure when addon blocks are used". Root cause is a bug in Scratch, this is a workaround
 - Don't show "Edit" when right clicking on an addon block
