### PR TITLE
better-img-uploads: remove gif from acceptable files

### DIFF
--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -13,7 +13,7 @@ export default async function ({ addon, console, safeMsg: m }) {
     <img class="${addon.tab.scratchClass("action-menu_more-icon")} sa-better-img-uploader" draggable="false" src="${
     addon.self.dir + "/icon.svg"
   }" height="10", width="10">
-     <input accept=".svg, .png, .bmp, .jpg, .jpeg, .gif" class="${addon.tab.scratchClass(
+     <input accept=".svg, .png, .bmp, .jpg, .jpeg" class="${addon.tab.scratchClass(
        "action-menu_file-input"
      )}" multiple="" type="file">
   </button>


### PR DESCRIPTION
Resolves #3027 

Reasons for this change:
- GIF files are already of poor resolution in most cases
- Most GIF files are animated and hard to deal with (do we see static GIF anywhere?)
- We can't add omggif (GIF parsing library used by Scratch) just for this small feature