### PR TITLE
Changed manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,9 +39,7 @@
   "homepage_url": "https://scratchaddons.com",
   "incognito": "spanning",
   "permissions": [
-    "https://scratch.mit.edu/*",
-    "https://api.scratch.mit.edu/*",
-    "https://clouddata.scratch.mit.edu/*",
+    "activeTab",
     "cookies",
     "webRequest",
     "webRequestBlocking",


### PR DESCRIPTION
### Changes

we can access ScratchAddons from every websites in the world

### Reason for changes

Because people can see scratch messages even if they don't have opened scratch

### Tests

No, but this will work. I am 100% sure
