### PR TITLE
paint-by-default: fix sound setting when no sounds exist

### DIFF
--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -80,7 +80,7 @@ export default async function ({ addon, console }) {
   const getButtonToClick = (mainButton) => {
     const assetPanelWrapper = mainButton.closest("[class*=asset-panel_wrapper_]");
     if (assetPanelWrapper) {
-      if (assetPanelWrapper.querySelector("[class*=sound-editor_editor-container_]")) {
+      if (addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 2) {
         return soundMeta[getSetting("sound")] || soundMeta.library;
       } else {
         return costumeMeta[getSetting("costume")] || costumeMeta.library;


### PR DESCRIPTION
Fixes a bug: The addon treated the "Add sound" button as if it was the "Add costume" button if the current sprite had no sounds
