### PR TITLE
gamepad: Be like the description

### DIFF
--- a/addons/gamepad/addon.json
+++ b/addons/gamepad/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gamepad support",
+  "name": "Gamepad/controller support",
   "description": "Interact with projects using a USB or Bluetooth controller/gamepad.",
   "credits": [
     {

--- a/addons/gamepad/addon.json
+++ b/addons/gamepad/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Gamepad/controller support",
-  "description": "Interact with projects using a USB or Bluetooth controller/gamepad.",
+  "name": "Gamepad/video game controller support",
+  "description": "Interact with projects using a USB or Bluetooth video game controller/gamepad.",
   "credits": [
     {
       "name": "GarboMuffin"


### PR DESCRIPTION
Resolves #3021

### Changes

Makes the title say "Gamepad/controller" like the description

### Reason for changes

It helps people who don't know what a gamepad is know what it is.

### Tests

None.