### PR TITLE
Increase hitbox for expanding/collapsing addons

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -9,8 +9,8 @@
           <img :src="addonIconSrc" class="icon-type" />
           <span @click="devShowAddonIds">{{ addon._displayedAddonId || addon.name }}</span>
         </div>
+        <addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
       </div>
-      <addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
       <div class="addon-description" v-show="!expanded" dir="auto">{{ addon.description }}</div>
       <div class="addon-check">
         <div
@@ -137,7 +137,7 @@
   }
   .addon-topbar {
     height: 50px;
-    padding: 0 5px;
+    padding-inline-end: 5px;
     display: flex;
     align-items: center;
   }
@@ -175,7 +175,7 @@
     padding: 5px;
     border-radius: 4px;
   }
-  .btn-dropdown:hover {
+  .clickeable-area:hover .btn-dropdown {
     background: rgba(255, 255, 255, 0.05);
   }
 
@@ -191,7 +191,15 @@
   .clickeable-area {
     cursor: pointer;
     display: flex;
+    align-self: stretch;
     align-items: center;
+    padding-inline-start: 5px;
+  }
+  .clickeable-area .tooltip {
+    cursor: pointer;
+  }
+  .iframe .clickeable-area {
+    flex-grow: 1;
   }
   .addon-notice {
     color: black;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -70,7 +70,7 @@ h1 {
   border-radius: 4px;
 }
 
-.addon-group > span > img:hover {
+.addon-group > span:hover > img {
   background-color: rgba(255, 255, 255, 0.05);
 }
 


### PR DESCRIPTION
### Changes

Makes the area that can be clicked to expand or collapse an addon on the settings page larger. This makes using the Addons tab in the popup much easier.