### PR TITLE
New addon: Fix forum links

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -95,6 +95,7 @@
   "forum-copy-code",
   "paint-by-default",
   "hide-project-stats",
+  "forums-links",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/forums-links/addon.json
+++ b/addons/forums-links/addon.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ScratchAddons/manifest-schema/dist/schema.json",
+  "name": "Forum link fix",
+  "description": "Fixes certain links in the forums, e.g Replit source URLs.",
+  "credits": [
+    {
+      "name": "9gr",
+      "link": "https://scratch.mit.edu/users/9gr/"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/discuss/topic/*"]
+    }
+  ],
+  "tags": ["community", "forums"],
+  "versionAdded": "1.20.0"
+}

--- a/addons/forums-links/userscript.js
+++ b/addons/forums-links/userscript.js
@@ -1,0 +1,10 @@
+export default async ({ addon }) => {
+  while (true) {
+    const link = await addon.tab.waitForElement("a", {
+      markAsSeen: true,
+      reduxCondition: (state) => (state.scratchGui ? state.scratchGui.mode.isPlayerOnly : true),
+    });
+
+    link.href = decodeURIComponent(link.href);
+  }
+};


### PR DESCRIPTION
### Changes

Adds small addon that fixes replit repl source URLs in forums (@'s get `encodeURIComponent`\`d).

### Reason for changes

Repl.it is a good place to share code on scratch

### Tests
Tested locally
<!-- If applicable. Have you tested this pull request? If so, how? -->
