### PR TITLE
Separate "featured new addons" and "other new addons" addon groups

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -253,11 +253,11 @@
     "description": "Tag for addons. Singular."
   },
   "newGroup": {
-    "message": "New",
+    "message": "Other new addons",
     "description": "Used as a category name for new addons"
   },
   "featuredNew": {
-    "message": "Featured new",
+    "message": "Featured new addons",
     "description": "Used as a category name for featured new addons"
   },
   "enabled": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -249,7 +249,16 @@
     "message": "Scratch Addons is not affiliated with Scratch."
   },
   "new": {
-    "message": "New!"
+    "message": "New!",
+    "description": "Tag for addons. Singular."
+  },
+  "newGroup": {
+    "message": "New",
+    "description": "Used as a category name for new addons"
+  },
+  "featuredNew": {
+    "message": "Featured new",
+    "description": "Used as a category name for featured new addons"
   },
   "enabled": {
     "message": "Enabled",

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -136,7 +136,7 @@ if (path[path.length - 1] !== "/") path += "/";
 const pathArr = path.split("/");
 if (pathArr[0] === "scratch-addons-extension") {
   if (pathArr[1] === "settings") {
-    let url = chrome.runtime.getURL("webpages/settings/index.html");
+    let url = chrome.runtime.getURL(`webpages/settings/index.html${window.location.search}`);
     if (location.hash) url += location.hash;
     chrome.runtime.sendMessage({ replaceTabWithUrl: url });
   }
@@ -515,7 +515,7 @@ const showBanner = () => {
             .outerHTML,
           */
           Object.assign(document.createElement("a"), {
-            href: "https://scratch.mit.edu/scratch-addons-extension/settings",
+            href: "https://scratch.mit.edu/scratch-addons-extension/settings?source=updatenotif",
             target: "_blank",
             textContent: chrome.i18n.getMessage("scratchAddonsSettings"),
           }).outerHTML,

--- a/webpages/settings/data/addon-groups.js
+++ b/webpages/settings/data/addon-groups.js
@@ -27,10 +27,18 @@ export default [
   },
 
   {
-    id: "new",
-    name: chrome.i18n.getMessage("new"),
+    id: "featuredNew",
+    name: chrome.i18n.getMessage("featuredNew"),
     addonIds: [],
     expanded: true,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
+  {
+    id: "new",
+    name: chrome.i18n.getMessage("newGroup"),
+    addonIds: [],
+    expanded: new URLSearchParams(window.location.search).get("source") === "updatenotif",
     iframeShow: false,
     fullscreenShow: true,
   },

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -15,15 +15,6 @@ if (window.parent !== window) {
   isIframe = true;
 }
 
-const NEW_ADDON_ORDER = [
-  "turbowarp-player",
-  "items-per-row",
-  "ctrl-enter-post",
-  "customize-avatar-border",
-  "compact-messages",
-  "default-project",
-];
-
 let vue;
 let fuse;
 
@@ -583,11 +574,6 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
     const order = [["danger", "beta"], "editor", "community", "popup"];
 
     vue.addonGroups.forEach((group) => {
-      if (group.id === "new") {
-        group.addonIds.sort((b, a) => NEW_ADDON_ORDER.indexOf(b) - NEW_ADDON_ORDER.indexOf(a));
-        return;
-      }
-
       group.addonIds = group.addonIds
         .map((id) => vue.manifestsById[id])
         .sort((manifestA, manifestB) => {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -532,7 +532,9 @@ chrome.storage.sync.get(["globalTheme"], function ({ globalTheme = false }) {
         const [addonMajor, addonMinor, __] = manifest.versionAdded.split(".");
         if (extMajor === addonMajor && extMinor === addonMinor) {
           manifest.tags.push("new");
-          manifest._groups.push("new");
+          manifest._groups.push(
+            manifest.tags.includes("recommended") || manifest.tags.includes("featured") ? "featuredNew" : "new"
+          );
         }
       }
 


### PR DESCRIPTION
"New" group is now collapsed on page load, unless user comes from the update notification.
If an addon is either recommended or featured, it gets into "featured new" instead of "new".

How it looks with "new" expanded, as if user came from update notification:
![image](https://user-images.githubusercontent.com/17484114/129591339-536f6963-99ae-4145-a774-75e3bb20ce34.png)

With "new" collapsed:
![image](https://user-images.githubusercontent.com/17484114/129591389-911851aa-c95a-45e8-bd59-eb2a5d07d52a.png)