### PR TITLE
editor-devtools: set window._devtoolsAddonEnabled=true before stopping addon

### DIFF
--- a/addons/editor-devtools/userscript.js
+++ b/addons/editor-devtools/userscript.js
@@ -4,6 +4,7 @@ export default async function ({ addon, global, console, msg, safeMsg: m }) {
   // noinspection JSUnresolvedVariable
   if (!addon.self._isDevtoolsExtension && window.initGUI) {
     console.log("Extension running, stopping addon");
+    window._devtoolsAddonEnabled = true;
     return;
   }
 


### PR DESCRIPTION
This will be useful in the future if we want DevtoolsExtension to automatically uninstall if the user already has editor-devtools addon enabled on Scratch Addons.