### PR TITLE
Add v1.20 update notification

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -236,14 +236,14 @@
   "extensionHasUpdated": {
     "message": "Scratch Addons has updated to v$1"
   },
-  "extensionUpdateInfo1_v1_19": {
-    "message": "New addon: \"paint costume by default\", which lets you change the default action of \"Choose a Sprite/Costume/Backdrop/Sound\" buttons. Go to $1 to enable it."
+  "extensionUpdateInfo1_v1_20": {
+    "message": "New addon: \"grab single block with Ctrl key\", which adds the ability to drag a single block out of the middle of a script (instead of the entire stack attached below it) while holding the Ctrl key. Go to $1 to enable it."
   },
   "scratchAddonsSettings": {
     "message": "Scratch Addons settings"
   },
-  "extensionUpdateInfo2_v1_19": {
-    "message": "The new \"name scripts before placing in backpack\" addon asks you to name scripts after you drag them into the backpack. Other new addons added this update are \"hide delete button\" and \"hide project stats\"."
+  "extensionUpdateInfo2_v1_20": {
+    "message": "The \"editor dark mode and customizable colors\" addon has a new \"Scratch 2.0\" color preset. Other new addons added this update are \"hide new variables\" and \"move costume to top or bottom\"."
   },
   "notAffiliated": {
     "message": "Scratch Addons is not affiliated with Scratch."

--- a/addons/hide-new-variables/addon.json
+++ b/addons/hide-new-variables/addon.json
@@ -12,7 +12,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "dynamicDisable": true,
   "dynamicEnable": true,
   "versionAdded": "1.20.0"

--- a/addons/remix-button/addon.json
+++ b/addons/remix-button/addon.json
@@ -13,7 +13,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["community", "projectPage", "featured"],
+  "tags": ["community", "projectPage"],
   "dynamicDisable": true,
   "dynamicEnable": true,
   "versionAdded": "1.20.0"

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -514,7 +514,7 @@ const showBanner = () => {
   });
   const notifInnerText1 = Object.assign(document.createElement("span"), {
     style: NOTIF_TEXT_STYLE,
-    innerHTML: escapeHTML(chrome.i18n.getMessage("extensionUpdateInfo1_v1_19", DOLLARS)).replace(
+    innerHTML: escapeHTML(chrome.i18n.getMessage("extensionUpdateInfo1_v1_20", DOLLARS)).replace(
       /\$(\d+)/g,
       (_, i) =>
         [
@@ -533,7 +533,7 @@ const showBanner = () => {
   });
   const notifInnerText2 = Object.assign(document.createElement("span"), {
     style: NOTIF_TEXT_STYLE,
-    textContent: chrome.i18n.getMessage("extensionUpdateInfo2_v1_19"),
+    textContent: chrome.i18n.getMessage("extensionUpdateInfo2_v1_20"),
   });
   const notifFooter = Object.assign(document.createElement("span"), {
     style: NOTIF_TEXT_STYLE,


### PR DESCRIPTION
I also made remix-button not be featured anymore, and hide-new-variables be featured. Which makes more sense. hide-new-variables is very useful, and remix-button is just a funny hack which rarely is useful by itself.

Youtube video TODO, will be replaced in the notification in a few days.

![image](https://user-images.githubusercontent.com/17484114/132998262-b2bb8bee-7a96-4d6b-9b63-6537cdfbcefe.png)
