### PR TITLE
editor-stepping: Allow changing highlight color

### DIFF
--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -17,13 +17,6 @@
       "default": "#0000ff"
     }
   ],
-  "info": [
-    {
-      "type": "notice",
-      "text": "Refresh the editor to apply color changes.",
-      "id": "refresh-editor"
-    }
-  ],
   "versionAdded": "1.0.0",
   "tags": ["editor", "codeEditor"],
   "enabledByDefault": false

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -1,12 +1,27 @@
 {
   "name": "Highlight currently executing blocks",
-  "description": "Adds a blue border to the blocks that are currently running in a project.",
+  "description": "Adds a colored border to the blocks that are currently running in a project.",
   "dynamicEnable": true,
   "dynamicDisable": true,
   "userscripts": [
     {
       "url": "userscript.js",
       "matches": ["https://scratch.mit.edu/projects/*"]
+    }
+  ],
+  "settings": [
+    {
+      "name": "Highlight color",
+      "id": "highlight-color",
+      "type": "color",
+      "default": "#0000ff"
+    }
+  ],
+  "info": [
+    {
+      "type": "notice",
+      "text": "Refresh the editor to apply color changes.",
+      "id": "refresh-editor"
     }
   ],
   "versionAdded": "1.0.0",

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -1,11 +1,9 @@
 export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
 
-  function stepping_updateColor() {
-    document.getElementById("editor-stepping-flood").setAttribute("flood-color", addon.settings.get("highlight-color")); //Change the color
-  }
+  const setColor = () =>
+    document.getElementById("editor-stepping-flood").setAttribute("flood-color", addon.settings.get("highlight-color"));
 
-  // Insert this amazing filter
   document.body.insertAdjacentHTML(
     "beforeend",
     `
@@ -31,7 +29,7 @@ export default async function ({ addon, global, console }) {
 </svg>
 `
   );
-  stepping_updateColor(); //Set the color
+  setColor();
   // Wait for Blockly, as it tends to not be ready sometimes...
   await addon.tab.traps.getBlockly();
   const elementsWithFilter = new Set();
@@ -68,7 +66,5 @@ export default async function ({ addon, global, console }) {
     }
   };
 
-  addon.settings.addEventListener("change", function () {
-    stepping_updateColor();
-  }); //Live update
+  addon.settings.addEventListener("change", setColor);
 }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -1,10 +1,10 @@
 export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
-  
+
   function stepping_updateColor() {
-	document.getElementById("editor-stepping-flood").setAttribute("flood-color", addon.settings.get("highlight-color")); //Change the color
+    document.getElementById("editor-stepping-flood").setAttribute("flood-color", addon.settings.get("highlight-color")); //Change the color
   }
-  
+
   // Insert this amazing filter
   document.body.insertAdjacentHTML(
     "beforeend",
@@ -67,6 +67,8 @@ export default async function ({ addon, global, console }) {
       });
     }
   };
-  
-  addon.settings.addEventListener("change", function() {stepping_updateColor()}); //Live update
+
+  addon.settings.addEventListener("change", function () {
+    stepping_updateColor();
+  }); //Live update
 }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -6,7 +6,7 @@ export default async function ({ addon, global, console }) {
     "beforeend",
     `
 <svg style="position: fixed; top: -999999%;">
-  <filter id="blueStackGlow" height="160%" width="180%" y="-30%" x="-40%">
+  <filter id="colorStackGlow" height="160%" width="180%" y="-30%" x="-40%">
     <feGaussianBlur in="SourceGraphic" stdDeviation="4">
     </feGaussianBlur>
 
@@ -15,7 +15,7 @@ export default async function ({ addon, global, console }) {
       </feFuncA>
     </feComponentTransfer>
 
-    <feFlood flood-color="blue" flood-opacity="1" result="outColor">
+    <feFlood flood-color="` + addon.settings.get("highlight-color")  + `" flood-opacity="1" result="outColor">
     </feFlood>
 
     <feComposite in="outColor" in2="outBlur" operator="in" result="outGlow">
@@ -55,7 +55,7 @@ export default async function ({ addon, global, console }) {
           });
           if (!childblock && block.svgPath_) {
             const svgPath = block.svgPath_;
-            svgPath.style.filter = "url(#blueStackGlow)";
+            svgPath.style.filter = "url(#colorStackGlow)";
             elementsWithFilter.add(svgPath);
           }
         });

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -1,6 +1,10 @@
 export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
-
+  
+  function stepping_updateColor() {
+	document.getElementById("editor-stepping-flood").setAttribute("flood-color", addon.settings.get("highlight-color")); //Change the color
+  }
+  
   // Insert this amazing filter
   document.body.insertAdjacentHTML(
     "beforeend",
@@ -15,7 +19,7 @@ export default async function ({ addon, global, console }) {
       </feFuncA>
     </feComponentTransfer>
 
-    <feFlood flood-color="` + addon.settings.get("highlight-color")  + `" flood-opacity="1" result="outColor">
+    <feFlood id="editor-stepping-flood" flood-color="blue" flood-opacity="1" result="outColor">
     </feFlood>
 
     <feComposite in="outColor" in2="outBlur" operator="in" result="outGlow">
@@ -27,6 +31,7 @@ export default async function ({ addon, global, console }) {
 </svg>
 `
   );
+  stepping_updateColor(); //Set the color
   // Wait for Blockly, as it tends to not be ready sometimes...
   await addon.tab.traps.getBlockly();
   const elementsWithFilter = new Set();
@@ -62,4 +67,5 @@ export default async function ({ addon, global, console }) {
       });
     }
   };
+  addon.settings.addEventListener("change", function() {stepping_updateColor()}); //Live update
 }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -67,5 +67,6 @@ export default async function ({ addon, global, console }) {
       });
     }
   };
+  
   addon.settings.addEventListener("change", function() {stepping_updateColor()}); //Live update
 }


### PR DESCRIPTION
Resolves #2957

### Changes

Adds a color option to recolor the border in the editor-stepping (Highlight currently executing blocks) addon. Also slightly rewords the addon to not use the word blue. The default color is still #0000FF blue.

### Reason for changes

Some people may not like the blue or think it's too strong:
>**FunctionalMetatable wrote:**
>
>I don't want blue to be the only color available for the highlighting blocks addon.

### Tests

Tested on Firefox, should work on Chrome.
![red](https://user-images.githubusercontent.com/68464103/125126125-ebf3c780-e0fa-11eb-8e76-74b8126fefcd.png)![green](https://user-images.githubusercontent.com/68464103/125126134-eeeeb800-e0fa-11eb-90e5-ba89b973ba86.png)![orange](https://user-images.githubusercontent.com/68464103/125126140-f1e9a880-e0fa-11eb-929f-eb6c0ee2770c.png)![black](https://user-images.githubusercontent.com/68464103/125126144-f3b36c00-e0fa-11eb-8059-40d526453773.png)![white](https://user-images.githubusercontent.com/68464103/125126155-f746f300-e0fa-11eb-8ded-3e2a7748f086.png)
