### PR TITLE
Run addons in TurboWarp embed

### DIFF
--- a/addon-api/common/Self.js
+++ b/addon-api/common/Self.js
@@ -46,4 +46,13 @@ export default class Self extends Listenable {
    * Restarts this addon. Only applicable to background scripts.
    */
   restart() {}
+
+  /**
+   * Gets a list of addon IDs enabled, optionally filtered using tags.
+   * @param {string=} tag - the tag for filtering.
+   * @returns {Promise<string[]>} enabled addons' IDs
+   */
+  getEnabledAddons(tag) {
+    return scratchAddons.methods.getEnabledAddons(tag);
+  }
 }

--- a/addon-api/content-script/Addon.js
+++ b/addon-api/content-script/Addon.js
@@ -30,4 +30,13 @@ export default class UserscriptAddon extends Addon {
   get _path() {
     return this.__path;
   }
+
+  /**
+   * Gets a list of addon IDs enabled, optionally filtered using tags.
+   * @param {string=} tag - the tag for filtering.
+   * @returns {Promise<string[]>} enabled addons' IDs
+   */
+  getEnabledAddons(tag) {
+    return scratchAddons.methods.getEnabledAddons(tag);
+  }
 }

--- a/addon-api/content-script/Addon.js
+++ b/addon-api/content-script/Addon.js
@@ -30,13 +30,4 @@ export default class UserscriptAddon extends Addon {
   get _path() {
     return this.__path;
   }
-
-  /**
-   * Gets a list of addon IDs enabled, optionally filtered using tags.
-   * @param {string=} tag - the tag for filtering.
-   * @returns {Promise<string[]>} enabled addons' IDs
-   */
-  getEnabledAddons(tag) {
-    return scratchAddons.methods.getEnabledAddons(tag);
-  }
 }

--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -66,6 +66,15 @@
       "if": {
         "settings": { "alternativePlayer": ["turbowarp", "forkphorus"] }
       }
+    },
+    {
+      "id": "enableTWAddons",
+      "name": "Enable TurboWarp addons",
+      "type": "boolean",
+      "default": true,
+      "if": {
+        "settings": { "alternativePlayer": ["turbowarp"] }
+      }
     }
   ],
   "tags": ["community", "profiles"],

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -75,7 +75,7 @@ export default async function ({ addon, msg }) {
     const usp = new URLSearchParams();
     if (autoPlay) usp.set("autoplay", "");
     if (enableTWAddons) usp.set("addons", enabledAddons.join(","));
-    iframeElement.setAttribute("src", `https://turbowarp.org/${projectId}/embed?${usp}#${projectId}`);
+    iframeElement.setAttribute("src", `https://turbowarp.org/${projectId}/embed?${usp}`);
     wrapperElement.dataset.player = "turbowarp";
     if (!showMenu) iframeElement.setAttribute("height", "260");
   };

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -4,7 +4,7 @@ export default async function ({ addon, msg }) {
   const alternativePlayer = addon.settings.get("alternativePlayer");
   const autoPlay = addon.settings.get("autoPlay");
   const enableTWAddons = addon.settings.get("enableTWAddons");
-  const enabledAddons = await addon.getEnabledAddons("editor");
+  const enabledAddons = await addon.self.getEnabledAddons("editor");
 
   const stageElement = document.querySelector(".stage");
   const projectId = window.Scratch.INIT_DATA.PROFILE.featuredProject.id;

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -75,7 +75,7 @@ export default async function ({ addon, msg }) {
     const usp = new URLSearchParams();
     if (autoPlay) usp.set("autoplay", "");
     if (enableTWAddons) usp.set("addons", enabledAddons.join(","));
-    iframeElement.setAttribute("src", `https://turbowarp.org/embed.html?${usp}#${projectId}`);
+    iframeElement.setAttribute("src", `https://turbowarp.org/${projectId}/embed?${usp}#${projectId}`);
     wrapperElement.dataset.player = "turbowarp";
     if (!showMenu) iframeElement.setAttribute("height", "260");
   };

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -3,6 +3,8 @@ export default async function ({ addon, msg }) {
   const forceAlternative = addon.settings.get("forceAlternative");
   const alternativePlayer = addon.settings.get("alternativePlayer");
   const autoPlay = addon.settings.get("autoPlay");
+  const enableTWAddons = addon.settings.get("enableTWAddons");
+  const enabledAddons = await addon.getEnabledAddons("editor");
 
   const stageElement = document.querySelector(".stage");
   const projectId = window.Scratch.INIT_DATA.PROFILE.featuredProject.id;
@@ -15,6 +17,10 @@ export default async function ({ addon, msg }) {
   iframeElement.setAttribute("height", "210");
   iframeElement.setAttribute("frameborder", "0");
   iframeElement.setAttribute("allowfullscreen", "");
+  iframeElement.setAttribute(
+    "allow",
+    "autoplay 'src'; camera 'src'; document-domain 'none'; fullscreen 'src'; gamepad 'src'; microphone 'src';"
+  );
   iframeElement.setAttribute("scrolling", "no");
 
   const wrapperElement = document.createElement("div");
@@ -66,7 +72,10 @@ export default async function ({ addon, msg }) {
   };
 
   const loadTurboWarp = () => {
-    iframeElement.setAttribute("src", `https://turbowarp.org/embed.html${autoPlay ? "?autoplay" : ""}#${projectId}`);
+    const usp = new URLSearchParams();
+    if (autoPlay) usp.set("autoplay", "");
+    if (enableTWAddons) usp.set("addons", enabledAddons.join(","));
+    iframeElement.setAttribute("src", `https://turbowarp.org/embed.html?${usp}#${projectId}`);
     wrapperElement.dataset.player = "turbowarp";
     if (!showMenu) iframeElement.setAttribute("height", "260");
   };

--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -4,7 +4,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "\"Replace player\" mode changes the Scratch player to a TurboWarp embed, which doesn't support Scratch editor addons nor seeing inside projects.",
+      "text": "\"Replace player\" mode changes the Scratch player to a TurboWarp embed, which doesn't support seeing inside projects.",
       "id": "addonsWontWork"
     },
     {
@@ -47,6 +47,12 @@
         }
       ],
       "default": "link"
+    },
+    {
+      "name": "Enable addons",
+      "id": "addons",
+      "type": "boolean",
+      "default": true
     }
   ],
   "versionAdded": "1.18.0",

--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -52,7 +52,10 @@
       "name": "Enable addons",
       "id": "addons",
       "type": "boolean",
-      "default": true
+      "default": true,
+      "if": {
+        "settings": { "action": "player" }
+      }
     }
   ],
   "versionAdded": "1.18.0",

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -7,6 +7,10 @@ export default async function ({ addon, console, msg }) {
   let twIframe = document.createElement("iframe");
   twIframe.setAttribute("allowtransparency", "true");
   twIframe.setAttribute("allowfullscreen", "true");
+  twIframe.setAttribute(
+    "allow",
+    "autoplay *; camera https://turbowarp.org; document-domain 'none'; fullscreen *; gamepad https://turbowarp.org; microphone https://turbowarp.org;"
+  );
   twIframe.className = "sa-tw-iframe";
   twIframeContainer.appendChild(twIframe);
 
@@ -27,9 +31,14 @@ export default async function ({ addon, console, msg }) {
       playerToggled = !playerToggled;
       if (playerToggled) {
         const username = await addon.auth.fetchUsername();
-        const usernameUrlParam = username ? `?username=${username}` : "";
+        const usp = new URLSearchParams();
+        if (username) usp.set("username", username);
         const projectId = window.location.pathname.split("/")[2];
-        const iframeUrl = `https://turbowarp.org/${projectId}/embed${usernameUrlParam}`;
+        if (addon.settings.get("addons")) {
+          const enabledAddons = await addon.getEnabledAddons("editor");
+          usp.set("addons", enabledAddons.join(","));
+        }
+        const iframeUrl = `https://turbowarp.org/${projectId}/embed?${usp}`;
         twIframe.src = "";
         scratchStage.parentElement.prepend(twIframeContainer);
         // Use location.replace to avoid creating a history entry

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -35,7 +35,7 @@ export default async function ({ addon, console, msg }) {
         if (username) usp.set("username", username);
         const projectId = window.location.pathname.split("/")[2];
         if (addon.settings.get("addons")) {
-          const enabledAddons = await addon.getEnabledAddons("editor");
+          const enabledAddons = await addon.self.getEnabledAddons("editor");
           usp.set("addons", enabledAddons.join(","));
         }
         const iframeUrl = `https://turbowarp.org/${projectId}/embed?${usp}`;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,5 +1,17 @@
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.replaceTabWithUrl) chrome.tabs.update(sender.tab.id, { url: request.replaceTabWithUrl });
+  else if (request.getEnabledAddons) {
+    let enabled = Object.keys(scratchAddons.localState.addonsEnabled).filter(
+      (addonId) => scratchAddons.localState.addonsEnabled[addonId]
+    );
+    const tag = request.getEnabledAddons.tag;
+    if (tag) {
+      enabled = enabled.filter((id) =>
+        scratchAddons.manifests.some(({ addonId, manifest }) => addonId === id && manifest.tags.includes(tag))
+      );
+    }
+    sendResponse(enabled);
+  }
 });
 
 scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) => {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -97,6 +97,19 @@ const cs = {
       );
     });
   },
+  getEnabledAddons(tag) {
+    // Return addons that are enabled
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage(
+        {
+          getEnabledAddons: {
+            tag,
+          },
+        },
+        (res) => resolve(res)
+      );
+    });
+  },
 };
 Comlink.expose(cs, Comlink.windowEndpoint(comlinkIframe1.contentWindow, comlinkIframe2.contentWindow));
 

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -194,6 +194,7 @@ function onDataReady() {
   scratchAddons.methods.copyImage = async (dataURL) => {
     return _cs_.copyImage(dataURL);
   };
+  scratchAddons.methods.getEnabledAddons = (tag) => _cs_.getEnabledAddons(tag);
 
   scratchAddons.sharedObserver = new SharedObserver();
 


### PR DESCRIPTION
Resolves #3285 

Of course, if people wants old behavior, they can toggle the settings.

Other stuff:

- New API: `addon.getEnabledAddons(tag)` (CS only) - get a promise of list of enabled addon IDs, optionally filtered with a tag. This must contact the background because project player might not be embedded on a project page and thus is not loaded on CS (i.e. live featured project)
- URLSearchParams to correctly pass multiple sometimes-missing params.
- Embed iframe now has a feature policy. Both will disable document-domain (to promote its deprecation, does not actually do anything). autoplay, camera, microphone are used by Scratch; fullscreen and gamepad by TurboWarp implementation.
- live featured project sets src attr, so `'src'` is enough.
- turbowarp-player's location.replace hack makes `'src'` unreliable, so either a wild-card for small stuff or origin for dangerous stuff.
- Notice amended to reflect changes.
- This is useless in live-featured-project if header is hidden (maybe except drag-drop and remove-curved-stage-border)