### PR TITLE
debugger: translatable block names and some bug fixes

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -31,7 +31,7 @@ const getNamesIdsDefaults = (blockData) => [
   blockData.args.map(() => ""),
 ];
 
-export const addBlock = (proccode, args, handler, hide) => {
+export const addBlock = (proccode, {args, callback, hidden}) => {
   if (getCustomBlock(proccode)) {
     return;
   }
@@ -41,8 +41,8 @@ export const addBlock = (proccode, args, handler, hide) => {
     secondaryColor: color.secondaryColor,
     tertiaryColor: color.tertiaryColor,
     args,
-    handler,
-    hide: !!hide,
+    handler: callback,
+    hide: !!hidden,
   };
   customBlocks[proccode] = blockData;
   customBlockParamNamesIdsDefaults[proccode] = getNamesIdsDefaults(blockData);

--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -31,20 +31,20 @@ const getNamesIdsDefaults = (blockData) => [
   blockData.args.map(() => ""),
 ];
 
-export const addBlock = (proccode, {args, callback, hidden, displayName}) => {
+export const addBlock = (proccode, { args, callback, hidden, displayName }) => {
   if (getCustomBlock(proccode)) {
     return;
   }
 
   // Make sure that the argument counts all appear to be consistent.
   // Any inconsistency may result in various strange behaviors, possibly including corruption.
-  const argumentsInProcCode = proccode.split('%').length - 1;
+  const argumentsInProcCode = proccode.split("%").length - 1;
   if (args.length !== argumentsInProcCode) {
-    throw new Error('Procedure code and argument list do not match');
+    throw new Error("Procedure code and argument list do not match");
   }
   if (displayName) {
     // Make sure that the display name has the same number of arguments as the actual procedure code
-    const argumentsInDisplayName = displayName.split('%').length - 1;
+    const argumentsInDisplayName = displayName.split("%").length - 1;
     if (argumentsInProcCode !== argumentsInDisplayName) {
       console.warn(`block displayName ${displayName} for ${proccode} has wrong number of arguments, ignoring it.`);
       displayName = proccode;
@@ -61,7 +61,7 @@ export const addBlock = (proccode, {args, callback, hidden, displayName}) => {
     args,
     handler: callback,
     hide: !!hidden,
-    displayName
+    displayName,
   };
   customBlocks[proccode] = blockData;
   customBlockParamNamesIdsDefaults[proccode] = getNamesIdsDefaults(blockData);
@@ -164,8 +164,8 @@ const injectWorkspace = (ScratchBlocks) => {
     return result;
   };
 
-  const originalCreateAllInputs = ScratchBlocks.Blocks['procedures_call'].createAllInputs_;
-  ScratchBlocks.Blocks['procedures_call'].createAllInputs_ = function (...args) {
+  const originalCreateAllInputs = ScratchBlocks.Blocks["procedures_call"].createAllInputs_;
+  ScratchBlocks.Blocks["procedures_call"].createAllInputs_ = function (...args) {
     const blockData = getCustomBlock(this.procCode_);
     if (blockData) {
       const originalProcCode = this.procCode_;

--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -31,10 +31,28 @@ const getNamesIdsDefaults = (blockData) => [
   blockData.args.map(() => ""),
 ];
 
-export const addBlock = (proccode, {args, callback, hidden}) => {
+export const addBlock = (proccode, {args, callback, hidden, displayName}) => {
   if (getCustomBlock(proccode)) {
     return;
   }
+
+  // Make sure that the argument counts all appear to be consistent.
+  // Any inconsistency may result in various strange behaviors, possibly including corruption.
+  const argumentsInProcCode = proccode.split('%').length - 1;
+  if (args.length !== argumentsInProcCode) {
+    throw new Error('Procedure code and argument list do not match');
+  }
+  if (displayName) {
+    // Make sure that the display name has the same number of arguments as the actual procedure code
+    const argumentsInDisplayName = displayName.split('%').length - 1;
+    if (argumentsInProcCode !== argumentsInDisplayName) {
+      console.warn(`block displayName ${displayName} for ${proccode} has wrong number of arguments, ignoring it.`);
+      displayName = proccode;
+    }
+  } else {
+    displayName = proccode;
+  }
+
   const blockData = {
     id: proccode,
     color: color.color,
@@ -43,6 +61,7 @@ export const addBlock = (proccode, {args, callback, hidden}) => {
     args,
     handler: callback,
     hide: !!hidden,
+    displayName
   };
   customBlocks[proccode] = blockData;
   customBlockParamNamesIdsDefaults[proccode] = getNamesIdsDefaults(blockData);
@@ -143,6 +162,19 @@ const injectWorkspace = (ScratchBlocks) => {
       };
     }
     return result;
+  };
+
+  const originalCreateAllInputs = ScratchBlocks.Blocks['procedures_call'].createAllInputs_;
+  ScratchBlocks.Blocks['procedures_call'].createAllInputs_ = function (...args) {
+    const blockData = getCustomBlock(this.procCode_);
+    if (blockData) {
+      const originalProcCode = this.procCode_;
+      this.procCode_ = blockData.displayName;
+      const ret = originalCreateAllInputs.call(this, ...args);
+      this.procCode_ = originalProcCode;
+      return ret;
+    }
+    return originalCreateAllInputs.call(this, ...args);
   };
 
   // Workspace update may be required to make category appear in flyout

--- a/addons-l10n/en/debugger.json
+++ b/addons-l10n/en/debugger.json
@@ -11,7 +11,6 @@
   "debugger/icon-warn": "Warning",
   "debugger/icon-error": "Error",
   "debugger/export-desc": "Click while holding Shift to customize export format.",
-  "debugger/block-sa-pause": "sa-pause",
   "debugger/block-breakpoint": "breakpoint",
   "debugger/block-log": "log %s",
   "debugger/block-warn": "warn %s",

--- a/addons-l10n/en/debugger.json
+++ b/addons-l10n/en/debugger.json
@@ -10,5 +10,10 @@
   "debugger/clone-of": "Clone of {spriteName}",
   "debugger/icon-warn": "Warning",
   "debugger/icon-error": "Error",
-  "debugger/export-desc": "Click while holding Shift to customize export format."
+  "debugger/export-desc": "Click while holding Shift to customize export format.",
+  "debugger/block-sa-pause": "sa-pause",
+  "debugger/block-breakpoint": "breakpoint",
+  "debugger/block-log": "log %s",
+  "debugger/block-warn": "warn %s",
+  "debugger/block-error": "error %s"
 }

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -25,16 +25,32 @@ export default async function ({ addon, global, console, msg }) {
     const pauseAddonButton = document.querySelector(".pause-btn");
     if (!pauseAddonButton || getComputedStyle(pauseAddonButton).display === "none") toggleConsole(true);
   };
-  addon.tab.addBlock("sa-pause", [], pause, true);
-  addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", [], pause);
-  addon.tab.addBlock("\u200B\u200Blog\u200B\u200B %s", ["content"], ({ content }, thread) => {
-    addItem(content, thread, "log");
+  addon.tab.addBlock("sa-pause", {
+    args: [],
+    callback: pause,
+    hidden: true
   });
-  addon.tab.addBlock("\u200B\u200Bwarn\u200B\u200B %s", ["content"], ({ content }, thread) => {
-    addItem(content, thread, "warn");
+  addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", {
+    args: [],
+    callback: pause
   });
-  addon.tab.addBlock("\u200B\u200Berror\u200B\u200B %s", ["content"], ({ content }, thread) => {
-    addItem(content, thread, "error");
+  addon.tab.addBlock("\u200B\u200Blog\u200B\u200B %s", {
+    args: ["content"],
+    callback: ({ content }, thread) => {
+      addItem(content, thread, "log");
+    }
+  });
+  addon.tab.addBlock("\u200B\u200Bwarn\u200B\u200B %s", {
+    args: ["content"],
+    callback: ({ content }, thread) => {
+      addItem(content, thread, "warn");
+    }
+  });
+  addon.tab.addBlock("\u200B\u200Berror\u200B\u200B %s", {
+    args: ["content"],
+    callback: ({ content }, thread) => {
+      addItem(content, thread, "error");
+    }
   });
 
   const consoleWrapper = Object.assign(document.createElement("div"), {

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -411,13 +411,15 @@ export default async function ({ addon, global, console, msg }) {
           }
         }
         if (text && category) {
-          const inputSpan = document.createElement("span");
-          inputSpan.textContent = text;
-          inputSpan.className = "console-variable";
-          inputSpan.dataset.category = category === "list" ? "data-lists" : category;
-          inputSpan.style.backgroundColor =
-            ScratchBlocks.Colours[category === "list" ? "data_lists" : category].primary;
-          wrapper.append(inputSpan);
+          const blocklyColor = ScratchBlocks.Colours[category === "list" ? "data_lists" : category];
+          if (blocklyColor) {
+            const inputSpan = document.createElement("span");
+            inputSpan.textContent = text;
+            inputSpan.className = "console-variable";
+            inputSpan.dataset.category = category === "list" ? "data-lists" : category;
+            inputSpan.style.backgroundColor = blocklyColor.primary;
+            wrapper.append(inputSpan);
+          }
         }
       }
     }

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -416,7 +416,11 @@ export default async function ({ addon, global, console, msg }) {
             const inputSpan = document.createElement("span");
             inputSpan.textContent = text;
             inputSpan.className = "console-variable";
-            inputSpan.dataset.category = category === "list" ? "data-lists" : category;
+            const colorCategoryMap = {
+              list: "data-lists",
+              more: "custom"
+            };
+            inputSpan.dataset.category = colorCategoryMap[category] || category;
             inputSpan.style.backgroundColor = blocklyColor.primary;
             wrapper.append(inputSpan);
           }

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -27,27 +27,32 @@ export default async function ({ addon, global, console, msg }) {
   };
   addon.tab.addBlock("sa-pause", {
     args: [],
+    displayName: msg('block-sa-pause'),
     callback: pause,
     hidden: true
   });
   addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", {
     args: [],
+    displayName: msg('block-breakpoint'),
     callback: pause
   });
   addon.tab.addBlock("\u200B\u200Blog\u200B\u200B %s", {
     args: ["content"],
+    displayName: msg('block-log'),
     callback: ({ content }, thread) => {
       addItem(content, thread, "log");
     }
   });
   addon.tab.addBlock("\u200B\u200Bwarn\u200B\u200B %s", {
     args: ["content"],
+    displayName: msg('block-warn'),
     callback: ({ content }, thread) => {
       addItem(content, thread, "warn");
     }
   });
   addon.tab.addBlock("\u200B\u200Berror\u200B\u200B %s", {
     args: ["content"],
+    displayName: msg('block-error'),
     callback: ({ content }, thread) => {
       addItem(content, thread, "error");
     }

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -27,7 +27,6 @@ export default async function ({ addon, global, console, msg }) {
   };
   addon.tab.addBlock("sa-pause", {
     args: [],
-    displayName: msg("block-sa-pause"),
     callback: pause,
     hidden: true,
   });

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -374,9 +374,20 @@ export default async function ({ addon, global, console, msg }) {
       const inputBlock = target.blocks.getBlock(inputId);
       if (inputBlock && inputBlock.opcode !== "text") {
         let text, category;
-        if (inputBlock.opcode === "data_variable" || inputBlock.opcode === "data_listcontents") {
+        if (
+          inputBlock.opcode === "data_variable" ||
+          inputBlock.opcode === "data_listcontents" ||
+          inputBlock.opcode === "argument_reporter_string_number" ||
+          inputBlock.opcode === "argument_reporter_boolean"
+        ) {
           text = Object.values(inputBlock.fields)[0].value;
-          category = inputBlock.opcode === "data_variable" ? "data" : "list";
+          if (inputBlock.opcode === "data_variable") {
+            category = "data";
+          } else if (inputBlock.opcode === "data_listcontents") {
+            category = "list";
+          } else {
+            category = "more";
+          }
         } else {
           // Try to call things like https://github.com/LLK/scratch-blocks/blob/develop/blocks_vertical/operators.js
           let jsonData;
@@ -393,6 +404,7 @@ export default async function ({ addon, global, console, msg }) {
               // ignore
             }
           }
+          // If the block has a simple message with no arguments, display it
           if (jsonData && jsonData.message0 && !jsonData.args0) {
             text = jsonData.message0;
             category = jsonData.category;

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -27,35 +27,35 @@ export default async function ({ addon, global, console, msg }) {
   };
   addon.tab.addBlock("sa-pause", {
     args: [],
-    displayName: msg('block-sa-pause'),
+    displayName: msg("block-sa-pause"),
     callback: pause,
-    hidden: true
+    hidden: true,
   });
   addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", {
     args: [],
-    displayName: msg('block-breakpoint'),
-    callback: pause
+    displayName: msg("block-breakpoint"),
+    callback: pause,
   });
   addon.tab.addBlock("\u200B\u200Blog\u200B\u200B %s", {
     args: ["content"],
-    displayName: msg('block-log'),
+    displayName: msg("block-log"),
     callback: ({ content }, thread) => {
       addItem(content, thread, "log");
-    }
+    },
   });
   addon.tab.addBlock("\u200B\u200Bwarn\u200B\u200B %s", {
     args: ["content"],
-    displayName: msg('block-warn'),
+    displayName: msg("block-warn"),
     callback: ({ content }, thread) => {
       addItem(content, thread, "warn");
-    }
+    },
   });
   addon.tab.addBlock("\u200B\u200Berror\u200B\u200B %s", {
     args: ["content"],
-    displayName: msg('block-error'),
+    displayName: msg("block-error"),
     callback: ({ content }, thread) => {
       addItem(content, thread, "error");
-    }
+    },
   });
 
   const consoleWrapper = Object.assign(document.createElement("div"), {


### PR DESCRIPTION
addon.tab.addBlock:

 - API changed to accept an object for most arguments instead of passing four of them individually (cleaner when more and more arguments get added)
 - Now accepts an optional displayName argument that allows the internal procedure code and the text that is displayed to be different when the addon is enabled.

Debugger addon:

 - Debugger block names are now translatable and can be changed without compatibility concerns
 - Fixes #2883
 - Fixes block previews for procedure arguments: https://user-images.githubusercontent.com/33787854/123903560-86eae580-d934-11eb-8c38-11f7af2ea63d.png
