### PR TITLE
Fix "copy link to comment" not working properly on profiles when loading more pages

### DIFF
--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -1,10 +1,22 @@
 export default async function ({ addon, global, console, msg }) {
+  let amtOfComments = 0;
+  let pass = 0;
   while (true) {
-    const comment = await addon.tab.waitForElement("div.comment", {
-      markAsSeen: true,
-    });
+    const newAmtOfComments = document.querySelectorAll("div.comment").length;
+    if (amtOfComments !== newAmtOfComments) {
+      pass++;
+      amtOfComments = newAmtOfComments;
+    }
+    const comment = await addon.tab.waitForElement(`div.comment:not([data-sa-copy-link-pass='${pass}'])`);
+    comment.dataset.saCopyLinkPass = pass;
+    if (comment.querySelector(".sa-copy-link-btn")) {
+      // This will to all comments after posting a new one,
+      // and to the first comment on every loaded page.
+      // Do not readd button if we already added it
+      continue;
+    }
     const newElem = document.createElement("span");
-    newElem.className = "actions report";
+    newElem.className = "actions report sa-copy-link-btn";
     newElem.textContent = msg("copyLink");
     newElem.onclick = () => {
       // For profiles, respect correct username casing in URL


### PR DESCRIPTION
Logic is simple:
1. Store number of comments on the page (initially 0).
2. Wait for a new comment element that doesn't match `[data-sa-copy-link-pass = currentPassNumber]`. This could match new comments (such as new posts or loading more comments pages), as well as comments we already added the button to before but we might need to add again.
3. Set the `data-sa-copy-link-pass` on the found comment to `currentPassNumber`.
4. Add the "copy link" button to the comment if it doesn't have it.
5. Check if amount of comments on the page has changed. If so, add 1 to the current pass number. This means all comments will be checked again.
6. Back to 2.

This works properly in all realistic situations, and there are no potential performance concerns unless the user posts a new comment.