### PR TITLE
editor-stage-left: rewrite fix-share-the-love without urlChange

### DIFF
--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -1,45 +1,18 @@
-export default function ({ addon, global, console }) {
-  let interval, injected;
-
-  addon.self.addEventListener("disabled", () => {
-    clearInterval(interval);
-    Blockly.getMainWorkspace().recordCachedAreas();
-  });
-  addon.self.addEventListener("reenabled", () => {
-    if (!injected) tryInjecting();
-    Blockly.getMainWorkspace().recordCachedAreas();
-  });
-
-  const inject = (workspace) => {
-    injected = true;
-    const originalGetClientRect = workspace.toolbox_.getClientRect;
-    workspace.toolbox_.getClientRect = function () {
-      // we are trying to undo the effect of BIG_NUM in https://github.com/LLK/scratch-blocks/blob/ab26fa2960643fa38fbc7b91ca2956be66055070/core/flyout_vertical.js#L739
-      const rect = originalGetClientRect.call(this);
-      if (!rect || addon.self.disabled) return rect;
-      if (rect.left > 0) return rect;
-      rect.left += 1000000000;
-      rect.width -= 1000000000;
-      return rect;
-    };
+export default async function ({ addon, global, console }) {
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const updateAreas = () => {
+    const workspace = Blockly.getMainWorkspace();
+    if (workspace) workspace.recordCachedAreas();
   };
-
-  function tryInjecting() {
-    if (addon.tab.editorMode === "editor") {
-      interval = setInterval(() => {
-        if (Blockly.getMainWorkspace()) {
-          inject(Blockly.getMainWorkspace());
-          clearInterval(interval);
-        }
-      }, 100);
-    }
-
-    addon.tab.addEventListener("urlChange", () => {
-      if (addon.tab.editorMode === "editor") {
-        // Inject even if addon is disabled, will pollute but not change function return value
-        inject(Blockly.getMainWorkspace());
-      }
-    });
-  }
-  tryInjecting();
+  addon.self.addEventListener("disabled", updateAreas);
+  addon.self.addEventListener("reenabled", updateAreas);
+  const originalGetClientRect = ScratchBlocks.Toolbox.prototype.getClientRect;
+  ScratchBlocks.Toolbox.prototype.getClientRect = function () {
+    // we are trying to undo the effect of BIG_NUM in https://github.com/LLK/scratch-blocks/blob/ab26fa2960643fa38fbc7b91ca2956be66055070/core/flyout_vertical.js#L739
+    const rect = originalGetClientRect.call(this);
+    if (!rect || addon.self.disabled) return rect;
+    rect.left += 1000000000;
+    rect.width -= 1000000000;
+    return rect;
+  };
 }


### PR DESCRIPTION
Just cleans up some old code and fixes some potential uncaught errors.

 - replace urlChange, editorMode, and setInterval with getBlockly
 - fixes dynamic enable/disable throwing error if workspace does not exist (don't think this actually broke anything)
 - should work slightly more reliably
