### PR TITLE
editor-searchable-dropdowns: smarter searching

### DIFF
--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -178,12 +178,9 @@ export default async function ({ addon, global, console, msg }) {
     return items
       .map((item, index) => ({
         item,
-        score: rank(item, currentDropdownOptions[index])
+        score: rank(item, currentDropdownOptions[index]),
       }))
-      .sort(({score: scoreA}, {score: scoreB}) => (
-        Math.max(0, scoreB) -
-        Math.max(0, scoreA)
-      ));
+      .sort(({ score: scoreA }, { score: scoreB }) => Math.max(0, scoreB) - Math.max(0, scoreA));
   }
 
   function updateSearch() {
@@ -199,14 +196,14 @@ export default async function ({ addon, global, console, msg }) {
       }
     }
     if (needToUpdateDOM && previousSearchedItems.length > 0) {
-      for (const {item} of previousSearchedItems) {
+      for (const { item } of previousSearchedItems) {
         item.element.remove();
       }
-      for (const {item} of searchedItems) {
+      for (const { item } of searchedItems) {
         blocklyDropdownMenu.appendChild(item.element);
       }
     }
-    for (const {item, score} of searchedItems) {
+    for (const { item, score } of searchedItems) {
       item.element.hidden = score < 0;
     }
   }
@@ -236,7 +233,7 @@ export default async function ({ addon, global, console, msg }) {
           return;
         }
       }
-      for (const {item} of searchedItems) {
+      for (const { item } of searchedItems) {
         if (!item.element.hidden) {
           selectItem(item.element, true);
           break;
@@ -250,9 +247,7 @@ export default async function ({ addon, global, console, msg }) {
       event.preventDefault();
       event.stopPropagation();
 
-      const items = searchedItems
-        .filter((i) => i.score >= 0)
-        .map((i) => i.item);
+      const items = searchedItems.filter((i) => i.score >= 0).map((i) => i.item);
       if (items.length === 0) {
         return;
       }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -64,6 +64,8 @@ export default async function ({ addon, global, console, msg }) {
   const oldDropDownDivClearContent = Blockly.DropDownDiv.clearContent;
   Blockly.DropDownDiv.clearContent = function () {
     oldDropDownDivClearContent.call(this);
+    items = [];
+    searchedItems = [];
     Blockly.DropDownDiv.content_.style.height = "";
   };
 

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -183,12 +183,26 @@ export default async function ({ addon, global, console, msg }) {
   }
 
   function updateSearch() {
+    const previousSearchedItems = searchedItems;
     searchedItems = performSearch();
-    for (const item of items) {
-      item.element.remove();
+    let needToUpdateDOM = previousSearchedItems.length !== searchedItems.length;
+    if (!needToUpdateDOM) {
+      for (let i = 0; i < searchedItems.length; i++) {
+        if (searchedItems[i] !== previousSearchedItems[i]) {
+          needToUpdateDOM = true;
+          break;
+        }
+      }
     }
-    for (const item of searchedItems) {
-      blocklyDropdownMenu.appendChild(item.element);
+    if (needToUpdateDOM) {
+      // There are probably more efficient ways to do this, but it doesn't seem necessary to optimize this yet
+      // It's still quite fast
+      for (const item of items) {
+        item.element.remove();
+      }
+      for (const item of searchedItems) {
+        blocklyDropdownMenu.appendChild(item.element);
+      }
     }
   }
 

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -159,9 +159,11 @@ export default async function ({ addon, global, console, msg }) {
   }
 
   function performSearch() {
-    const rank = (item, option) => {
+    const query = searchBar.value.toLowerCase().trim();
+    const rank = (item, index) => {
       // Negative number will hide
       // Higher numbers will appear first
+      const option = currentDropdownOptions[index];
       if (SCRATCH_ITEMS_TO_HIDE.includes(option[1])) {
         return query ? -1 : 0;
       } else if (ADDON_ITEMS.includes(option[1])) {
@@ -175,13 +177,15 @@ export default async function ({ addon, global, console, msg }) {
       if (itemText.startsWith(query)) {
         return 1;
       }
-      return itemText.includes(query) ? 0 : -1;
+      if (itemText.includes(query)) {
+        return 0;
+      }
+      return -1;
     };
-    const query = searchBar.value.toLowerCase().trim();
     return items
       .map((item, index) => ({
         item,
-        score: rank(item, currentDropdownOptions[index]),
+        score: rank(item, index),
       }))
       .sort(({ score: scoreA }, { score: scoreB }) => Math.max(0, scoreB) - Math.max(0, scoreA));
   }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -170,6 +170,9 @@ export default async function ({ addon, global, console, msg }) {
       }
       const itemText = item.text.toLowerCase();
       if (query === itemText) {
+        return 2;
+      }
+      if (itemText.startsWith(query)) {
         return 1;
       }
       return itemText.includes(query) ? 0 : -1;

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -198,7 +198,7 @@ export default async function ({ addon, global, console, msg }) {
         }
       }
     }
-    if (needToUpdateDOM) {
+    if (needToUpdateDOM && previousSearchedItems.length > 0) {
       for (const {item} of previousSearchedItems) {
         item.element.remove();
       }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -14,8 +14,8 @@ export default async function ({ addon, global, console, msg }) {
   let blocklyDropdownMenu = null;
   let searchBar = null;
   // Contains DOM and addon state
-  let items;
-  let searchedItems;
+  let items = [];
+  let searchedItems = [];
   // Tracks internal Scratch state
   let currentDropdownOptions = [];
   let resultOfLastGetOptions = [];

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -236,9 +236,11 @@ export default async function ({ addon, global, console, msg }) {
           return;
         }
       }
-      const topItem = searchedItems[0];
-      if (topItem) {
-        selectItem(topItem.element, true);
+      for (const {item} of searchedItems) {
+        if (!item.element.hidden) {
+          selectItem(item.element, true);
+          break;
+        }
       }
       // If there is no top value, do nothing and leave the dropdown open
     } else if (event.key === "Escape") {
@@ -248,19 +250,22 @@ export default async function ({ addon, global, console, msg }) {
       event.preventDefault();
       event.stopPropagation();
 
-      if (searchedItems.length === 0) {
+      const items = searchedItems
+        .filter((i) => i.score >= 0)
+        .map((i) => i.item);
+      if (items.length === 0) {
         return;
       }
 
       let selectedIndex = -1;
-      for (let i = 0; i < searchedItems.length; i++) {
-        if (searchedItems[i].element.classList.contains("goog-menuitem-highlight")) {
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].element.classList.contains("goog-menuitem-highlight")) {
           selectedIndex = i;
           break;
         }
       }
 
-      const lastIndex = searchedItems.length - 1;
+      const lastIndex = items.length - 1;
       let newIndex = 0;
       if (event.key === "ArrowDown") {
         if (selectedIndex === -1 || selectedIndex === lastIndex) {
@@ -276,7 +281,7 @@ export default async function ({ addon, global, console, msg }) {
         }
       }
 
-      selectItem(searchedItems[newIndex].element, false);
+      selectItem(items[newIndex].element, false);
     }
   }
 


### PR DESCRIPTION
Items now get sorted in this order:

1. Exact matches
2. Items that start with the query
3. Items that contain the query

https://discord.com/channels/806602307750985799/806609030935740477/865200426861199362

Tried using Fusejs for a little bit and it didn't seem to work particularly well, so I'll just leave it like this