### PR TITLE
Run 60fps, mute-project, and pause in embeds

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -23,7 +23,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects"]
+      "matches": ["projects", "projectEmbeds"]
     }
   ],
   "settings": [

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -10,7 +10,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects"]
+      "matches": ["projects", "projectEmbeds"]
     }
   ],
   "versionAdded": "1.7.0",

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -15,13 +15,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects"]
+      "matches": ["projects", "projectEmbeds"]
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["projects"]
+      "matches": ["projects", "projectEmbeds"]
     }
   ],
   "tags": ["editor", "projectPlayer", "recommended"],


### PR DESCRIPTION
Makes 60fps, mute-projects, and pause addons run in embeds again, allowing them to be used together with live featured project.