### PR TITLE
Fix incorrect text color of custom block parameters

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -178,7 +178,7 @@ function updateSettings(addon, newStyle) {
         --sa-block-secondary-color: ${secondaryActive};
       }
       g[data-category="${prop}"] > .blocklyText,
-      g[data-category="${prop}"] > g:not(.blocklyDraggable) > .blocklyText /* variable and list reporters */ {
+      g[data-category="${prop}"] > g:not([data-id]) > .blocklyText /* variable and list reporters */ {
         fill: var(--editorTheme3-${settingName}Color);
       }
       g[data-category="${prop}"] > g[data-argument-type="dropdown"] > .blocklyDropdownText,


### PR DESCRIPTION
Resolves #3275

### Changes

Fixes custom block parameters using the text color of their parent block in colored text modes. Apparently the `.blocklyDraggable` class is not set consistently.