### PR TITLE
Add old studio layout addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -92,5 +92,6 @@
   "editor-theme3",
   "// For website:",
   "scratchr2",
-  "dark-www"
+  "dark-www",
+  "old-studio-layout"
 ]

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -37,6 +37,7 @@ body:not(.sa-body-editor) .join-flow-title,
 .studio-page,
 .user-projects-modal .user-projects-modal-content {
   background: #252c37;
+  --sa-oldstudio-background: #202020;
 }
 #view,
 .crash-container,
@@ -241,4 +242,36 @@ body:not(.sa-body-editor) .select select option,
 .monitor_label_ci1ok, /* for some strange reason, variable names inherit their color from the body, unlike list title names */
 .monitor_list-empty_1UKsB {
   color: #575e75;
+}
+
+.studio-info,
+.studio-tabs {
+  --sa-oldstudio-default-background: #333333;
+  --sa-oldstudio-default-border: #606060;
+  --sa-oldstudio-default-inner-border: transparent;
+}
+.studio-tab-nav {
+  --sa-oldstudio-scratchr2-background: #282828;
+}
+.sub-nav li {
+  --sa-oldstudio-scratchr2-hover-border: rgba(255, 255, 255, 0.2);
+}
+.studio-tab-nav .active > li,
+.studio-tab-nav a.active.nav_link:hover > li {
+  --sa-oldstudio-default-background: #282828;
+  --sa-oldstudio-text: white;
+  --sa-oldstudio-icon-filter: none;
+}
+.studio-tabs > div:not(.studio-tab-nav) {
+  --sa-oldstudio-default-background: #282828;
+}
+.studio-adder-section .studio-adder-row button ~ button /* browse projects */ {
+  --sa-oldstudio-background: #282828;
+  --sa-oldstudio-border: #606060;
+  --sa-oldstudio-text: white;
+  --sa-oldstudio-icon-filter: none;
+}
+.replies.collapsed > .comment:last-of-type::after {
+  --sa-oldstudio-collapsed-gradient: linear-gradient(rgba(32, 32, 32, 0), #202020);
+  --sa-oldstudio-default-collapsed-gradient: linear-gradient(rgba(40, 40, 40, 0), #282828);
 }

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -1,0 +1,70 @@
+{
+  "name": "Old studio layout",
+  "description": "Reverts the layout of the studio page back to the one used before the studio update or the one previously available as part of the Scratch 2.0 \u2192 3.0 addon.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "This addon doesn't work well on mobile devices and in small windows.",
+      "id": "mobile"
+    }
+  ],
+  "tags": ["community", "theme"],
+  "credits": [
+    {
+      "name": "Maximouse",
+      "link": "https://scratch.mit.edu/users/Maximouse/"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "injectAsStyleElt": true,
+  "updateUserstylesOnSettingsChange": true,
+  "versionAdded": "1.17.0",
+  "userscripts": [
+    {
+      "url": "classes.js",
+      "matches": ["https://scratch.mit.edu/studios/*"],
+      "runAtComplete": false
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "style.css",
+      "matches": ["https://scratch.mit.edu/studios/*"]
+    },
+    {
+      "url": "default.css",
+      "matches": ["https://scratch.mit.edu/studios/*"],
+      "settingMatch": {
+        "id": "version",
+        "value": "default"
+      }
+    },
+    {
+      "url": "scratchr2.css",
+      "matches": ["https://scratch.mit.edu/studios/*"],
+      "settingMatch": {
+        "id": "version",
+        "value": "scratchr2"
+      }
+    }
+  ],
+  "settings": [
+    {
+      "id": "version",
+      "type": "select",
+      "name": "Version",
+      "potentialValues": [
+        {
+          "id": "default",
+          "name": "Default"
+        },
+        {
+          "id": "scratchr2",
+          "name": "Scratch 2.0 \u2192 3.0"
+        }
+      ],
+      "default": "default"
+    }
+  ]
+}

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -8,7 +8,7 @@
       "id": "mobile"
     }
   ],
-  "tags": ["community", "theme"],
+  "tags": ["community", "theme", "studios"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/old-studio-layout/classes.js
+++ b/addons/old-studio-layout/classes.js
@@ -1,0 +1,16 @@
+export default async function({ addon, console }) {
+  addon.tab.waitForElement("#navigation .login-item").then(() => {
+    addon.tab.waitForElement(".studio-page").then((page) => {
+      page.classList.add("sa-oldstudio-logged-out");
+      addon.tab.waitForElement("#navigation .account-nav").then(() => {
+        /* user signed back in - this is possible without reloading the page */
+        addon.tab.waitForElement(".studio-page").then((page) => {
+          page.classList.remove("sa-oldstudio-logged-out");
+        });
+      });
+    });
+  });
+  addon.tab.waitForElement(".studio-follow-button").then((followButton) => {
+    followButton.parentElement.classList.add("sa-oldstudio-follow-section");
+  });
+}

--- a/addons/old-studio-layout/classes.js
+++ b/addons/old-studio-layout/classes.js
@@ -1,4 +1,4 @@
-export default async function({ addon, console }) {
+export default async function ({ addon, console }) {
   addon.tab.waitForElement("#navigation .login-item").then(() => {
     addon.tab.waitForElement(".studio-page").then((page) => {
       page.classList.add("sa-oldstudio-logged-out");

--- a/addons/old-studio-layout/default.css
+++ b/addons/old-studio-layout/default.css
@@ -9,7 +9,7 @@
   box-shadow: 0 1px 0 inset var(--sa-oldstudio-default-inner-border, white);
 }
 .studio-info {
-  margin-top: 116px;
+  margin-top: 88px;
   padding: 10px;
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
@@ -17,7 +17,7 @@
 .studio-tabs {
   display: flex;
   flex-direction: column;
-  padding-top: 93px;
+  padding-top: 65px;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
 }
@@ -31,18 +31,14 @@
   right: 10px;
 }
 .studio-info .studio-info-footer-stats > div:nth-child(2) /* follower count */ {
-  top: 55px;
+  top: 31px;
   right: 10px;
 }
 .sa-oldstudio-logged-out .studio-info {
   margin-top: 98px;
 }
-.sa-oldstudio-logged-out .studio-tabs {
-  padding-top: 75px;
-}
 .sa-oldstudio-logged-out .studio-info .studio-info-footer-stats > div:nth-child(2) {
-  top: 17px;
-  width: auto;
+  top: 21px;
 }
 .studio-tab-nav {
   margin: 0;

--- a/addons/old-studio-layout/default.css
+++ b/addons/old-studio-layout/default.css
@@ -1,0 +1,89 @@
+.studio-page #view .studio-shell {
+  gap: 0;
+  grid-template-columns: 270px minmax(0, 1fr);
+}
+.studio-info,
+.studio-tabs {
+  background-color: var(--sa-oldstudio-default-background, #f2f2f2);
+  border: 1px solid var(--sa-oldstudio-default-border, #d9d9d9);
+  box-shadow: 0 1px 0 inset var(--sa-oldstudio-default-inner-border, white);
+}
+.studio-info {
+  margin-top: 116px;
+  padding: 10px;
+  border-top-left-radius: 10px;
+  border-bottom-left-radius: 10px;
+}
+.studio-tabs {
+  display: flex;
+  flex-direction: column;
+  padding-top: 93px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+.studio-info-section:first-child /* title */ {
+  top: 10px;
+  left: 280px;
+  width: calc(100% - 510px);
+}
+.studio-info .sa-oldstudio-follow-section {
+  top: 10px;
+  right: 10px;
+}
+.studio-info .studio-info-footer-stats > div:nth-child(2) /* follower count */ {
+  top: 55px;
+  right: 10px;
+}
+.sa-oldstudio-logged-out .studio-info {
+  margin-top: 98px;
+}
+.sa-oldstudio-logged-out .studio-tabs {
+  padding-top: 75px;
+}
+.sa-oldstudio-logged-out .studio-info .studio-info-footer-stats > div:nth-child(2) {
+  top: 17px;
+  width: auto;
+}
+.studio-tab-nav {
+  margin: 0;
+  padding: 0 10px;
+  box-sizing: border-box;
+  border-color: var(--sa-oldstudio-default-border, #d9d9d9);
+}
+.studio-tab-nav li {
+  position: relative;
+  top: 1px;
+  margin-top: 0;
+  margin-bottom: 0;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  background: transparent;
+  border-color: transparent;
+}
+.studio-tab-nav a.nav_link:hover > li,
+.studio-tab-nav li:active {
+  background-color: var(--sa-oldstudio-default-border, #d9d9d9);
+  border: 1px solid transparent;
+}
+.studio-tab-nav .active > li,
+.studio-tab-nav a.active.nav_link:hover > li {
+  background-color: var(--sa-oldstudio-default-background, white);
+  border-color: var(--sa-oldstudio-default-border, #d9d9d9);
+  border-bottom-color: var(--sa-oldstudio-default-background, white);
+  color: var(--sa-oldstudio-text, #575e75);
+}
+.studio-tab-nav .active > li img,
+.studio-tab-nav a.active.nav_link:hover > li img {
+  filter: var(--sa-oldstudio-icon-filter, invert(0.55));
+}
+.studio-tabs > div:not(.studio-tab-nav) {
+  flex-grow: 1;
+  padding: 10px;
+  padding-top: 0;
+  background-color: var(--sa-oldstudio-default-background, white);
+}
+.replies.collapsed > .comment:last-of-type::after {
+  background-image: var(--sa-oldstudio-default-collapsed-gradient, linear-gradient(rgba(255, 255, 255, 0), white));
+}

--- a/addons/old-studio-layout/scratchr2.css
+++ b/addons/old-studio-layout/scratchr2.css
@@ -1,0 +1,61 @@
+.studio-page #view .studio-shell {
+  padding-top: 93px;
+  grid-template-columns: 250px minmax(0, 1fr);
+}
+.studio-info-section:first-child /* title */ {
+  top: 0;
+  left: 0;
+  width: calc(100% - 220px);
+}
+.studio-info .studio-title {
+  font-weight: 500;
+}
+.studio-info .sa-oldstudio-follow-section {
+  top: 0;
+  right: 0;
+}
+.studio-info .studio-info-footer-stats > div:nth-child(2) /* follower count */ {
+  top: 45px;
+  right: 0;
+}
+.sa-oldstudio-logged-out #view .studio-shell {
+  padding-top: 65px;
+}
+.sa-oldstudio-logged-out .studio-info .studio-info-footer-stats > div:nth-child(2) {
+  top: 7px;
+  width: auto;
+}
+.studio-tab-nav {
+  margin: 0;
+  padding: 0;
+  background-color: var(--sa-oldstudio-scratchr2-background, white);
+  border: none;
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.25);
+}
+.sub-nav.sub-nav-align-left {
+  justify-content: center;
+}
+.sub-nav li,
+.studio-tab-nav a.nav_link:not(.active) > li {
+  margin: 0;
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  border-radius: 0;
+}
+.studio-tab-nav a.nav_link:hover > li,
+.sub-nav li:active {
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid var(--sa-oldstudio-scratchr2-hover-border, rgba(0, 0, 0, 0.2));
+}
+.studio-tab-nav .active > li,
+.studio-tab-nav a.active.nav_link:hover > li {
+  background: transparent;
+  border-color: #0fbd8c;
+  color: var(--sa-oldstudio-text, #575e75);
+}
+.studio-tab-nav .active > li img,
+.studio-tab-nav a.active.nav_link:hover > li img {
+  filter: var(--sa-oldstudio-icon-filter, invert(0.55));
+}

--- a/addons/old-studio-layout/scratchr2.css
+++ b/addons/old-studio-layout/scratchr2.css
@@ -1,5 +1,5 @@
 .studio-page #view .studio-shell {
-  padding-top: 93px;
+  padding-top: 65px;
   grid-template-columns: 250px minmax(0, 1fr);
 }
 .studio-info-section:first-child /* title */ {
@@ -15,15 +15,11 @@
   right: 0;
 }
 .studio-info .studio-info-footer-stats > div:nth-child(2) /* follower count */ {
-  top: 45px;
+  top: 21px;
   right: 0;
 }
-.sa-oldstudio-logged-out #view .studio-shell {
-  padding-top: 65px;
-}
 .sa-oldstudio-logged-out .studio-info .studio-info-footer-stats > div:nth-child(2) {
-  top: 7px;
-  width: auto;
+  top: 11px;
 }
 .studio-tab-nav {
   margin: 0;

--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -21,6 +21,10 @@
   position: absolute;
   width: 200px;
 }
+.studio-info .studio-follow-button {
+  padding-top: 4px;
+  padding-bottom: 24px;
+}
 .sa-leave-section {
   grid-area: 3 / 1 / 4 / 2; /* below footer */
 }
@@ -51,9 +55,16 @@
 }
 .studio-info .studio-info-footer-stats > div:nth-child(2) /* follower count */ {
   position: absolute;
-  margin-right: 0;
+  margin: 0;
+}
+.studio-page:not(.sa-oldstudio-logged-out) .studio-info .studio-info-footer-stats > div:nth-child(2) {
   width: 200px;
   justify-content: center;
+  font-size: 14px;
+  color: var(--scratchr2-primaryColor-text, white);
+}
+.studio-page:not(.sa-oldstudio-logged-out) .studio-info .studio-info-footer-stats > div:nth-child(2) img {
+  filter: var(--scratchr2-primaryColor-reverseFilter, brightness(0) invert(1));
 }
 .studio-info .studio-info-footer-report button {
   margin: 0.25em;

--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -1,0 +1,163 @@
+.studio-page {
+  background-color: var(--sa-oldstudio-background, #fcfcfc);
+}
+.studio-page #view {
+  max-width: 942px;
+}
+.studio-page #view .studio-shell {
+  padding: 0;
+  position: relative;
+}
+.studio-info-section:first-child /* title */ {
+  position: absolute;
+  line-height: 45px;
+}
+.studio-info textarea.studio-title {
+  width: 100%;
+  height: 45px;
+  line-height: 30px;
+}
+.studio-info .sa-oldstudio-follow-section {
+  position: absolute;
+  width: 200px;
+}
+.sa-leave-section {
+  grid-area: 3 / 1 / 4 / 2; /* below footer */
+}
+.studio-info,
+.studio-info .studio-description,
+.studio-info textarea.studio-description {
+  width: 250px;
+}
+.studio-info .studio-image {
+  width: 250px;
+  height: 147px;
+}
+.studio-thumb-edit-img {
+  padding: 0 0.25em;
+}
+.studio-info .studio-description {
+  font-size: 13px;
+}
+.studio-info .studio-description.uneditable {
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+}
+.studio-info .studio-info-footer {
+  grid-area: 2 / 1 / 3 / 2;
+  flex-direction: column-reverse;
+}
+.studio-info .studio-info-footer-stats > div:nth-child(2) /* follower count */ {
+  position: absolute;
+  margin-right: 0;
+  width: 200px;
+  justify-content: center;
+}
+.studio-info .studio-info-footer-report button {
+  margin: 0.25em;
+  padding: 0;
+  background: transparent;
+  color: var(--scratchr2-linkColor, #4d97ff);
+  font-size: 1em;
+  font-weight: bold;
+}
+.studio-info .studio-info-footer-report button:hover {
+  background: transparent;
+  color: var(--scratchr2-activeColor, #4280d7);
+}
+.studio-info .studio-info-footer-report button img {
+  filter: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><filter id='recolor'><feColorMatrix values='0 0 0 0 0.3 0 0 0 0 0.59 0 0 0 0 1 0 0 0 1 0'/></filter></svg>#recolor");
+  margin-right: 0.25em;
+}
+.studio-info .studio-info-footer-report button:hover img {
+  filter: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><filter id='recolor'><feColorMatrix values='0 0 0 0 0.26 0 0 0 0 0.5 0 0 0 0 0.84 0 0 0 1 0'/></filter></svg>#recolor");
+}
+.studio-tab-nav li img {
+  height: 1.5em;
+}
+.studio-adder-section .studio-adder-row .studio-adder-vertical-divider {
+  display: none;
+}
+.studio-adder-section .studio-adder-row button ~ button /* browse projects */ {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 15;
+  background-color: var(--sa-oldstudio-background, white);
+  border-top: 1px solid var(--sa-oldstudio-border, #d9d9d9);
+  border-radius: 0;
+  color: var(--sa-oldstudio-text, #575e75);
+  text-align: left;
+}
+.overflow-menu-container .overflow-menu-dropdown {
+  z-index: 20; /* above adder row */
+}
+.studio-adder-section .studio-adder-row button ~ button::before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 8px;
+  width: 20px;
+  height: 20px;
+  background: url(/images/dropdown.png) no-repeat center center;
+  background-size: 50%;
+  filter: var(--sa-oldstudio-icon-filter, brightness(0.4));
+  transform: scaleY(-1);
+}
+.user-projects-modal {
+  position: fixed;
+  bottom: 46px;
+  left: 0;
+  margin: 0;
+  width: 100%;
+  height: unset;
+  border-radius: 0;
+  box-shadow: none;
+}
+.user-projects-modal .user-projects-modal-title {
+  padding-left: 30px;
+  border-radius: 0;
+  text-align: left;
+}
+.user-projects-modal .user-projects-modal-nav {
+  position: absolute;
+  top: 0;
+  right: 3rem;
+  padding: 1px 0;
+  border: none;
+}
+.user-projects-modal .user-projects-modal-nav button {
+  background: transparent;
+  color: white;
+}
+.user-projects-modal .user-projects-modal-nav button:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+.user-projects-modal .user-projects-modal-nav button:active {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+.user-projects-modal .user-projects-modal-nav button.active {
+  background-color: white;
+  color: #575e75;
+}
+.user-projects-modal .user-projects-modal-content {
+  height: 150px;
+}
+@media (min-height: 500px) {
+  .user-projects-modal .user-projects-modal-content {
+    height: 250px;
+  }
+}
+.user-projects-modal-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+.user-projects-modal .studio-projects-done-row {
+  display: none;
+}
+.replies.collapsed > .comment:last-of-type::after {
+  background-image: var(--sa-oldstudio-collapsed-gradient, linear-gradient(rgba(252, 252, 252, 0), #fcfcfc));
+}

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -46,6 +46,18 @@
       }
     },
     {
+      "name": "primaryColor-reverseFilter",
+      "value": {
+        "type": "textColor",
+        "black": "none",
+        "white": "brightness(0) invert(1)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "primaryColor"
+        }
+      }
+    },
+    {
       "name": "activeColor-text",
       "value": {
         "type": "textColor",

--- a/addons/studio-tools/migrated.js
+++ b/addons/studio-tools/migrated.js
@@ -3,7 +3,7 @@ export default async ({ addon, console, msg }) => {
   const studioId = redux.state.studio.id;
 
   const MAX_MANAGERS = 40;
-  
+
   let isOwner = false;
   let isManager = false;
   let isCurator = false;

--- a/addons/studio-tools/migrated.js
+++ b/addons/studio-tools/migrated.js
@@ -1,12 +1,20 @@
 export default async ({ addon, console, msg }) => {
   const { redux } = addon.tab;
-  const isOwner = redux.state.studio.owner === redux.state.session.session?.user?.id;
-  const isManager = redux.state.studio.manager || isOwner;
-  const isCurator = redux.state.studio.curator;
-  const canLeave = (isCurator || isManager) && !isOwner;
   const studioId = redux.state.studio.id;
 
   const MAX_MANAGERS = 40;
+  
+  let isOwner = false;
+  let isManager = false;
+  let isCurator = false;
+  let canLeave = false;
+  const checkPermissions = () => {
+    isOwner = redux.state.studio.owner === redux.state.session.session?.user?.id;
+    isManager = redux.state.studio.manager || isOwner;
+    isCurator = redux.state.studio.curator;
+    canLeave = (isCurator || isManager) && !isOwner;
+  };
+  checkPermissions();
 
   const makeAdder = (headerMsg, btnMsg, cb, optDisable) => {
     const disabledMessage = optDisable && optDisable();
@@ -138,7 +146,7 @@ export default async ({ addon, console, msg }) => {
     if (canLeave) {
       /*<button class="button x-button studio-follow-button"><span>Follow Studio</span></button>*/
       leaveSection = document.createElement("div");
-      leaveSection.className = "studio-info-section";
+      leaveSection.className = "studio-info-section sa-leave-section";
 
       let leaveBtn = document.createElement("button");
       leaveBtn.className = "button sa-leave-button";
@@ -171,4 +179,10 @@ export default async ({ addon, console, msg }) => {
   };
   render();
   addon.tab.addEventListener("urlChange", render);
+  redux.addEventListener("statechanged", (e) => {
+    if (e.detail.action.type == "SET_ROLES") {
+      checkPermissions();
+      render();
+    }
+  });
 };


### PR DESCRIPTION
Resolves #2935

### Changes

Adds an addon that reverts studios to either the old design or the 2.0 → 3.0 design. Adjusts studio-tools for compatibility with the added addon and attempts to fix a bug causing the leave button to not always appear.

### Screenshots

Default:
![image](https://user-images.githubusercontent.com/51849865/124927894-6808e500-dfff-11eb-8e3b-4e6c3d60703a.png)

Scratch 2.0 → 3.0:
![image](https://user-images.githubusercontent.com/51849865/124928114-9edefb00-dfff-11eb-98b2-ba75cebf6e1c.png)

Adding projects:
![image](https://user-images.githubusercontent.com/51849865/124928201-b74f1580-dfff-11eb-8176-a2abf8243aab.png)