### PR TITLE
editor-stage-left: fix a couple bugs

### DIFF
--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -15,4 +15,5 @@ export default async function ({ addon, global, console }) {
     rect.width -= 1000000000;
     return rect;
   };
+  if (addon.self.enabledLate) updateAreas();
 }

--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -1,11 +1,11 @@
 export default async function ({ addon, global, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
-  const updateAreas = () => {
+  const resize = () => {
     const workspace = Blockly.getMainWorkspace();
     if (workspace) window.dispatchEvent(new Event('resize'));
   };
-  addon.self.addEventListener("disabled", updateAreas);
-  addon.self.addEventListener("reenabled", updateAreas);
+  addon.self.addEventListener("disabled", resize);
+  addon.self.addEventListener("reenabled", resize);
   const originalGetClientRect = ScratchBlocks.Toolbox.prototype.getClientRect;
   ScratchBlocks.Toolbox.prototype.getClientRect = function () {
     // we are trying to undo the effect of BIG_NUM in https://github.com/LLK/scratch-blocks/blob/ab26fa2960643fa38fbc7b91ca2956be66055070/core/flyout_vertical.js#L739
@@ -15,5 +15,5 @@ export default async function ({ addon, global, console }) {
     rect.width -= 1000000000;
     return rect;
   };
-  if (addon.self.enabledLate) updateAreas();
+  if (addon.self.enabledLate) resize();
 }

--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -2,7 +2,7 @@ export default async function ({ addon, global, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
   const updateAreas = () => {
     const workspace = Blockly.getMainWorkspace();
-    if (workspace) workspace.recordCachedAreas();
+    if (workspace) window.dispatchEvent(new Event('resize'));
   };
   addon.self.addEventListener("disabled", updateAreas);
   addon.self.addEventListener("reenabled", updateAreas);

--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -2,7 +2,7 @@ export default async function ({ addon, global, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
   const resize = () => {
     const workspace = Blockly.getMainWorkspace();
-    if (workspace) window.dispatchEvent(new Event('resize'));
+    if (workspace) window.dispatchEvent(new Event("resize"));
   };
   addon.self.addEventListener("disabled", resize);
   addon.self.addEventListener("reenabled", resize);


### PR DESCRIPTION
 - Fixes https://discord.com/channels/751206349614088204/819307061493760031/869286894578577479

>1. Load the editor with editor-stage-left off
>2. Drag any block from the block palette (not workspace) into another sprite
>3. Enable editor-stage-left (dynamicEnable)
>4. (Try to) drag any block from the block palette (not workspace) into another sprite

 - Fixes mouse coordinate blocks reporting wrong values after dynamic enable/disable