### PR TITLE
show ocular easter egg emojis

### DIFF
--- a/addons/my-ocular/reactions.js
+++ b/addons/my-ocular/reactions.js
@@ -59,10 +59,40 @@ export default async function ({ addon, global, console, msg }) {
           if (reactionButton) reactionButton.className = "my-ocular-reaction-button";
           if (reactionButton) reactionButton.innerText = `${reaction.emoji} ${reaction.reactions.length}`;
 
+          if (reactionButton && reaction.emoji.startsWith(':') && reaction.emoji.endsWith(':')) {
+            // special case for "easter egg emojis", load the emoji from the emoji from https://ocular.jeffalo.net/emojis/:name.png
+
+            let emojiName = reaction.emoji.slice(1, -1);
+            let url = `https://ocular.jeffalo.net/emojis/${emojiName}.png`;
+            
+            let img = document.createElement("img");
+            img.src = url;
+
+            reactionButton.innerText = "";
+            reactionButton.appendChild(img);
+            
+            let reactionAmount = document.createElement("span");
+            reactionAmount.innerText = ` ${reaction.reactions.length}`;
+            reactionButton.appendChild(reactionAmount);
+          }
+
           let reactionMenuItem = document.createElement("a");
           reactionMenuItem.href = "";
           reactionMenuItem.className = "my-ocular-reaction-button";
           reactionMenuItem.innerText = reaction.emoji;
+
+          if (reaction.emoji.startsWith(':') && reaction.emoji.endsWith(':')) {
+            // special case for "easter egg emojis", load the emoji from the emoji from https://ocular.jeffalo.net/emojis/:name.png
+
+            let emojiName = reaction.emoji.slice(1, -1);
+            let url = `https://ocular.jeffalo.net/emojis/${emojiName}.png`;
+
+            let img = document.createElement("img");
+            img.src = url;
+
+            reactionMenuItem.innerText = "";
+            reactionMenuItem.appendChild(img);
+          }
 
           if (reaction.reactions.find((r) => r.user === username)) {
             if (reactionButton) reactionButton.classList.add("selected");

--- a/addons/my-ocular/reactions.js
+++ b/addons/my-ocular/reactions.js
@@ -59,18 +59,18 @@ export default async function ({ addon, global, console, msg }) {
           if (reactionButton) reactionButton.className = "my-ocular-reaction-button";
           if (reactionButton) reactionButton.innerText = `${reaction.emoji} ${reaction.reactions.length}`;
 
-          if (reactionButton && reaction.emoji.startsWith(':') && reaction.emoji.endsWith(':')) {
+          if (reactionButton && reaction.emoji.startsWith(":") && reaction.emoji.endsWith(":")) {
             // special case for "easter egg emojis", load the emoji from the emoji from https://ocular.jeffalo.net/emojis/:name.png
 
             let emojiName = reaction.emoji.slice(1, -1);
             let url = `https://ocular.jeffalo.net/emojis/${emojiName}.png`;
-            
+
             let img = document.createElement("img");
             img.src = url;
 
             reactionButton.innerText = "";
             reactionButton.appendChild(img);
-            
+
             let reactionAmount = document.createElement("span");
             reactionAmount.innerText = ` ${reaction.reactions.length}`;
             reactionButton.appendChild(reactionAmount);
@@ -81,7 +81,7 @@ export default async function ({ addon, global, console, msg }) {
           reactionMenuItem.className = "my-ocular-reaction-button";
           reactionMenuItem.innerText = reaction.emoji;
 
-          if (reaction.emoji.startsWith(':') && reaction.emoji.endsWith(':')) {
+          if (reaction.emoji.startsWith(":") && reaction.emoji.endsWith(":")) {
             // special case for "easter egg emojis", load the emoji from the emoji from https://ocular.jeffalo.net/emojis/:name.png
 
             let emojiName = reaction.emoji.slice(1, -1);


### PR DESCRIPTION
### Changes

I've added support for ocular easter egg emojis, this is in preparation for an update to ocular, see https://github.com/jeffalo/ocular/pull/109

Any reaction that starts and ends with a colon, will load an image from ocular.jeffalo.net/emojis/, these can only be set by admins currently, however it will be extended in the future. 

This PR just makes sure that they don't look funny when the changes to ocular launch.

### Reason for changes

Compatibility between ocular.jeffalo.net and the addon.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
I've tested this locally.