### PR TITLE
Fix dropdown on addon-body look like it's hovering

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -175,7 +175,7 @@
     padding: 5px;
     border-radius: 4px;
   }
-  .clickeable-area:hover .btn-dropdown {
+  .btn-dropdown:hover {
     background: rgba(255, 255, 255, 0.05);
   }
 


### PR DESCRIPTION
I'm not sure what to call this, but it causes this:
![image](https://user-images.githubusercontent.com/72760579/125453043-a5e63c78-01ca-4a38-ba00-60e45ecd53a8.png)
The mouse being pointer is ok, but the dropdown should not look like it's being hovered.

Regressed by #2949, I'm sure this wasn't intensional.