### PR TITLE
editor-messages: add support for browser containers

### DIFF
--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -15,7 +15,7 @@ export default async function ({ addon, global, console, msg }) {
     );
     const msgCount = Number(msgRes.count);
     messageCount.innerText = msgCount;
-    if (msgCount === 0 || msgCount === 'NaN') {
+    if (msgCount === 0 || msgCount === "NaN") {
       messageCount.setAttribute("style", `display: none;`);
     } else {
       messageCount.setAttribute("style", "");

--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -15,7 +15,7 @@ export default async function ({ addon, global, console, msg }) {
     );
     const msgCount = Number(msgRes.count);
     messageCount.innerText = msgCount;
-    if (msgCount === 0) {
+    if (msgCount === 0 || msgCount === 'NaN') {
       messageCount.setAttribute("style", `display: none;`);
     } else {
       messageCount.setAttribute("style", "");

--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -10,7 +10,9 @@ export default async function ({ addon, global, console, msg }) {
   messages.appendChild(messageCount);
   const setMessages = async () => {
     let user = document.querySelector("[class*='account-nav_profile-name']").innerHTML;
-    let msgRes = await fetch(`https://api.scratch.mit.edu/users/${user}/messages/count`).then(response => response.json());
+    let msgRes = await fetch(`https://api.scratch.mit.edu/users/${user}/messages/count`).then((response) =>
+      response.json()
+    );
     const msgCount = Number(msgRes.count);
     messageCount.innerText = msgCount;
     if (msgCount === 0) {

--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -9,7 +9,9 @@ export default async function ({ addon, global, console, msg }) {
   messageCount.classList.add("sa-editormessages-count");
   messages.appendChild(messageCount);
   const setMessages = async () => {
-    const msgCount = Number(await addon.account.getMsgCount());
+    let user = document.querySelector("[class*='account-nav_profile-name']").innerHTML;
+    let msgRes = await fetch(`https://api.scratch.mit.edu/users/${user}/messages/count`).then(response => response.json());
+    const msgCount = Number(msgRes.count);
     messageCount.innerText = msgCount;
     if (msgCount === 0) {
       messageCount.setAttribute("style", `display: none;`);


### PR DESCRIPTION
The current implementation of the addon gets the message count from the account that the messaging extension is signed in to. This works fine for most cases, but when Firefox's containers feature is utilized to sign in to an alt account, the message count does not show the correct number.

### Changes
The addon now determines which user is signed in to the editor tab and makes a direct API call to Scratch to get the message count.

### Reason for changes
An incorrect message count shouldn't be displayed near the alt's username:

![image](https://user-images.githubusercontent.com/43426138/124849737-eebcb400-df64-11eb-87ad-7eaa85d9c114.png)

### Tests
Tested in Chromium when signed in and when signed out.
Tested in Firefox across containers.