### PR TITLE
Improve follower tiles and remove unnecessarily duplicated Scratch CSS

### DIFF
--- a/addons/studio-followers/lib.js
+++ b/addons/studio-followers/lib.js
@@ -4,7 +4,7 @@ export function createModal(addon, title, msg, switchType) {
   });
 
   const div = Object.assign(document.createElement("div"), {
-    className: "sa-followers-main modal-content user-projects-modal modal-content user-projects-modal",
+    className: "sa-followers-main modal-content user-projects-modal",
     tabindex: "-1",
     role: "dialog",
   });
@@ -103,22 +103,22 @@ export function createModal(addon, title, msg, switchType) {
 export function createUser(follower, addon, msg, members) {
   let { redux } = addon.tab;
   const btn = Object.assign(document.createElement("div"), {
-    className: "studio-follower mod-clickable studio-project-tile",
+    className: "mod-clickable studio-project-tile studio-follower",
     tabindex: "0",
     role: "button",
   });
   const userImage = Object.assign(document.createElement("img"), {
-    className: "studio-follower-pfp",
+    className: "studio-project-image",
     src: `https://cdn2.scratch.mit.edu/get_image/user/${follower.id}_90x90.png`,
   });
 
   btn.appendChild(userImage);
 
   const bottom = Object.assign(document.createElement("div"), {
-    className: "studio-follower-bottom",
+    className: "studio-project-bottom",
   });
   const username = Object.assign(document.createElement("div"), {
-    className: "studio-follower-username",
+    className: "studio-project-title",
     innerText: follower.username,
     title: follower.username,
   });
@@ -129,7 +129,7 @@ export function createUser(follower, addon, msg, members) {
   });
 
   const img = Object.assign(document.createElement("img"), {
-    className: "studio-follower-add-remove-image",
+    className: "studio-project-add-remove-image",
     src: addon.self.dir + "/add.svg",
   });
 
@@ -153,7 +153,7 @@ export function createUser(follower, addon, msg, members) {
       return alert(msg("fetch-err"));
     }
     btn.classList.remove("mod-mutating");
-    add.classList.add("studio-follower-dynamic-remove");
+    add.classList.add("studio-tile-dynamic-remove");
     img.src = addon.self.dir + "/tick.svg";
     btn.removeEventListener("click", onclick);
   };
@@ -162,7 +162,7 @@ export function createUser(follower, addon, msg, members) {
     btn.addEventListener("click", onclick);
   } else {
     btn.classList.remove("mod-mutating");
-    add.classList.add("studio-follower-dynamic-remove");
+    add.classList.add("studio-tile-dynamic-remove");
     img.src = addon.self.dir + "/tick.svg";
   }
 

--- a/addons/studio-followers/modal.css
+++ b/addons/studio-followers/modal.css
@@ -2,70 +2,23 @@
   grid-template-columns: repeat(7, minmax(0, 1fr));
 }
 
-.studio-follower {
-  background: white;
-  border-radius: 8px;
-  border: 1px solid #d9d9d9;
-  position: relative;
-  margin: 0;
-  padding: 0;
-}
-
-.studio-follower-pfp {
-  max-width: 100%;
-  background: #a0c6fc;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  width: 100%;
+.studio-follower .studio-project-image {
+  background: transparent;
   aspect-ratio: 1 / 1;
+  object-fit: fill;
 }
 
-.studio-follower-bottom {
-  display: flex;
-  padding: 6px 4px 6px 10px;
-  justify-content: space-between;
-  overflow: hidden;
+/* Make add icon smaller and closer to edge - profile pictures are much smaller
+   than project tiles: */
+
+.studio-follower .studio-tile-dynamic-remove,
+.studio-follower .studio-tile-dynamic-add {
+  top: 5px;
+  right: 5px;
+  width: 24px;
+  height: 24px;
 }
 
-.studio-follower-username {
-  color: #4c97ff;
-  font-weight: 700;
-  font-size: 14px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.studio-follower-add-remove-image {
-  margin: 7px;
-}
-
-.studio-follower-dynamic-add {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 20px;
-  height: 20px;
-  background: rgba(0, 0, 0, 0.25);
-  border: 3px solid rgba(0, 0, 0, 0.1);
-  background-clip: padding-box;
-  color: white;
-  border-radius: 100%;
-  font-weight: bold;
-  margin: 0;
-  padding: 0;
-  line-height: 32px;
-  align-content: center;
-  display: flex;
-  justify-content: center;
-}
-
-.studio-follower-dynamic-remove {
-  background: #0fbd8c;
-  background-clip: padding-box;
-  border: 3px solid rgba(15, 189, 140, 0.2);
-}
-
-.studio-adder-section {
-  margin-top: 7px;
+.studio-follower .studio-project-add-remove-image {
+  margin: 3px;
 }

--- a/addons/studio-followers/modal.css
+++ b/addons/studio-followers/modal.css
@@ -17,8 +17,7 @@
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
   width: 100%;
-  aspect-ratio: 9 / 10;
-  object-fit: cover;
+  aspect-ratio: 1 / 1;
 }
 
 .studio-follower-bottom {


### PR DESCRIPTION
### Changes

Changes to the Browse Followers modal:
- Makes profile pictures square and stretch to fit
- Removes unnecessary CSS and uses Scratch classes instead
- Makes the add icon smaller and closer to the edge so that it doesn't cover too much of the profile picture