### PR TITLE
Make dark costume editor optional

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -692,6 +692,13 @@
       }
     },
     {
+      "url": "paper.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": { "affectPaper": true }
+      }
+    },
+    {
       "url": "stage.css",
       "matches": ["projects"],
       "if": {
@@ -828,6 +835,12 @@
       "id": "textShadow",
       "type": "boolean",
       "default": false
+    },
+    {
+      "name": "Change the costume editor background and selection borders",
+      "id": "affectPaper",
+      "type": "boolean",
+      "default": true
     },
     {
       "name": "Change the colors of variables, lists, speech bubbles, and answer inputs on the stage",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -195,9 +195,6 @@ div.s3devDDOut.vis,
   border-top: 9px solid var(--editorDarkMode-accent);
   border-bottom: 10px solid var(--editorDarkMode-accent);
 }
-.paper-canvas_paper-canvas_1y588 {
-  background-color: var(--editorDarkMode-accent-paintEditorBackground);
-}
 .sa-body-editor .stage-header_stage-button-icon_3zzFK,
 .sprite-info_icon-wrapper_3Wbqq:not(.sprite-info_radio_v-fgn),
 img.tool-select-base_tool-select-icon_tJ-rr,

--- a/addons/editor-dark-mode/paper.css
+++ b/addons/editor-dark-mode/paper.css
@@ -1,0 +1,3 @@
+.paper-canvas_paper-canvas_1y588 {
+  background-color: var(--editorDarkMode-accent-paintEditorBackground);
+}

--- a/addons/editor-dark-mode/paper.js
+++ b/addons/editor-dark-mode/paper.js
@@ -11,12 +11,14 @@ export default async function ({ addon, console }) {
       60
     );
 
+  const darkPaperDisabled = () => addon.self.disabled || !addon.settings.get("affectPaper");
+
   // Change the colors used by the selection tool
   const isDefaultGuideColor = (color) =>
     color.type === "rgb" && color.red === 0 && color.green === 0.615686274509804 && color.blue === 0.9254901960784314;
   const oldItemDraw = paper.Item.prototype.draw;
   paper.Item.prototype.draw = function (...args) {
-    if (addon.self.disabled) {
+    if (darkPaperDisabled()) {
       this.saColorChanged = false;
       if (this.saOldFillColor) this.fillColor = this.saOldFillColor;
       if (this.saOldStrokeColor) this.strokeColor = this.saOldStrokeColor;
@@ -52,7 +54,7 @@ export default async function ({ addon, console }) {
     }
     return oldItemDraw.apply(this, args);
   };
-  paper.Item.prototype.getSelectedColor = () => (addon.self.disabled ? null : new paper.Color(secondaryColor()));
+  paper.Item.prototype.getSelectedColor = () => (darkPaperDisabled() ? null : new paper.Color(secondaryColor()));
 
   // Change the colors of background layers
   const updateColors = () => {
@@ -62,7 +64,7 @@ export default async function ({ addon, console }) {
     let blueOutlineColor;
     let crosshairOuterColor;
     let crosshairInnerColor;
-    if (!addon.self.disabled) {
+    if (!darkPaperDisabled()) {
       artboardBackground = addon.settings.get("accent");
       workspaceBackground = alphaBlend(
         addon.settings.get("accent"),


### PR DESCRIPTION
### Changes

Adds a setting (on by default) that controls if editor dark mode affects the costume editor.

### Reason for changes

Feedback: https://github.com/ScratchAddons/ScratchAddons/pull/3077#issuecomment-894536073