### PR TITLE
Scratch 1.x preset

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1031,6 +1031,34 @@
       }
     },
     {
+      "name": "Scratch 1.x",
+      "id": "scratch1",
+      "description": "A theme based on Scratch 1.x's colors.",
+      "values": {
+        "page": "#c0c3c6",
+        "primary": "#5498c7",
+        "highlightText": "#21211f",
+        "menuBar": "#c0c3c6",
+        "activeTab": "#b9d7e5",
+        "tab": "#adadb5",
+        "selector": "#6a6a6a",
+        "selector2": "#7c8083",
+        "selectorSelection": "#404143",
+        "accent": "#959a9f",
+        "input": "#5f6265",
+        "workspace": "#7c8083",
+        "categoryMenu": "#969a9f",
+        "palette": "#7c8083",
+        "fullscreen": "#000001",
+        "stageHeader": "#000001",
+        "border": "#0000006b",
+        "textShadow": false,
+        "dots": false,
+        "darkComments": false,
+        "darkScrollbars": false
+      }
+    },
+    {
       "name": "Scratch's default colors",
       "id": "scratch",
       "description": "The colors normally used by Scratch",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -463,6 +463,7 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 }
 
 /* Text and icon highlight color */
+.sa-body-editor a:link,
 .gui_tab_27Unf.gui_is-selected_sHAiu,
 .dropdown_dropdown_yOinO,
 .record-modal_playing-text_1tknI,


### PR DESCRIPTION
### Changes

Adds a preset to editor dark mode that uses colors from Scratch 1.4.
![image](https://user-images.githubusercontent.com/51849865/133254781-3ac26da0-bccd-4efb-957a-6cd6c9197470.png)

If `affectStage` is enabled:
![image](https://user-images.githubusercontent.com/51849865/133254957-cdaa8bcb-a764-42e7-a5b0-0a1bf0ec021a.png)