### PR TITLE
Do not load scratchblocks addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -109,6 +109,5 @@
   "dark-www",
   "old-studio-layout",
   "compact-messages",
-  "customize-avatar-border",
-  "scratchblocks"
+  "customize-avatar-border"
 ]


### PR DESCRIPTION
scratchblocks addon will no longer be loaded, enabled or even recognized by the SA. Code will remain. If you can fix this mess, please make a PR. If nobody can before v1.19 releases, then the code will be removed as well.

We can't ship a broken addon.