### PR TITLE
Fix TurboWarp Addon Error and Devtools clean up msg being wrong

### DIFF
--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -53,12 +53,12 @@ export default class DevTools {
         oldCleanUpFunc.call(this);
       }
     };
-    
+
     let orginialMsg = blockly.Msg.CLEAN_UP;
     if (this.addon.settings.get("enableCleanUpPlus")) blockly.Msg.CLEAN_UP = this.m("clean-plus");
     this.addon.settings.addEventListener("change", () => {
       if (this.addon.settings.get("enableCleanUpPlus")) blockly.Msg.CLEAN_UP = this.m("clean-plus");
-      else blockly.Msg.CLEAN_UP = orginialMsg
+      else blockly.Msg.CLEAN_UP = orginialMsg;
     });
 
     this.addon.tab.createBlockContextMenu(

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -53,9 +53,12 @@ export default class DevTools {
         oldCleanUpFunc.call(this);
       }
     };
+    
+    let orginialMsg = blockly.Msg.CLEAN_UP;
     if (this.addon.settings.get("enableCleanUpPlus")) blockly.Msg.CLEAN_UP = this.m("clean-plus");
     this.addon.settings.addEventListener("change", () => {
       if (this.addon.settings.get("enableCleanUpPlus")) blockly.Msg.CLEAN_UP = this.m("clean-plus");
+      else blockly.Msg.CLEAN_UP = orginialMsg
     });
 
     this.addon.tab.createBlockContextMenu(

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -43,8 +43,6 @@ export default async function ({ addon, console, msg }) {
     }
   };
 
-  addon.tab.addEventListener("urlChange", removeIframe);
-
   let showAlert = true;
   while (true) {
     const seeInside = await addon.tab.waitForElement(".see-inside-button", {


### PR DESCRIPTION
### Changes

- An error that occers with the turbowarp addon when seeing inside
- The clean up message in the context menu when you change the setting for devtools.

### Tests

Yep, self merging, these changes are only on master, not on stable.