### PR TITLE
confirm-actions: confirm project unshare

### DIFF
--- a/addons-l10n/en/confirm-actions.json
+++ b/addons-l10n/en/confirm-actions.json
@@ -1,5 +1,6 @@
 {
   "confirm-actions/share": "Scratch Addons:\nAre you sure you want to share?",
+  "confirm-actions/unshare": "Scratch Addons:\nAre you sure you want to unshare?",
   "confirm-actions/follow": "Scratch Addons:\nAre you sure you want to follow/unfollow this user?",
   "confirm-actions/joinstudio": "Scratch Addons:\nAre you sure you would like to join this studio?",
   "confirm-actions/closetopic": "Scratch Addons:\nAre you sure you want to close this topic?"

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -25,6 +25,12 @@
       "default": true
     },
     {
+      "name": "Confirm project unsharing",
+      "id": "projectunsharing",
+      "type": "boolean",
+      "default": true
+    },
+    {
       "name": "Confirm following/unfollowing users",
       "id": "followinguser",
       "type": "boolean",

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -8,6 +8,8 @@ export default async function ({ addon, console, msg }) {
         e.target.closest("[class*='share-button_share-button']:not([class*='is-shared']), .banner-button")
       ) {
         cancelMessage = msg("share");
+      } else if (addon.settings.get("projectunsharing") && e.target.closest(".media-stats a.unshare")) {
+        cancelMessage = msg("unshare");
       } else if (addon.settings.get("followinguser") && e.target.closest("#profile-data .follow-button")) {
         cancelMessage = msg("follow");
       } else if (


### PR DESCRIPTION
Parity with the editor unshare button which already has confirmation.

Suggested by CreativeCat at https://discord.com/channels/806602307750985799/806609030935740477/891940176845217812