### PR TITLE
dark-www: fix `semicolon` addon showing white background and incorrect font color

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -1,6 +1,7 @@
 html,
 body,
-#pagewrapper {
+#pagewrapper,
+.semicolon {
   background: #202020;
   color: #fff;
   text-shadow: none;

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -19,12 +19,13 @@ a.social-messages-profile-link,
 .studio-project-tile .studio-project-username,
 #footer,
 #donor,
+.semicolon,
 .subactions .share-date,
 .developers #faq p,
 .social-form,
 body:not(.sa-body-editor) .join-flow-title,
 .initiatives-section .initiatives-tools .subsection-tag.collaborator {
-  color: #fff !important;
+  color: #fff;
 }
 .sa-body-editor h1,
 .sa-body-editor h2,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -24,7 +24,7 @@ a.social-messages-profile-link,
 .social-form,
 body:not(.sa-body-editor) .join-flow-title,
 .initiatives-section .initiatives-tools .subsection-tag.collaborator {
-  color: #fff;
+  color: #fff !important;
 }
 .sa-body-editor h1,
 .sa-body-editor h2,
@@ -45,7 +45,7 @@ body:not(.sa-body-editor) .join-flow-title,
 .tips-getting-started,
 .tips-activity-guides,
 .studio-report-modal .studio-report-tile,
-.studio-report-modal .button:disabled {
+.studio-report-modal .button:disabled, .semicolon {
   background: #202020;
 }
 .box .box-header,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -45,7 +45,8 @@ body:not(.sa-body-editor) .join-flow-title,
 .tips-getting-started,
 .tips-activity-guides,
 .studio-report-modal .studio-report-tile,
-.studio-report-modal .button:disabled, .semicolon {
+.studio-report-modal .button:disabled,
+.semicolon {
   background: #202020;
 }
 .box .box-header,

--- a/addons/semicolon/semicolon.css
+++ b/addons/semicolon/semicolon.css
@@ -1,5 +1,5 @@
 .semicolon {
   margin: 0;
-  background: white !important;
-  color: black !important;
+  background: white;
+  color: black;
 }


### PR DESCRIPTION

Resolves #1604

### Changes
Adds dark background to semicolon when both semicolon and dark-www addons are enabled.


### Tests
Tested locally
