### PR TITLE
[addon-body]: make `addonSettings` also include the addon id

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -58,7 +58,7 @@
         <component
           :is="'preview-' + addon.addonPreview.type"
           :options="addon.addonPreview"
-          :settings="addonSettings[addon._addonId]"
+          :settings="addonSettings"
           :hovered-setting-id="hoveredSettingId"
           @areahover="highlightSetting"
         />

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -43,7 +43,7 @@ export default async function ({ template }) {
       loadPreset(preset) {
         if (window.confirm(chrome.i18n.getMessage("confirmPreset"))) {
           for (const property of Object.keys(preset.values)) {
-            this.$root.addonSettings[property] = preset.values[property];
+            this.addonSettings[property] = preset.values[property];
           }
           this.$root.updateSettings(this.addon);
           console.log(`Loaded preset ${preset.id} for ${this.addon._addonId}`);
@@ -52,7 +52,7 @@ export default async function ({ template }) {
       loadDefaults() {
         if (window.confirm(chrome.i18n.getMessage("confirmReset"))) {
           for (const property of this.addon.settings) {
-            this.$root.addonSettings[property.id] = property.default;
+            this.addonSettings[property.id] = property.default;
           }
           this.$root.updateSettings(this.addon);
           console.log(`Loaded default values for ${this.addon._addonId}`);

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -28,7 +28,7 @@ export default async function ({ template }) {
         return `../../images/icons/${map[this.addon._icon]}.svg`;
       },
       addonSettings() {
-        return this.$root.addonSettings;
+        return this.$root.addonSettings[this.addon._addonId];
       },
     },
     methods: {
@@ -43,7 +43,7 @@ export default async function ({ template }) {
       loadPreset(preset) {
         if (window.confirm(chrome.i18n.getMessage("confirmPreset"))) {
           for (const property of Object.keys(preset.values)) {
-            this.$root.addonSettings[this.addon._addonId][property] = preset.values[property];
+            this.$root.addonSettings[property] = preset.values[property];
           }
           this.$root.updateSettings(this.addon);
           console.log(`Loaded preset ${preset.id} for ${this.addon._addonId}`);
@@ -52,7 +52,7 @@ export default async function ({ template }) {
       loadDefaults() {
         if (window.confirm(chrome.i18n.getMessage("confirmReset"))) {
           for (const property of this.addon.settings) {
-            this.$root.addonSettings[this.addon._addonId][property.id] = property.default;
+            this.$root.addonSettings[property.id] = property.default;
           }
           this.$root.updateSettings(this.addon);
           console.log(`Loaded default values for ${this.addon._addonId}`);

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -12,7 +12,7 @@
       <input
         type="checkbox"
         class="setting-input check"
-        v-model="addonSettings[addon._addonId][setting.id]"
+        v-model="addonSettings[setting.id]"
         @change="updateSettings()"
         :disabled="!addon._enabled"
       />
@@ -22,7 +22,7 @@
         <div
           class="filter-option"
           v-for="option of setting.potentialValues"
-          :class="{'sel' : addonSettings[addon._addonId][setting.id] === option.id, 'disabled': !addon._enabled}"
+          :class="{'sel' : addonSettings[setting.id] === option.id, 'disabled': !addon._enabled}"
           @click="updateOption(option.id);"
         >
           {{ option.name }}
@@ -34,7 +34,7 @@
         <input
           type="number"
           class="setting-input number"
-          v-model="addonSettings[addon._addonId][setting.id]"
+          v-model="addonSettings[setting.id]"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           min="0"
@@ -47,7 +47,7 @@
         <input
           type="number"
           class="setting-input number"
-          v-model="addonSettings[addon._addonId][setting.id]"
+          v-model="addonSettings[setting.id]"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           :min="setting.min"
@@ -61,7 +61,7 @@
         <input
           type="text"
           class="setting-input string"
-          v-model="addonSettings[addon._addonId][setting.id]"
+          v-model="addonSettings[setting.id]"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           :placeholder="setting.default"
@@ -76,7 +76,7 @@
         <input
           type="text"
           class="setting-input"
-          v-model="addonSettings[addon._addonId][setting.id]"
+          v-model="addonSettings[setting.id]"
           @input="updateSettings()"
           @keydown="keySettingKeyDown"
           @keyup="keySettingKeyUp"
@@ -90,7 +90,7 @@
       </template>
       <template v-if="setting.type === 'color'">
         <picker
-          :value="addonSettings[addon._addonId][setting.id] || setting.default"
+          :value="addonSettings[setting.id] || setting.default"
           :setting="setting"
           :addon="addon"
           :no_alpha="!setting.allowTransparency"

--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -18,7 +18,7 @@ export default async function ({ template }) {
             const arr = Array.isArray(this.setting.if.settings[settingName])
               ? this.setting.if.settings[settingName]
               : [this.setting.if.settings[settingName]];
-            return arr.some((possibleValue) => this.addonSettings[this.addon._addonId][settingName] === possibleValue);
+            return arr.some((possibleValue) => this.addonSettings[settingName] === possibleValue);
           });
           if (anyMatches === true) return true;
         }
@@ -58,9 +58,7 @@ export default async function ({ template }) {
         let input = document.querySelector(
           `input[data-addon-id='${this.addon._addonId}'][data-setting-id='${this.setting.id}']`
         );
-        this.addonSettings[this.addon._addonId][this.setting.id] = input.validity.valid
-          ? input.value
-          : this.setting.default;
+        this.addonSettings[this.setting.id] = input.validity.valid ? input.value : this.setting.default;
       },
       keySettingKeyDown(e) {
         e.preventDefault();
@@ -90,7 +88,7 @@ export default async function ({ template }) {
         this.$root.updateSettings(...params);
       },
       updateOption(newValue) {
-        this.addonSettings[this.addon._addonId][this.setting.id] = newValue;
+        this.addonSettings[this.setting.id] = newValue;
         this.updateSettings();
       },
     },

--- a/webpages/settings/components/picker-component.js
+++ b/webpages/settings/components/picker-component.js
@@ -22,7 +22,7 @@ export default async function ({ template }) {
       this.$els.pickr.addEventListener("input", (e) => {
         this.color = "#" + e.detail.value;
         if (this.value !== this.color) {
-          this.$parent.addonSettings[this.addon._addonId][this.setting.id] = "#" + this.$els.pickr.hex8;
+          this.$parent.addonSettings[this.setting.id] = "#" + this.$els.pickr.hex8;
           this.$parent.updateSettings(this.addon, { wait: 250, settingId: this.setting.id });
         }
       });
@@ -57,7 +57,7 @@ export default async function ({ template }) {
         this.$els.pickr._valueChanged();
         this.color = "#" + this.$els.pickr.hex8;
         if (this.value !== this.color) {
-          this.$parent.addonSettings[addon._addonId][setting.id] = "#" + this.$els.pickr.hex8;
+          this.$parent.addonSettings[setting.id] = "#" + this.$els.pickr.hex8;
           this.$parent.updateSettings(addon, { wait: 250, settingId: setting.id });
         }
         this.canCloseOutside = false;

--- a/webpages/settings/components/reset-dropdown.js
+++ b/webpages/settings/components/reset-dropdown.js
@@ -24,12 +24,12 @@ export default async function ({ template }) {
         this.$root.closeResetDropdowns({ isTrusted: true }, this); // close other dropdowns
       },
       resetToDefault() {
-        this.$parent.addonSettings[this.addon._addonId][this.setting.id] = this.setting.default;
+        this.$parent.addonSettings[this.setting.id] = this.setting.default;
         this.$parent.updateSettings(this.addon, { settingId: this.setting.id });
         this.toggle();
       },
       resetToPreset(preset) {
-        this.$parent.addonSettings[this.addon._addonId][this.setting.id] = preset.values[this.setting.id];
+        this.$parent.addonSettings[this.setting.id] = preset.values[this.setting.id];
         this.$parent.updateSettings(this.addon, { settingId: this.setting.id });
         this.toggle();
       },


### PR DESCRIPTION
### Changes
Changes
https://github.com/ScratchAddons/ScratchAddons/blob/d6f41737c8162e6feeb98f6a9f5b479378e8b813/webpages/settings/components/addon-body.js#L30-L32 to
https://github.com/ScratchAddons/ScratchAddons/blob/7cdda720df1b3392951616a189984828706aac8c/webpages/settings/components/addon-body.js#L30-L32
Which basically changes all other stuff that uses addonSettings (addon-body, addon-settings, picker, etc.) to change something like this:
```js
this.addonSettings[this.addon._addonId][property] = "hi"
```
to something like
```js
this.addonSettings[property] = "hi"
```

### Reason for changes

addon-body and addon-settings don't need to include the same thing 1000 times (and also this is something I did for my table pr for nested addon-settings).

### Tests

Tested.