### PR TITLE
Include list of enabled addons when sending feedback

### DIFF
--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -369,7 +369,7 @@ export default async function ({ addon, global, console, msg, safeMsg }) {
     const s = document.createElement("span");
     s.innerHTML = safeMsg("feedback-log", {
       logLink: Object.assign(document.createElement("a"), {
-        href: "https://scratchaddons.com/feedback?version=1.18-debugger",
+        href: "https://scratchaddons.com/feedback/?ext_version=1.18%2Bdebugger",
         className: "sa-debugger-feedback",
         target: "_blank",
         textContent: msg("feedback-log-link"),

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -392,7 +392,7 @@ function forumWarning(key) {
     const uiLanguage = chrome.i18n.getUILanguage();
     const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
     const utm = `utm_source=extension&utm_medium=forumwarning&utm_campaign=v${chrome.runtime.getManifest().version}`;
-    reportLink.href = `https://scratchaddons.com/${localeSlash}feedback/?version=${
+    reportLink.href = `https://scratchaddons.com/${localeSlash}feedback/?ext_version=${
       chrome.runtime.getManifest().version
     }&${utm}`;
     reportLink.target = "_blank";
@@ -502,9 +502,9 @@ const showBanner = () => {
     textContent: chrome.i18n.getMessage("notifChangelog"),
   });
   const notifFooterFeedback = Object.assign(document.createElement("a"), {
-    href: `https://scratchaddons.com/${localeSlash}feedback/?version=${
+    href: `https://scratchaddons.com/${localeSlash}feedback/?ext_version=${
       chrome.runtime.getManifest().version
-    }-notif&${utm}`,
+    }&${utm}`,
     target: "_blank",
     textContent: chrome.i18n.getMessage("feedback"),
   });

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -648,7 +648,7 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
     }, 0);
 
     let binaryNum = "";
-    manifests.forEach(({addonId}) => binaryNum += addonsEnabled[addonId] === true ? "1" : "0");
+    manifests.forEach(({ addonId }) => (binaryNum += addonsEnabled[addonId] === true ? "1" : "0"));
     const addonsEnabledBase36 = BigInt(`0b${binaryNum}`).toString(36);
     vue.sidebarUrls.feedback += `#_${addonsEnabledBase36}`;
   });

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -200,7 +200,7 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
           const utm = `utm_source=extension&utm_medium=settingspage&utm_campaign=v${version}`;
           return {
             contributors: `https://scratchaddons.com/${localeSlash}contributors?${utm}`,
-            feedback: `https://scratchaddons.com/${localeSlash}feedback/?version=${versionName}&${utm}`,
+            feedback: `https://scratchaddons.com/${localeSlash}feedback/?ext_version=${versionName}&${utm}`,
             changelog: `https://scratchaddons.com/${localeSlash}changelog?${utm}`,
           };
         })(),
@@ -646,6 +646,11 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
         }
       }
     }, 0);
+
+    let binaryNum = "";
+    manifests.forEach(({addonId}) => binaryNum += addonsEnabled[addonId] === true ? "1" : "0");
+    const addonsEnabledBase36 = BigInt(`0b${binaryNum}`).toString(36);
+    vue.sidebarUrls.feedback += `#_${addonsEnabledBase36}`;
   });
 
   window.addEventListener("keydown", function (e) {


### PR DESCRIPTION
Requires changes to website
Users can opt out of sending enabled addons list when sending feedback