### PR TITLE
We can keep the stage the exact same size

### DIFF
--- a/addons/turbowarp-player/style.css
+++ b/addons/turbowarp-player/style.css
@@ -39,9 +39,8 @@
 }
 
 .sa-tw-iframe {
-  width: calc(100% + 8px);
+  width: 100%;
   height: calc(100% + 10px);
-  margin-left: -4px;
   margin-top: -3px;
   border: none;
 }

--- a/addons/turbowarp-player/style.css
+++ b/addons/turbowarp-player/style.css
@@ -40,7 +40,12 @@
 
 .sa-tw-iframe {
   width: 100%;
+  /* TW scratch-gui/src/lib/screen-utils.js, line 57
+     The stage height should be 360px
+     innerHeight = 360px + 44px + 12px = 416px = 100% + 10px */
   height: calc(100% + 10px);
+  /* Move the stage up to align it with the project description */
   margin-top: -3px;
+
   border: none;
 }

--- a/addons/turbowarp-player/style.css
+++ b/addons/turbowarp-player/style.css
@@ -26,19 +26,22 @@
   background-image: url(https://scratch.mit.edu/favicon.ico);
 }
 
-.sa-tw-iframe {
-  overflow: hidden;
-  box-sizing: border-box;
-
-  /* Same styles as .project-description */
-  border: 1px solid rgba(77, 151, 255, 0.1);
-  border-radius: 8px;
-  background-color: rgba(77, 151, 255, 0.1);
-
+.sa-tw-iframe-container {
   /* Same styles as .guiPlayer */
   display: inline-block;
   position: relative;
   z-index: 1;
   width: 482px;
   height: 406px;
+
+  /* Hide part of loading screen to make it the same size as Scratch's */
+  overflow: hidden;
+}
+
+.sa-tw-iframe {
+  width: calc(100% + 8px);
+  height: calc(100% + 10px);
+  margin-left: -4px;
+  margin-top: -3px;
+  border: none;
 }

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -2,17 +2,20 @@ export default async function ({ addon, console, msg }) {
   const action = addon.settings.get("action");
   let playerToggled = false;
   let scratchStage;
+  let twIframeContainer = document.createElement("div");
+  twIframeContainer.className = "sa-tw-iframe-container";
   let twIframe = document.createElement("iframe");
   twIframe.setAttribute("allowtransparency", "true");
   twIframe.setAttribute("allowfullscreen", "true");
   twIframe.className = "sa-tw-iframe";
+  twIframeContainer.appendChild(twIframe);
 
   const button = document.createElement("button");
   button.className = "button sa-tw-button";
   button.title = "TurboWarp";
 
   function removeIframe() {
-    twIframe.remove();
+    twIframeContainer.remove();
     scratchStage.style.display = "";
     button.classList.remove("scratch");
     playerToggled = false;
@@ -27,7 +30,7 @@ export default async function ({ addon, console, msg }) {
         const projectId = window.location.pathname.split("/")[2];
         const iframeUrl = `https://turbowarp.org/${projectId}/embed${usernameUrlParam}`;
         twIframe.src = "";
-        scratchStage.parentElement.prepend(twIframe);
+        scratchStage.parentElement.prepend(twIframeContainer);
         // Use location.replace to avoid creating a history entry
         twIframe.contentWindow.location.replace(iframeUrl);
 


### PR DESCRIPTION
See https://github.com/ScratchAddons/ScratchAddons/pull/2682#issuecomment-888570607

### Changes

Makes the TurboWarp stage the same size as Scratch's stage and removes the now unnecessary background and border from the iframe.