### PR TITLE
Allow extension usage on incognito

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
     "open_in_tab": true
   },
   "homepage_url": "https://scratchaddons.com",
-  "incognito": "not_allowed",
+  "incognito": "spanning",
   "permissions": [
     "https://scratch.mit.edu/*",
     "https://api.scratch.mit.edu/*",


### PR DESCRIPTION
Resolves #3476 
There's no issues with addon.auth because we already support Firefox containers. That means, Scratch Messaging and Notifier will continue to make use of the account that's logged into the main session, not incognito.

Related: #203