### PR TITLE
Enable recommended addons by default, new "featured" tag

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -42,10 +42,20 @@
     "message": "Unmute"
   },
   "recommended": {
-    "message": "Recommended"
+    "message": "Recommended",
+    "description": "Tag for single addon. Singular."
+  },
+  "recommendedGroup": {
+    "message": "Recommended",
+    "description": "Name of addon group. Plural, if possible."
   },
   "beta": {
-    "message": "Beta"
+    "message": "Beta",
+    "description": "Tag for single addon. Singular."
+  },
+  "betaGroup": {
+    "message": "Beta",
+    "description": "Name of addon group. Plural, if possible."
   },
   "danger": {
     "message": "Dangerous"
@@ -61,6 +71,14 @@
   },
   "forWebsite": {
     "message": "For website"
+  },
+  "featured": {
+    "message": "Featured",
+    "description": "Singular"
+  },
+  "featuredGroup": {
+    "message": "Featured",
+    "description": "Name of addon group. Plural, if possible."
   },
   "confirmPreset": {
     "message": "Are you sure you want to load this preset?"
@@ -246,7 +264,12 @@
     "message": "Scratch Addons is not affiliated with Scratch."
   },
   "new": {
-    "message": "New!"
+    "message": "New!",
+    "description": "Tag for single addon. Singular."
+  },
+  "newGroup": {
+    "message": "New",
+    "description": "Name of addon group. Plural, if possible."
   },
   "enabled": {
     "message": "Enabled",

--- a/addons/2d-color-picker/addon.json
+++ b/addons/2d-color-picker/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "2D color picker",
   "description": "Replaces saturation and brightness sliders with a 2D color picker. Hold Shift while dragging the cursor to change the values on a single axis.",
-  "tags": ["editor", "costumeEditor"],
+  "tags": ["editor", "costumeEditor", "featured"],
   "credits": [
     {
       "name": "Ucrash",

--- a/addons/account-settings-capitalize/addon.json
+++ b/addons/account-settings-capitalize/addon.json
@@ -7,6 +7,6 @@
       "matches": ["https://scratch.mit.edu/*"]
     }
   ],
-  "tags": ["easterEgg", "community"],
+  "tags": ["community"],
   "versionAdded": "1.9.0"
 }

--- a/addons/better-featured-project/addon.json
+++ b/addons/better-featured-project/addon.json
@@ -30,5 +30,5 @@
     }
   ],
   "versionAdded": "1.5.0",
-  "tags": ["community", "recommended", "profiles"]
+  "tags": ["community", "featured", "profiles"]
 }

--- a/addons/block-palette-icons/addon.json
+++ b/addons/block-palette-icons/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Block palette category icons",
   "description": "Adds icons inside the colored circles that identify block categories.",
-  "tags": ["editor", "codeEditor", "theme"],
+  "tags": ["editor", "codeEditor", "theme", "featured"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true,

--- a/addons/block-switching/addon.json
+++ b/addons/block-switching/addon.json
@@ -85,5 +85,5 @@
     }
   ],
   "libraries": ["scratch-blocks"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -32,7 +32,7 @@
     }
   ],
   "versionAdded": "1.14.0",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "enabledByDefault": false,
   "libraries": ["scratch-blocks"]
 }

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -21,6 +21,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor", "projectPlayer"],
+  "tags": ["editor", "projectPlayer", "featured"],
   "enabledByDefault": false
 }

--- a/addons/color-picker/addon.json
+++ b/addons/color-picker/addon.json
@@ -25,5 +25,5 @@
   ],
   "versionAdded": "1.6.0",
   "libraries": ["tinycolor2"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -44,5 +44,5 @@
     }
   ],
   "tags": ["community", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/copy-message-link/addon.json
+++ b/addons/copy-message-link/addon.json
@@ -27,5 +27,5 @@
   ],
   "versionAdded": "1.10.0",
   "tags": ["community", "comments", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/custom-block-shape/addon.json
+++ b/addons/custom-block-shape/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Custom block shape",
   "description": "Adjust the padding, corner radius, and notch height of Scratch blocks.",
-  "tags": ["editor", "codeEditor", "theme", "recommended"],
+  "tags": ["editor", "codeEditor", "theme", "featured"],
   "credits": [
     {
       "name": "SheepTester",

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Website dark mode",
   "description": "Dark theme for the Scratch website, both for 2.0 and 3.0 pages.",
-  "tags": ["community", "theme", "recommended"],
+  "tags": ["community", "theme", "featured"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/data-category-tweaks-v2/addon.json
+++ b/addons/data-category-tweaks-v2/addon.json
@@ -34,6 +34,6 @@
       "default": false
     }
   ],
-  "tags": ["editor", "codeEditor", "recommended"],
+  "tags": ["editor", "codeEditor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -24,7 +24,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "beta"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false,
   "versionAdded": "1.16.0"
 }

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -20,5 +20,5 @@
   ],
   "versionAdded": "1.12.0",
   "tags": ["editor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -22,6 +22,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor", "codeEditor", "theme"],
+  "tags": ["editor", "codeEditor", "theme", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -950,6 +950,6 @@
       }
     }
   ],
-  "tags": ["editor", "theme", "recommended"],
+  "tags": ["editor", "theme", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-messages/addon.json
+++ b/addons/editor-messages/addon.json
@@ -19,6 +19,6 @@
     }
   ],
   "versionAdded": "1.4.0",
-  "tags": ["editor", "editorMenuBar", "recommended"],
+  "tags": ["editor", "editorMenuBar", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-searchable-dropdowns/addon.json
+++ b/addons/editor-searchable-dropdowns/addon.json
@@ -22,5 +22,5 @@
   ],
   "versionAdded": "1.0.0",
   "tags": ["editor", "codeEditor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -21,7 +21,7 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor", "theme", "recommended"],
+  "tags": ["editor", "theme", "featured"],
   "versionAdded": "1.1.0",
   "enabledByDefault": false
 }

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -10,6 +10,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -135,7 +135,7 @@
       ]
     }
   ],
-  "tags": ["editor", "theme", "codeEditor", "recommended"],
+  "tags": ["editor", "theme", "codeEditor", "featured"],
   "enabledByDefault": false,
   "presets": [
     {

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -62,6 +62,6 @@
     }
   ],
   "versionAdded": "1.2.0",
-  "tags": ["community", "recommended", "profiles", "forums", "studios"],
+  "tags": ["community", "featured", "profiles", "forums", "studios"],
   "enabledByDefault": false
 }

--- a/addons/expanding-search-bar/addon.json
+++ b/addons/expanding-search-bar/addon.json
@@ -16,6 +16,6 @@
     }
   ],
   "versionAdded": "1.16.0",
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "enabledByDefault": false
 }

--- a/addons/feature-unshared/addon.json
+++ b/addons/feature-unshared/addon.json
@@ -14,6 +14,6 @@
     }
   ],
   "versionAdded": "1.4.0",
-  "tags": ["community", "profiles"],
+  "tags": ["community", "profiles", "featured"],
   "enabledByDefault": false
 }

--- a/addons/fix-pasted-scripts/addon.json
+++ b/addons/fix-pasted-scripts/addon.json
@@ -25,5 +25,5 @@
   ],
   "tags": ["editor", "recommended", "codeEditor"],
   "versionAdded": "1.15.0",
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/folders/addon.json
+++ b/addons/folders/addon.json
@@ -33,5 +33,5 @@
   ],
   "versionAdded": "1.11.0",
   "tags": ["editor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/gamepad/addon.json
+++ b/addons/gamepad/addon.json
@@ -30,7 +30,7 @@
       "id": "hide"
     }
   ],
-  "tags": ["editor", "projectPlayer", "recommended"],
+  "tags": ["editor", "projectPlayer", "featured"],
   "enabledByDefault": false,
   "versionAdded": "1.14.0",
   "dynamicEnable": true,

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -73,5 +73,5 @@
       "default": "default"
     }
   ],
-  "tags": ["editor", "codeEditor", "recommended"]
+  "tags": ["editor", "codeEditor", "featured"]
 }

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -74,7 +74,7 @@
       }
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "versionAdded": "1.2.0",
   "enabledByDefault": false
 }

--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -62,7 +62,7 @@
       ]
     }
   ],
-  "tags": ["community", "profiles"],
+  "tags": ["community", "profiles", "featured"],
   "versionAdded": "1.3.0",
   "enabledByDefault": false
 }

--- a/addons/longer-wiwo/addon.json
+++ b/addons/longer-wiwo/addon.json
@@ -14,6 +14,6 @@
     }
   ],
   "versionAdded": "1.11.0",
-  "tags": ["community", "profiles"],
+  "tags": ["community", "profiles", "featured"],
   "enabledByDefault": false
 }

--- a/addons/mediarecorder/addon.json
+++ b/addons/mediarecorder/addon.json
@@ -15,5 +15,5 @@
     }
   ],
   "versionAdded": "1.6.0",
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -18,6 +18,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "enabledByDefault": false
 }

--- a/addons/mouse-pos/addon.json
+++ b/addons/mouse-pos/addon.json
@@ -21,6 +21,6 @@
       "matches": ["https://scratch.mit.edu/projects/*"]
     }
   ],
-  "tags": ["editor", "projectPlayer", "recommended"],
+  "tags": ["editor", "projectPlayer", "featured"],
   "enabledByDefault": false
 }

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -14,5 +14,6 @@
     }
   ],
   "versionAdded": "1.7.0",
-  "tags": ["editor", "projectPlayer", "recommended"]
+  "tags": ["editor", "projectPlayer", "recommended"],
+  "enabledByDefault": true
 }

--- a/addons/onion-skinning/addon.json
+++ b/addons/onion-skinning/addon.json
@@ -106,5 +106,5 @@
   "tags": ["editor", "costumeEditor", "recommended"],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -32,5 +32,5 @@
     }
   ],
   "tags": ["editor", "projectPlayer", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -35,5 +35,5 @@
   ],
   "versionAdded": "1.0.0",
   "tags": ["editor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Sprite and script count",
   "description": "Shows the number of sprites and scripts a project has.",
-  "tags": ["community", "projectPage"],
+  "tags": ["community", "projectPage", "featured"],
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/project-notes-tabs/addon.json
+++ b/addons/project-notes-tabs/addon.json
@@ -21,6 +21,6 @@
     }
   ],
   "versionAdded": "1.4.0",
-  "tags": ["community", "projectPage"],
+  "tags": ["community", "projectPage", "featured"],
   "enabledByDefault": false
 }

--- a/addons/redirect-mobile-forums/addon.json
+++ b/addons/redirect-mobile-forums/addon.json
@@ -15,6 +15,6 @@
     }
   ],
   "versionAdded": "1.16.0",
-  "tags": ["community", "forums", "easterEgg"],
+  "tags": ["community", "forums"],
   "enabledByDefault": false
 }

--- a/addons/remix-tree-button/addon.json
+++ b/addons/remix-tree-button/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Remix tree button on project pages",
   "description": "Brings back the remix tree button to project pages.",
-  "tags": ["community", "recommended", "projectPage"],
+  "tags": ["community", "featured", "projectPage"],
   "credits": [
     {
       "name": "Ucrash",

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -8,6 +8,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["editor", "recommended"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/scratch-notifier/addon.json
+++ b/addons/scratch-notifier/addon.json
@@ -103,6 +103,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["community", "recommended"],
+  "tags": ["community", "featured"],
   "enabledByDefault": false
 }

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -2,6 +2,7 @@
   "name": "Scratch 2.0 \u2192 3.0",
   "description": "Makes Scratch 2.0-styled pages look like Scratch 3.0.",
   "tags": ["community", "theme", "recommended"],
+  "enabledByDefault": true,
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/search-profile/addon.json
+++ b/addons/search-profile/addon.json
@@ -11,5 +11,5 @@
   "credits": [{ "name": "Geotale" }, { "name": "pufferfish101007" }],
   "tags": ["community", "recommended", "profiles"],
   "versionAdded": "1.1.0",
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -22,6 +22,6 @@
     }
   ],
   "versionAdded": "1.11.0",
-  "tags": ["editor", "recommended"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false
 }

--- a/webpages/settings/components/addon-tag.html
+++ b/webpages/settings/components/addon-tag.html
@@ -10,7 +10,8 @@
       'darkred': tagInfo.color === 'darkred',
       'green': tagInfo.color === 'green',
       'darkgreen': tagInfo.color === 'darkgreen',
-      'purple': tagInfo.color === 'purple'
+      'purple': tagInfo.color === 'purple',
+      'lightblue': tagInfo.color === 'lightblue'
       }"
   >
     {{ tagName }}

--- a/webpages/settings/data/addon-groups.js
+++ b/webpages/settings/data/addon-groups.js
@@ -28,7 +28,7 @@ export default [
 
   {
     id: "new",
-    name: chrome.i18n.getMessage("new"),
+    name: chrome.i18n.getMessage("newGroup"),
     addonIds: [],
     expanded: true,
     iframeShow: false,
@@ -44,7 +44,15 @@ export default [
   },
   {
     id: "recommended",
-    name: chrome.i18n.getMessage("recommended"),
+    name: chrome.i18n.getMessage("recommendedGroup"),
+    addonIds: [],
+    expanded: true,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
+  {
+    id: "featured",
+    name: chrome.i18n.getMessage("featuredGroup"),
     addonIds: [],
     expanded: true,
     iframeShow: false,
@@ -59,8 +67,16 @@ export default [
     fullscreenShow: true,
   },
   {
+    id: "forums",
+    name: chrome.i18n.getMessage("forums"),
+    addonIds: [],
+    expanded: false,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
+  {
     id: "beta",
-    name: chrome.i18n.getMessage("beta"),
+    name: chrome.i18n.getMessage("betaGroup"),
     addonIds: [],
     expanded: false,
     iframeShow: false,

--- a/webpages/settings/data/tags.js
+++ b/webpages/settings/data/tags.js
@@ -14,6 +14,11 @@ export default [
     color: "blue",
   },
   {
+    name: "featured",
+    matchName: "featured",
+    color: "yellow",
+  },
+  {
     name: "new",
     matchName: "new",
     color: "purple",
@@ -42,7 +47,7 @@ export default [
   {
     name: "forWebsite",
     matchName: "community",
-    color: "yellow",
+    color: "lightblue",
     addonTabShow: {
       theme: true,
     },

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -522,6 +522,8 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
       else {
         // Addon is disabled
         if (manifest.tags.includes("recommended")) manifest._groups.push("recommended");
+        else if (manifest.tags.includes("featured")) manifest._groups.push("featured");
+        else if (manifest.tags.includes("forums")) manifest._groups.push("forums");
         else if (manifest.tags.includes("beta") || manifest.tags.includes("danger")) manifest._groups.push("beta");
         else manifest._groups.push("others");
       }

--- a/webpages/styles/components/badges.css
+++ b/webpages/styles/components/badges.css
@@ -42,6 +42,11 @@
   background: rgb(177, 23, 248);
   border-color: #b20eb8;
 }
+.badge.lightblue {
+  background: #6CD4FF;
+  border-color: #5cb4da;
+  color: #333;
+}
 .filter-option.sel.blue {
   background: #175ef8;
 }

--- a/webpages/styles/components/badges.css
+++ b/webpages/styles/components/badges.css
@@ -43,7 +43,7 @@
   border-color: #b20eb8;
 }
 .badge.lightblue {
-  background: #6CD4FF;
+  background: #6cd4ff;
   border-color: #5cb4da;
   color: #333;
 }


### PR DESCRIPTION
Resolves #2617

- Create featured tag
- Use yellow color for featured tag
- Use new lightblue color for "for website" tag, that previously used the yellow
- Create featured addon group
- Create forums addon group, and have it unexpanded by default. This makes the "others" addon group cleaner. We have around 10 forum addons, and most of our users will never use them.
- Rename `New!` addon group to `New`. Tag is still called `New!`. Allow translators to use plurals in languages that support it (example: Spanish `recomendados` will be the addon group name, and `recomendado` will continue to be the tag).

Note that addons that say "enabled by default" will only be enabled by default for new users.

\- 2d-color-picker: others → featured (changes UI, cannot be recommended)
\- account-settings-capitalize: easter egg → others (small addon)
\- better-featured-project: recommended → featured (widely used, cannot be recommended)
\- block-pallete-icons: others → featured (widely used)
**\- block-switching: enable by default** (scratch 2.0 feature, was already recommended)
\- cat-blocks: others → featured (widely used)
\- clones: others → featured (widely used)
**\- color-picker: enable by default** (useful, additive, was already recommended)
**\- confirm-actions: enable by default** (only setting enabled by default is confirming sharing projects, others require optin)
**\- copy-message-link: enable by default** (useful, additive, was already recommended)
\- custom-block-shape: recommended → featured (used to achieve 2.0 looks, cannot be recommended)
\- dark-www: recommended → featured (widely used, cannot be recommended)
\- data-category-tweaks-v2: recommended → featured (scratch 2.0 feature, cannot be recommended)
\- debugger: beta → featured (useful)
**\- drag-drop: enable by default** (useful, additive, was already recommended)
\- editor-colored-context-menus: others → featured (scratch 2.0 feature)
\- editor-dark-mode: recommended → featured (widely used, cannot be recommended)
\- editor-messages: recommended → featured (widely used, cannot be recommended because it might be annoying/distracting to the user)
**\- editor-searchable-dropdowns: enable by default** (useful, additive, was already recommended)
\- editor-stage-left: recommended → featured (scratch 2.0 feature, cannot be recommended)
\- editor-stepping: others → featured (useful)
\- editor-theme3: recommended → featured (used to achieve 2.0 looks, cannot be recommended)
\- exact-count: recommended → featured (useful, cannot be recommended)
\- expanding-search-bar: others → featured (useful, scratch wiki feature)
\- feature-unshared: others → featured (useful, hacky)
**\- fix-pasted-scripts: enable by default** (fixes vanilla Scratch bug, was already recommended)
**\- folders: enable by default** (useful, additive, was already recommended)
\- gamepad: recommended → featured (gamepad is niche, cannot be recommended)
\- hide-flyout: recommended → featured (useful, widely used, cannot be recommended)
\- infinite-scroll: others → featured (widely used)
\- live-featured-project: others → featured (scratch 2.0 feature)
\- longer-wiwo: others → featured (useful, hacky)
**\- mediarecorder: enable by default** (we might to wait until we clean up the editor menu bar before turning this by default)
\- more-links: others → featured (useful, cannot be recommended because of security issues)
\- mouse-pos: recommended → featured (cannot be recommended, can be distracting)
**\- mute-project: enable by default** (scratch 2.0 feature, was already recommended)
**\- onion-skinning: enable by default** (useful, additive, was already recommended)
**\- pause: enable by default** (useful, additive, widely used, was already recommended)
**\- progress-bar: enable by default** (useful, additive, was already recommended)
\- project-info: others → featured (scratch 2.0 feature)
\- project-notes-tabs: others → featured (scratch 2.0 feature)
\- redirect-mobile-forums: easter egg → forums
\- remix-tree-button: others → featured (scratch 2.0 feature, might cause overflow)
\- remove-sprite-confirm: recommended → featured (cannot be enabled by default, might be annoying)
\- scratch-notifier: recommended → featured (cannot be enabled by default, annoying + permission issues)
**\- scratchr2: enable by default** (not entirely 100% sure about this one, but I feel it makes sense to enable UI consistency by default)
**\- search-profile: enable by default** (useful, additive, was already recommended)
\- variable-manager: recommended → featured (technically additive, but adding a whole editor tab by default doesn't sound right)

New users will get this on the settings page after installing:
![image](https://user-images.githubusercontent.com/17484114/124398939-c461c100-dcee-11eb-9166-b04fc92dc33a.png)
We could probably show the featured group as a grid, to incentivize users to enable them and show a screenshot of the addon in action.
If the user disables a recommended addon, the recommended addon group comes back.