### PR TITLE
old-studio-layout: properly keep "browse projects" button

### DIFF
--- a/addons/old-studio-layout/classes.js
+++ b/addons/old-studio-layout/classes.js
@@ -14,18 +14,6 @@ export default async function ({ addon, console }) {
     followButton.parentElement.classList.add("sa-oldstudio-follow-section");
   });
 
-  // Keep "browse projects" button
-  addon.tab.waitForElement(".studio-adder-section .studio-adder-row button ~ button").then((realButton) => {
-    const button = document.createElement("button");
-    button.classList = "button sa-pseudobutton";
-    const span = document.createElement("span");
-    span.textContent = realButton.textContent;
-    button.appendChild(span);
-    button.onclick = () => realButton.click();
-    addon.tab.displayNoneWhileDisabled(button);
-    document.querySelector(".studio-adder-section .studio-adder-row .studio-adder-vertical-divider").after(button);
-  });
-
   // Keep "invite followers" button
   addon.tab.waitForElement("#sa-studio-followers-btn").then((realButton) => {
     const button = document.createElement("button");
@@ -44,4 +32,22 @@ export default async function ({ addon, console }) {
       }
     });
   });
+
+  // Keep "browse projects" button
+  while (true) {
+    const realButton = await addon.tab.waitForElement(
+      ".studio-adder-section .studio-adder-row button ~ button:not(.sa-pseudobutton)",
+      {
+        markAsSeen: true,
+      }
+    );
+    const button = document.createElement("button");
+    button.classList = "button sa-pseudobutton";
+    const span = document.createElement("span");
+    span.textContent = realButton.textContent;
+    button.appendChild(span);
+    button.onclick = () => realButton.click();
+    addon.tab.displayNoneWhileDisabled(button);
+    document.querySelector(".studio-adder-section .studio-adder-row .studio-adder-vertical-divider").after(button);
+  }
 }


### PR DESCRIPTION
Fixes "add projects" pseudobutton not being there after going to projects tab, then to another tab, then back.