### PR TITLE
Remove "button color" setting from remix-tree-button

### DIFF
--- a/addons/remix-tree-button/addon.json
+++ b/addons/remix-tree-button/addon.json
@@ -23,13 +23,5 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "settings": [
-    {
-      "name": "Button Color",
-      "id": "buttonColor",
-      "type": "color",
-      "default": "#4d97ff"
-    }
-  ],
   "versionAdded": "1.2.0"
 }

--- a/addons/remix-tree-button/main.js
+++ b/addons/remix-tree-button/main.js
@@ -22,9 +22,6 @@ export default async function ({ addon, global, console, msg }) {
               window.location.href.split("projects")[1].split("/")[1]
             }/remixtree`;
           });
-          if (addon.settings.get("buttonColor")) {
-            remixtree.style.backgroundColor = addon.settings.get("buttonColor");
-          }
           addon.tab.appendToSharedSpace({ space: "afterCopyLinkButton", element: remixtree, order: 0 });
         });
     }


### PR DESCRIPTION
Resolves #1262

Discussion happened in the issue, but in a nutshell, this level of customization is not suitable for a settings page GUI. If users really want to style specific buttons, they should create their own CSS userstyle.