### PR TITLE
expanding-search-bar: add dynamic enable/disable

### DIFF
--- a/addons/expanding-search-bar/addon.json
+++ b/addons/expanding-search-bar/addon.json
@@ -15,6 +15,8 @@
       "runAtComplete": false
     }
   ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
   "versionAdded": "1.16.0",
   "tags": ["community"],
   "enabledByDefault": false

--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -32,7 +32,7 @@ export default async function ({ addon, global, console }) {
 
       function exsearch_clickIn() {
         //Clicking into the search bar
-		if (addon.self.disabled) return; //Don't expand if addon disabled
+		    if (addon.self.disabled) return; //Don't expand if addon disabled
         let i;
         exsearch_links = exsearch_getLinks(); //Get the links
         for (i = 0; i < exsearch_links.length; i++) {
@@ -66,7 +66,7 @@ export default async function ({ addon, global, console }) {
       //Functions
       function exsearch_clickIn() {
         //Clicking into the search bar
-		if (addon.self.disabled) return; //Don't expand if addon disabled
+	    	if (addon.self.disabled) return; //Don't expand if addon disabled
         exsearch_siteNav.style.display = "none"; //Hide the site navigation
       }
       function exsearch_clickOut() {

--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -32,6 +32,7 @@ export default async function ({ addon, global, console }) {
 
       function exsearch_clickIn() {
         //Clicking into the search bar
+		if (addon.self.disabled) return; //Don't expand if addon disabled
         let i;
         exsearch_links = exsearch_getLinks(); //Get the links
         for (i = 0; i < exsearch_links.length; i++) {
@@ -65,6 +66,7 @@ export default async function ({ addon, global, console }) {
       //Functions
       function exsearch_clickIn() {
         //Clicking into the search bar
+		if (addon.self.disabled) return; //Don't expand if addon disabled
         exsearch_siteNav.style.display = "none"; //Hide the site navigation
       }
       function exsearch_clickOut() {
@@ -76,4 +78,5 @@ export default async function ({ addon, global, console }) {
       exsearch_searchBar.addEventListener("focusout", exsearch_clickOut);
     }
   }
+  addon.self.addEventListener("disabled", () => exsearch_clickOut());
 }

--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -32,7 +32,7 @@ export default async function ({ addon, global, console }) {
 
       function exsearch_clickIn() {
         //Clicking into the search bar
-		    if (addon.self.disabled) return; //Don't expand if addon disabled
+        if (addon.self.disabled) return; //Don't expand if addon disabled
         let i;
         exsearch_links = exsearch_getLinks(); //Get the links
         for (i = 0; i < exsearch_links.length; i++) {
@@ -66,7 +66,7 @@ export default async function ({ addon, global, console }) {
       //Functions
       function exsearch_clickIn() {
         //Clicking into the search bar
-	    	if (addon.self.disabled) return; //Don't expand if addon disabled
+        if (addon.self.disabled) return; //Don't expand if addon disabled
         exsearch_siteNav.style.display = "none"; //Hide the site navigation
       }
       function exsearch_clickOut() {


### PR DESCRIPTION
### Changes

Adds dynamic enabling/disabling to Expandable search bar.

### Reason for changes

To add dynamic enable/disable to more addons.

### Tests

Tested on Firefox. Also did some tests with switching in/out of editor, and on scratchr2 pages.
