### PR TITLE
Create "featured" addon group, separate "forums" group, rename ocular addon

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -44,6 +44,9 @@
   "recommended": {
     "message": "Recommended"
   },
+  "featured": {
+    "message": "Featured"
+  },
   "beta": {
     "message": "Beta"
   },

--- a/addons/account-settings-capitalize/addon.json
+++ b/addons/account-settings-capitalize/addon.json
@@ -7,6 +7,6 @@
       "matches": ["https://scratch.mit.edu/*"]
     }
   ],
-  "tags": ["easterEgg", "community"],
+  "tags": ["community"],
   "versionAdded": "1.9.0"
 }

--- a/addons/account-settings-capitalize/addon.json
+++ b/addons/account-settings-capitalize/addon.json
@@ -7,6 +7,6 @@
       "matches": ["https://scratch.mit.edu/*"]
     }
   ],
-  "tags": ["community"],
+  "tags": ["easterEgg", "community"],
   "versionAdded": "1.9.0"
 }

--- a/addons/better-featured-project/addon.json
+++ b/addons/better-featured-project/addon.json
@@ -30,5 +30,5 @@
     }
   ],
   "versionAdded": "1.5.0",
-  "tags": ["community", "recommended", "profiles"]
+  "tags": ["community", "featured", "profiles"]
 }

--- a/addons/block-palette-icons/addon.json
+++ b/addons/block-palette-icons/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Block palette category icons",
   "description": "Adds icons inside the colored circles that identify block categories.",
-  "tags": ["editor", "codeEditor", "theme"],
+  "tags": ["editor", "codeEditor", "theme", "featured"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true,

--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -32,7 +32,7 @@
     }
   ],
   "versionAdded": "1.14.0",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "enabledByDefault": false,
   "libraries": ["scratch-blocks"]
 }

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -21,6 +21,6 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "projectPlayer"],
+  "tags": ["editor", "projectPlayer", "recommended"],
   "enabledByDefault": false
 }

--- a/addons/custom-block-shape/addon.json
+++ b/addons/custom-block-shape/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Customizable block shape",
   "description": "Adjust the padding, corner radius, and notch height of blocks.",
-  "tags": ["editor", "codeEditor", "theme", "recommended"],
+  "tags": ["editor", "codeEditor", "theme", "featured"],
   "credits": [
     {
       "name": "SheepTester",

--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Customizable code area zoom",
   "description": "Choose custom settings for the minimum, maximum, speed, and start size of the zoom of scripts in the code area, and autohide the controls.",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "credits": [
     {
       "name": "ErrorGamer2000",

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Website dark mode",
   "description": "Dark theme for the Scratch website.",
-  "tags": ["community", "theme", "recommended"],
+  "tags": ["community", "theme", "featured"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -24,7 +24,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false,
   "versionAdded": "1.16.0"
 }

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -23,7 +23,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false,
   "dynamicDisable": true,
   "dynamicEnable": true,

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -22,6 +22,6 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "codeEditor", "theme"],
+  "tags": ["editor", "codeEditor", "theme", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1031,6 +1031,6 @@
       }
     }
   ],
-  "tags": ["editor", "theme", "recommended"],
+  "tags": ["editor", "theme", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -21,7 +21,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "theme", "recommended"],
+  "tags": ["editor", "theme", "featured"],
   "versionAdded": "1.1.0",
   "enabledByDefault": false
 }

--- a/addons/editor-stepping/addon.json
+++ b/addons/editor-stepping/addon.json
@@ -18,6 +18,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -145,7 +145,7 @@
       ]
     }
   ],
-  "tags": ["editor", "theme", "codeEditor", "recommended"],
+  "tags": ["editor", "theme", "codeEditor", "featured"],
   "enabledByDefault": false,
   "presets": [
     {

--- a/addons/expanding-search-bar/addon.json
+++ b/addons/expanding-search-bar/addon.json
@@ -18,6 +18,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.16.0",
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "enabledByDefault": false
 }

--- a/addons/feature-unshared/addon.json
+++ b/addons/feature-unshared/addon.json
@@ -14,6 +14,6 @@
     }
   ],
   "versionAdded": "1.4.0",
-  "tags": ["community", "profiles"],
+  "tags": ["community", "profiles", "featured"],
   "enabledByDefault": false
 }

--- a/addons/gamepad/addon.json
+++ b/addons/gamepad/addon.json
@@ -30,7 +30,7 @@
       "id": "hide"
     }
   ],
-  "tags": ["editor", "projectPlayer", "recommended"],
+  "tags": ["editor", "projectPlayer", "featured"],
   "enabledByDefault": false,
   "versionAdded": "1.14.0",
   "dynamicEnable": true,

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -114,7 +114,7 @@
       }
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "versionAdded": "1.2.0",
   "enabledByDefault": false
 }

--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -38,6 +38,6 @@
     }
   ],
   "versionAdded": "1.13.0",
-  "tags": ["editor"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/items-per-row/addon.json
+++ b/addons/items-per-row/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "More items per row",
   "description": "Lets you change the number of items displayed in a single row in a grid of projects, studios, or users.",
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -68,7 +68,7 @@
       }
     }
   ],
-  "tags": ["community", "profiles"],
+  "tags": ["community", "profiles", "featured"],
   "versionAdded": "1.3.0",
   "enabledByDefault": false
 }

--- a/addons/load-extensions/addon.json
+++ b/addons/load-extensions/addon.json
@@ -34,5 +34,5 @@
     }
   ],
   "versionAdded": "1.10.0",
-  "tags": ["editor", "codeEditor"]
+  "tags": ["editor", "codeEditor", "featured"]
 }

--- a/addons/longer-wiwo/addon.json
+++ b/addons/longer-wiwo/addon.json
@@ -14,6 +14,6 @@
     }
   ],
   "versionAdded": "1.11.0",
-  "tags": ["community", "profiles"],
+  "tags": ["community", "profiles", "featured"],
   "enabledByDefault": false
 }

--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -17,6 +17,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["community"],
+  "tags": ["community", "featured"],
   "enabledByDefault": false
 }

--- a/addons/my-ocular/addon.json
+++ b/addons/my-ocular/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "ocular.jeffalo.net integration",
+  "name": "ocular integration",
   "description": "Shows ocular statuses and forum post reactions. Uses my-ocular.jeffalo.net to obtain data.",
   "credits": [
     {

--- a/addons/name-backpack-items/addon.json
+++ b/addons/name-backpack-items/addon.json
@@ -6,7 +6,7 @@
       "name": "TheColaber"
     }
   ],
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "versionAdded": "1.19.0",
   "userscripts": [
     {

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -13,7 +13,7 @@
       "id": "itemsPerRow"
     }
   ],
-  "tags": ["community", "theme", "studios"],
+  "tags": ["community", "theme", "studios", "featured"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Sprite and script count",
   "description": "Shows the number of sprites and scripts a project has next to the Remix button.",
-  "tags": ["community", "projectPage"],
+  "tags": ["community", "projectPage", "featured"],
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/redirect-mobile-forums/addon.json
+++ b/addons/redirect-mobile-forums/addon.json
@@ -15,6 +15,6 @@
     }
   ],
   "versionAdded": "1.16.0",
-  "tags": ["community", "forums", "easterEgg"],
+  "tags": ["community", "forums"],
   "enabledByDefault": false
 }

--- a/addons/studio-followers/addon.json
+++ b/addons/studio-followers/addon.json
@@ -25,6 +25,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.17.0",
-  "tags": ["community", "studios"],
+  "tags": ["community", "studios", "featured"],
   "enabledByDefault": false
 }

--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -50,5 +50,5 @@
     }
   ],
   "versionAdded": "1.18.0",
-  "tags": ["community", "projectPage"]
+  "tags": ["community", "projectPage", "featured"]
 }

--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -24,6 +24,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.11.0",
-  "tags": ["editor", "recommended"],
+  "tags": ["editor", "featured"],
   "enabledByDefault": false
 }

--- a/webpages/settings/data/addon-groups.js
+++ b/webpages/settings/data/addon-groups.js
@@ -51,6 +51,22 @@ export default [
     fullscreenShow: true,
   },
   {
+    id: "featured",
+    name: chrome.i18n.getMessage("featured"),
+    addonIds: [],
+    expanded: true,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
+  {
+    id: "forums",
+    name: chrome.i18n.getMessage("forums"),
+    addonIds: [],
+    expanded: false,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
+  {
     id: "others",
     name: chrome.i18n.getMessage("others"),
     addonIds: [],

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -415,6 +415,7 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
           obj.matchesCategory =
             !shouldHideAsEasterEgg && (newValue === "all" || obj.manifest._categories.includes(newValue));
         });
+        if (newValue === "forums") this.addonGroups.find((group) => group.id === "forums").expanded = true;
       },
     },
     ready() {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -547,7 +547,9 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
       else {
         // Addon is disabled
         if (manifest.tags.includes("recommended")) manifest._groups.push("recommended");
+        else if (manifest.tags.includes("featured")) manifest._groups.push("featured");
         else if (manifest.tags.includes("beta") || manifest.tags.includes("danger")) manifest._groups.push("beta");
+        else if (manifest.tags.includes("forums")) manifest._groups.push("forums");
         else manifest._groups.push("others");
       }
 


### PR DESCRIPTION
Okay, my 3rd PR :P

We can deal on whether some addons should be enabled by default or not in a future PR, please leave that for the future.
Recommended tag has not changed - there are still many recommended addons that aren't enabled by default.

Whether an addon is recommended, featured, or none, is very opiniated. I suggest you avoid discussing addons that fall in a gray area. We'll soon have a source of truth for what addons people use because of #3283, so let's just wait until we can use that. In general, recommended addons should be those that more than 75% of users use, and featured ones should be idk, more than 20%? We'll see how it plays out.
Featured tag is not visible as a tag - it's only used for grouping. Because of this reason, forum tag (green background tag, not literal manifest tag) could be removed, sure (just noticed while writing this, after commiting)

Ocular addon was renamed per mxmou's suggestion https://github.com/ScratchAddons/ScratchAddons/pull/3155#issuecomment-890038913
Some easter egg addons are now under "other" group
Clone counter is now recommended, it was previously under "others" group
For whole list of changes see changed files, I'll just list downgrades (addons that go from recommended to featured)
- better-featured-project: I don't like recommended themes
- custom-block-shape: let's try to keep 2.0 look addons under featured
- dark-www: same as below
- editor-dark-mode: same as better-featured-project. I didn't remove scratchr2 from recommended tho, because it brings consistency.
- editor-stage-left: same as custom-block-shape
- editor-theme3: same as above
- gamepad: not everyone has a controller