### PR TITLE
scratch-messaging: fix profile comments with linebreaks

### DIFF
--- a/addons/comments-linebreaks/addon.json
+++ b/addons/comments-linebreaks/addon.json
@@ -10,20 +10,14 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": [
-        "profiles"
-      ],
+      "matches": ["profiles"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "break-spaces.css",
-      "matches": [
-        "studios",
-        "projects",
-        "profiles"
-      ]
+      "matches": ["studios", "projects", "profiles"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/comments-linebreaks/addon.json
+++ b/addons/comments-linebreaks/addon.json
@@ -11,13 +11,22 @@
     {
       "url": "userscript.js",
       "matches": [
-        "https://scratch.mit.edu/users/*/",
-        "https://scratch.mit.edu/projects/*",
-        "https://scratch.mit.edu/studios/*"
+        "profiles"
       ],
       "runAtComplete": false
     }
   ],
+  "userstyles": [
+    {
+      "url": "break-spaces.css",
+      "matches": [
+        "studios",
+        "projects",
+        "profiles"
+      ]
+    }
+  ],
+  "dynamicEnable": true,
   "versionAdded": "1.8.0",
   "tags": ["community", "comments"]
 }

--- a/addons/comments-linebreaks/break-spaces.css
+++ b/addons/comments-linebreaks/break-spaces.css
@@ -1,0 +1,3 @@
+.comment-content, .comment .content {
+  white-space: break-spaces;
+}

--- a/addons/comments-linebreaks/break-spaces.css
+++ b/addons/comments-linebreaks/break-spaces.css
@@ -1,3 +1,4 @@
-.comment-content, .comment .content {
+.comment-content,
+.comment .content {
   white-space: break-spaces;
 }

--- a/addons/comments-linebreaks/userscript.js
+++ b/addons/comments-linebreaks/userscript.js
@@ -1,41 +1,8 @@
+import formatProfileComments from "../../libraries/common/cs/format-profile-comments.js";
+
 export default async function ({ addon, global, console }) {
   while (true) {
-    let comment = await addon.tab.waitForElement(".comment .content, .comment-content", {
-      markAsSeen: true,
-      reduxCondition: (state) => {
-        if (!state.scratchGui) return true;
-        return state.scratchGui.mode.isPlayerOnly;
-      },
-    });
-    comment.style.whiteSpace = "break-spaces";
-    if (!comment.classList.contains("comment-content")) {
-      let nodes = comment.childNodes;
-      for (let child of nodes) {
-        if (child instanceof Text) {
-          if (child === nodes[0]) {
-            child.textContent = child.textContent.trimStart();
-            if (!child.nextSibling) {
-              child.textContent = child.textContent.trim();
-            }
-          } else {
-            if (child === nodes[nodes.length - 1]) {
-              child.textContent = child.textContent.trimEnd();
-            }
-            const firstA = Array.prototype.find.call(
-              nodes,
-              (n) => n instanceof HTMLAnchorElement && (!n.previousSibling || !n.previousSibling.textContent)
-            );
-
-            if (firstA && child.previousSibling === firstA) {
-              if (child.textContent.startsWith("*")) {
-                child.textContent = "* " + child.textContent.replace(/^\*\s*/, "");
-              } else {
-                child.textContent = " " + child.textContent.trimStart();
-              }
-            }
-          }
-        }
-      }
-    }
+    const comment = await addon.tab.waitForElement(".comment .content", { markAsSeen: true });
+    formatProfileComments(comment);
   }
 }

--- a/addons/scratch-messaging/background.js
+++ b/addons/scratch-messaging/background.js
@@ -1,5 +1,6 @@
 import commentEmojis from "../scratch-notifier/comment-emojis.js";
 import { linkifyTextNode, pingifyTextNode } from "../../libraries/common/cs/fast-linkify.js";
+import formatProfileComments from "../../libraries/common/cs/format-profile-comments.js";
 
 export default async function ({ addon, global, console, setTimeout, setInterval, clearTimeout, clearInterval }) {
   let lastDateTime;
@@ -338,6 +339,7 @@ export default async function ({ addon, global, console, setTimeout, setInterval
     if (value instanceof Node) {
       // profile
       node = value.cloneNode(true);
+      if (shouldInsertLinebreak) formatProfileComments(node);
     } else {
       // JSON API
       const fragment = parser.parseFromString(value.trim(), "text/html");

--- a/libraries/common/cs/format-profile-comments.js
+++ b/libraries/common/cs/format-profile-comments.js
@@ -1,0 +1,34 @@
+/**
+ * Formats profile comments by removing unnecessary spaces.
+ * This modifies the element in-place.
+ * @param {HTMLElement} comment - the element that contains text, i.e. div.content
+ */
+export default (comment) => {
+  let nodes = comment.childNodes;
+  for (let child of nodes) {
+    if (child instanceof Text) {
+      if (child === nodes[0]) {
+        child.textContent = child.textContent.trimStart();
+        if (!child.nextSibling) {
+          child.textContent = child.textContent.trim();
+        }
+      } else {
+        if (child === nodes[nodes.length - 1]) {
+          child.textContent = child.textContent.trimEnd();
+        }
+        const firstA = Array.prototype.find.call(
+          nodes,
+          (n) => n instanceof HTMLAnchorElement && (!n.previousSibling || !n.previousSibling.textContent)
+        );
+
+        if (firstA && child.previousSibling === firstA) {
+          if (child.textContent.startsWith("*")) {
+            child.textContent = "* " + child.textContent.replace(/^\*\s*/, "");
+          } else {
+            child.textContent = " " + child.textContent.trimStart();
+          }
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Resolves #3340

Also refactors comments-linebreak; no longer uses userscript for WWW, and supports dynamicEnable. dynamicDisable-ing is currently impossible due to profile comment mess.