### PR TITLE
editor-theme3: remove refresheditor notice

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -1,13 +1,6 @@
 {
   "name": "Customizable block colors",
   "description": "Edit block colors for each category in the editor.",
-  "info": [
-    {
-      "type": "notice",
-      "text": "Refresh the editor after enabling/disabling this theme.",
-      "id": "refresheditor"
-    }
-  ],
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"


### PR DESCRIPTION
Unless I'm missing something, this addon does not require a reload after being enabled or disabled, so remove the notice that says it does.