### PR TITLE
msg-count-badge: add indicator when signed out

### DIFF
--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -30,7 +30,7 @@
       "id": "offlineText",
       "type": "string",
       "default": "?",
-      "min": "1"
+      "min": 1
     }
   ],
   "presets": [

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -9,7 +9,7 @@
   "settings": [
     {
       "name": "Badge color for message count",
-      "id": "countColor",
+      "id": "color",
       "type": "color",
       "default": "#008000"
     },

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -8,7 +8,7 @@
   "versionAdded": "1.0.0",
   "settings": [
     {
-      "name": "Badge color for message count",
+      "name": "Badge color",
       "id": "color",
       "type": "color",
       "default": "#008000"
@@ -18,19 +18,6 @@
       "id": "showOffline",
       "type": "boolean",
       "default": false
-    },
-    {
-      "name": "Badge color when not signed in",
-      "id": "offlineColor",
-      "type": "color",
-      "default": "#e90404"
-    },
-    {
-      "name": "Badge indicator when not signed in",
-      "id": "offlineText",
-      "type": "string",
-      "default": "?",
-      "min": 1
     }
   ],
   "presets": [

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -8,32 +8,59 @@
   "versionAdded": "1.0.0",
   "settings": [
     {
-      "name": "Badge color",
-      "id": "color",
+      "name": "Badge color for message count",
+      "id": "countColor",
       "type": "color",
       "default": "#008000"
+    },
+    {
+      "name": "Indicate when not signed in",
+      "id": "showOffline",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "name": "Badge color when not signed in",
+      "id": "offlineColor",
+      "type": "color",
+      "default": "#e90404"
+    },
+    {
+      "name": "Badge indicator when not signed in",
+      "id": "offlineText",
+      "type": "string",
+      "default": "?",
+      "min": "1"
     }
   ],
   "presets": [
     {
-      "name": "Old light green",
+      "name": "Legacy",
       "id": "oldLightGreen",
+      "description": "The badge color from the original Scratch Messaging extension.",
       "values": {
-        "color": "#8ce68c"
+        "countColor": "#8ce68c"
       }
     },
     {
       "name": "Blue",
       "id": "blue",
       "values": {
-        "color": "#175ef8"
+        "countColor": "#175ef8"
+      }
+    },
+    {
+      "name": "Red",
+      "id": "red",
+      "values": {
+        "countColor": "#e90404"
       }
     },
     {
       "name": "Black",
       "id": "black",
       "values": {
-        "color": "#000000"
+        "countColor": "#000000"
       }
     }
   ]

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -22,32 +22,25 @@
   ],
   "presets": [
     {
-      "name": "Legacy",
+      "name": "Old light green",
       "id": "oldLightGreen",
-      "description": "The badge color from the original Scratch Messaging extension.",
+      "description": "The badge color from the original Scratch Messaging Extension.",
       "values": {
-        "countColor": "#8ce68c"
+        "color": "#8ce68c"
       }
     },
     {
       "name": "Blue",
       "id": "blue",
       "values": {
-        "countColor": "#175ef8"
-      }
-    },
-    {
-      "name": "Red",
-      "id": "red",
-      "values": {
-        "countColor": "#e90404"
+        "color": "#175ef8"
       }
     },
     {
       "name": "Black",
       "id": "black",
       "values": {
-        "countColor": "#000000"
+        "color": "#000000"
       }
     }
   ]

--- a/addons/msg-count-badge/background.js
+++ b/addons/msg-count-badge/background.js
@@ -1,12 +1,34 @@
 export default async function ({ addon, global, console, setTimeout, setInterval, clearTimeout, clearInterval }) {
+
   const setBadge = async () => {
+
     const msgCount = await addon.account.getMsgCount();
-    addon.badge.text = msgCount;
+
+    if (addon.settings.get("showOffline") && isNaN(parseInt(msgCount))) {
+
+      // Offline badge color
+      addon.badge.color = addon.settings.get("offlineColor");
+
+      // Offline badge indicator
+      addon.badge.text = addon.settings.get("offlineText");
+
+    } else {
+
+      // Regular badge color
+      addon.badge.color = addon.settings.get("countColor");
+
+      // Regular message count
+      addon.badge.text = msgCount;
+
+    };
   };
+  
   setBadge();
-  addon.badge.color = addon.settings.get("color");
+
   addon.settings.addEventListener("change", () => {
-    addon.badge.color = addon.settings.get("color");
+    setBadge();
   });
+
   setInterval(setBadge, 2500);
-}
+
+};

--- a/addons/msg-count-badge/background.js
+++ b/addons/msg-count-badge/background.js
@@ -10,7 +10,7 @@ export default async function ({ addon, global, console, setTimeout, setInterval
       addon.badge.text = addon.settings.get("offlineText");
     } else {
       // Regular badge color
-      addon.badge.color = addon.settings.get("countColor");
+      addon.badge.color = addon.settings.get("color");
 
       // Regular message count
       addon.badge.text = msgCount;

--- a/addons/msg-count-badge/background.js
+++ b/addons/msg-count-badge/background.js
@@ -1,27 +1,23 @@
 export default async function ({ addon, global, console, setTimeout, setInterval, clearTimeout, clearInterval }) {
-  const setBadge = async () => {
-    const msgCount = await addon.account.getMsgCount();
+  let msgCount;
 
-    if (addon.settings.get("showOffline") && isNaN(parseInt(msgCount))) {
-      // Offline badge color
-      addon.badge.color = addon.settings.get("offlineColor");
-
-      // Offline badge indicator
-      addon.badge.text = addon.settings.get("offlineText");
+  const setBadge = () => {
+    if (msgCount === null && addon.settings.get("showOffline")) {
+      addon.badge.color = "black";
+      addon.badge.text = "?";
     } else {
-      // Regular badge color
       addon.badge.color = addon.settings.get("color");
-
-      // Regular message count
       addon.badge.text = msgCount;
     }
   };
-
-  setBadge();
-
-  addon.settings.addEventListener("change", () => {
+  const getMsgCountAndSetBadge = async () => {
+    msgCount = await addon.account.getMsgCount();
     setBadge();
-  });
+  };
 
-  setInterval(setBadge, 2500);
+  getMsgCountAndSetBadge();
+
+  addon.settings.addEventListener("change", setBadge);
+
+  setInterval(getMsgCountAndSetBadge, 2500);
 }

--- a/addons/msg-count-badge/background.js
+++ b/addons/msg-count-badge/background.js
@@ -3,7 +3,7 @@ export default async function ({ addon, global, console, setTimeout, setInterval
 
   const setBadge = () => {
     if (msgCount === null && addon.settings.get("showOffline")) {
-      addon.badge.color = "black";
+      addon.badge.color = "#dd2222";
       addon.badge.text = "?";
     } else {
       addon.badge.color = addon.settings.get("color");

--- a/addons/msg-count-badge/background.js
+++ b/addons/msg-count-badge/background.js
@@ -1,28 +1,22 @@
 export default async function ({ addon, global, console, setTimeout, setInterval, clearTimeout, clearInterval }) {
-
   const setBadge = async () => {
-
     const msgCount = await addon.account.getMsgCount();
 
     if (addon.settings.get("showOffline") && isNaN(parseInt(msgCount))) {
-
       // Offline badge color
       addon.badge.color = addon.settings.get("offlineColor");
 
       // Offline badge indicator
       addon.badge.text = addon.settings.get("offlineText");
-
     } else {
-
       // Regular badge color
       addon.badge.color = addon.settings.get("countColor");
 
       // Regular message count
       addon.badge.text = msgCount;
-
-    };
+    }
   };
-  
+
   setBadge();
 
   addon.settings.addEventListener("change", () => {
@@ -30,5 +24,4 @@ export default async function ({ addon, global, console, setTimeout, setInterval
   });
 
   setInterval(setBadge, 2500);
-
-};
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #1756.

Currently, it is impossible to tell the difference between not having any messages and not being signed in. Because Scratch sessions can expire without action on the user's behalf, a user may falsely believe that they have no messages under the notion that they're still logged in.

It's also useful to know when the Scratch website experiences downtime and/or if the network connection as a whole is down.

### Changes

<!-- Please describe the changes you've made. -->
A new option has been added to "Message count on extension icon". It's disabled by default.

![image](https://user-images.githubusercontent.com/43426138/127586431-f047b023-8c39-4482-95f7-676c2301f33a.png)

When the option is enabled, a special badge appears when the user is offline, signed out, or having other connection issues to Scratch.

![image](https://user-images.githubusercontent.com/43426138/127586329-5c49e0ea-c283-401f-9e5c-40d500b0a3d1.png)

Additional options are available to customize this offline badge.

![image](https://user-images.githubusercontent.com/43426138/127586693-126dabf4-c3f7-40b5-ab33-3f80ac7ede61.png)
![image](https://user-images.githubusercontent.com/43426138/127586697-e7b1b177-7033-4716-b3d4-b508ccd7f3ba.png)

The default red for the setting has also been added as a preset for the regular badge color. Additionally, the "Old light green" preset was renamed to "Legacy" and given a tooltip description. Presets (as of now) only affect the regular badge color, not the offline badge.

![image](https://user-images.githubusercontent.com/43426138/127587898-08c8f5e1-8c5b-492b-9afd-8964b0c98078.png)

### Reasons for changes

<!-- Why should these changes be made? -->
~~You can put a dango in the badge~~
![image](https://user-images.githubusercontent.com/43426138/127589365-2c0c2088-b01f-4444-98b5-b6e29b35daa5.png)


### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested in Chromium 92 and Firefox 90.
Does not impact previous behavior when the "Indicate when not signed in" option is disabled.
Being signed out, signing in, and signing back out all function as expected.

### To-do
- [ ] When #3151 is merged, use the `if` property to hide the last two addon settings when `showOffline` is `false`.
