### PR TITLE
drag-drop: set dropEffect to "copy"

### DIFF
--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -109,7 +109,9 @@ export default async function ({ addon, global, console }) {
 
     const handleDragOver = (e) => {
       e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
     };
+    e.dataTransfer.dropEffect = 'copy';
 
     const handleDragLeave = (e) => {
       e.preventDefault();

--- a/addons/drag-drop/userscript.js
+++ b/addons/drag-drop/userscript.js
@@ -109,9 +109,9 @@ export default async function ({ addon, global, console }) {
 
     const handleDragOver = (e) => {
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'copy';
+      e.dataTransfer.dropEffect = "copy";
     };
-    e.dataTransfer.dropEffect = 'copy';
+    e.dataTransfer.dropEffect = "copy";
 
     const handleDragLeave = (e) => {
       e.preventDefault();


### PR DESCRIPTION
This provides slightly better feedback to the user about what will happen if they drop a file. On Windows, this changes the tooltip from "Move" to "Copy". Similar changes happen on other operating systems.