### PR TITLE
editor-stage-left: fix fix-share-the-love in RTL languages

### DIFF
--- a/addons/editor-stage-left/fix-share-the-love.js
+++ b/addons/editor-stage-left/fix-share-the-love.js
@@ -6,12 +6,14 @@ export default async function ({ addon, global, console }) {
   };
   addon.self.addEventListener("disabled", resize);
   addon.self.addEventListener("reenabled", resize);
-  const originalGetClientRect = ScratchBlocks.Toolbox.prototype.getClientRect;
-  ScratchBlocks.Toolbox.prototype.getClientRect = function () {
-    // we are trying to undo the effect of BIG_NUM in https://github.com/LLK/scratch-blocks/blob/ab26fa2960643fa38fbc7b91ca2956be66055070/core/flyout_vertical.js#L739
+  const originalGetClientRect = ScratchBlocks.VerticalFlyout.prototype.getClientRect;
+  ScratchBlocks.VerticalFlyout.prototype.getClientRect = function () {
     const rect = originalGetClientRect.call(this);
     if (!rect || addon.self.disabled) return rect;
-    rect.left += 1000000000;
+    // undo the effect of BIG_NUM in https://github.com/LLK/scratch-blocks/blob/ab26fa2960643fa38fbc7b91ca2956be66055070/core/flyout_vertical.js#L739
+    if (this.toolboxPosition_ === ScratchBlocks.TOOLBOX_AT_LEFT) {
+      rect.left += 1000000000;
+    }
     rect.width -= 1000000000;
     return rect;
   };


### PR DESCRIPTION
From feedback:

> When setting the scratch editor's language to Arabic and then enabling the (Display stage on left side), The Method of deleting blocks by throwing them in the Catagory Displayer becomes broken.

Hopefully this is the last time I have a reason to touch this file