### PR TITLE
Disable infinite-scroll for studio-followers

### DIFF
--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -70,11 +70,14 @@ export default async function ({ addon, global, console }) {
     commentLoader(addon, "#view", ".studio-activity .studio-grid-load-more > button", "activity");
 
   // Enable scrolling for studio-followers
+  // Disabled, see #3238
+  /*
   if (isStudio && addon.settings.get("studioBrowseProjectScroll")) {
     addon.tab.waitForElement(".sa-followers-main .user-projects-modal-content").then((el) => {
       el.setAttribute("data-scrollable", "true");
     });
   }
+  */
 
   if (isStudio && addon.tab.redux.state) {
     // Fix vanilla bug causing unnecessary re-fetch


### PR DESCRIPTION
Related to #3238

Some users couldn't load more followers, so it's better to remove infinite-scroll support until we find a solution.

Weirdly enough, infinite scrolling works differently for the vanilla "browse projects" modal and our own "browse followers" modal? Strangely, what we do is make infinite-scroll tell browse-followers to handle the infinite scrolling by itself:
https://github.com/ScratchAddons/ScratchAddons/blob/master/addons/studio-followers/userscript.js#L139