### PR TITLE
Block switching: "play sound" → "start sound"

### DIFF
--- a/addons-l10n/en/block-switching.json
+++ b/addons-l10n/en/block-switching.json
@@ -60,7 +60,7 @@
   "block-switching/pen_setPenSizeTo": "set size",
   "block-switching/sensing_mousex": "mouse x",
   "block-switching/sensing_mousey": "mouse y",
-  "block-switching/sound_play": "play",
+  "block-switching/sound_play": "start",
   "block-switching/sound_playuntildone": "play until done",
   "block-switching/sound_changeeffectby": "change effect",
   "block-switching/sound_seteffectto": "set effect",


### PR DESCRIPTION
Block is called "start sound" since 3.0

![image](https://user-images.githubusercontent.com/17484114/131412016-bec7b756-f8e2-4177-b154-fa603518cf4f.png)
