### PR TITLE
infinite-scroll: Fix donor text with "fix footer"

### DIFF
--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -88,6 +88,15 @@
         "https://scratch.mit.edu/users/*",
         "https://scratch.mit.edu/messages"
       ]
+    },
+	{
+      "url": "moveDonor.js",
+      "matches": ["https://scratch.mit.edu/"],
+      "settingMatch": {
+        "id": "showFooter",
+        "value": true
+      },
+	  "runAtComplete": false
     }
   ],
   "userstyles": [

--- a/addons/infinite-scroll/footer.css
+++ b/addons/infinite-scroll/footer.css
@@ -29,5 +29,5 @@ body, /* scratch-www */
 }
 
 :root {
-	--footer-hover-height: 300px; /* How high the hovered footer is (for donor text fix) */
+  --footer-hover-height: 300px; /* How high the hovered footer is (for donor text fix) */
 }

--- a/addons/infinite-scroll/footer.css
+++ b/addons/infinite-scroll/footer.css
@@ -21,9 +21,13 @@ body, /* scratch-www */
   padding-top: 20px;
 }
 #footer:hover {
-  height: 300px;
+  height: var(--footer-hover-height);
 }
 
 .page > #view {
   margin-bottom: 0;
+}
+
+:root {
+	--footer-hover-height: 300px; /* How high the hovered footer is (for donor text fix) */
 }

--- a/addons/infinite-scroll/moveDonor.js
+++ b/addons/infinite-scroll/moveDonor.js
@@ -1,0 +1,8 @@
+export default async function ({ addon, global, console }) {
+	const root = document.documentElement; //The :root element
+	const footer = await addon.tab.waitForElement("#footer"); //The footer
+	const donor = await addon.tab.waitForElement("#donor"); //The donor text
+	
+	footer.appendChild(donor); //Move the donor text to inside the footer
+	root.style.setProperty("--footer-hover-height", "400px"); //Also make the hovered footer higher so the text is actually visible
+}


### PR DESCRIPTION
Resolves #1600

### Changes

In the `infintie-scroll` addon, this adds a simple userscript for the home page that simply moves the donor text (the "Scratch is available for free..." text) into the footer, allowing it to show when the footer is hovered over instead of being at the bottom of the page.
This also adds a CSS variable for the hovered footer's height so that the userscript can change it to make the text visible once it runs.

### Reason for changes

Not having the donor text be with the footer just looks weird.

### Tests

Seems to work.
![pic](https://user-images.githubusercontent.com/68464103/127449631-b13607d8-f74b-4947-a70e-6b4e49e73ac2.png)
The donor text script moves the text about 1-2 secs after the footer style loads which is okay.