### PR TITLE
Use "projects" match for editor and project player addons

### DIFF
--- a/addons/2d-color-picker/addon.json
+++ b/addons/2d-color-picker/addon.json
@@ -11,13 +11,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "libraries": ["tinycolor2"],

--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -23,7 +23,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/animated-thumb/addon.json
+++ b/addons/animated-thumb/addon.json
@@ -25,11 +25,11 @@
   ],
   "userscripts": [
     {
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "url": "userscript.js"
     },
     {
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "url": "persistent-thumb.js",
       "settingMatch": {
         "id": "persistentThumb",
@@ -40,7 +40,7 @@
   "userstyles": [
     {
       "url": "userscript.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/better-img-uploads/addon.json
+++ b/addons/better-img-uploads/addon.json
@@ -29,13 +29,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/bitmap-copy/addon.json
+++ b/addons/bitmap-copy/addon.json
@@ -11,7 +11,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/block-palette-icons/addon.json
+++ b/addons/block-palette-icons/addon.json
@@ -8,7 +8,7 @@
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.11.0",

--- a/addons/block-switching/addon.json
+++ b/addons/block-switching/addon.json
@@ -12,7 +12,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "codeEditor", "recommended"],

--- a/addons/blocks2image/addon.json
+++ b/addons/blocks2image/addon.json
@@ -11,7 +11,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.13.0",

--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -13,7 +13,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "info": [

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -12,13 +12,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "projectPlayer"],

--- a/addons/color-picker/addon.json
+++ b/addons/color-picker/addon.json
@@ -14,13 +14,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/custom-block-shape/addon.json
+++ b/addons/custom-block-shape/addon.json
@@ -21,7 +21,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "info": [

--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -13,13 +13,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/data-category-tweaks-v2/addon.json
+++ b/addons/data-category-tweaks-v2/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],

--- a/addons/disable-auto-save/addon.json
+++ b/addons/disable-auto-save/addon.json
@@ -17,7 +17,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.8.0",

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -9,13 +9,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "dragged-over.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -13,13 +13,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "userscript.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "codeEditor", "theme"],

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -660,42 +660,22 @@
   "userscripts": [
     {
       "url": "bubbles.js",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ]
+      "matches": ["projects"]
     },
     {
       "url": "paper.js",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "experimental_editor.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ]
+      "matches": ["projects"]
     },
     {
       "url": "text-shadow.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ],
+      "matches": ["projects"],
       "settingMatch": {
         "id": "textShadow",
         "value": true
@@ -703,12 +683,7 @@
     },
     {
       "url": "hide_dots.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ],
+      "matches": ["projects"],
       "settingMatch": {
         "id": "dots",
         "value": false
@@ -716,12 +691,7 @@
     },
     {
       "url": "stage.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ],
+      "matches": ["projects"],
       "settingMatch": {
         "id": "affectStage",
         "value": true
@@ -729,12 +699,7 @@
     },
     {
       "url": "dark_comments.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ],
+      "matches": ["projects"],
       "settingMatch": {
         "id": "darkComments",
         "value": true
@@ -742,12 +707,7 @@
     },
     {
       "url": "scrollbar.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/",
-        "https://scratch.mit.edu/projects/*/editor",
-        "https://scratch.mit.edu/projects/*/fullscreen",
-        "https://scratch.mit.edu/projects/editor"
-      ],
+      "matches": ["projects"],
       "settingMatch": {
         "id": "darkScrollbars",
         "value": true

--- a/addons/editor-devtools/addon.json
+++ b/addons/editor-devtools/addon.json
@@ -36,13 +36,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "userscript.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.0.0",

--- a/addons/editor-messages/addon.json
+++ b/addons/editor-messages/addon.json
@@ -9,13 +9,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.4.0",

--- a/addons/editor-searchable-dropdowns/addon.json
+++ b/addons/editor-searchable-dropdowns/addon.json
@@ -11,13 +11,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "userscript.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.0.0",

--- a/addons/editor-sounds/addon.json
+++ b/addons/editor-sounds/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "codeEditor"],

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "fix-share-the-love.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,
@@ -18,7 +18,7 @@
   "userstyles": [
     {
       "url": "stageleft.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "theme", "recommended"],

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -6,7 +6,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -17,13 +17,13 @@
   "userscripts": [
     {
       "url": "theme3.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "theme3.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/fix-uploaded-svgs/addon.json
+++ b/addons/fix-uploaded-svgs/addon.json
@@ -4,7 +4,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],

--- a/addons/folders/addon.json
+++ b/addons/folders/addon.json
@@ -21,14 +21,14 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.11.0",

--- a/addons/gamepad/addon.json
+++ b/addons/gamepad/addon.json
@@ -9,17 +9,17 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     },
     {
       "url": "gamepadlib.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -17,7 +17,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [

--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -10,7 +10,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -14,7 +14,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.2.0",

--- a/addons/load-extensions/addon.json
+++ b/addons/load-extensions/addon.json
@@ -4,7 +4,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/mediarecorder/addon.json
+++ b/addons/mediarecorder/addon.json
@@ -5,13 +5,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.6.0",

--- a/addons/mouse-pos/addon.json
+++ b/addons/mouse-pos/addon.json
@@ -12,13 +12,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "projectPlayer", "recommended"],

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -10,7 +10,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.7.0",

--- a/addons/onion-skinning/addon.json
+++ b/addons/onion-skinning/addon.json
@@ -9,13 +9,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -15,13 +15,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "tags": ["editor", "projectPlayer", "recommended"],

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -9,14 +9,14 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -11,11 +11,11 @@
   "userscripts": [
     {
       "url": "projectstats.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     },
     {
       "url": "blockcount.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "settingMatch": {
         "id": "editorCount",
         "value": true
@@ -25,7 +25,7 @@
   "userstyles": [
     {
       "url": "userscript.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/project-notes-tabs/addon.json
+++ b/addons/project-notes-tabs/addon.json
@@ -10,14 +10,14 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.4.0",

--- a/addons/remix-tree-button/addon.json
+++ b/addons/remix-tree-button/addon.json
@@ -11,14 +11,14 @@
   "userscripts": [
     {
       "url": "main.js",
-      "matches": ["https://scratch.mit.edu/projects/*"],
+      "matches": ["projects"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "button.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/remove-curved-stage-border/addon.json
+++ b/addons/remove-curved-stage-border/addon.json
@@ -15,7 +15,7 @@
   "userstyles": [
     {
       "url": "remove-borders.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ]
 }

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -4,7 +4,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -12,13 +12,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,


### PR DESCRIPTION
### Changes

Uses `"matches": ["projects"]` for editor and project player addons. I thought this would improve performance (for example when enabling and disabling addons) on project remixes and studios pages, but it doesn't seem to.

### Tests

Going to https://scratch.mit.edu/projects/60917032/remixes/ now only shows website addons.