### PR TITLE
`emoji-picker`: Fix some positioning issues

### DIFF
--- a/addons/emoji-picker/userscript.js
+++ b/addons/emoji-picker/userscript.js
@@ -5,7 +5,7 @@ export default async function ({ addon, global, console, msg }) {
   //Functions
 
   const setEmojiPickerPos = function () {
-	  emojiPicker.classList.remove("sa-emoji-picker-offscreen");
+    emojiPicker.classList.remove("sa-emoji-picker-offscreen");
     //scratchr2 makes the body and root <html>'s height value the size of the screen somehow so this has to be done
     const realDocumentBody =
       addon.tab.clientVersion === "scratchr2" ? document.querySelector("#pagewrapper") : document.body;

--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -18,10 +18,18 @@
   right: -7px;
 }
 
-.sa-emoji-button-r2 .sa-emoji-picker:not(.sa-emoji-picker-offscreen) { top: 33px; }
-.sa-emoji-button-www .sa-emoji-picker:not(.sa-emoji-picker-offscreen) { top: calc(11rem + 5px); }
-.sa-emoji-button-r2 .sa-emoji-picker.sa-emoji-picker-offscreen { bottom: 35px; }
-.sa-emoji-button-www .sa-emoji-picker.sa-emoji-picker-offscreen { bottom: 52px; }
+.sa-emoji-button-r2 .sa-emoji-picker:not(.sa-emoji-picker-offscreen) {
+  top: 33px;
+}
+.sa-emoji-button-www .sa-emoji-picker:not(.sa-emoji-picker-offscreen) {
+  top: calc(11rem + 5px);
+}
+.sa-emoji-button-r2 .sa-emoji-picker.sa-emoji-picker-offscreen {
+  bottom: 35px;
+}
+.sa-emoji-button-www .sa-emoji-picker.sa-emoji-picker-offscreen {
+  bottom: 52px;
+}
 
 .sa-emoji-picker-item {
   cursor: pointer;


### PR DESCRIPTION
### Changes

Moves the scratchr2 emoji picker's alignment to the left of the button, and fixes the scratch-www picker's position (which was above the button for some reason).
![](https://user-images.githubusercontent.com/68464103/136661065-8f77b93b-493f-464b-a06f-d3a50a9728c2.png)

### Reason for changes

Bugfixing, and to prevent the picker possibly being off screen.

### Tests

Haven't tested much (and only on Firefox as usual), but should work maybe.
