### PR TITLE
add comment blocks

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -105,6 +105,7 @@
   "block-duplicate",
   "disable-paste-offset",
   "emoji-picker",
+  "comment-blocks",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/comment-blocks/addon.json
+++ b/addons/comment-blocks/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Comment blocks",
+  "description": "Adds comment blocks as an alternative to vanilla comments.",
+  "credits": [
+    {
+      "name": "MrEgggga"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "tags": ["editor"],
+  "enabledByDefault": false,
+  "versionAdded": "1.21.0"
+}

--- a/addons/comment-blocks/addon.json
+++ b/addons/comment-blocks/addon.json
@@ -3,7 +3,8 @@
   "description": "Adds comment blocks as an alternative to vanilla comments.",
   "credits": [
     {
-      "name": "MrEgggga"
+      "name": "MrEgggga",
+      "link": "https://github.com/MrEgggga"
     }
   ],
   "userscripts": [

--- a/addons/comment-blocks/userscript.js
+++ b/addons/comment-blocks/userscript.js
@@ -1,0 +1,5 @@
+export default async function ({ addon }) {
+  addon.tab.addBlock('\u200B\u200Bcomment %s', {
+    args: ["content"]
+  });
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #3614 

### Changes

This addon adds a block to the Debugger category called "comment" which takes one argument (a string) and does nothing, imitating a comment.

### Reason for changes

Some people don't like vanilla comments and have to create an empty custom block per sprite for this.

### Tests

I have tested this addon by loading the extension on Firefox and checking that:
- the block exists
- it does nothing
- The addon listing looks fine
I didn't make any other tests so there might be problems.
