### PR TITLE
editor-devtools: fix find bar not working in some languages

### DIFF
--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -277,7 +277,7 @@ export default class DevTools {
         if (!procCode) {
           continue;
         }
-        const indexOfLabel = root.inputList.findIndex(i => i.fieldRow.length > 0);
+        const indexOfLabel = root.inputList.findIndex((i) => i.fieldRow.length > 0);
         if (indexOfLabel === -1) {
           continue;
         }


### PR DESCRIPTION
Fixes #3657

This part of devtools could use some significant refactoring. This is a small diff that just tries to fix this particular issue.