### PR TITLE
New addon: Create empty sprite/costume instead of opening library

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -87,6 +87,7 @@
   "default-project",
   "turbowarp-player",
   "ctrl-enter-post",
+  "paint-by-default",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "Create empty sprite/costume instead of opening library",
+  "description": "Changes the \"Choose a Sprite\" and \"Choose a Costume\" buttons to create an empty sprite/costume instead of opening the library.",
+  "credits": [
+    {
+      "name": "GarboMuffin"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.19.0",
+  "tags": ["editor"],
+  "enabledByDefault": false
+}

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -62,6 +62,30 @@
       "default": "paint"
     },
     {
+      "id": "backdrop",
+      "name": "Add backdrop",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "Open Library",
+          "name": "Open Library"
+        },
+        {
+          "id": "paint",
+          "name": "Create Empty"
+        },
+        {
+          "id": "surprise",
+          "name": "Surprise"
+        },
+        {
+          "id": "upload",
+          "name": "Upload"
+        }
+      ],
+      "default": "paint"
+    },
+    {
       "id": "sound",
       "name": "Add sound",
       "type": "select",

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -12,6 +12,80 @@
       "matches": ["projects"]
     }
   ],
+  "settings": [
+    {
+      "id": "sprite",
+      "name": "Add sprite",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "library",
+          "name": "Open Library"
+        },
+        {
+          "id": "paint",
+          "name": "Create Empty"
+        },
+        {
+          "id": "surprise",
+          "name": "Surprise"
+        },
+        {
+          "id": "upload",
+          "name": "Upload"
+        }
+      ],
+      "default": "paint"
+    },
+    {
+      "id": "costume",
+      "name": "Add costume",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "Open Library",
+          "name": "Open Library"
+        },
+        {
+          "id": "paint",
+          "name": "Create Empty"
+        },
+        {
+          "id": "surprise",
+          "name": "Surprise"
+        },
+        {
+          "id": "upload",
+          "name": "Upload"
+        }
+      ],
+      "default": "paint"
+    },
+    {
+      "id": "sound",
+      "name": "Add sound",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "library",
+          "name": "Open Library"
+        },
+        {
+          "id": "record",
+          "name": "Record"
+        },
+        {
+          "id": "surprise",
+          "name": "Surprise"
+        },
+        {
+          "id": "upload",
+          "name": "Upload"
+        }
+      ],
+      "default": "library"
+    }
+  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.19.0",

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Change behavior of create new sprite/backdrop/costume/sound buttons",
-  "description": "Changes create asset buttons to create an empty costume, upload a file, or create a random asset instead of opening the library.",
+  "name": "Paint costume by default",
+  "description": "Changes the default action of \"Choose a Sprite/Costume/Backdrop/Sound\" buttons, which open the library by default.",
   "credits": [
     {
       "name": "GarboMuffin"
@@ -20,11 +20,11 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search library"
+          "name": "Library"
         },
         {
           "id": "paint",
-          "name": "Create empty"
+          "name": "Paint"
         },
         {
           "id": "surprise",
@@ -44,11 +44,11 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search library"
+          "name": "Library"
         },
         {
           "id": "paint",
-          "name": "Create empty"
+          "name": "Paint"
         },
         {
           "id": "surprise",
@@ -68,11 +68,11 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search library"
+          "name": "Library"
         },
         {
           "id": "paint",
-          "name": "Create empty"
+          "name": "Paint"
         },
         {
           "id": "surprise",
@@ -92,7 +92,7 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search library"
+          "name": "Library"
         },
         {
           "id": "record",
@@ -113,6 +113,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.19.0",
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabledByDefault": false
 }

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -43,7 +43,7 @@
       "type": "select",
       "potentialValues": [
         {
-          "id": "Open Library",
+          "id": "library",
           "name": "Open Library"
         },
         {
@@ -67,7 +67,7 @@
       "type": "select",
       "potentialValues": [
         {
-          "id": "Open Library",
+          "id": "library",
           "name": "Open Library"
         },
         {

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Create empty sprite/costume instead of opening library",
-  "description": "Changes the \"Choose a Sprite\" and \"Choose a Costume\" buttons to create an empty sprite/costume instead of opening the library.",
+  "name": "Change behavior of create new sprite/backdrop/costume/sound buttons",
+  "description": "Changes create asset buttons to create an empty costume, upload a file, or create a random asset instead of opening the library.",
   "credits": [
     {
       "name": "GarboMuffin"
@@ -20,7 +20,7 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Open Library"
+          "name": "Search Library"
         },
         {
           "id": "paint",
@@ -44,7 +44,7 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Open Library"
+          "name": "Search Library"
         },
         {
           "id": "paint",
@@ -68,7 +68,7 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Open Library"
+          "name": "Search Library"
         },
         {
           "id": "paint",
@@ -92,7 +92,7 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Open Library"
+          "name": "Search Library"
         },
         {
           "id": "record",

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -20,11 +20,11 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search Library"
+          "name": "Search library"
         },
         {
           "id": "paint",
-          "name": "Create Empty"
+          "name": "Create empty"
         },
         {
           "id": "surprise",
@@ -44,11 +44,11 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search Library"
+          "name": "Search library"
         },
         {
           "id": "paint",
-          "name": "Create Empty"
+          "name": "Create empty"
         },
         {
           "id": "surprise",
@@ -68,11 +68,11 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search Library"
+          "name": "Search library"
         },
         {
           "id": "paint",
-          "name": "Create Empty"
+          "name": "Create empty"
         },
         {
           "id": "surprise",
@@ -92,7 +92,7 @@
       "potentialValues": [
         {
           "id": "library",
-          "name": "Search Library"
+          "name": "Search library"
         },
         {
           "id": "record",

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -1,34 +1,89 @@
 export default async function ({ addon, console }) {
+  const spriteMeta = {
+    upload: {
+      index: 0,
+      tooltip: "gui.spriteSelector.addSpriteFromFile"
+    },
+    surprise: {
+      index: 1,
+      tooltip: "gui.spriteSelector.addSpriteFromSurprise"
+    },
+    paint: {
+      index: 2,
+      tooltip: "gui.spriteSelector.addSpriteFromPaint"
+    },
+    library: {
+      index: 3,
+      tooltip: "gui.spriteSelector.addSpriteFromLibrary"
+    }
+  };
+  const backdropMeta = {
+    upload: {
+      index: 0,
+      tooltip: "gui.stageSelector.addBackdropFromFile"
+    },
+    surprise: {
+      index: 1,
+      tooltip: "gui.stageSelector.addBackdropFromSurprise"
+    },
+    paint: {
+      index: 2,
+      tooltip: "gui.stageSelector.addBackdropFromPaint"
+    },
+    library: {
+      index: 3,
+      tooltip: "gui.spriteSelector.addBackdropFromLibrary"
+    }
+  };
+  const costumeMeta = {
+    upload: {
+      index: 0,
+      tooltip: "gui.costumeTab.addFileCostume"
+    },
+    surprise: {
+      index: 1,
+      tooltip: "gui.costumeTab.addSurpriseCostume"
+    },
+    paint: {
+      index: 2,
+      tooltip: "gui.costumeTab.addBlankCostume"
+    },
+    library: {
+      index: 3,
+      tooltip: "gui.costumeTab.addCostumeFromLibrary"
+    }
+  };
+  const soundMeta = {
+    upload: {
+      index: 0,
+      tooltip: "gui.soundTab.fileUploadSound"
+    },
+    surprise: {
+      index: 1,
+      tooltip: "gui.soundTab.surpriseSound"
+    },
+    record: {
+      index: 2,
+      tooltip: "gui.soundTab.recordSound"
+    },
+    library: {
+      index: 3,
+      tooltip: "gui.soundTab.addSoundFromLibrary"
+    }
+  };
   const getButtonToClick = (mainButton) => {
-    let index;
-    const indexes = {
-      upload: 0,
-      surprise: 1,
-      paint: 2,
-      record: 2,
-      library: 3
-    };
     const assetPanelWrapper = mainButton.closest("[class*=asset-panel_wrapper_]");
     if (assetPanelWrapper) {
       if (assetPanelWrapper.querySelector("[class*=sound-editor_editor-container_]")) {
-        index = indexes[addon.settings.get("sound")];
+        return soundMeta[addon.settings.get("sound")];
       } else {
-        index = indexes[addon.settings.get("costume")];
+        return costumeMeta[addon.settings.get("costume")];
       }
-    } else if (mainButton.closest("[class*=target-pane_stage-selector-wrapper]")) {
-      index = indexes[addon.settings.get("backdrop")];
+    } else if (mainButton.closest('[class*="target-pane_stage-selector-wrapper"]')) {
+      return backdropMeta[addon.settings.get("backdrop")];
     } else {
-      index = indexes[addon.settings.get("sprite")];
+      return spriteMeta[addon.settings.get("sprite")];
     }
-    if (typeof index !== 'number') {
-      // should never happen
-      return;
-    }
-    const moreButtonsElement = mainButton.parentElement.querySelector('[class*="action-menu_more-buttons_"]');
-    const moreButtons = moreButtonsElement.children;
-    // Search from end of array for compatibility with better-img-uploads
-    const buttonToClick = moreButtons[moreButtons.length - (4 - index)];
-    return buttonToClick;
   };
   document.body.addEventListener(
     "click",
@@ -40,11 +95,12 @@ export default async function ({ addon, console }) {
       if (!mainButton) {
         return;
       }
-      const buttonToClick = getButtonToClick(mainButton);
-      if (!buttonToClick) {
-        return;
-      }
       e.stopPropagation();
+      const moreButtonsElement = mainButton.parentElement.querySelector('[class*="action-menu_more-buttons_"]');
+      const moreButtons = moreButtonsElement.children;
+      const {index} = getButtonToClick(mainButton);
+      // better-img-uploads can add a button at the start, so search "from the end" for compatibility
+      const buttonToClick = moreButtons[moreButtons.length - (4 - index)];
       const elementToClick = buttonToClick.querySelector("button");
       elementToClick.click();
     },
@@ -52,4 +108,14 @@ export default async function ({ addon, console }) {
       bubble: true,
     }
   );
+  /*
+  const updateTooltips = () => {
+    const messages = addon.tab.redux.state.locales.messages;
+    messages[spriteMeta.library.tooltip] = messages[spriteMeta[addon.settings.get("sprite")].tooltip];
+    messages[backdropMeta.library.tooltip] = messages[backdropMeta[addon.settings.get("backdrop")].tooltip];
+    messages[costumeMeta.library.tooltip] = messages[costumeMeta[addon.settings.get("costume")].tooltip];
+    messages[soundMeta.library.tooltip] = messages[soundMeta[addon.settings.get("sound")].tooltip];
+  };
+  updateTooltips();
+  */
 }

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -71,18 +71,24 @@ export default async function ({ addon, console }) {
       tooltip: "gui.soundTab.addSoundFromLibrary"
     }
   };
+  const getSetting = (id) => {
+    if (addon.self.disabled) {
+      return "library";
+    }
+    return addon.settings.get(id);
+  };
   const getButtonToClick = (mainButton) => {
     const assetPanelWrapper = mainButton.closest("[class*=asset-panel_wrapper_]");
     if (assetPanelWrapper) {
       if (assetPanelWrapper.querySelector("[class*=sound-editor_editor-container_]")) {
-        return soundMeta[addon.settings.get("sound")];
+        return soundMeta[getSetting("sound")] || soundMeta.library;
       } else {
-        return costumeMeta[addon.settings.get("costume")];
+        return costumeMeta[getSetting("costume")] || costumeMeta.library;
       }
     } else if (mainButton.closest('[class*="target-pane_stage-selector-wrapper"]')) {
-      return backdropMeta[addon.settings.get("backdrop")];
+      return backdropMeta[getSetting("backdrop")] || backdropMeta.library;
     } else {
-      return spriteMeta[addon.settings.get("sprite")];
+      return spriteMeta[getSetting("sprite")] || spriteMeta.library;
     }
   };
   document.body.addEventListener(
@@ -117,12 +123,13 @@ export default async function ({ addon, console }) {
       }
       const tooltipElement = mainButton.parentElement.querySelector(".__react_component_tooltip");
       const {tooltip} = getButtonToClick(mainButton);
-      const messages = addon.tab.redux.state.locales.messages;
-      const translatedTooltip = messages[tooltip];
-      if (translatedTooltip) {
+      const translatedTooltip = addon.tab.redux.state.locales.messages[tooltip];
+      const needToFixTooltipText = translatedTooltip && tooltipElement.textContent !== translatedTooltip;
+      if (needToFixTooltipText) {
         tooltipElement.textContent = translatedTooltip;
         setTimeout(() => {
           tooltipElement.textContent = translatedTooltip;
+          mainButton.dispatchEvent(new Event("mouseenter"));
         });
       }
     },

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -15,6 +15,8 @@ export default async function ({ addon, console }) {
       } else {
         index = indexes[addon.settings.get("costume")];
       }
+    } else if (mainButton.closest("[class*=target-pane_stage-selector-wrapper]")) {
+      index = indexes[addon.settings.get("backdrop")];
     } else {
       index = indexes[addon.settings.get("sprite")];
     }

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -108,14 +108,26 @@ export default async function ({ addon, console }) {
       bubble: true,
     }
   );
-  /*
-  const updateTooltips = () => {
-    const messages = addon.tab.redux.state.locales.messages;
-    messages[spriteMeta.library.tooltip] = messages[spriteMeta[addon.settings.get("sprite")].tooltip];
-    messages[backdropMeta.library.tooltip] = messages[backdropMeta[addon.settings.get("backdrop")].tooltip];
-    messages[costumeMeta.library.tooltip] = messages[costumeMeta[addon.settings.get("costume")].tooltip];
-    messages[soundMeta.library.tooltip] = messages[soundMeta[addon.settings.get("sound")].tooltip];
-  };
-  updateTooltips();
-  */
+  document.body.addEventListener(
+    "mouseover",
+    (e) => {
+      const mainButton = e.target.closest('[class*="action-menu_main-button_"]');
+      if (!mainButton) {
+        return;
+      }
+      const tooltipElement = mainButton.parentElement.querySelector(".__react_component_tooltip");
+      const {tooltip} = getButtonToClick(mainButton);
+      const messages = addon.tab.redux.state.locales.messages;
+      const translatedTooltip = messages[tooltip];
+      if (translatedTooltip) {
+        tooltipElement.textContent = translatedTooltip;
+        setTimeout(() => {
+          tooltipElement.textContent = translatedTooltip;
+        });
+      }
+    },
+    {
+      bubble: true
+    }
+  );
 }

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, console }) {
-  const spriteMeta = {
+  const spriteMeta = Object.assign(Object.create(null), {
     upload: {
       index: 0,
       tooltip: "gui.spriteSelector.addSpriteFromFile",
@@ -16,8 +16,8 @@ export default async function ({ addon, console }) {
       index: 3,
       tooltip: "gui.spriteSelector.addSpriteFromLibrary",
     },
-  };
-  const backdropMeta = {
+  });
+  const backdropMeta = Object.assign(Object.create(null), {
     upload: {
       index: 0,
       tooltip: "gui.stageSelector.addBackdropFromFile",
@@ -34,8 +34,8 @@ export default async function ({ addon, console }) {
       index: 3,
       tooltip: "gui.spriteSelector.addBackdropFromLibrary",
     },
-  };
-  const costumeMeta = {
+  });
+  const costumeMeta = Object.assign(Object.create(null), {
     upload: {
       index: 0,
       tooltip: "gui.costumeTab.addFileCostume",
@@ -52,8 +52,8 @@ export default async function ({ addon, console }) {
       index: 3,
       tooltip: "gui.costumeTab.addCostumeFromLibrary",
     },
-  };
-  const soundMeta = {
+  });
+  const soundMeta = Object.assign(Object.create(null), {
     upload: {
       index: 0,
       tooltip: "gui.soundTab.fileUploadSound",
@@ -70,7 +70,7 @@ export default async function ({ addon, console }) {
       index: 3,
       tooltip: "gui.soundTab.addSoundFromLibrary",
     },
-  };
+  });
   const getSetting = (id) => {
     if (addon.self.disabled) {
       return "library";

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -1,4 +1,33 @@
 export default async function ({ addon, console }) {
+  const getButtonToClick = (mainButton) => {
+    let index;
+    const indexes = {
+      upload: 0,
+      surprise: 1,
+      paint: 2,
+      record: 2,
+      library: 3
+    };
+    const assetPanelWrapper = mainButton.closest("[class*=asset-panel_wrapper_]");
+    if (assetPanelWrapper) {
+      if (assetPanelWrapper.querySelector("[class*=sound-editor_editor-container_]")) {
+        index = indexes[addon.settings.get("sound")];
+      } else {
+        index = indexes[addon.settings.get("costume")];
+      }
+    } else {
+      index = indexes[addon.settings.get("sprite")];
+    }
+    if (typeof index !== 'number') {
+      // should never happen
+      return;
+    }
+    const moreButtonsElement = mainButton.parentElement.querySelector('[class*="action-menu_more-buttons_"]');
+    const moreButtons = moreButtonsElement.children;
+    // Search from end of array for compatibility with better-img-uploads
+    const buttonToClick = moreButtons[moreButtons.length - (4 - index)];
+    return buttonToClick;
+  };
   document.body.addEventListener(
     "click",
     (e) => {
@@ -6,19 +35,16 @@ export default async function ({ addon, console }) {
         return;
       }
       const mainButton = e.target.closest('[class*="action-menu_main-button_"]');
-      if (mainButton) {
-        const assetPanelWrapper = mainButton.closest("[class*=asset-panel_wrapper_]");
-        if (assetPanelWrapper && assetPanelWrapper.querySelector("[class*=sound-editor_editor-container_]")) {
-          return;
-        }
-        e.stopPropagation();
-        const moreButtonsElement = mainButton.parentElement.querySelector('[class*="action-menu_more-buttons_"]');
-        const moreButtons = moreButtonsElement.children;
-        // use "second from last" to find the paint button for compatibility with HD image uploads
-        const buttonToClick = moreButtons[moreButtons.length - 2];
-        const elementToClick = buttonToClick.querySelector("button");
-        elementToClick.click();
+      if (!mainButton) {
+        return;
       }
+      const buttonToClick = getButtonToClick(mainButton);
+      if (!buttonToClick) {
+        return;
+      }
+      e.stopPropagation();
+      const elementToClick = buttonToClick.querySelector("button");
+      elementToClick.click();
     },
     {
       bubble: true,

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -1,0 +1,27 @@
+export default async function ({ addon, console }) {
+  document.body.addEventListener(
+    "click",
+    (e) => {
+      if (addon.self.disabled) {
+        return;
+      }
+      const mainButton = e.target.closest('[class*="action-menu_main-button_"]');
+      if (mainButton) {
+        const assetPanelWrapper = mainButton.closest("[class*=asset-panel_wrapper_]");
+        if (assetPanelWrapper && assetPanelWrapper.querySelector("[class*=sound-editor_editor-container_]")) {
+          return;
+        }
+        e.stopPropagation();
+        const moreButtonsElement = mainButton.parentElement.querySelector('[class*="action-menu_more-buttons_"]');
+        const moreButtons = moreButtonsElement.children;
+        // use "second from last" to find the paint button for compatibility with HD image uploads
+        const buttonToClick = moreButtons[moreButtons.length - 2];
+        const elementToClick = buttonToClick.querySelector("button");
+        elementToClick.click();
+      }
+    },
+    {
+      bubble: true,
+    }
+  );
+}

--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -2,74 +2,74 @@ export default async function ({ addon, console }) {
   const spriteMeta = {
     upload: {
       index: 0,
-      tooltip: "gui.spriteSelector.addSpriteFromFile"
+      tooltip: "gui.spriteSelector.addSpriteFromFile",
     },
     surprise: {
       index: 1,
-      tooltip: "gui.spriteSelector.addSpriteFromSurprise"
+      tooltip: "gui.spriteSelector.addSpriteFromSurprise",
     },
     paint: {
       index: 2,
-      tooltip: "gui.spriteSelector.addSpriteFromPaint"
+      tooltip: "gui.spriteSelector.addSpriteFromPaint",
     },
     library: {
       index: 3,
-      tooltip: "gui.spriteSelector.addSpriteFromLibrary"
-    }
+      tooltip: "gui.spriteSelector.addSpriteFromLibrary",
+    },
   };
   const backdropMeta = {
     upload: {
       index: 0,
-      tooltip: "gui.stageSelector.addBackdropFromFile"
+      tooltip: "gui.stageSelector.addBackdropFromFile",
     },
     surprise: {
       index: 1,
-      tooltip: "gui.stageSelector.addBackdropFromSurprise"
+      tooltip: "gui.stageSelector.addBackdropFromSurprise",
     },
     paint: {
       index: 2,
-      tooltip: "gui.stageSelector.addBackdropFromPaint"
+      tooltip: "gui.stageSelector.addBackdropFromPaint",
     },
     library: {
       index: 3,
-      tooltip: "gui.spriteSelector.addBackdropFromLibrary"
-    }
+      tooltip: "gui.spriteSelector.addBackdropFromLibrary",
+    },
   };
   const costumeMeta = {
     upload: {
       index: 0,
-      tooltip: "gui.costumeTab.addFileCostume"
+      tooltip: "gui.costumeTab.addFileCostume",
     },
     surprise: {
       index: 1,
-      tooltip: "gui.costumeTab.addSurpriseCostume"
+      tooltip: "gui.costumeTab.addSurpriseCostume",
     },
     paint: {
       index: 2,
-      tooltip: "gui.costumeTab.addBlankCostume"
+      tooltip: "gui.costumeTab.addBlankCostume",
     },
     library: {
       index: 3,
-      tooltip: "gui.costumeTab.addCostumeFromLibrary"
-    }
+      tooltip: "gui.costumeTab.addCostumeFromLibrary",
+    },
   };
   const soundMeta = {
     upload: {
       index: 0,
-      tooltip: "gui.soundTab.fileUploadSound"
+      tooltip: "gui.soundTab.fileUploadSound",
     },
     surprise: {
       index: 1,
-      tooltip: "gui.soundTab.surpriseSound"
+      tooltip: "gui.soundTab.surpriseSound",
     },
     record: {
       index: 2,
-      tooltip: "gui.soundTab.recordSound"
+      tooltip: "gui.soundTab.recordSound",
     },
     library: {
       index: 3,
-      tooltip: "gui.soundTab.addSoundFromLibrary"
-    }
+      tooltip: "gui.soundTab.addSoundFromLibrary",
+    },
   };
   const getSetting = (id) => {
     if (addon.self.disabled) {
@@ -104,7 +104,7 @@ export default async function ({ addon, console }) {
       e.stopPropagation();
       const moreButtonsElement = mainButton.parentElement.querySelector('[class*="action-menu_more-buttons_"]');
       const moreButtons = moreButtonsElement.children;
-      const {index} = getButtonToClick(mainButton);
+      const { index } = getButtonToClick(mainButton);
       // better-img-uploads can add a button at the start, so search "from the end" for compatibility
       const buttonToClick = moreButtons[moreButtons.length - (4 - index)];
       const elementToClick = buttonToClick.querySelector("button");
@@ -122,7 +122,7 @@ export default async function ({ addon, console }) {
         return;
       }
       const tooltipElement = mainButton.parentElement.querySelector(".__react_component_tooltip");
-      const {tooltip} = getButtonToClick(mainButton);
+      const { tooltip } = getButtonToClick(mainButton);
       const translatedTooltip = addon.tab.redux.state.locales.messages[tooltip];
       const needToFixTooltipText = translatedTooltip && tooltipElement.textContent !== translatedTooltip;
       if (needToFixTooltipText) {
@@ -134,7 +134,7 @@ export default async function ({ addon, console }) {
       }
     },
     {
-      bubble: true
+      bubble: true,
     }
   );
 }


### PR DESCRIPTION
Adds an addon that makes the "Choose a Sprite" and "Choose a Costume" buttons create an empty sprite/costume instead of opening the library. Does not change the "Choose a Sound" button.

Has been requested a couple times:  
https://discord.com/channels/806602307750985799/806609030935740477/871487795456249877  
https://discord.com/channels/806602307750985799/806602307750985803/871533280233664522
