### PR TITLE
infinite-scroll: add settingMatch to discuss.css

### DIFF
--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -101,7 +101,11 @@
     },
     {
       "url": "discuss.css",
-      "matches": ["https://scratch.mit.edu/discuss/*/"]
+      "matches": ["https://scratch.mit.edu/discuss/*/"],
+      "settingMatch": {
+        "id": "forumScroll",
+        "value": true
+      }
     }
   ],
   "tags": ["community"],


### PR DESCRIPTION
Resolves #2991

### Changes

Adds a settingMatch for forumScroll to discuss.css in the `infinite-scroll` addon. This fixes a bug where the page navigation is always hidden even if the forums option is disabled.

### Reason for changes

Bugfixing.

### Tests

Tested lightly on Firefox only, should work on other browsers.
