### PR TITLE
editor-theme3 fixes

### DIFF
--- a/addons/editor-colored-context-menus/userscript.css
+++ b/addons/editor-colored-context-menus/userscript.css
@@ -1,14 +1,15 @@
 .u-contextmenu-colored .blocklyContextMenu {
   background-color: var(--u-contextmenu-bg);
-  border-color: #0003;
+  border-color: var(--u-contextmenu-border);
+}
+.u-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight,
+.u-contextmenu-colored .s3dev-mi:hover {
+  background-color: var(--u-contextmenu-hover);
+  border-color: transparent !important;
+}
+.u-contextmenu-colored .blocklyContextMenu .goog-menuitem[style*="border-top"] {
+  border-top-color: var(--u-contextmenu-border) !important;
 }
 .u-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {
-  color: white;
-}
-.u-contextmenu-colored .blocklyContextMenu .goog-menuitem:hover.goog-menuitem-highlight,
-.s3dev-mi:hover {
-  border-color: transparent;
-}
-.u-contextmenu-colored .blocklyContextMenu .goog-menuitem:hover {
-  background-color: rgba(0, 0, 0, 0.2);
+  color: var(--u-contextmenu-text);
 }

--- a/addons/editor-colored-context-menus/userscript.js
+++ b/addons/editor-colored-context-menus/userscript.js
@@ -51,15 +51,15 @@ function handleClick(e) {
     return;
   }
 
-  const fillHex = fill.substr(1);
-  const rgb = parseInt(fillHex, 16);
-  const hsl = rgb2hsl(rgb);
-  hsl[2] = Math.max(hsl[2] - 15, 0);
-  const border = "hsl(" + hsl[0] + ", " + hsl[1] + "%, " + hsl[2] + "%)";
+  const border = window.getComputedStyle(background).getPropertyValue("stroke") || "#0003";
+  const textColor = window.getComputedStyle(background).getPropertyValue("--sa-block-text-color") || "#fff";
+  const hoverBg = window.getComputedStyle(background).getPropertyValue("--sa-block-secondary-color") || "#0001";
 
   widgetDiv.classList.add("u-contextmenu-colored");
   widgetDiv.style.setProperty("--u-contextmenu-bg", fill);
   widgetDiv.style.setProperty("--u-contextmenu-border", border);
+  widgetDiv.style.setProperty("--u-contextmenu-text", textColor);
+  widgetDiv.style.setProperty("--u-contextmenu-hover", hoverBg);
 }
 
 function rgb2hsl(rgb) {

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -266,8 +266,9 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
   stroke: var(--editorDarkMode-input);
 }
 .blocklyDropDownDiv[style*="background-color: rgb(255, 255, 255)"] {
-  /* scratch-blocks color picker */
+  /* scratch-blocks color pickers and result bubbles */
   background-color: var(--editorDarkMode-input) !important;
+  color: var(--editorDarkMode-input-text);
 }
 .scratchEyedropper img,
 .sa-onion-settings .sa-onion-image {

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -24,10 +24,6 @@ g[data-argument-type*="text"] > path,
   border-color: #0003 !important;
 }
 
-#s3devDD > li.extension {
-  background-color: var(--editorTheme3-PenColor);
-}
-
 .fieldTextInput {
   border-color: #0003 !important;
 }

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -5,13 +5,16 @@ g[data-category] > path.blocklyBlockBackground {
   stroke: #0003;
 }
 g[data-argument-type="dropdown"] > path,
-g[data-argument-type="dropdown"] > rect,
-g[data-argument-type="variable"] > rect,
 g[data-argument-type="variable"] > path,
-g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > path,
-path[data-argument-type="boolean"] {
+path[data-argument-type="boolean"],
+g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > path /* block preview in define block */ {
   stroke: #0003;
   fill: #0001;
+}
+g[data-argument-type="dropdown"] > rect,
+g[data-argument-type="variable"] > rect {
+  stroke: #0003;
+  fill: none;
 }
 g[data-argument-type*="text"] > path,
 [data-category] g > line {
@@ -23,10 +26,6 @@ g[data-argument-type*="text"] > path,
 
 #s3devDD > li.extension {
   background-color: var(--editorTheme3-PenColor);
-}
-
-.blocklyEditableText rect {
-  fill: #0001;
 }
 
 .fieldTextInput {

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -16,6 +16,21 @@ function updateSettings(addon, newStyle) {
         color: #575e75;
       }`;
   }
+  if (textMode === "colorOnWhite") {
+    stylesheet += `
+      .blocklyDropDownDiv:not([style*="rgb(255, 255, 255)"]) .goog-menuitem {
+        color: #575e75;
+      }`;
+  }
+  if (textMode === "colorOnBlack") {
+    stylesheet += `
+      .blocklyDropDownDiv:not([style*="rgb(255, 255, 255)"]) .goog-option-selected .goog-menuitem-checkbox {
+        filter: brightness(0) invert(1);
+      }
+      .u-dropdown-searchbar {
+        border-color: rgba(255, 255, 255, 0.15);
+      }`;
+  }
   var categories = {
     motion: {
       color: "#4C97FF",
@@ -77,6 +92,9 @@ function updateSettings(addon, newStyle) {
         fill: var(--editorTheme3-${settingName}Color);
         ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
       }
+      .blocklyBlockBackground[fill="${categories[prop].tertiaryColor}"] /* open dropdown */ {
+        fill: #0003;
+      }
       .scratchCategoryId-${categories[prop].alt ? categories[prop].alt : prop} > .scratchCategoryItemBubble {
         background-color: var(--editorTheme3-${settingName}Color) !important;
       }
@@ -130,6 +148,7 @@ function updateSettings(addon, newStyle) {
       let background = { colorOnWhite: "#fff", colorOnBlack: "#282828" }[textMode];
       let inputShadow = { colorOnWhite: "#00000026", colorOnBlack: "#fff3" }[textMode];
       let secondary = multiply(addon.settings.get(prop + "-color"), { a: 0.15 });
+      let secondaryActive = multiply(addon.settings.get(prop + "-color"), { a: 0.2 });
       let menuText = { colorOnWhite: "#575e75", colorOnBlack: "#fff" }[textMode];
       stylesheet += `g[data-category="${prop}"] > path.blocklyBlockBackground,
       g[data-category="${prop}"] > g[data-argument-type="dropdown"] > rect,
@@ -137,10 +156,10 @@ function updateSettings(addon, newStyle) {
         fill: ${background};
         stroke: var(--editorTheme3-${settingName}Color);
         --sa-block-text-color: ${menuText};
-        --sa-block-secondary-color: ${secondary};
+        --sa-block-secondary-color: ${secondaryActive};
       }
       g[data-category="${prop}"] > .blocklyText,
-      g[data-category="${prop}"] > g:not([data-category]) > .blocklyText /* variable and list reporters */ {
+      g[data-category="${prop}"] > g:not(.blocklyDraggable) > .blocklyText /* variable and list reporters */ {
         fill: var(--editorTheme3-${settingName}Color);
       }
       g[data-category="${prop}"] > g[data-argument-type="dropdown"] > .blocklyDropdownText,
@@ -154,6 +173,9 @@ function updateSettings(addon, newStyle) {
         fill: ${secondary};
         stroke: var(--editorTheme3-${settingName}Color);
       }
+      .blocklyBlockBackground[fill="${categories[prop].tertiaryColor}"] /* open dropdown */ {
+        fill: ${secondaryActive} !important;
+      }
       .scratchCategoryId-${categories[prop].alt ? categories[prop].alt : prop} > .scratchCategoryItemBubble {
         background-color: var(--editorTheme3-${settingName}Color) !important;
       }
@@ -161,8 +183,8 @@ function updateSettings(addon, newStyle) {
         background-color: ${background} !important;
         border-color: var(--editorTheme3-${settingName}Color) !important;
       }
-      .blocklyDropDownDiv[data-category="${prop}"] .goog-menuitem {
-        color: var(--editorTheme3-${settingName}Color);
+      .blocklyDropDownDiv[data-category="${prop}"] .goog-menuitem-highlight {
+        background-color: ${secondaryActive};
       }
       .blocklyBubbleCanvas [stroke="${categories[prop].tertiaryColor}"],
       g[data-category=${prop}] > g[data-argument-type*="text"] > path,
@@ -184,7 +206,7 @@ function updateSettings(addon, newStyle) {
           fill: ${background};
           stroke: var(--editorTheme3-${prop}Color);
           --sa-block-text-color: ${menuText};
-          --sa-block-secondary-color: ${secondary};
+          --sa-block-secondary-color: ${secondaryActive};
         }
         path.blocklyBlockBackground[fill="#FF6680"] ~ .blocklyText,
         g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > .blocklyText,
@@ -205,15 +227,13 @@ function updateSettings(addon, newStyle) {
       }
       if (prop === "sensing") {
         stylesheet += `path.blocklyBlockBackground[fill="#5CB1D6"],
-        g[data-argument-type="dropdown"] > rect[fill="#5CB1D6"],
-        g[data-argument-type="dropdown"] > rect[fill="#2E8EB8"] {
+        g[data-argument-type="dropdown"] > rect[fill="#5CB1D6"] {
           fill: ${background};
           stroke: var(--editorTheme3-${prop}Color);
           --sa-block-text-color: ${menuText};
-          --sa-block-secondary-color: ${secondary};
+          --sa-block-secondary-color: ${secondaryActive};
         }
-        g[data-argument-type="dropdown"] > path[fill="#47A8D1"],
-        g[data-argument-type="dropdown"] > path[fill="#2E8EB8"] {
+        g[data-argument-type="dropdown"] > path[fill="#47A8D1"] {
           fill: ${secondary};
           stroke: var(--editorTheme3-${prop}Color);
         }
@@ -230,8 +250,8 @@ function updateSettings(addon, newStyle) {
           background-color: ${background} !important;
           border-color: var(--editorTheme3-${settingName}Color) !important;
         }
-        .blocklyDropDownDiv[style*="rgb(92, 177, 214)"] .goog-menuitem {
-          color: var(--editorTheme3-${settingName}Color);
+        .blocklyDropDownDiv[style*="rgb(92, 177, 214)"] .goog-menuitem-highlight {
+          background-color: ${secondaryActive};
         }`;
       }
       if (prop === "events") {
@@ -241,7 +261,7 @@ function updateSettings(addon, newStyle) {
           fill: ${background};
           stroke: var(--editorTheme3-${settingName}Color);
           --sa-block-text-color: ${menuText};
-          --sa-block-secondary-color: ${secondary};
+          --sa-block-secondary-color: ${secondaryActive};
         }
         path.blocklyBlockBackground[fill="#FFBF00"] ~ .blocklyText {
           fill: var(--editorTheme3-${prop}Color);
@@ -257,8 +277,8 @@ function updateSettings(addon, newStyle) {
           background-color: ${background} !important;
           border-color: var(--editorTheme3-${settingName}Color) !important;
         }
-        .blocklyDropDownDiv[style*="rgb(255, 191, 0)"] .goog-menuitem {
-          color: var(--editorTheme3-${settingName}Color);
+        .blocklyDropDownDiv[style*="rgb(255, 191, 0)"] .goog-menuitem-highlight {
+          background-color: ${secondaryActive};
         }`;
       }
       if (prop === "Pen") {
@@ -266,7 +286,7 @@ function updateSettings(addon, newStyle) {
           fill: ${background};
           stroke: var(--editorTheme3-${prop}Color);
           --sa-block-text-color: ${menuText};
-          --sa-block-secondary-color: ${secondary};
+          --sa-block-secondary-color: ${secondaryActive};
         }
         path.blocklyBlockBackground[fill="#0FBD8C"] ~ .blocklyText {
           fill: var(--editorTheme3-${prop}Color);
@@ -274,14 +294,16 @@ function updateSettings(addon, newStyle) {
         path.blocklyBlockBackground[fill="#0FBD8C"] ~ g[data-argument-type="dropdown"] > g > .blocklyDropdownText {
           fill: var(--editorTheme3-${prop}Color) !important;
         }
-        g[data-argument-type="dropdown"] > path[fill="#0DA57A"],
-        g[data-argument-type="dropdown"] > path[fill="#0B8E69"] {
+        g[data-argument-type="dropdown"] > path[fill="#0DA57A"] {
           fill: ${secondary};
           stroke: var(--editorTheme3-${prop}Color);
         }
         .blocklyDropDownDiv[style*="rgb(15, 189, 140)"] {
           background-color: ${background} !important;
           border-color: var(--editorTheme3-${settingName}Color) !important;
+        }
+        .blocklyDropDownDiv[style*="rgb(15, 189, 140)"] .goog-menuitem-highlight {
+          background-color: ${secondaryActive};
         }
         path.blocklyBlockBackground[fill="#0FBD8C"] ~ [data-argument-type="text"] > path,
         path.blocklyBlockBackground[fill="#0FBD8C"] ~ g > line  {

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -88,6 +88,7 @@ function updateSettings(addon, newStyle) {
   for (var prop of Object.keys(categories)) {
     var settingName = categories[prop].var ? categories[prop].var : prop;
     if (textMode === "white" || textMode === "black") {
+      let tertiary = multiply(addon.settings.get(prop + "-color"), { r: 0.8, g: 0.8, b: 0.8 });
       stylesheet += `g[data-category="${prop}"] > path.blocklyBlockBackground {
         fill: var(--editorTheme3-${settingName}Color);
         ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
@@ -108,6 +109,10 @@ function updateSettings(addon, newStyle) {
       #s3devIDD > li.${prop} {
         background-color: var(--editorTheme3-${settingName}Color);
       }
+      #s3devIDD > li.${prop}:hover,
+      #s3devIDD > li.${prop}.sel {
+        background-color: ${tertiary};
+      }
       .console-variable[data-category="${prop}"] {
         background-color: var(--editorTheme3-${settingName}Color) !important;
       }
@@ -116,6 +121,13 @@ function updateSettings(addon, newStyle) {
         stylesheet += `path.blocklyBlockBackground[fill="#FF6680"] {
           fill: var(--editorTheme3-${prop}Color);
           ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
+        }
+        #s3devIDD > li.null {
+          background-color: var(--editorTheme3-${settingName}Color);
+        }
+        #s3devIDD > li.null:hover,
+        #s3devIDD > li.null.sel {
+          background-color: ${tertiary};
         }`;
       }
       if (prop === "sensing") {
@@ -142,6 +154,13 @@ function updateSettings(addon, newStyle) {
         .blocklyDropDownDiv[style*="rgb(15, 189, 140)"] {
           background-color: var(--editorTheme3-${prop}Color) !important;
           border-color: #0003 !important;
+        }
+        #s3devIDD > li.extension {
+          background-color: var(--editorTheme3-${settingName}Color);
+        }
+        #s3devIDD > li.extension:hover,
+        #s3devIDD > li.extension.sel {
+          background-color: ${tertiary};
         }`;
       }
     } else {
@@ -195,11 +214,12 @@ function updateSettings(addon, newStyle) {
         box-shadow: 0 0 0 4px ${inputShadow} !important;
       }
       #s3devIDD > li.${prop} {
-        background-color: ${background};
+        background-color: ${secondary};
         color: var(--editorTheme3-${settingName}Color);
       }
-      #s3devIDD > li.${prop}:not(.boolean) {
-        border: 1px solid var(--editorTheme3-${settingName}Color);
+      #s3devIDD > li.${prop}:hover,
+      #s3devIDD > li.${prop}.sel {
+        background-color: ${secondaryActive};
       }`;
       if (prop === "custom") {
         stylesheet += `path.blocklyBlockBackground[fill="#FF6680"] {
@@ -223,6 +243,14 @@ function updateSettings(addon, newStyle) {
         }
         .blocklyEditableText > rect[fill="#FF3355"] {
           fill: ${secondary};
+        }
+        #s3devIDD > li.null {
+          background-color: ${secondary};
+          color: var(--editorTheme3-${settingName}Color);
+        }
+        #s3devIDD > li.null:hover,
+        #s3devIDD > li.null.sel {
+          background-color: ${secondaryActive};
         }`;
       }
       if (prop === "sensing") {
@@ -310,11 +338,12 @@ function updateSettings(addon, newStyle) {
           stroke: var(--editorTheme3-${prop}Color);
         }
         #s3devIDD > li.extension {
-          background-color: ${background};
+          background-color: ${secondary};
           color: var(--editorTheme3-${settingName}Color);
         }
-        #s3devIDD > li.extension:not(.boolean) {
-          border: 1px solid var(--editorTheme3-${settingName}Color);
+        #s3devIDD > li.extension:hover,
+        #s3devIDD > li.extension.sel {
+          background-color: ${secondaryActive};
         }`;
       }
     }

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -91,7 +91,7 @@ function updateSettings(addon, newStyle) {
       let tertiary = multiply(addon.settings.get(prop + "-color"), { r: 0.8, g: 0.8, b: 0.8 });
       stylesheet += `g[data-category="${prop}"] > path.blocklyBlockBackground {
         fill: var(--editorTheme3-${settingName}Color);
-        ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
+        ${textMode === "black" ? "--sa-block-text-color: #575e75;" : ""}
       }
       .blocklyBlockBackground[fill="${categories[prop].tertiaryColor}"] /* open dropdown */ {
         fill: #0003;
@@ -120,7 +120,7 @@ function updateSettings(addon, newStyle) {
       if (prop === "custom") {
         stylesheet += `path.blocklyBlockBackground[fill="#FF6680"] {
           fill: var(--editorTheme3-${prop}Color);
-          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;" : ""}
         }
         #s3devIDD > li.null {
           background-color: var(--editorTheme3-${settingName}Color);
@@ -133,13 +133,13 @@ function updateSettings(addon, newStyle) {
       if (prop === "sensing") {
         stylesheet += `path.blocklyBlockBackground[fill="#5CB1D6"] {
           fill: var(--editorTheme3-${prop}Color);
-          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;" : ""}
         }`;
       }
       if (prop === "events") {
         stylesheet += `path.blocklyBlockBackground[fill="#FFBF00"] {
           fill: var(--editorTheme3-${prop}Color);
-          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;" : ""}
         }
         .blocklyDropDownDiv[style*="rgb(255, 191, 0)"] {
           background-color: var(--editorTheme3-${prop}Color) !important;
@@ -149,7 +149,7 @@ function updateSettings(addon, newStyle) {
       if (prop === "Pen") {
         stylesheet += `path.blocklyBlockBackground[fill="#0FBD8C"] {
           fill: var(--editorTheme3-${prop}Color);
-          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;" : ""}
         }
         .blocklyDropDownDiv[style*="rgb(15, 189, 140)"] {
           background-color: var(--editorTheme3-${prop}Color) !important;

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -148,7 +148,7 @@ function updateSettings(addon, newStyle) {
       let background = { colorOnWhite: "#fff", colorOnBlack: "#282828" }[textMode];
       let inputShadow = { colorOnWhite: "#00000026", colorOnBlack: "#fff3" }[textMode];
       let secondary = multiply(addon.settings.get(prop + "-color"), { a: 0.15 });
-      let secondaryActive = multiply(addon.settings.get(prop + "-color"), { a: 0.2 });
+      let secondaryActive = multiply(addon.settings.get(prop + "-color"), { a: 0.25 });
       let menuText = { colorOnWhite: "#575e75", colorOnBlack: "#fff" }[textMode];
       stylesheet += `g[data-category="${prop}"] > path.blocklyBlockBackground,
       g[data-category="${prop}"] > g[data-argument-type="dropdown"] > rect,

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -75,6 +75,7 @@ function updateSettings(addon, newStyle) {
     if (textMode === "white" || textMode === "black") {
       stylesheet += `g[data-category="${prop}"] > path.blocklyBlockBackground {
         fill: var(--editorTheme3-${settingName}Color);
+        ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
       }
       .scratchCategoryId-${categories[prop].alt ? categories[prop].alt : prop} > .scratchCategoryItemBubble {
         background-color: var(--editorTheme3-${settingName}Color) !important;
@@ -96,16 +97,19 @@ function updateSettings(addon, newStyle) {
       if (prop === "custom") {
         stylesheet += `path.blocklyBlockBackground[fill="#FF6680"] {
           fill: var(--editorTheme3-${prop}Color);
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
         }`;
       }
       if (prop === "sensing") {
         stylesheet += `path.blocklyBlockBackground[fill="#5CB1D6"] {
           fill: var(--editorTheme3-${prop}Color);
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
         }`;
       }
       if (prop === "events") {
         stylesheet += `path.blocklyBlockBackground[fill="#FFBF00"] {
           fill: var(--editorTheme3-${prop}Color);
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
         }
         .blocklyDropDownDiv[style*="rgb(255, 191, 0)"] {
           background-color: var(--editorTheme3-${prop}Color) !important;
@@ -115,6 +119,7 @@ function updateSettings(addon, newStyle) {
       if (prop === "Pen") {
         stylesheet += `path.blocklyBlockBackground[fill="#0FBD8C"] {
           fill: var(--editorTheme3-${prop}Color);
+          ${textMode === "black" ? "--sa-block-text-color: #575e75;": ""}
         }
         .blocklyDropDownDiv[style*="rgb(15, 189, 140)"] {
           background-color: var(--editorTheme3-${prop}Color) !important;
@@ -125,11 +130,14 @@ function updateSettings(addon, newStyle) {
       let background = { colorOnWhite: "#fff", colorOnBlack: "#282828" }[textMode];
       let inputShadow = { colorOnWhite: "#00000026", colorOnBlack: "#fff3" }[textMode];
       let secondary = multiply(addon.settings.get(prop + "-color"), { a: 0.15 });
+      let menuText = { colorOnWhite: "#575e75", colorOnBlack: "#fff" }[textMode];
       stylesheet += `g[data-category="${prop}"] > path.blocklyBlockBackground,
       g[data-category="${prop}"] > g[data-argument-type="dropdown"] > rect,
       g[data-category="${prop}"] > g[data-argument-type="variable"] > rect {
         fill: ${background};
         stroke: var(--editorTheme3-${settingName}Color);
+        --sa-block-text-color: ${menuText};
+        --sa-block-secondary-color: ${secondary};
       }
       g[data-category="${prop}"] > .blocklyText {
         fill: var(--editorTheme3-${settingName}Color);
@@ -174,6 +182,8 @@ function updateSettings(addon, newStyle) {
         stylesheet += `path.blocklyBlockBackground[fill="#FF6680"] {
           fill: ${background};
           stroke: var(--editorTheme3-${prop}Color);
+          --sa-block-text-color: ${menuText};
+          --sa-block-secondary-color: ${secondary};
         }
         path.blocklyBlockBackground[fill="#FF6680"] ~ .blocklyText,
         g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable) > .blocklyText,
@@ -198,6 +208,8 @@ function updateSettings(addon, newStyle) {
         g[data-argument-type="dropdown"] > rect[fill="#2E8EB8"] {
           fill: ${background};
           stroke: var(--editorTheme3-${prop}Color);
+          --sa-block-text-color: ${menuText};
+          --sa-block-secondary-color: ${secondary};
         }
         g[data-argument-type="dropdown"] > path[fill="#47A8D1"],
         g[data-argument-type="dropdown"] > path[fill="#2E8EB8"] {
@@ -227,6 +239,8 @@ function updateSettings(addon, newStyle) {
         g[data-argument-type="dropdown"] > rect[fill="#CC9900"] {
           fill: ${background};
           stroke: var(--editorTheme3-${settingName}Color);
+          --sa-block-text-color: ${menuText};
+          --sa-block-secondary-color: ${secondary};
         }
         path.blocklyBlockBackground[fill="#FFBF00"] ~ .blocklyText {
           fill: var(--editorTheme3-${prop}Color);
@@ -250,6 +264,8 @@ function updateSettings(addon, newStyle) {
         stylesheet += `g[data-category] /* specificity */ > path.blocklyBlockBackground[fill="#0FBD8C"] {
           fill: ${background};
           stroke: var(--editorTheme3-${prop}Color);
+          --sa-block-text-color: ${menuText};
+          --sa-block-secondary-color: ${secondary};
         }
         path.blocklyBlockBackground[fill="#0FBD8C"] ~ .blocklyText {
           fill: var(--editorTheme3-${prop}Color);

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -80,7 +80,7 @@ function updateSettings(addon, newStyle) {
       .scratchCategoryId-${categories[prop].alt ? categories[prop].alt : prop} > .scratchCategoryItemBubble {
         background-color: var(--editorTheme3-${settingName}Color) !important;
       }
-      .blocklyDropDownDiv[data-category="${prop}"] {
+      .blocklyDropDownDiv[data-category="${prop}"]:not([style*="rgb(255, 255, 255)"]) {
         background-color: var(--editorTheme3-${settingName}Color) !important;
         border-color: #0003 !important;
       }
@@ -156,7 +156,7 @@ function updateSettings(addon, newStyle) {
       .scratchCategoryId-${categories[prop].alt ? categories[prop].alt : prop} > .scratchCategoryItemBubble {
         background-color: var(--editorTheme3-${settingName}Color) !important;
       }
-      .blocklyDropDownDiv[data-category="${prop}"] {
+      .blocklyDropDownDiv[data-category="${prop}"]:not([style*="rgb(255, 255, 255)"]) {
         background-color: ${background} !important;
         border-color: var(--editorTheme3-${settingName}Color) !important;
       }

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -139,7 +139,8 @@ function updateSettings(addon, newStyle) {
         --sa-block-text-color: ${menuText};
         --sa-block-secondary-color: ${secondary};
       }
-      g[data-category="${prop}"] > .blocklyText {
+      g[data-category="${prop}"] > .blocklyText,
+      g[data-category="${prop}"] > g:not([data-category]) > .blocklyText /* variable and list reporters */ {
         fill: var(--editorTheme3-${settingName}Color);
       }
       g[data-category="${prop}"] > g[data-argument-type="dropdown"] > .blocklyDropdownText,


### PR DESCRIPTION
Resolves #2553
Resolves #2644
Resolves #3002

### Changes

Fixes some bugs in the customizable block colors addon:
* Improves compatibility with developer tools and colored context menus
* Fixes result bubbles and color pickers being affected
* Fixes white text on variable and list reporters in "colored on white background" and "colored on black background" modes
* Dropdown changes