### PR TITLE
replace "9gr" with "Verixion"

### DIFF
--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -3,8 +3,8 @@
   "description": "Automatically posts the comment or forum post on Ctrl+Enter.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion"
     }
   ],
   "info": [

--- a/addons/default-project/addon.json
+++ b/addons/default-project/addon.json
@@ -3,8 +3,8 @@
   "description": "Change the default project from the Scratch Cat to any existing project.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr/"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion/"
     }
   ],
   "userscripts": [

--- a/addons/editor-unshare-button/addon.json
+++ b/addons/editor-unshare-button/addon.json
@@ -3,8 +3,8 @@
   "description": "Replaces the \"Shared\" button next to the project title box with a button to unshare the project.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr/"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion/"
     }
   ],
   "userscripts": [

--- a/addons/hide-project-stats/addon.json
+++ b/addons/hide-project-stats/addon.json
@@ -3,8 +3,8 @@
   "description": "Lets you hide love, favorite, remix and view counts in the front page and project pages.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr/"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion/"
     }
   ],
   "userstyles": [

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -7,8 +7,8 @@
       "link": "https://scratch.mit.edu/users/TheColaber"
     },
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion"
     }
   ],
   "userscripts": [

--- a/addons/redirect-mobile-forums/addon.json
+++ b/addons/redirect-mobile-forums/addon.json
@@ -3,8 +3,8 @@
   "description": "Redirects you to the standard (\"main\") forums when you click a link to the mobile forums.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion"
     }
   ],
   "userscripts": [

--- a/addons/remix-button/addon.json
+++ b/addons/remix-button/addon.json
@@ -3,8 +3,8 @@
   "description": "Adds the Remix button to your own projects.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr/"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion/"
     }
   ],
   "userscripts": [

--- a/addons/scratchblocks/addon.json
+++ b/addons/scratchblocks/addon.json
@@ -3,8 +3,8 @@
   "description": "Enables the new version of scratchblocks on the forums.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr/"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion/"
     },
     {
       "name": "CubeyTheCube",

--- a/addons/studio-followers/addon.json
+++ b/addons/studio-followers/addon.json
@@ -3,8 +3,8 @@
   "description": "Adds a button at the top of the \"curators\" tab in studios you manage, that lists your followers and followed users and lets you invite a shown user with a single click.",
   "credits": [
     {
-      "name": "9gr",
-      "link": "https://scratch.mit.edu/users/9gr"
+      "name": "Verixion",
+      "link": "https://scratch.mit.edu/users/Verixion"
     },
     {
       "name": "World_Languages"


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #3658

### Changes

<!-- Please describe the changes you've made. -->
Changes all references to "9gr" with "Verixion". Does the same with links
### Reason for changes

<!-- Why should these changes be made? -->
They wanted this to be done earlier, I told then I could, and I had extra time today.
### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested with 

- Windows 10 Pro x64 21H1
- Microsoft Edge 94.0.992.47 64-bit
- Mozilla Firefox 93.0 64-bit