### PR TITLE
Fix Color Pickers causing scrollbar and being cut off

### DIFF
--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -60,6 +60,7 @@ h1 {
 }
 
 .addons-container {
+  flex: 1;
   overflow-y: auto;
   padding: 20px;
   padding-top: 10px;


### PR DESCRIPTION
Fixes this: 
![image](https://user-images.githubusercontent.com/72760579/137626355-ce508f3d-69df-4b12-9d02-5060d1280992.png)

To repro:
1. search "badge"
2. Open color picker for addon
3. Observe cut off color picker and new scrollbar that appears

Before, it was limited to this space
![image](https://user-images.githubusercontent.com/72760579/137626489-3cf37dbc-135f-4641-89e3-59ad8d1557e5.png)
Now, it has it all
![image](https://user-images.githubusercontent.com/72760579/137626516-8048ed60-7128-4fc3-9bd5-e472d173f08a.png)


Tested.