### PR TITLE
Fix post links with Scratch 2.0 → 3.0

### DIFF
--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -96,6 +96,13 @@
 #brdfooter .box-content button {
   margin: 0;
 }
+.blockpost {
+  position: relative;
+}
+.blockpost > a[name] {
+  position: absolute;
+  top: -55px;
+}
 .blockpost div.box {
   background-color: #0fbd8c;
   border-top-color: #0fbd8c;


### PR DESCRIPTION
Resolves #3133

### Changes

Makes the whole post visible when opening a link to it.