### PR TITLE
default-project addon: work while logged out, avoid corrupt empty projects

### DIFF
--- a/addons/default-project/addon.json
+++ b/addons/default-project/addon.json
@@ -10,8 +10,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects"],
-      "runAtComplete": false
+      "matches": ["projects"]
     }
   ],
   "settings": [

--- a/addons/default-project/userscript.js
+++ b/addons/default-project/userscript.js
@@ -1,34 +1,32 @@
 export default async function ({ addon, global, console, msg }) {
   let pendingReplacement = false;
-  const replace = async () => {
-    // Current loadingState is LOADING_VM_NEW_DEFAULT
-
-    if (pendingReplacement) {
-      // Never happens AFAIK
-      console.log("Pending replacement");
-      return;
-    }
-    pendingReplacement = true;
-
-    const isLoggedIn = await addon.auth.fetchIsLoggedIn();
-    if (isLoggedIn) {
-      await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState === "SHOWING_WITH_ID");
-    } else {
-      // If the user is logged out, SHOWING_WITHOUT_ID will be the last state.
-      await addon.tab.redux.waitForState(
-        (state) => state.scratchGui.projectState.loadingState === "SHOWING_WITHOUT_ID"
-      );
-    }
-
-    const projectId = addon.settings.get("projectId");
-    if (projectId !== 510186917) addon.tab.traps.vm.downloadProjectId(projectId);
-    pendingReplacement = false;
-  };
-
-  if (addon.tab.redux.state.scratchGui.projectState.loadingState === "LOADING_VM_NEW_DEFAULT") replace();
-
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", async (e) => {
-    if (e.detail.action.type === "scratch-gui/project-state/DONE_FETCHING_DEFAULT") replace();
+    if (e.detail.action.type === "scratch-gui/project-state/DONE_LOADING_VM_WITHOUT_ID") {
+      // Current loadingState is SHOWING_WITHOUT_ID
+
+      if (pendingReplacement) {
+        // Never happens AFAIK
+        console.log("Pending replacement");
+        return;
+      }
+      pendingReplacement = true;
+
+      let expired = false; // So that nothing goes catastrophically wrong
+      setTimeout(() => (expired = true), 10000);
+
+      const isLoggedIn = await addon.auth.fetchIsLoggedIn();
+      if (isLoggedIn) {
+        await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState === "CREATING_NEW");
+        await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState === "SHOWING_WITH_ID");
+        await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState === "AUTO_UPDATING");
+        await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState === "SHOWING_WITH_ID");
+        // By this point, vanilla new project was saved to cloud
+      }
+
+      const projectId = addon.settings.get("projectId");
+      if (projectId !== 510186917 && !expired) addon.tab.traps.vm.downloadProjectId(projectId);
+      pendingReplacement = false;
+    }
   });
 }


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/pull/3046#issuecomment-889397472

Note that there was never real data loss, this only happened if you never clicked "save now"
This also makes it work reliably while logged out