### PR TITLE
Comment Blocks

### DIFF
--- a/addons/dark-www/experimental_forums.css
+++ b/addons/dark-www/experimental_forums.css
@@ -111,3 +111,7 @@
 .my-ocular-popup::after {
   border-top-color: #202020;
 }
+
+.closed-topic a {
+    color: #c0c0c0;
+}

--- a/addons/dark-www/experimental_forums.css
+++ b/addons/dark-www/experimental_forums.css
@@ -113,5 +113,5 @@
 }
 
 .closed-topic a {
-    color: #c0c0c0;
+  color: #c0c0c0;
 }

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Debugger",
-  "description": "Adds a new \"debugger\" block category and a \"logs\" window to the editor. The \"log\", \"warn\" and \"error\" blocks will print the specified message into the logs window. The \"breakpoint\" block will pause the project when executed.",
+  "description": "Adds a new \"debugger\" block category and a \"logs\" window to the editor. The \"log\", \"warn\" and \"error\" blocks will print the specified message into the logs window. The \"breakpoint\" block will pause the project when executed. The \"comment\" ",
   "credits": [
     {
       "name": "GrahamSH"
@@ -10,6 +10,9 @@
     },
     {
       "name": "retronbv"
+    },
+    {
+      "name":"8bitjake"
     }
   ],
   "userscripts": [
@@ -22,6 +25,14 @@
     {
       "url": "style.css",
       "matches": ["projects"]
+    }
+  ],
+  "settings": [
+    {
+      "id": "comments",
+      "name": "Comment Blocks",
+      "default": true,
+      "type": "boolean"
     }
   ],
   "tags": ["editor", "beta"],

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -30,6 +30,12 @@ export default async function ({ addon, global, console, msg }) {
     callback: pause,
     hidden: true,
   });
+  if (addon.settings.get("comments")) { // feel free to remove the setting
+  addon.tab.addBlock("\u200B\u200Bcomment %s", {
+    args: ["content"],
+    displayName: msg("block-comment"),
+  });
+}
   addon.tab.addBlock("\u200B\u200Bbreakpoint\u200B\u200B", {
     args: [],
     displayName: msg("block-breakpoint"),


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

This does not resolve any issues.

### Changes

I've added a "comment blocks" setting to the debugger addon, along with code to add the block. Feel free to move this to its own addon, it should probably be one 😛

### Reason for changes

A few users have suggested a comment block addon. Although you can already create a comment block in vanilla Scratch (see below image), this is here for convenience.
![image](https://user-images.githubusercontent.com/75950907/127246222-a0f4474c-5535-4a6d-8447-3ea97461e252.png)


### Tests

Tested via a custom SA installation on Google Chrome (version 92.0.4515.107).
Screenshot of addon in action:
![image](https://cdn.discordapp.com/attachments/806602307750985803/869738227429437491/unknown.png)


p.s: my fork also includes the code from #2956, I closed it so I could make this pr
go check it out!


