### PR TITLE
Fix #2557

### DIFF
--- a/addons/load-extensions/userscript.js
+++ b/addons/load-extensions/userscript.js
@@ -1,10 +1,18 @@
 export default async function ({ addon, global, console }) {
-  // IDs are taken from https://github.com/LLK/scratch-vm/blob/ffa78b91b8645b6a8c80f698a3637bb73abf2931/src/extension-support/extension-manager.js#L11
-  const Extensions = ["music", "pen", "text2speech", "translate"];
-  for (let ext of Extensions) {
-    // Check if setting enabled and it's not already loaded
-    if (addon.settings.get(ext) && !addon.tab.traps.vm.extensionManager.isExtensionLoaded(ext)) {
-      addon.tab.traps.vm.extensionManager.loadExtensionIdSync(ext);
+  const vm = addon.tab.traps.vm;
+  const loadExtensions = () => {
+    // IDs are taken from https://github.com/LLK/scratch-vm/blob/ffa78b91b8645b6a8c80f698a3637bb73abf2931/src/extension-support/extension-manager.js#L11
+    const EXTENSIONS = ["music", "pen", "text2speech", "translate"];
+    for (let ext of EXTENSIONS) {
+      // Check if setting enabled and it's not already loaded
+      if (addon.settings.get(ext) && !vm.extensionManager.isExtensionLoaded(ext)) {
+        vm.extensionManager.loadExtensionIdSync(ext);
+      }
     }
+  };
+  if (vm.editingTarget) {
+    loadExtensions();
+  } else {
+    vm.runtime.once("PROJECT_LOADED", loadExtensions);
   }
 }


### PR DESCRIPTION
Fixes #2557

Was caused by load-extensions trying to load the music extension before scratch-audio is set up (racey)

![chrome_NYvesAfeSq](https://user-images.githubusercontent.com/33787854/124660274-9eadf680-de6b-11eb-8e8b-0a2976061173.png)
