### PR TITLE
Improve Browse Followers modal scrolling

### DIFF
--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -10,7 +10,7 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
         return state.scratchGui.mode.isPlayerOnly;
       },
     });
-    yProvider = yProviderValue && document.querySelector(yProviderValue);
+    yProvider = yProviderValue && el.closest(yProviderValue);
     const scrollDetecter = yProvider || window;
     if (func && prevScrollDetector) prevScrollDetector.removeEventListener("scroll", func, { passive: true });
     el.style.display = "none";
@@ -19,12 +19,12 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
     func = () => {
       const threshold = yProvider ? yProvider.scrollTop + yProvider.clientHeight : window.scrollY + window.innerHeight;
       if (typeof pathname === "string" && (window.location.pathname.split("/")[3] || "") !== pathname) return;
-      if (!edge && threshold >= document.querySelector(heightControl).offsetHeight - 500) {
+      if (!edge && threshold >= el.closest(heightControl).offsetHeight - 500) {
         edge = true;
         if (el) {
           el.click();
         }
-      } else if (threshold < document.querySelector(heightControl).offsetHeight - 500) {
+      } else if (threshold < el.closest(heightControl).offsetHeight - 500) {
         edge = false;
       }
     };
@@ -33,24 +33,22 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
 }
 
 export default async function ({ addon, global, console }) {
-  const isStudio = window.location.pathname.split("/")[1] === "studios";
-  if (isStudio && addon.settings.get("studioScroll")) {
-    commentLoader(addon, "#view", ".studio-compose-container > .load-more-button", "comments");
-  }
   if (window.location.pathname.split("/")[1] === "users" && addon.settings.get("profileCommentScroll"))
     commentLoader(addon, "#content", "[data-control=load-more]");
-  if (window.location.pathname.split("/")[1] === "projects" && addon.settings.get("projectScroll")) {
+  const isStudio = window.location.pathname.split("/")[1] === "studios";
+  const isStudioComments = isStudio && addon.settings.get("studioScroll");
+  const isProjectComments = window.location.pathname.split("/")[1] === "projects" && addon.settings.get("projectScroll");
+  if (isProjectComments || isStudioComments) {
+    const buttonSelector = isStudioComments
+      ? ".studio-compose-container .load-more-button"
+      : "div.comments-container > div.flex-row.comments-list > button";
     const run = () =>
-      commentLoader(
-        addon,
-        "#view",
-        "#view > div > div.project-lower-container > div > div > div.comments-container > div.flex-row.comments-list > button"
-      );
+      commentLoader(addon, "#view", buttonSelector, isStudioComments ? "comments" : null);
     if (location.hash.startsWith("#comments-")) {
       // Wait until user clicks "see all comments"
       // Note: we ignore the cases where the comment can't be found (e.g. /projects/x/#comments-0)
       const listener = (e) => {
-        if (e.target.closest("div.comments-container > div.flex-row.comments-list > button")) {
+        if (e.target.closest(buttonSelector)) {
           document.removeEventListener("click", listener, true);
           run();
         }
@@ -63,11 +61,22 @@ export default async function ({ addon, global, console }) {
   if (isStudio && addon.settings.get("studioProjectScroll"))
     commentLoader(addon, "#view", ".studio-projects-grid .studio-grid-load-more > button", "");
   if (isStudio && addon.settings.get("studioBrowseProjectScroll"))
-    commentLoader(addon, ".user-projects-modal-grid", ".user-projects-modal-grid .studio-grid-load-more > button", "", {
-      yProvider: ".user-projects-modal-content",
-    });
+    commentLoader(
+      addon,
+      ".user-projects-modal-grid",
+      ".user-projects-modal:not(.sa-followers-main) .user-projects-modal-grid .studio-grid-load-more > button",
+      "",
+      {yProvider: ".user-projects-modal-content"}
+    );
   if (isStudio && addon.settings.get("studioCuratorScroll"))
     commentLoader(addon, "#view", "div > .studio-members:last-child .studio-grid-load-more > button", "curators"); // Only scrolling curators for now
   if (isStudio && addon.settings.get("studioActivityScroll"))
     commentLoader(addon, "#view", ".studio-activity .studio-grid-load-more > button", "activity");
+  
+  // Enable scrolling for studio-followers
+  if (isStudio && addon.settings.get("studioBrowseProjectScroll")) {
+    addon.tab.waitForElement(".sa-followers-main .user-projects-modal-content").then((el) => {
+      el.setAttribute("data-scrollable", "true");
+    });
+  }
 }

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -37,13 +37,13 @@ export default async function ({ addon, global, console }) {
     commentLoader(addon, "#content", "[data-control=load-more]");
   const isStudio = window.location.pathname.split("/")[1] === "studios";
   const isStudioComments = isStudio && addon.settings.get("studioScroll");
-  const isProjectComments = window.location.pathname.split("/")[1] === "projects" && addon.settings.get("projectScroll");
+  const isProjectComments =
+    window.location.pathname.split("/")[1] === "projects" && addon.settings.get("projectScroll");
   if (isProjectComments || isStudioComments) {
     const buttonSelector = isStudioComments
       ? ".studio-compose-container .load-more-button"
       : "div.comments-container > div.flex-row.comments-list > button";
-    const run = () =>
-      commentLoader(addon, "#view", buttonSelector, isStudioComments ? "comments" : null);
+    const run = () => commentLoader(addon, "#view", buttonSelector, isStudioComments ? "comments" : null);
     if (location.hash.startsWith("#comments-")) {
       // Wait until user clicks "see all comments"
       // Note: we ignore the cases where the comment can't be found (e.g. /projects/x/#comments-0)
@@ -66,13 +66,13 @@ export default async function ({ addon, global, console }) {
       ".user-projects-modal-grid",
       ".user-projects-modal:not(.sa-followers-main) .user-projects-modal-grid .studio-grid-load-more > button",
       "",
-      {yProvider: ".user-projects-modal-content"}
+      { yProvider: ".user-projects-modal-content" }
     );
   if (isStudio && addon.settings.get("studioCuratorScroll"))
     commentLoader(addon, "#view", "div > .studio-members:last-child .studio-grid-load-more > button", "curators"); // Only scrolling curators for now
   if (isStudio && addon.settings.get("studioActivityScroll"))
     commentLoader(addon, "#view", ".studio-activity .studio-grid-load-more > button", "activity");
-  
+
   // Enable scrolling for studio-followers
   if (isStudio && addon.settings.get("studioBrowseProjectScroll")) {
     addon.tab.waitForElement(".sa-followers-main .user-projects-modal-content").then((el) => {

--- a/addons/studio-followers/modal.css
+++ b/addons/studio-followers/modal.css
@@ -1,5 +1,6 @@
 .sa-followers-modal-grid {
   grid-template-columns: repeat(7, minmax(0, 1fr));
+  overflow-anchor: none;
 }
 
 .studio-follower {

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -15,15 +15,16 @@ export default async function ({ addon, global, console, msg }) {
   const isOwner = redux.state.studio.owner === redux.state.session.session?.user?.id;
   const isManager = redux.state.studio.manager || isOwner;
   if (!isManager) return;
+  const itemPageLimit = 28;
   const data = {
     followers: {
-      offset: -40,
+      offset: -itemPageLimit,
       activated: false,
       grid: null,
       fetchedAll: false,
     },
     following: {
-      offset: -40,
+      offset: -itemPageLimit,
       activated: false,
       grid: null,
       fetchedAll: false,
@@ -52,16 +53,16 @@ export default async function ({ addon, global, console, msg }) {
     if (isFetching) return;
     if (data[type].fetchedAll) return;
     isFetching = true;
-    data[type].offset += 40;
+    data[type].offset += itemPageLimit;
     const res = await fetch(
-      `https://api.scratch.mit.edu/users/${addon.auth.username}/${type}?offset=${data[type].offset}&limit=40`
+      `https://api.scratch.mit.edu/users/${addon.auth.username}/${type}?offset=${data[type].offset}&limit=${itemPageLimit}`
     );
     if (!res.ok) {
       // Cooldown in case something went wrong
       setTimeout(() => (isFetching = false), 1000);
     }
     const json = await res.json();
-    if (json.length < 40) data[type].fetchedAll = true;
+    if (json.length < itemPageLimit) data[type].fetchedAll = true;
     const username = json.map((follower) => {
       const user = createUser(follower, addon, msg, members);
       data[type].grid.appendChild(user);

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -21,6 +21,7 @@ export default async function ({ addon, global, console, msg }) {
       offset: -itemPageLimit,
       activated: false,
       grid: null,
+      gridScrollPosition: 0,
       moreButton: null,
       fetchedAll: false,
     },
@@ -28,6 +29,7 @@ export default async function ({ addon, global, console, msg }) {
       offset: -itemPageLimit,
       activated: false,
       grid: null,
+      gridScrollPosition: 0,
       moreButton: null,
       fetchedAll: false,
     },
@@ -36,7 +38,9 @@ export default async function ({ addon, global, console, msg }) {
 
   const modal = createModal(addon, msg("modal-title"), msg, (nextType) => {
     if (nextType === currentType) return;
+    data[currentType].gridScrollPosition = data[currentType].grid.parentElement.scrollTop;
     data[nextType].grid.style.display = null;
+    data[nextType].grid.parentElement.scrollTop = data[nextType].gridScrollPosition;
     if (!data[nextType].activated) {
       data[nextType].activated = true;
       loadData(nextType);

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -21,12 +21,14 @@ export default async function ({ addon, global, console, msg }) {
       offset: -itemPageLimit,
       activated: false,
       grid: null,
+      moreButton: null,
       fetchedAll: false,
     },
     following: {
       offset: -itemPageLimit,
       activated: false,
       grid: null,
+      moreButton: null,
       fetchedAll: false,
     },
   };
@@ -52,6 +54,7 @@ export default async function ({ addon, global, console, msg }) {
   async function loadData(type) {
     if (isFetching) return;
     if (data[type].fetchedAll) return;
+    if (data[type].moreButton) data[type].moreButton.classList.add("mod-mutating");
     isFetching = true;
     data[type].offset += itemPageLimit;
     const res = await fetch(
@@ -68,6 +71,21 @@ export default async function ({ addon, global, console, msg }) {
       data[type].grid.appendChild(user);
       return follower.username;
     });
+    if (data[type].moreButton) data[type].moreButton.remove();
+    else {
+      const moreButton = document.createElement("div");
+      data[type].moreButton = moreButton;
+      data[type].grid.appendChild(moreButton);
+      moreButton.className = "studio-grid-load-more";
+      const moreButtonInner = document.createElement("button");
+      moreButton.appendChild(moreButtonInner);
+      moreButtonInner.className = "button";
+      moreButtonInner.innerText = addon.tab.scratchMessage("general.loadMore");
+      moreButtonInner.addEventListener("click", (e) => {
+        loadData(type);
+        e.stopPropagation();
+      });
+    }
     isFetching = false;
     return username;
   }

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -130,7 +130,7 @@ export default async function ({ addon, global, console, msg }) {
   if (location.pathname.split("/")[3] == "curators") {
     init();
   }
-  
+
   // Infinite scrolling
 
   function checkVisible(el, container) {

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -69,13 +69,13 @@ export default async function ({ addon, global, console, msg }) {
       setTimeout(() => (isFetching = false), 1000);
     }
     const json = await res.json();
-    if (json.length < itemPageLimit) data[type].fetchedAll = true;
     const username = json.map((follower) => {
       const user = createUser(follower, addon, msg, members);
       data[type].grid.appendChild(user);
       return follower.username;
     });
     if (data[type].moreButton) data[type].moreButton.remove();
+    if (json.length < itemPageLimit) data[type].fetchedAll = true;
     else if (data[type].grid.parentNode.getAttribute("data-scrollable") !== "true") {
       const moreButton = document.createElement("div");
       data[type].moreButton = moreButton;

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -76,7 +76,7 @@ export default async function ({ addon, global, console, msg }) {
       return follower.username;
     });
     if (data[type].moreButton) data[type].moreButton.remove();
-    else {
+    else if (data[type].grid.parentNode.getAttribute("data-scrollable") !== "true") {
       const moreButton = document.createElement("div");
       data[type].moreButton = moreButton;
       data[type].grid.appendChild(moreButton);
@@ -130,4 +130,26 @@ export default async function ({ addon, global, console, msg }) {
   if (location.pathname.split("/")[3] == "curators") {
     init();
   }
+  
+  // Infinite scrolling
+
+  function checkVisible(el, container) {
+    const { bottom, height, top } = el.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+
+    return top <= containerRect.top ? containerRect.top - top <= height : bottom - containerRect.bottom <= height;
+  }
+
+  let flex = data.followers.grid.parentNode; // div.user-projects-modal-content
+
+  flex.addEventListener(
+    "scroll",
+    (e) => {
+      let els = Array.from(data[currentType].grid.childNodes);
+      if (checkVisible(els[els.length - 1], flex) && flex.getAttribute("data-scrollable") === "true") {
+        loadData(currentType);
+      }
+    },
+    { passive: true }
+  );
 }

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -108,26 +108,4 @@ export default async function ({ addon, global, console, msg }) {
   if (location.pathname.split("/")[3] == "curators") {
     init();
   }
-
-  // Infinite scrolling
-
-  function checkVisible(el, container) {
-    const { bottom, height, top } = el.getBoundingClientRect();
-    const containerRect = container.getBoundingClientRect();
-
-    return top <= containerRect.top ? containerRect.top - top <= height : bottom - containerRect.bottom <= height;
-  }
-
-  let flex = data.followers.grid.parentNode; // div.user-projects-modal-content
-
-  flex.addEventListener(
-    "scroll",
-    (e) => {
-      let els = Array.from(data[currentType].grid.childNodes);
-      if (checkVisible(els[els.length - 1], flex)) {
-        loadData(currentType);
-      }
-    },
-    { passive: true }
-  );
 }


### PR DESCRIPTION
### Changes

- Changes the number of items loaded at once to 28 (four rows, two if old studio layout is enabled)
- Replaces infinite scrolling with a Load More button to match Scratch's add projects modal
- Remembers the scroll position when switching between Followers and Following tabs