### PR TITLE
Fix unreadable text in popup modal when enabling addon that needs permissions

### DIFF
--- a/webpages/styles/components/enablepopup.css
+++ b/webpages/styles/components/enablepopup.css
@@ -8,7 +8,6 @@
   text-align: center;
   padding: 20px;
   top: 0px;
-  color: white;
   border-radius: 0px 0px 10px 10px;
   transition: top 300ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
   display: flex;


### PR DESCRIPTION
Fixes this: 
![image](https://user-images.githubusercontent.com/72760579/137627215-bf68afc0-84cf-4dbe-b9dd-94dfd47ef4a4.png)


Tested.