### PR TITLE
Update debug.svg

### DIFF
--- a/addons/debugger/debug.svg
+++ b/addons/debugger/debug.svg
@@ -1,1 +1,75 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#575e75" viewBox="0 0 20 20"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 6.5 4.5 3-4.5 3m6 0h5"/><rect rx="2" ry="2" x="1.5" y="2.5" height="15" width="17"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20px"
+   height="20px"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg837"
+   sodipodi:docname="debugger.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview839"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="9.9180775"
+     inkscape:cx="7.3098844"
+     inkscape:cy="1.5628029"
+     inkscape:window-width="1440"
+     inkscape:window-height="751"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Small-Stage-(inactive)" />
+  <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title824">Small Stage (inactive)</title>
+  <desc
+     id="desc826">Created with Sketch.</desc>
+  <defs
+     id="defs828" />
+  <g
+     id="Page-1"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd"
+     stroke-linecap="round"
+     stroke-linejoin="round">
+    <g
+       id="Small-Stage-(inactive)"
+       stroke="#4C97FF">
+      <path
+         id="rect1567"
+         style="fill:#8f8f8f;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         d="M 4,3.5 C 3.169,3.5 2.5,4.169 2.5,5 v 10 c 0,0.831 0.669,1.5 1.5,1.5 h 12 c 0.831,0 1.5,-0.669 1.5,-1.5 V 5 C 17.5,4.169 16.831,3.5 16,3.5 Z m 0,1 h 12 c 0.277,0 0.5,0.223 0.5,0.5 v 10 c 0,0.277 -0.223,0.5 -0.5,0.5 H 4 C 3.723,15.5 3.5,15.277 3.5,15 V 5 C 3.5,4.723 3.723,4.5 4,4.5 Z" />
+      <path
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         d="M 5.4166663,7.5000001 9.1666664,9.9999997 5.4166663,12.5 m 4.9999997,0 h 4.166668"
+         id="path3515-0-2"
+         style="fill:none;stroke:#8f8f8f;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+  <metadata
+     id="metadata1505">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Small Stage (inactive)</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>


### PR DESCRIPTION
### Changes
Change debug icon.

### Reason for changes

The styles of the Scratch icon and the addon icon was different.
![スクリーンショット 2021-09-18 午後4 44 36](https://user-images.githubusercontent.com/86896657/133881355-8a7ae458-8090-4355-a09b-c69aff798acf.png)