### PR TITLE
drag-drop: do not HD-upload images

### DIFF
--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -15,7 +15,7 @@ export default async function ({ addon, console, safeMsg: m }) {
   }" height="10", width="10">
      <input accept=".svg, .png, .bmp, .jpg, .jpeg" class="${addon.tab.scratchClass(
        "action-menu_file-input"
-     )}" multiple="" type="file">
+     )} sa-better-img-uploads-input" multiple="" type="file">
   </button>
   <div class="__react_component_tooltip place-${right ? "left" : "right"} type-dark ${addon.tab.scratchClass(
     "action-menu_tooltip"

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -14,7 +14,7 @@ export default async function ({ addon, console, safeMsg: m }) {
     addon.self.dir + "/icon.svg"
   }" height="10", width="10">
      <input accept=".svg, .png, .bmp, .jpg, .jpeg" class="${addon.tab.scratchClass(
-       "action-menu_file-input"
+       "action-menu_file-input" /* TODO: when adding dynamicDisable, ensure compat with drag-drop */
      )} sa-better-img-uploads-input" multiple="" type="file">
   </button>
   <div class="__react_component_tooltip place-${right ? "left" : "right"} type-dark ${addon.tab.scratchClass(

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -18,6 +18,17 @@
       "matches": ["projects"]
     }
   ],
+  "settings": [
+    {
+      "id": "use-hd-upload",
+      "name": "Use HD uploads",
+      "type": "boolean",
+      "default": false,
+      "if": {
+        "addonEnabled": "better-img-uploads"
+      }
+    }
+  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.12.0",

--- a/addons/drag-drop/addon.json
+++ b/addons/drag-drop/addon.json
@@ -18,17 +18,6 @@
       "matches": ["projects"]
     }
   ],
-  "settings": [
-    {
-      "id": "use-hd-upload",
-      "name": "Use HD uploads",
-      "type": "boolean",
-      "default": false,
-      "if": {
-        "addonEnabled": "better-img-uploads"
-      }
-    }
-  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.12.0",

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -22,7 +22,8 @@ export default async function ({ addon, global, console }) {
       (el = e.target.closest('div[class*="selector_wrapper"]'))
     ) {
       callback = (files) => {
-        const fileInput = el.querySelector('input[class*="action-menu_file-input"]');
+        const hdFilter = addon.settings.get("use-hd-upload") ? "" : ":not(.sa-better-img-uploads-input)";
+        const fileInput = el.querySelector('input[class*="action-menu_file-input"]' + hdFilter);
         fileInput.files = files;
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
       };

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -22,8 +22,7 @@ export default async function ({ addon, global, console }) {
       (el = e.target.closest('div[class*="selector_wrapper"]'))
     ) {
       callback = (files) => {
-        const hdFilter = addon.settings.get("use-hd-upload") ? "" : ":not(.sa-better-img-uploads-input)";
-        const fileInput = el.querySelector('input[class*="action-menu_file-input"]' + hdFilter);
+        const fileInput = el.querySelector('input[class*="action-menu_file-input"]:not(.sa-better-img-uploads-input)');
         fileInput.files = files;
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
       };

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -22,7 +22,8 @@ export default async function ({ addon, global, console }) {
       (el = e.target.closest('div[class*="selector_wrapper"]'))
     ) {
       callback = (files) => {
-        const fileInput = el.querySelector('input[class*="action-menu_file-input"]:not(.sa-better-img-uploads-input)');
+        const hdFilter = addon.settings.get("use-hd-upload") ? "" : ":not(.sa-better-img-uploads-input)";
+        const fileInput = el.querySelector('input[class*="action-menu_file-input"]' + hdFilter);
         fileInput.files = files;
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
       };


### PR DESCRIPTION
Resolves a bug where all drag-drop uploads were HD when better-img-uploads is enabled. In case anyone wants old behavior, this is now a setting (off by default, only shows if someone is using HD upload addon).

This code should not break in most circumstances - if better-img-uploads is not available when the settings is true, then it'll just fallback to normal upload (aka existing code path). Dynamic enabling of better-img-uploads should also be fine. It might break when better-img-uploads was dynamically disabled (drag-drop would still upload as HD), but better-img-uploads isn't dynamically disableable yet, so who cares
