### PR TITLE
Add TurboWarp dark mode as a preset for editor-dark-mode

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -963,6 +963,34 @@
       }
     },
     {
+      "name": "TurboWarp Dark",
+      "id": "tw-dark",
+      "description": "A dark theme based on TurboWarp's dark mode.",
+      "values": {
+        "page": "#111111",
+        "primary": "#4d97ff",
+        "highlightText": "#4d97ff",
+        "menuBar": "#333333",
+        "activeTab": "#1e1e1e",
+        "tab": "#2e2e2e",
+        "selector": "#1e1e1e",
+        "selector2": "#2e2e2e",
+        "selectorSelection": "#111111",
+        "accent": "#111111",
+        "input": "#1e1e1e",
+        "workspace": "#1e1e1e",
+        "categoryMenu": "#111111",
+        "palette": "#111111",
+        "fullscreen": "#111111",
+        "stageHeader": "#111111",
+        "border": "#00000026",
+        "textShadow": false,
+        "dots": true,
+        "darkComments": false,
+        "darkScrollbars": false
+      }
+    },
+    {
       "name": "Scratch's default colors",
       "id": "scratch",
       "description": "The colors normally used by Scratch",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -13,6 +13,10 @@
     {
       "name": "_nix (Dark editor)",
       "link": "https://github.com/towerofnix"
+    },
+    {
+      "name": "GarboMuffin (TurboWarp Dark)",
+      "link": "https://github.com/GarboMuffin"
     }
   ],
   "customCssVariables": [

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -986,8 +986,8 @@
         "border": "#00000026",
         "textShadow": false,
         "dots": true,
-        "darkComments": false,
-        "darkScrollbars": false
+        "darkComments": true,
+        "darkScrollbars": true
       }
     },
     {

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -972,8 +972,8 @@
       "description": "A dark theme based on TurboWarp's dark mode.",
       "values": {
         "page": "#111111",
-        "primary": "#4d97ff",
-        "highlightText": "#4d97ff",
+        "primary": "#ff4d4d",
+        "highlightText": "#ff4d4d",
         "menuBar": "#333333",
         "activeTab": "#1e1e1e",
         "tab": "#2e2e2e",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -983,7 +983,7 @@
         "palette": "#111111",
         "fullscreen": "#111111",
         "stageHeader": "#111111",
-        "border": "#00000026",
+        "border": "#ffffff0d",
         "textShadow": false,
         "dots": true,
         "darkComments": true,


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2246

### Changes

Adds TurboWarp's dark mode as a preset for the `editor-dark-mode` addon.

### Reason for changes

Because a lot of people like TurboWarp's dark theme and it's annoying having to set each colour manually.

### Tests

Tested locally on Edge.
