### PR TITLE
studio-tools: remove locale `username` and replace with native message

### DIFF
--- a/addons-l10n/en/studio-tools.json
+++ b/addons-l10n/en/studio-tools.json
@@ -3,7 +3,6 @@
   "studio-tools/remove-new": "Remove Curators",
   "studio-tools/leave": "Leave",
   "studio-tools/leave-new": "Leave Studio",
-  "studio-tools/username": "Username",
   "studio-tools/promote-btn": "Promote",
   "studio-tools/remove-btn": "Remove",
   "studio-tools/owner-error": "You are the owner of the studio.",

--- a/addons/studio-tools/migrated.js
+++ b/addons/studio-tools/migrated.js
@@ -42,7 +42,7 @@ export default async ({ addon, console, msg }) => {
 
     const inputTag = document.createElement("input");
     inputTag.type = "text";
-    inputTag.placeholder = addon.tab.scratchMessage('studio.inviteCuratorPlaceholder');
+    inputTag.placeholder = addon.tab.scratchMessage("studio.inviteCuratorPlaceholder");
     adderRow.appendChild(inputTag);
 
     const btn = document.createElement("button");

--- a/addons/studio-tools/migrated.js
+++ b/addons/studio-tools/migrated.js
@@ -42,7 +42,7 @@ export default async ({ addon, console, msg }) => {
 
     const inputTag = document.createElement("input");
     inputTag.type = "text";
-    inputTag.placeholder = msg("username");
+    inputTag.placeholder = addon.tab.scratchMessage('studio.inviteCuratorPlaceholder');
     adderRow.appendChild(inputTag);
 
     const btn = document.createElement("button");


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #3013

### Changes
Removes locale `username` and replaced by native scratch-www message

### Reason for changes

why are we wasting translators time :P

### Tests

tested locally