### PR TITLE
last-edit-tooltip: use redux instead of fetching

### DIFF
--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -1,13 +1,10 @@
 export default async function ({ addon, global, console, msg }) {
-  let { redux } = addon.tab
+  let { redux } = addon.tab;
 
-  await redux.waitForState(
-    (state) => state.preview.status.project === "FETCHED",
-    {
-      actions: ["SET_INFO"],
-    }
-  );
-  
+  await redux.waitForState((state) => state.preview.status.project === "FETCHED", {
+    actions: ["SET_INFO"],
+  });
+
   let data = redux.state.preview.projectInfo;
 
   if (!data.history) return;

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -1,12 +1,14 @@
 export default async function ({ addon, global, console, msg }) {
-  const headers = new Headers();
-  if (addon.auth.xToken) headers.set("X-Token", addon.auth.xToken);
+  let { redux } = addon.tab
 
-  const path = location.pathname.match(/\/projects\/[0-9]+/g);
-  // Return if there is no project id... for example, if the user visits
-  // scratch.mit.edu/projects/editor/?tutorial=getStarted
-  if (!path.length) return;
-  const data = await (await fetch("https://api.scratch.mit.edu" + path[0], { headers })).json();
+  await redux.waitForState(
+    (state) => state.preview.status.project === "FETCHED",
+    {
+      actions: ["SET_INFO"],
+    }
+  );
+  
+  let data = redux.state.preview.projectInfo;
 
   if (!data.history) return;
 


### PR DESCRIPTION
### Changes

Uses redux instead of fetching by itself in last-edit-tooltip to get the dates

### Reason for changes

Less requests

### Tests

Tested locally (edge)