### PR TITLE
More reliable ctrl key detection

### DIFF
--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -1,13 +1,11 @@
 export default async function ({ addon, global, console }) {
   const BlocklyInstance = await addon.tab.traps.getBlockly();
 
-  // Necessary to detect the CTRL/CMD key
   let ctrlKeyPressed = false;
-  document.addEventListener("keydown", function (e) {
+  document.addEventListener("mousedown", function (e) {
     ctrlKeyPressed = e.ctrlKey || e.metaKey;
-  });
-  document.addEventListener("keyup", function (e) {
-    ctrlKeyPressed = e.ctrlKey || e.metaKey;
+  }, {
+    capture: true
   });
 
   // https://github.com/LLK/scratch-blocks/blob/102b33d14b25400c064e9bf6924a7ae1b0dcb2ab/core/block_dragger.js#L160

--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -2,11 +2,15 @@ export default async function ({ addon, global, console }) {
   const BlocklyInstance = await addon.tab.traps.getBlockly();
 
   let ctrlKeyPressed = false;
-  document.addEventListener("mousedown", function (e) {
-    ctrlKeyPressed = e.ctrlKey || e.metaKey;
-  }, {
-    capture: true
-  });
+  document.addEventListener(
+    "mousedown",
+    function (e) {
+      ctrlKeyPressed = e.ctrlKey || e.metaKey;
+    },
+    {
+      capture: true,
+    }
+  );
 
   // https://github.com/LLK/scratch-blocks/blob/102b33d14b25400c064e9bf6924a7ae1b0dcb2ab/core/block_dragger.js#L160
   let isInStartBlockDrag = false;

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -7,11 +7,15 @@ export default async function ({ addon, global, console }) {
   const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
 
   let ctrlKeyPressed = false;
-  document.addEventListener("mousedown", function (e) {
-    ctrlKeyPressed = e.ctrlKey || e.metaKey;
-  }, {
-    capture: true
-  });
+  document.addEventListener(
+    "mousedown",
+    function (e) {
+      ctrlKeyPressed = e.ctrlKey || e.metaKey;
+    },
+    {
+      capture: true,
+    }
+  );
 
   // Limits all script running to CTRL + click
   const newBlocklyListen = function (e) {

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -6,27 +6,11 @@ export default async function ({ addon, global, console }) {
   });
   const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
 
-  // Necessary to detect the CTRL/CMD key
-  var ctrlKeyPressed = false;
-  document.addEventListener("keydown", function (e) {
-    if (e.ctrlKey) {
-      ctrlKeyPressed = true;
-    }
-  });
-  document.addEventListener("keyup", function (e) {
-    if (!e.ctrlKey) {
-      ctrlKeyPressed = false;
-    }
-  });
-  document.addEventListener("keydown", function (e) {
-    if (e.metaKey) {
-      ctrlKeyPressed = true;
-    }
-  });
-  document.addEventListener("keyup", function (e) {
-    if (!e.metaKey) {
-      ctrlKeyPressed = false;
-    }
+  let ctrlKeyPressed = false;
+  document.addEventListener("mousedown", function (e) {
+    ctrlKeyPressed = e.ctrlKey || e.metaKey;
+  }, {
+    capture: true
   });
 
   // Limits all script running to CTRL + click


### PR DESCRIPTION
block-cherry-picking and ctrl-click-run-scripts now detect the control key more reliably. Notably, devtool's paste context menu item will no longer cause issues. It will also avoid issues when alt+tabbing while holding control.