### PR TITLE
Fix variable tab getting inserted after devtools find bar sometimes

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -325,7 +325,7 @@ export default class Tab extends Listenable {
       afterSoundTab: {
         element: () => q("[class^='react-tabs_react-tabs__tab-list']"),
         from: () => [q("[class^='react-tabs_react-tabs__tab-list']").children[2]],
-        until: () => [q(".s3devToolBar")],
+        until: () => [q("#s3devToolBar")],
       },
       forumsBeforePostReport: {
         element: () => scope.querySelector(".postfootright > ul"),


### PR DESCRIPTION
It's a very inconsistent, but sometimes this could happen:

![image](https://user-images.githubusercontent.com/33787854/128643722-1dac2efc-dc76-43dc-a447-9d1ecb67d28c.png)

fix is simple: s3devToolBar is an ID, not a class