### PR TITLE
Remove labels from reset buttons

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -140,6 +140,9 @@
   "viewLicenses": {
     "message": "View library licenses"
   },
+  "reset": {
+    "message": "Reset"
+  },
   "default": {
     "message": "Default"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -140,9 +140,6 @@
   "viewLicenses": {
     "message": "View library licenses"
   },
-  "reset": {
-    "message": "Reset"
-  },
   "default": {
     "message": "Default"
   },

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -100,6 +100,7 @@
         v-if="showResetDropdown()"
         :setting="setting"
         :addon="addon"
+        :label="msg('reset')"
         :default-label="msg('default')"
         v-click-outside="closeResetDropdowns"
       ></reset-dropdown>
@@ -108,6 +109,7 @@
         type="button"
         class="large-button clear-button"
         :disabled="!addon._enabled"
+        :title="msg('reset')"
         @click="updateOption(setting.default)"
       >
         <img src="../../images/icons/undo.svg" class="icon-type" />

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -100,7 +100,6 @@
         v-if="showResetDropdown()"
         :setting="setting"
         :addon="addon"
-        :label="msg('reset')"
         :default-label="msg('default')"
         v-click-outside="closeResetDropdowns"
       ></reset-dropdown>
@@ -111,7 +110,7 @@
         :disabled="!addon._enabled"
         @click="updateOption(setting.default)"
       >
-        <span>{{ msg("reset") }}</span><img src="../../images/icons/undo.svg" class="icon-type" />
+        <img src="../../images/icons/undo.svg" class="icon-type" />
       </button>
     </div>
   </div>

--- a/webpages/settings/components/reset-dropdown.html
+++ b/webpages/settings/components/reset-dropdown.html
@@ -1,7 +1,7 @@
 <template>
   <div :class="{'setting-dropdown': true, open: isOpen}">
     <button type="button" class="large-button clear-button" :disabled="!addon._enabled" @click="toggle">
-      <span>{{ label }}</span><img src="../../images/icons/expand.svg" class="icon-type" />
+      <img src="../../images/icons/expand.svg" class="icon-type" />
     </button>
     <ul>
       <li @click="resetToDefault">

--- a/webpages/settings/components/reset-dropdown.html
+++ b/webpages/settings/components/reset-dropdown.html
@@ -1,6 +1,6 @@
 <template>
   <div :class="{'setting-dropdown': true, open: isOpen}">
-    <button type="button" class="large-button clear-button" :disabled="!addon._enabled" @click="toggle">
+    <button type="button" class="large-button clear-button" :disabled="!addon._enabled" @click="toggle" :title="label">
       <img src="../../images/icons/expand.svg" class="icon-type" />
     </button>
     <ul>

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -135,7 +135,7 @@ h1 {
 }
 
 .clear-button {
-  padding-inline-end: 10px;
+  padding-inline: 7px;
   border-radius: 0 4px 4px 0;
   border-inline-start: none !important;
 }
@@ -148,12 +148,8 @@ h1 {
 [dir="rtl"] .number-setting .clear-button {
   border-radius: 16px 0 0 16px;
 }
-.clear-button span {
-  vertical-align: middle;
-}
 .clear-button .icon-type {
-  margin-inline-start: 6px;
-  margin-inline-end: 0;
+  margin: 0;
 }
 
 .reverted {


### PR DESCRIPTION
### Changes

#3156 increased the number of reset buttons and dropdowns, which take up quite a bit of space. The icon is enough to make their purpose obvious, so this makes them smaller by removing the labels.