### PR TITLE
block-duplicate: fix obscured shadow IDs

### DIFF
--- a/addons/block-duplicate/userscript.js
+++ b/addons/block-duplicate/userscript.js
@@ -10,7 +10,7 @@ export default async function ({ addon, global, console }) {
       this.mostRecentEvent_.altKey &&
       !addon.self.disabled
     ) {
-      // Will be rest when the drag ends
+      // Scratch will reset these when the drag ends
       if (!ScratchBlocks.Events.getGroup()) {
         ScratchBlocks.Events.setGroup(true);
       }


### PR DESCRIPTION
This fixes
https://user-images.githubusercontent.com/33279053/136592196-d242b5e6-4545-49e8-b286-fad2b48944c6.mp4
https://discord.com/channels/806602307750985799/809063831841407018/895906418622873611
> I found an annoying glitch, that happens with the new alt-click to duplicate, is that when u use it (on blocks on text inputs) and when u get the block out of the input, the input is glitched

The problem was that Scratch's `shouldDuplicateOnDrag_` does not call `changeObscuredShadowIds` unlike right click > duplicate