### PR TITLE
Stop addon execution when color picker update is detected

### DIFF
--- a/addons/2d-color-picker/paint-editor.js
+++ b/addons/2d-color-picker/paint-editor.js
@@ -67,6 +67,10 @@ export default async ({ addon, console, msg }) => {
       reduxCondition: (state) => state.scratchGui.editorTab.activeTabIndex === 1 && !state.scratchGui.mode.isPlayerOnly,
     });
     rateLimiter.abort(false);
+    if (!("colorIndex" in addon.tab.redux.state.scratchPaint.fillMode)) {
+      console.error("Detected new paint editor; this will be supported in future versions.");
+      return;
+    }
 
     // update the bg color of the picker
     function updateColor() {

--- a/addons/color-picker/paint-editor.js
+++ b/addons/color-picker/paint-editor.js
@@ -51,6 +51,10 @@ export default async ({ addon, console, msg }) => {
     });
     rateLimiter.abort(false);
     addon.tab.redux.initialize();
+    if (!("colorIndex" in addon.tab.redux.state.scratchPaint.fillMode)) {
+      console.error("Detected new paint editor; this will be supported in future versions.");
+      return;
+    }
     if (addon.tab.redux && typeof prevEventHandler === "function") {
       addon.tab.redux.removeEventListener("statechanged", prevEventHandler);
       prevEventHandler = null;

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -2,6 +2,15 @@ export default async function ({ addon, global, console, msg }) {
   const paper = await addon.tab.traps.getPaper();
 
   const paintEditorCanvasContainer = await addon.tab.waitForElement("[class^='paint-editor_canvas-container']");
+  try {
+    if (!("colorIndex" in addon.tab.redux.state.scratchPaint.fillMode)) {
+      console.error("Detected new paint editor; this will be supported in future versions.");
+      return;
+    }
+  } catch (_) {
+    // The check can technically fail when Redux isn't supported (rare cases)
+    // Just ignore in this case
+  }
   const REACT_INTERNAL_PREFIX = "__reactInternalInstance$";
   const reactInternalKey = Object.keys(paintEditorCanvasContainer).find((i) => i.startsWith(REACT_INTERNAL_PREFIX));
   const paperCanvas = paintEditorCanvasContainer[reactInternalKey].child.child.child.stateNode;


### PR DESCRIPTION
See https://github.com/LLK/scratch-paint/pull/1698/files#diff-ba47b319faac03f59857691b06c8b1f8896c38c7c5bd0b28c230993d77eecc2aR4

The check uses Redux. For 2d-color-picker and color-picker this is fine because both addons are already powered by redux. For onion skinning this is not the case, so I just ignored any error that could come from lack of redux.