### PR TITLE
Settings popup: fix disabled searched addons staying after clearing search

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -188,9 +188,11 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
     computed: {
       addonList() {
         if (!this.searchInput) {
-          this.addonListObjs
-            .filter((obj) => obj.group.id !== "_iframeSearch")
-            .forEach((obj) => (obj.matchesSearch = true));
+          this.addonListObjs.forEach((obj) => {
+            // Hide addons from _iframeSearch pseudogroup when not searching (popup)
+            if (obj.group.id === "_iframeSearch") obj.matchesSearch = false;
+            else obj.matchesSearch = true;
+          });
           return this.addonListObjs.sort((b, a) => b.naturalIndex - a.naturalIndex);
         }
 


### PR DESCRIPTION
Easy fix: no addons group the `_iframeSearch` pseudogroup should match search if the search input is empty. Addons not from that pseudogroup continue to match search if the search input is empty for obvious reasons.

To reproduce:
1. Open "addons" tab in popup
2. Search for a disabled addon with the search bar
3. Clear the search term - all search results stay

![image](https://user-images.githubusercontent.com/17484114/122612860-3df48080-d05a-11eb-8880-7ca837789c8b.png)
