### PR TITLE
Change bottom border radius on banner add-on

### DIFF
--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -154,3 +154,9 @@
 .portrait [data-control="edit"] {
   border-top-left-radius: 5px;
 }
+
+.box#profile-data .box-head {
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+}
+

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -159,4 +159,5 @@
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }
+ 
 

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -155,7 +155,7 @@
   border-top-left-radius: 5px;
 }
 
-#profile-data .box-head {
+#profile-data .box-head::before {
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -159,5 +159,3 @@
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }
- 
-

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -155,7 +155,7 @@
   border-top-left-radius: 5px;
 }
 
-.box#profile-data .box-head {
+#profile-data .box-head {
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -156,7 +156,7 @@
 }
 
 .box#profile-data .box-head {
-    border-bottom-left-radius: 10px;
-    border-bottom-right-radius: 10px;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 }
 


### PR DESCRIPTION

<!-- Please describe the changes you've made. -->

I changed the bottom border radius for banner add-on just to look more appealing to the eye. 

<!-- Why should these changes be made? -->

The two cornered radius borders look ugly in the 3.0 add-on with the banner add-on. I think it should be changed
<img width="500" src="https://user-images.githubusercontent.com/65277548/123614166-6db83b00-d847-11eb-8b27-3a12ecf3f2be.png">
Add this bit of code down below to the 3.0 add-on css file for the profile page
```css
.box#profile-data .box-head {
    border-bottom-left-radius: 10px;
    border-bottom-right-radius: 10px;
}
```
<img width="500" src="https://user-images.githubusercontent.com/65277548/123614171-6e50d180-d847-11eb-84fb-f9779a5ddb38.png">
Much better

### Tests
It works when a inspect the scratch website.
When i disable the banner and apply the code it looks normal. Nothing changed without the banner on.

@mxmou this is your add-on so I think i need approval from you first.