### PR TITLE
Instead of hiding settings when the `if` evaluates to `false`, just show them as disabled

### DIFF
--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -1,11 +1,11 @@
 <template>
   <div
-    v-show="show"
     class="addon-setting"
     :class="{
     'boolean-setting': setting.type === 'boolean',
     'number-setting': setting.type === 'integer' || setting.type === 'positive_integer',
   }"
+    v-bind:class="[show ? '' : 'disabled']"
   >
     <div class="setting-label" v-html="settingsName(addon)"></div>
     <template v-if="setting.type === 'boolean'">
@@ -14,7 +14,7 @@
         class="setting-input check"
         v-model="addonSettings[addon._addonId][setting.id]"
         @change="updateSettings()"
-        :disabled="!addon._enabled"
+        :disabled="!addon._enabled||!show"
       />
     </template>
     <template v-if="setting.type === 'select'">
@@ -22,7 +22,7 @@
         <div
           class="filter-option"
           v-for="option of setting.potentialValues"
-          :class="{'sel' : addonSettings[addon._addonId][setting.id] === option.id, 'disabled': !addon._enabled}"
+          :class="{'sel' : addonSettings[addon._addonId][setting.id] === option.id, 'disabled': !addon._enabled||!show}"
           @click="updateOption(option.id);"
         >
           {{ option.name }}
@@ -36,7 +36,7 @@
           class="setting-input number"
           v-model="addonSettings[addon._addonId][setting.id]"
           @change="checkValidity() || updateSettings()"
-          :disabled="!addon._enabled"
+          :disabled="!addon._enabled||!show"
           min="0"
           :data-addon-id="addon._addonId"
           :data-setting-id="setting.id"
@@ -49,7 +49,7 @@
           class="setting-input number"
           v-model="addonSettings[addon._addonId][setting.id]"
           @change="checkValidity() || updateSettings()"
-          :disabled="!addon._enabled"
+          :disabled="!addon._enabled||!show"
           :min="setting.min"
           :max="setting.max"
           :data-addon-id="addon._addonId"
@@ -63,7 +63,7 @@
           class="setting-input string"
           v-model="addonSettings[addon._addonId][setting.id]"
           @change="checkValidity() || updateSettings()"
-          :disabled="!addon._enabled"
+          :disabled="!addon._enabled||!show"
           :placeholder="setting.default"
           :maxlength="setting.max || 100"
           :minlength="setting.min || 0"
@@ -80,7 +80,7 @@
           @input="updateSettings()"
           @keydown="keySettingKeyDown"
           @keyup="keySettingKeyUp"
-          :disabled="!addon._enabled"
+          :disabled="!addon._enabled||!show"
           :placeholder="setting.default"
           maxlength="100"
           :data-addon-id="addon._addonId"
@@ -93,6 +93,7 @@
           :value="addonSettings[addon._addonId][setting.id] || setting.default"
           :setting="setting"
           :addon="addon"
+          :show="show"
           :no_alpha="!setting.allowTransparency"
           v-click-outside="closePickers"
         ></picker>
@@ -101,6 +102,7 @@
         v-if="showResetDropdown()"
         :setting="setting"
         :addon="addon"
+        :show="show"
         :label="msg('reset')"
         :default-label="msg('default')"
         v-click-outside="closeResetDropdowns"
@@ -109,7 +111,7 @@
         v-else
         type="button"
         class="large-button clear-button"
-        :disabled="!addon._enabled"
+        :disabled="!addon._enabled||!show"
         :title="msg('reset')"
         @click="updateOption(setting.default)"
       >

--- a/webpages/settings/components/picker-component.html
+++ b/webpages/settings/components/picker-component.html
@@ -3,7 +3,7 @@
     <button
       :style="{'background-color': color }"
       class="setting-input color"
-      :class="{'action-disabled': !addon._enabled, 'open': isOpen }"
+      :class="{'action-disabled': !addon._enabled||!show, 'open': isOpen }"
       @click="toggle(addon, setting)"
     ></button>
     <template v-if="loadColorPicker">

--- a/webpages/settings/components/picker-component.js
+++ b/webpages/settings/components/picker-component.js
@@ -1,6 +1,6 @@
 export default async function ({ template }) {
   const ColorInput = Vue.extend({
-    props: ["value", "addon", "setting", "no_alpha"],
+    props: ["value", "addon", "setting", "no_alpha","show"],
     template,
     data() {
       return {

--- a/webpages/settings/components/picker-component.js
+++ b/webpages/settings/components/picker-component.js
@@ -1,6 +1,6 @@
 export default async function ({ template }) {
   const ColorInput = Vue.extend({
-    props: ["value", "addon", "setting", "no_alpha","show"],
+    props: ["value", "addon", "setting", "no_alpha", "show"],
     template,
     data() {
       return {

--- a/webpages/settings/components/reset-dropdown.html
+++ b/webpages/settings/components/reset-dropdown.html
@@ -1,6 +1,12 @@
 <template>
   <div :class="{'setting-dropdown': true, open: isOpen}">
-    <button type="button" class="large-button clear-button" :disabled="!addon._enabled||!show" @click="toggle" :title="label">
+    <button
+      type="button"
+      class="large-button clear-button"
+      :disabled="!addon._enabled||!show"
+      @click="toggle"
+      :title="label"
+    >
       <img src="../../images/icons/expand.svg" class="icon-type" />
     </button>
     <ul>

--- a/webpages/settings/components/reset-dropdown.html
+++ b/webpages/settings/components/reset-dropdown.html
@@ -1,6 +1,6 @@
 <template>
   <div :class="{'setting-dropdown': true, open: isOpen}">
-    <button type="button" class="large-button clear-button" :disabled="!addon._enabled" @click="toggle" :title="label">
+    <button type="button" class="large-button clear-button" :disabled="!addon._enabled||!show" @click="toggle" :title="label">
       <img src="../../images/icons/expand.svg" class="icon-type" />
     </button>
     <ul>

--- a/webpages/settings/components/reset-dropdown.js
+++ b/webpages/settings/components/reset-dropdown.js
@@ -1,6 +1,6 @@
 export default async function ({ template }) {
   const ResetDropdown = Vue.extend({
-    props: ["addon", "setting", "label", "defaultLabel","show"],
+    props: ["addon", "setting", "label", "defaultLabel", "show"],
     template,
     data() {
       return {

--- a/webpages/settings/components/reset-dropdown.js
+++ b/webpages/settings/components/reset-dropdown.js
@@ -1,6 +1,6 @@
 export default async function ({ template }) {
   const ResetDropdown = Vue.extend({
-    props: ["addon", "setting", "label", "defaultLabel"],
+    props: ["addon", "setting", "label", "defaultLabel","show"],
     template,
     data() {
       return {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves no open issues

### Changes

Instead of hiding settings when the `if` evaluates to `false`, just show them as disabled

### Reason for changes

To stop other settings from jumping around. also lets the user know that the option is there, it's just not compatible with their other settings.

### Tests

tested locally
