### PR TITLE
Dark speech bubbles

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -597,6 +597,17 @@
   "injectAsStyleElt": true,
   "versionAdded": "1.0.0",
   "updateUserstylesOnSettingsChange": true,
+  "userscripts": [
+    {
+      "url": "bubbles.js",
+      "matches": [
+        "https://scratch.mit.edu/projects/*/",
+        "https://scratch.mit.edu/projects/*/editor",
+        "https://scratch.mit.edu/projects/*/fullscreen",
+        "https://scratch.mit.edu/projects/editor"
+      ]
+    }
+  ],
   "userstyles": [
     {
       "url": "experimental_editor.css",
@@ -790,7 +801,7 @@
       "default": false
     },
     {
-      "name": "Change the colors of variables, lists, and answer inputs on the stage",
+      "name": "Change the colors of variables, lists, speech bubbles, and answer inputs on the stage",
       "id": "affectStage",
       "type": "boolean",
       "default": false

--- a/addons/editor-dark-mode/bubbles.js
+++ b/addons/editor-dark-mode/bubbles.js
@@ -1,0 +1,140 @@
+import { textColor } from "../../libraries/common/cs/text-color.esm.js";
+
+export default async function ({ addon, console }) {
+  const renderer = addon.tab.traps.vm.runtime.renderer;
+  const oldCreateTextSkin = renderer.createTextSkin.bind(renderer);
+  renderer.createTextSkin = function (...args) {
+    const skinId = oldCreateTextSkin(...args);
+    const skin = renderer._allSkins[skinId];
+    const oldRenderTextBubble = skin._renderTextBubble.bind(skin);
+    skin._renderTextBubble = (scale) => {
+      // Based on code from scratch-render/src/TextBubbleSkin.js
+      if (addon.self.disabled || !addon.settings.get("affectStage")) return oldRenderTextBubble(scale);
+
+      const BubbleStyle = {
+        MAX_LINE_WIDTH: 170, // Maximum width, in Scratch pixels, of a single line of text
+
+        MIN_WIDTH: 50, // Minimum width, in Scratch pixels, of a text bubble
+        STROKE_WIDTH: 4, // Thickness of the stroke around the bubble. Only half's visible because it's drawn under the fill
+        PADDING: 10, // Padding around the text area
+        CORNER_RADIUS: 16, // Radius of the rounded corners
+        TAIL_HEIGHT: 12, // Height of the speech bubble's "tail". Probably should be a constant.
+
+        FONT: "Helvetica", // Font to render the text with
+        FONT_SIZE: 14, // Font size, in Scratch pixels
+        FONT_HEIGHT_RATIO: 0.9, // Height, in Scratch pixels, of the text, as a proportion of the font's size
+        LINE_HEIGHT: 16, // Spacing between each line of text
+
+        COLORS: {
+          BUBBLE_FILL: addon.settings.get("accent"),
+          BUBBLE_STROKE: textColor(addon.settings.get("accent"), "rgba(0, 0, 0, 0.15)", "rgba(255, 255, 255, 0.15"),
+          TEXT_FILL: textColor(addon.settings.get("accent"), "#575e75", "#ffffff"),
+        },
+      };
+      
+      const ctx = skin._canvas.getContext("2d");
+
+      if (skin._textDirty) {
+        skin._reflowLines();
+      }
+
+      // Calculate the canvas-space sizes of the padded text area and full text bubble
+      const paddedWidth = skin._textAreaSize.width;
+      const paddedHeight = skin._textAreaSize.height;
+
+      // Resize the canvas to the correct screen-space size
+      skin._canvas.width = Math.ceil(skin._size[0] * scale);
+      skin._canvas.height = Math.ceil(skin._size[1] * scale);
+      skin._restyleCanvas();
+
+      // Reset the transform before clearing to ensure 100% clearage
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, skin._canvas.width, skin._canvas.height);
+
+      ctx.scale(scale, scale);
+      ctx.translate(BubbleStyle.STROKE_WIDTH * 0.5, BubbleStyle.STROKE_WIDTH * 0.5);
+
+      // If the text bubble points leftward, flip the canvas
+      ctx.save();
+      if (skin._pointsLeft) {
+        ctx.scale(-1, 1);
+        ctx.translate(-paddedWidth, 0);
+      }
+
+      // Draw the bubble's rounded borders
+      ctx.beginPath();
+      ctx.moveTo(BubbleStyle.CORNER_RADIUS, paddedHeight);
+      ctx.arcTo(0, paddedHeight, 0, paddedHeight - BubbleStyle.CORNER_RADIUS, BubbleStyle.CORNER_RADIUS);
+      ctx.arcTo(0, 0, paddedWidth, 0, BubbleStyle.CORNER_RADIUS);
+      ctx.arcTo(paddedWidth, 0, paddedWidth, paddedHeight, BubbleStyle.CORNER_RADIUS);
+      ctx.arcTo(paddedWidth, paddedHeight, paddedWidth - BubbleStyle.CORNER_RADIUS, paddedHeight,
+        BubbleStyle.CORNER_RADIUS);
+
+      // Translate the canvas so we don't have to do a bunch of width/height arithmetic
+      ctx.save();
+      ctx.translate(paddedWidth - BubbleStyle.CORNER_RADIUS, paddedHeight);
+
+      // Draw the bubble's "tail"
+      if (skin._bubbleType === "say") {
+        // For a speech bubble, draw one swoopy thing
+        ctx.bezierCurveTo(0, 4, 4, 8, 4, 10);
+        ctx.arcTo(4, 12, 2, 12, 2);
+        ctx.bezierCurveTo(-1, 12, -11, 8, -16, 0);
+
+        ctx.closePath();
+      } else {
+        // For a thinking bubble, draw a partial circle attached to the bubble...
+        ctx.arc(-16, 0, 4, 0, Math.PI);
+
+        ctx.closePath();
+
+        // and two circles detached from it
+        ctx.moveTo(-7, 7.25);
+        ctx.arc(-9.25, 7.25, 2.25, 0, Math.PI * 2);
+
+        ctx.moveTo(0, 9.5);
+        ctx.arc(-1.5, 9.5, 1.5, 0, Math.PI * 2);
+      }
+
+      // Un-translate the canvas and fill + stroke the text bubble
+      ctx.restore();
+
+      ctx.fillStyle = BubbleStyle.COLORS.BUBBLE_FILL;
+      ctx.strokeStyle = BubbleStyle.COLORS.BUBBLE_STROKE;
+      ctx.lineWidth = BubbleStyle.STROKE_WIDTH;
+
+      ctx.stroke();
+      ctx.fill();
+
+      // Un-flip the canvas if it was flipped
+      ctx.restore();
+
+      // Draw each line of text
+      ctx.fillStyle = BubbleStyle.COLORS.TEXT_FILL;
+      ctx.font = `${BubbleStyle.FONT_SIZE}px ${BubbleStyle.FONT}, sans-serif`;
+      const lines = skin._lines;
+      for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
+        const line = lines[lineNumber];
+        ctx.fillText(
+          line,
+          BubbleStyle.PADDING,
+          BubbleStyle.PADDING + (BubbleStyle.LINE_HEIGHT * lineNumber) +
+            (BubbleStyle.FONT_HEIGHT_RATIO * BubbleStyle.FONT_SIZE)
+        );
+      }
+
+      skin._renderedScale = scale;
+    };
+    return skinId;
+  };
+  
+  const updateBubbles = () => {
+    // Re-render all text bubbles on settings change
+    for (let skin of renderer._allSkins) {
+      if (skin && skin.hasOwnProperty("_bubbleType")) skin._textureDirty = true;
+    }
+  };
+  addon.settings.addEventListener("change", updateBubbles);
+  addon.self.addEventListener("disabled", updateBubbles);
+  addon.self.addEventListener("reenabled", updateBubbles);
+}

--- a/addons/editor-dark-mode/bubbles.js
+++ b/addons/editor-dark-mode/bubbles.js
@@ -149,7 +149,7 @@ export default async function ({ addon, console }) {
     if (addon.settings.get("affectStage") && !usingModifiedCreateTextSkin) {
       overrideCreateTextSkin();
       usingModifiedCreateTextSkin = true;
-    };
+    }
     updateBubbles();
   });
   addon.self.addEventListener("disabled", updateBubbles);

--- a/addons/editor-dark-mode/bubbles.js
+++ b/addons/editor-dark-mode/bubbles.js
@@ -15,13 +15,9 @@ export default async function ({ addon, console }) {
         if (addon.self.disabled || !addon.settings.get("affectStage")) return oldRenderTextBubble(scale);
 
         const BubbleStyle = {
-          MAX_LINE_WIDTH: 170, // Maximum width, in Scratch pixels, of a single line of text
-
-          MIN_WIDTH: 100, // Minimum width, in Scratch pixels, of a text bubble
           STROKE_WIDTH: 4, // Thickness of the stroke around the bubble. Only half's visible because it's drawn under the fill
           PADDING: 10, // Padding around the text area
           CORNER_RADIUS: 16, // Radius of the rounded corners
-          TAIL_HEIGHT: 12, // Height of the speech bubble's "tail". Probably should be a constant.
 
           FONT: "Helvetica", // Font to render the text with
           FONT_SIZE: 14, // Font size, in Scratch pixels

--- a/addons/editor-dark-mode/bubbles.js
+++ b/addons/editor-dark-mode/bubbles.js
@@ -2,136 +2,140 @@ import { textColor } from "../../libraries/common/cs/text-color.esm.js";
 
 export default async function ({ addon, console }) {
   const renderer = addon.tab.traps.vm.runtime.renderer;
-  const oldCreateTextSkin = renderer.createTextSkin.bind(renderer);
-  renderer.createTextSkin = function (...args) {
-    const skinId = oldCreateTextSkin(...args);
-    const skin = renderer._allSkins[skinId];
-    const oldRenderTextBubble = skin._renderTextBubble.bind(skin);
-    skin._renderTextBubble = (scale) => {
-      // Based on code from scratch-render/src/TextBubbleSkin.js
-      if (addon.self.disabled || !addon.settings.get("affectStage")) return oldRenderTextBubble(scale);
+  let usingModifiedCreateTextSkin = false;
 
-      const BubbleStyle = {
-        MAX_LINE_WIDTH: 170, // Maximum width, in Scratch pixels, of a single line of text
+  const overrideCreateTextSkin = () => {
+    const oldCreateTextSkin = renderer.createTextSkin.bind(renderer);
+    renderer.createTextSkin = function (...args) {
+      const skinId = oldCreateTextSkin(...args);
+      const skin = renderer._allSkins[skinId];
+      const oldRenderTextBubble = skin._renderTextBubble.bind(skin);
+      skin._renderTextBubble = (scale) => {
+        // Based on code from scratch-render/src/TextBubbleSkin.js
+        if (addon.self.disabled || !addon.settings.get("affectStage")) return oldRenderTextBubble(scale);
 
-        MIN_WIDTH: 50, // Minimum width, in Scratch pixels, of a text bubble
-        STROKE_WIDTH: 4, // Thickness of the stroke around the bubble. Only half's visible because it's drawn under the fill
-        PADDING: 10, // Padding around the text area
-        CORNER_RADIUS: 16, // Radius of the rounded corners
-        TAIL_HEIGHT: 12, // Height of the speech bubble's "tail". Probably should be a constant.
+        const BubbleStyle = {
+          MAX_LINE_WIDTH: 170, // Maximum width, in Scratch pixels, of a single line of text
 
-        FONT: "Helvetica", // Font to render the text with
-        FONT_SIZE: 14, // Font size, in Scratch pixels
-        FONT_HEIGHT_RATIO: 0.9, // Height, in Scratch pixels, of the text, as a proportion of the font's size
-        LINE_HEIGHT: 16, // Spacing between each line of text
+          MIN_WIDTH: 100, // Minimum width, in Scratch pixels, of a text bubble
+          STROKE_WIDTH: 4, // Thickness of the stroke around the bubble. Only half's visible because it's drawn under the fill
+          PADDING: 10, // Padding around the text area
+          CORNER_RADIUS: 16, // Radius of the rounded corners
+          TAIL_HEIGHT: 12, // Height of the speech bubble's "tail". Probably should be a constant.
 
-        COLORS: {
-          BUBBLE_FILL: addon.settings.get("accent"),
-          BUBBLE_STROKE: textColor(addon.settings.get("accent"), "rgba(0, 0, 0, 0.15)", "rgba(255, 255, 255, 0.15"),
-          TEXT_FILL: textColor(addon.settings.get("accent"), "#575e75", "#ffffff"),
-        },
-      };
+          FONT: "Helvetica", // Font to render the text with
+          FONT_SIZE: 14, // Font size, in Scratch pixels
+          FONT_HEIGHT_RATIO: 0.9, // Height, in Scratch pixels, of the text, as a proportion of the font's size
+          LINE_HEIGHT: 16, // Spacing between each line of text
 
-      const ctx = skin._canvas.getContext("2d");
+          COLORS: {
+            BUBBLE_FILL: addon.settings.get("accent"),
+            BUBBLE_STROKE: textColor(addon.settings.get("accent"), "rgba(0, 0, 0, 0.15)", "rgba(255, 255, 255, 0.15"),
+            TEXT_FILL: textColor(addon.settings.get("accent"), "#575e75", "#ffffff"),
+          },
+        };
 
-      if (skin._textDirty) {
-        skin._reflowLines();
-      }
+        const ctx = skin._canvas.getContext("2d");
 
-      // Calculate the canvas-space sizes of the padded text area and full text bubble
-      const paddedWidth = skin._textAreaSize.width;
-      const paddedHeight = skin._textAreaSize.height;
+        if (skin._textDirty) {
+          skin._reflowLines();
+        }
 
-      // Resize the canvas to the correct screen-space size
-      skin._canvas.width = Math.ceil(skin._size[0] * scale);
-      skin._canvas.height = Math.ceil(skin._size[1] * scale);
-      skin._restyleCanvas();
+        // Calculate the canvas-space sizes of the padded text area and full text bubble
+        const paddedWidth = skin._textAreaSize.width;
+        const paddedHeight = skin._textAreaSize.height;
 
-      // Reset the transform before clearing to ensure 100% clearage
-      ctx.setTransform(1, 0, 0, 1, 0, 0);
-      ctx.clearRect(0, 0, skin._canvas.width, skin._canvas.height);
+        // Resize the canvas to the correct screen-space size
+        skin._canvas.width = Math.ceil(skin._size[0] * scale);
+        skin._canvas.height = Math.ceil(skin._size[1] * scale);
+        skin._restyleCanvas();
 
-      ctx.scale(scale, scale);
-      ctx.translate(BubbleStyle.STROKE_WIDTH * 0.5, BubbleStyle.STROKE_WIDTH * 0.5);
+        // Reset the transform before clearing to ensure 100% clearage
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, skin._canvas.width, skin._canvas.height);
 
-      // If the text bubble points leftward, flip the canvas
-      ctx.save();
-      if (skin._pointsLeft) {
-        ctx.scale(-1, 1);
-        ctx.translate(-paddedWidth, 0);
-      }
+        ctx.scale(scale, scale);
+        ctx.translate(BubbleStyle.STROKE_WIDTH * 0.5, BubbleStyle.STROKE_WIDTH * 0.5);
 
-      // Draw the bubble's rounded borders
-      ctx.beginPath();
-      ctx.moveTo(BubbleStyle.CORNER_RADIUS, paddedHeight);
-      ctx.arcTo(0, paddedHeight, 0, paddedHeight - BubbleStyle.CORNER_RADIUS, BubbleStyle.CORNER_RADIUS);
-      ctx.arcTo(0, 0, paddedWidth, 0, BubbleStyle.CORNER_RADIUS);
-      ctx.arcTo(paddedWidth, 0, paddedWidth, paddedHeight, BubbleStyle.CORNER_RADIUS);
-      ctx.arcTo(
-        paddedWidth,
-        paddedHeight,
-        paddedWidth - BubbleStyle.CORNER_RADIUS,
-        paddedHeight,
-        BubbleStyle.CORNER_RADIUS
-      );
+        // If the text bubble points leftward, flip the canvas
+        ctx.save();
+        if (skin._pointsLeft) {
+          ctx.scale(-1, 1);
+          ctx.translate(-paddedWidth, 0);
+        }
 
-      // Translate the canvas so we don't have to do a bunch of width/height arithmetic
-      ctx.save();
-      ctx.translate(paddedWidth - BubbleStyle.CORNER_RADIUS, paddedHeight);
-
-      // Draw the bubble's "tail"
-      if (skin._bubbleType === "say") {
-        // For a speech bubble, draw one swoopy thing
-        ctx.bezierCurveTo(0, 4, 4, 8, 4, 10);
-        ctx.arcTo(4, 12, 2, 12, 2);
-        ctx.bezierCurveTo(-1, 12, -11, 8, -16, 0);
-
-        ctx.closePath();
-      } else {
-        // For a thinking bubble, draw a partial circle attached to the bubble...
-        ctx.arc(-16, 0, 4, 0, Math.PI);
-
-        ctx.closePath();
-
-        // and two circles detached from it
-        ctx.moveTo(-7, 7.25);
-        ctx.arc(-9.25, 7.25, 2.25, 0, Math.PI * 2);
-
-        ctx.moveTo(0, 9.5);
-        ctx.arc(-1.5, 9.5, 1.5, 0, Math.PI * 2);
-      }
-
-      // Un-translate the canvas and fill + stroke the text bubble
-      ctx.restore();
-
-      ctx.fillStyle = BubbleStyle.COLORS.BUBBLE_FILL;
-      ctx.strokeStyle = BubbleStyle.COLORS.BUBBLE_STROKE;
-      ctx.lineWidth = BubbleStyle.STROKE_WIDTH;
-
-      ctx.stroke();
-      ctx.fill();
-
-      // Un-flip the canvas if it was flipped
-      ctx.restore();
-
-      // Draw each line of text
-      ctx.fillStyle = BubbleStyle.COLORS.TEXT_FILL;
-      ctx.font = `${BubbleStyle.FONT_SIZE}px ${BubbleStyle.FONT}, sans-serif`;
-      const lines = skin._lines;
-      for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
-        const line = lines[lineNumber];
-        ctx.fillText(
-          line,
-          BubbleStyle.PADDING,
-          BubbleStyle.PADDING +
-            BubbleStyle.LINE_HEIGHT * lineNumber +
-            BubbleStyle.FONT_HEIGHT_RATIO * BubbleStyle.FONT_SIZE
+        // Draw the bubble's rounded borders
+        ctx.beginPath();
+        ctx.moveTo(BubbleStyle.CORNER_RADIUS, paddedHeight);
+        ctx.arcTo(0, paddedHeight, 0, paddedHeight - BubbleStyle.CORNER_RADIUS, BubbleStyle.CORNER_RADIUS);
+        ctx.arcTo(0, 0, paddedWidth, 0, BubbleStyle.CORNER_RADIUS);
+        ctx.arcTo(paddedWidth, 0, paddedWidth, paddedHeight, BubbleStyle.CORNER_RADIUS);
+        ctx.arcTo(
+          paddedWidth,
+          paddedHeight,
+          paddedWidth - BubbleStyle.CORNER_RADIUS,
+          paddedHeight,
+          BubbleStyle.CORNER_RADIUS
         );
-      }
 
-      skin._renderedScale = scale;
+        // Translate the canvas so we don't have to do a bunch of width/height arithmetic
+        ctx.save();
+        ctx.translate(paddedWidth - BubbleStyle.CORNER_RADIUS, paddedHeight);
+
+        // Draw the bubble's "tail"
+        if (skin._bubbleType === "say") {
+          // For a speech bubble, draw one swoopy thing
+          ctx.bezierCurveTo(0, 4, 4, 8, 4, 10);
+          ctx.arcTo(4, 12, 2, 12, 2);
+          ctx.bezierCurveTo(-1, 12, -11, 8, -16, 0);
+
+          ctx.closePath();
+        } else {
+          // For a thinking bubble, draw a partial circle attached to the bubble...
+          ctx.arc(-16, 0, 4, 0, Math.PI);
+
+          ctx.closePath();
+
+          // and two circles detached from it
+          ctx.moveTo(-7, 7.25);
+          ctx.arc(-9.25, 7.25, 2.25, 0, Math.PI * 2);
+
+          ctx.moveTo(0, 9.5);
+          ctx.arc(-1.5, 9.5, 1.5, 0, Math.PI * 2);
+        }
+
+        // Un-translate the canvas and fill + stroke the text bubble
+        ctx.restore();
+
+        ctx.fillStyle = BubbleStyle.COLORS.BUBBLE_FILL;
+        ctx.strokeStyle = BubbleStyle.COLORS.BUBBLE_STROKE;
+        ctx.lineWidth = BubbleStyle.STROKE_WIDTH;
+
+        ctx.stroke();
+        ctx.fill();
+
+        // Un-flip the canvas if it was flipped
+        ctx.restore();
+
+        // Draw each line of text
+        ctx.fillStyle = BubbleStyle.COLORS.TEXT_FILL;
+        ctx.font = `${BubbleStyle.FONT_SIZE}px ${BubbleStyle.FONT}, sans-serif`;
+        const lines = skin._lines;
+        for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
+          const line = lines[lineNumber];
+          ctx.fillText(
+            line,
+            BubbleStyle.PADDING,
+            BubbleStyle.PADDING +
+              BubbleStyle.LINE_HEIGHT * lineNumber +
+              BubbleStyle.FONT_HEIGHT_RATIO * BubbleStyle.FONT_SIZE
+          );
+        }
+
+        skin._renderedScale = scale;
+      };
+      return skinId;
     };
-    return skinId;
   };
 
   const updateBubbles = () => {
@@ -140,7 +144,18 @@ export default async function ({ addon, console }) {
       if (skin && skin.hasOwnProperty("_bubbleType")) skin._textureDirty = true;
     }
   };
-  addon.settings.addEventListener("change", updateBubbles);
+
+  if (addon.settings.get("affectStage")) {
+    overrideCreateTextSkin();
+    usingModifiedCreateTextSkin = true;
+  }
+  addon.settings.addEventListener("change", () => {
+    if (addon.settings.get("affectStage") && !usingModifiedCreateTextSkin) {
+      overrideCreateTextSkin();
+      usingModifiedCreateTextSkin = true;
+    };
+    updateBubbles();
+  });
   addon.self.addEventListener("disabled", updateBubbles);
   addon.self.addEventListener("reenabled", updateBubbles);
 }

--- a/addons/editor-dark-mode/bubbles.js
+++ b/addons/editor-dark-mode/bubbles.js
@@ -31,7 +31,7 @@ export default async function ({ addon, console }) {
           TEXT_FILL: textColor(addon.settings.get("accent"), "#575e75", "#ffffff"),
         },
       };
-      
+
       const ctx = skin._canvas.getContext("2d");
 
       if (skin._textDirty) {
@@ -67,8 +67,13 @@ export default async function ({ addon, console }) {
       ctx.arcTo(0, paddedHeight, 0, paddedHeight - BubbleStyle.CORNER_RADIUS, BubbleStyle.CORNER_RADIUS);
       ctx.arcTo(0, 0, paddedWidth, 0, BubbleStyle.CORNER_RADIUS);
       ctx.arcTo(paddedWidth, 0, paddedWidth, paddedHeight, BubbleStyle.CORNER_RADIUS);
-      ctx.arcTo(paddedWidth, paddedHeight, paddedWidth - BubbleStyle.CORNER_RADIUS, paddedHeight,
-        BubbleStyle.CORNER_RADIUS);
+      ctx.arcTo(
+        paddedWidth,
+        paddedHeight,
+        paddedWidth - BubbleStyle.CORNER_RADIUS,
+        paddedHeight,
+        BubbleStyle.CORNER_RADIUS
+      );
 
       // Translate the canvas so we don't have to do a bunch of width/height arithmetic
       ctx.save();
@@ -118,8 +123,9 @@ export default async function ({ addon, console }) {
         ctx.fillText(
           line,
           BubbleStyle.PADDING,
-          BubbleStyle.PADDING + (BubbleStyle.LINE_HEIGHT * lineNumber) +
-            (BubbleStyle.FONT_HEIGHT_RATIO * BubbleStyle.FONT_SIZE)
+          BubbleStyle.PADDING +
+            BubbleStyle.LINE_HEIGHT * lineNumber +
+            BubbleStyle.FONT_HEIGHT_RATIO * BubbleStyle.FONT_SIZE
         );
       }
 
@@ -127,7 +133,7 @@ export default async function ({ addon, console }) {
     };
     return skinId;
   };
-  
+
   const updateBubbles = () => {
     // Re-render all text bubbles on settings change
     for (let skin of renderer._allSkins) {


### PR DESCRIPTION
### Changes

Changes editor dark mode to use the accent background for speech bubbles if the `affectStage` setting is enabled.