### PR TITLE
block-cherry-picking: allow cherry-picking the top block of a script

### DIFF
--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -17,6 +17,9 @@
     {
       "name": "lisa_wolfgang",
       "link": "https://scratch.mit.edu/users/lisa_wolfgang"
+    },
+    {
+      "name": "GarboMuffin"
     }
   ],
   "userscripts": [

--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, global, console }) {
-  const BlocklyInstance = await addon.tab.traps.getBlockly();
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
 
   let ctrlKeyPressed = false;
   document.addEventListener(
@@ -13,25 +13,17 @@ export default async function ({ addon, global, console }) {
   );
 
   // https://github.com/LLK/scratch-blocks/blob/102b33d14b25400c064e9bf6924a7ae1b0dcb2ab/core/block_dragger.js#L160
-  let isInStartBlockDrag = false;
-  const originalStartBlockDrag = BlocklyInstance.BlockDragger.prototype.startBlockDrag;
-  BlocklyInstance.BlockDragger.prototype.startBlockDrag = function (...args) {
-    isInStartBlockDrag = true;
-    try {
-      return originalStartBlockDrag.call(this, ...args);
-    } finally {
-      isInStartBlockDrag = false;
+  const originalStartBlockDrag = ScratchBlocks.BlockDragger.prototype.startBlockDrag;
+  ScratchBlocks.BlockDragger.prototype.startBlockDrag = function (...args) {
+    if (!addon.self.disabled) {
+      const invert = addon.settings.get("invertDrag") && this.draggingBlock_.getParent();
+      if (ctrlKeyPressed === !invert) {
+        if (!ScratchBlocks.Events.getGroup()) {
+          ScratchBlocks.Events.setGroup(true);
+        }
+        this.draggingBlock_.unplug(true);
+      }
     }
-  };
-
-  // `opt_healStack` is a built-in option in scratch-blocks that enables cherry-picking behavior.
-  // All this function does is enable that built-in option for every block.
-  // https://github.com/LLK/scratch-blocks/blob/102b33d14b25400c064e9bf6924a7ae1b0dcb2ab/core/block.js#L336
-  const originalUnplug = BlocklyInstance.Block.prototype.unplug;
-  BlocklyInstance.BlockSvg.prototype.unplug = function (opt_healStack) {
-    if (isInStartBlockDrag && ctrlKeyPressed !== addon.settings.get("invertDrag") && !addon.self.disabled) {
-      opt_healStack = true;
-    }
-    return originalUnplug.call(this, opt_healStack);
+    return originalStartBlockDrag.call(this, ...args);
   };
 }


### PR DESCRIPTION
Previously, dragging the top block of a script would always drag the entire script regardless of control being pressed or not. Now it's possible to drag just the top block.

The "flip controls" setting is always disabled when dragging the top block. This matches the current behavior which allows people to easily move scripts around without pressing control when that setting is enabled. They can still drag just the top block by pressing control, which is weird, but I'm not aware of a better solution. Adding another setting seems unnecessary.
