### PR TITLE
ctrl-enter-post: stop erroring in console when topic is closed

### DIFF
--- a/addons/ctrl-enter-post/forums.js
+++ b/addons/ctrl-enter-post/forums.js
@@ -1,4 +1,4 @@
-export default function ({ addon }) {
+export default async function ({ addon }) {
   let type = location.pathname.split("/")[2];
 
   let textarea = document.querySelector(type === "settings" ? "#id_signature" : "#id_body");

--- a/addons/ctrl-enter-post/forums.js
+++ b/addons/ctrl-enter-post/forums.js
@@ -1,9 +1,10 @@
-export default async function ({ addon }) {
+export default function ({ addon }) {
   let type = location.pathname.split("/")[2];
 
   let textarea = document.querySelector(type === "settings" ? "#id_signature" : "#id_body");
   let postButton = document.querySelector(type === "topic" ? ".button.grey:nth-child(1)" : "button");
 
+  if (!textarea) return
   textarea.addEventListener("keyup", (e) => {
     if ((e.ctrlKey || e.metaKey) && (e.code === "Enter" || e.code === "NumpadEnter")) {
       postButton.click();


### PR DESCRIPTION
### Changes

Stops errors in console when ctrl-enter-post in forums are enabled and topic is closed

### Reason for changes

<!-- Why should these changes be made? -->
Errors fill up the console

### Tests

Tested locally
