### PR TITLE
Small CSS fixes

### DIFF
--- a/popups/scratch-messaging/light.css
+++ b/popups/scratch-messaging/light.css
@@ -23,8 +23,8 @@ button {
 .btn-dropdown img {
   filter: invert(1);
 }
-.btn-dropdown:hover {
-  background: rgba(0, 0, 0, 0.1);
+.message-type-title:hover .btn-dropdown {
+  background: rgba(0, 0, 0, 0.05);
 }
 
 .comment {

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -10,7 +10,7 @@ button {
 }
 
 .contents {
-  max-height: 95vh;
+  max-height: calc(100vh - 24px);
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: grey transparent;
@@ -22,7 +22,7 @@ button {
   padding: 5px;
   border-radius: 4px;
 }
-.btn-dropdown:hover {
+.message-type-title:hover .btn-dropdown {
   background: rgba(255, 255, 255, 0.05);
 }
 
@@ -63,6 +63,8 @@ button {
   z-index: 999;
   border: none;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
 }
 
 .thread-list {
@@ -251,7 +253,6 @@ a.message-type-title-text {
   bottom: 0;
   left: 0;
   right: 0;
-  min-height: 5vh;
   background: #222;
   border-top: 1px solid #00000038;
   font-size: 12px;

--- a/webpages/settings/light.css
+++ b/webpages/settings/light.css
@@ -112,8 +112,8 @@ img :not(.navbar, .icon-type) {
 .addon-group > span:after {
   filter: invert(1) brightness(0);
 }
-.btn-dropdown:hover {
-  background: rgba(0, 0, 0, 0.1);
+.clickeable-area:hover .btn-dropdown {
+  background: rgba(0, 0, 0, 0.05);
 }
 
 .category.sel {


### PR DESCRIPTION
### Changes

- Fixes the recently changed expand button hover state not working in light mode
- Makes the same change in the messaging popup
- Fixes a small gap in the messaging popup (caused by a change in #2871 - an element can't have more than one `min-height`)
- Fixes part of the rounded corners of some message types being cut off