### PR TITLE
Remove Minifiers

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -100,6 +100,7 @@
   "block-cherry-picking",
   "hide-new-variables",
   "move-to-top-bottom",
+  "remove-minifiers",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/remove-minifiers/addon.json
+++ b/addons/remove-minifiers/addon.json
@@ -1,6 +1,6 @@
 {
     "name": "Remove Minifiers",
-    "description": "Removes minifiers on forum sections because its useless.",
+    "description": "Removes the minifier button in sections on the forums",
     "userscripts": [
         {
           "url": "userscript.js",

--- a/addons/remove-minifiers/addon.json
+++ b/addons/remove-minifiers/addon.json
@@ -1,0 +1,19 @@
+{
+    "name": "Remove Minifiers",
+    "description": "Removes minifiers on forum sections because its useless.",
+    "userscripts": [
+        {
+          "url": "userscript.js",
+          "matches": ["https://scratch.mit.edu/discuss/"]
+        }
+    ],
+    "credits": [
+      {
+        "name": "Polygon",
+        "link": "https://scratch.mit.edu/users/PoIygon"
+      }
+    ],
+    "tags": ["community", "forums"],
+    "versionAdded": "1.21.0"   
+}
+  

--- a/addons/remove-minifiers/userscript.js
+++ b/addons/remove-minifiers/userscript.js
@@ -1,0 +1,1 @@
+$(".toggle").remove();


### PR DESCRIPTION
### Changes

<!-- Please describe the changes you've made. -->
I have made a new add-on that removes minifiers from section titles in the forums.
### Reason for changes

<!-- Why should these changes be made? -->
The changes should be made because nobody uses the minifiers and nobody cares about it.
### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
I have tested it by using the temporary add-on feature in Firefox and it works perfectly fine.