### PR TITLE
Improve readability of closed topic links

### DIFF
--- a/addons/dark-www/experimental_forums.css
+++ b/addons/dark-www/experimental_forums.css
@@ -111,3 +111,7 @@
 .my-ocular-popup::after {
   border-top-color: #202020;
 }
+
+.closed-topic a {
+    color: #c0c0c0;
+}

--- a/addons/dark-www/experimental_forums.css
+++ b/addons/dark-www/experimental_forums.css
@@ -113,5 +113,5 @@
 }
 
 .closed-topic a {
-    color: #c0c0c0;
+  color: #c0c0c0;
 }

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -27,14 +27,6 @@
       "matches": ["projects"]
     }
   ],
-  "settings": [
-    {
-      "id": "comments",
-      "name": "Comment Blocks",
-      "default": true,
-      "type": "boolean"
-    }
-  ],
   "tags": ["editor", "beta"],
   "enabledByDefault": false,
   "versionAdded": "1.16.0"

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Debugger",
-  "description": "Adds a new \"debugger\" block category and a \"logs\" window to the editor. The \"log\", \"warn\" and \"error\" blocks will print the specified message into the logs window. The \"breakpoint\" block will pause the project when executed.",
+  "description": "Adds a new \"debugger\" block category and a \"logs\" window to the editor. The \"log\", \"warn\" and \"error\" blocks will print the specified message into the logs window. The \"breakpoint\" block will pause the project when executed. The \"comment\" ",
   "credits": [
     {
       "name": "GrahamSH"
@@ -10,6 +10,9 @@
     },
     {
       "name": "retronbv"
+    },
+    {
+      "name":"8bitjake"
     }
   ],
   "userscripts": [
@@ -22,6 +25,14 @@
     {
       "url": "style.css",
       "matches": ["projects"]
+    }
+  ],
+  "settings": [
+    {
+      "id": "comments",
+      "name": "Comment Blocks",
+      "default": true,
+      "type": "boolean"
     }
   ],
   "tags": ["editor", "beta"],

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -30,12 +30,6 @@ export default async function ({ addon, global, console, msg }) {
     callback: pause,
     hidden: true,
   });
-  if (addon.settings.get("comments")) { // feel free to remove the setting
-  addon.tab.addBlock("\u200B\u200Bcomment %s", {
-    args: ["content"],
-    displayName: msg("block-comment"),
-  });
-}
   addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", {
     args: [],
     displayName: msg("block-breakpoint"),

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -30,6 +30,12 @@ export default async function ({ addon, global, console, msg }) {
     callback: pause,
     hidden: true,
   });
+  if (addon.settings.get("comments")) { // feel free to remove the setting
+  addon.tab.addBlock("\u200B\u200Bcomment %s", {
+    args: ["content"],
+    displayName: msg("block-comment"),
+  });
+}
   addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", {
     args: [],
     displayName: msg("block-breakpoint"),


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

This resolves an undocumented issue where links to closed forum topics are hard to read in dark mode.

### Changes

I simply added a .closed-topic CSS tag with a lighter color to experimental_forums.css in the dark-www addon.

### Reason for changes

Again, right now the links are hard to read.

### Tests

I've tested this change by simply changing the color value of the existing tag (in the original scratch css file) in inspect element.
