### PR TITLE
Add credits to Compact Messages Addon

### DIFF
--- a/addons/compact-messages/addon.json
+++ b/addons/compact-messages/addon.json
@@ -3,10 +3,6 @@
   "description": "Makes Scratch's messages page more compact and easier to read.",
   "credits": [
     {
-      "name": "World_Languages",
-      "link": "https://github.com/WorldLanguages/"
-    },
-    {
       "name": "LankyBox01",
       "link": "https://lankybox01.leahcimto.com/"
     }

--- a/addons/compact-messages/addon.json
+++ b/addons/compact-messages/addon.json
@@ -1,6 +1,20 @@
 {
   "name": "Compact messages",
   "description": "Makes Scratch's messages page more compact and easier to read.",
+  "credits": [
+    {
+      "name": "World_Languages",
+      "link": "https://github.com/WorldLanguages/"
+    },
+    {
+      "name": "LankyBox01",
+      "link": "https://lankybox01.leahcimto.com/"
+    },
+    {
+      "name": "RedGuy7",
+      "link": "https://paul-s-reid.com/web-dev/"
+    }
+  ],
   "settings": [
     {
       "name": "Hide message type icons",

--- a/addons/compact-messages/addon.json
+++ b/addons/compact-messages/addon.json
@@ -9,10 +9,6 @@
     {
       "name": "LankyBox01",
       "link": "https://lankybox01.leahcimto.com/"
-    },
-    {
-      "name": "RedGuy7",
-      "link": "https://paul-s-reid.com/web-dev/"
     }
   ],
   "settings": [


### PR DESCRIPTION
Am i doing this right?

### Changes

Adds a "credits" category to addon.json

### Reason for changes

Because the credits paragraph doesn't show up when locally testing. every other addon has it.

### Tests

I did download my fork and test it, and it looks like this:
![image](https://user-images.githubusercontent.com/79767244/127733650-f5513270-f0ef-47de-9a96-ba25a1c19497.png)