### PR TITLE
New addon: better editor comments

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -105,6 +105,7 @@
   "block-duplicate",
   "disable-paste-offset",
   "emoji-picker",
+  "fix-editor-comments",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/fix-editor-comments/addon.json
+++ b/addons/fix-editor-comments/addon.json
@@ -1,0 +1,62 @@
+{
+  "name": "Better editor comments",
+  "description": "Makes numerous changes to comments in the Scratch editor: fixes a bug where comments attached to blocks don't save their positions correctly after dragging, adds a scroll bar on comments where text is clipped, and allows you to edit standalone comments by clicking directly where you want to start typing.",
+  "tags": ["editor", "codeEditor"],
+  "credits": [
+    {
+      "name": "GarboMuffin",
+      "link": "https://github.com/GarboMuffin"
+    },
+    {
+      "name": "lisa_wolfgang",
+      "link": "https://github.com/lisa-wolfgang"
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "standalone-edit.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": { "standalone-edit": true }
+      }
+    },
+    {
+      "url": "scroll.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": { "scroll": true }
+      }
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "fix-drag.js",
+      "matches": ["projects"]
+    }
+  ],
+  "settings": [
+    {
+      "name": "Fix dragging block comments",
+      "id": "fix-drag",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Add scroll bars to clipped comments",
+      "id": "scroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Directly edit standalone comments",
+      "id": "standalone-edit",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "updateUserstylesOnSettingsChange": true,
+  "versionAdded": "1.22.0",
+  "enabledByDefault": false
+}

--- a/addons/fix-editor-comments/fix-drag.js
+++ b/addons/fix-editor-comments/fix-drag.js
@@ -1,0 +1,27 @@
+/**
+ * When a block with a comment attached is dragged, the comment now properly
+ * stores its updated position.
+ * https://github.com/LLK/scratch-blocks/blob/develop/core/scratch_bubble.js#L536
+ */
+export default async function ({ addon, global, console }) {
+  const vm = addon.tab.traps.vm;
+  await new Promise((resolve, reject) => {
+    if (vm.editingTarget) return resolve();
+    vm.runtime.once("PROJECT_LOADED", resolve);
+  });
+  const Blockly = await addon.tab.traps.getBlockly();
+  const originalMove = Blockly.ScratchBubble.prototype.setAnchorLocation;
+  Blockly.ScratchBubble.prototype.setAnchorLocation = function (xy) {
+    if (!addon.self.disabled && addon.settings.get("fix-drag")) {
+      var event = new Blockly.Events.CommentMove(this.comment);
+      this.anchorXY_ = xy;
+      if (this.rendered_) {
+        this.positionBubble_();
+      }
+      event.recordNew();
+      Blockly.Events.fire(event);
+    } else {
+      return originalMove.call(this, xy);
+    }
+  };
+}

--- a/addons/fix-editor-comments/scroll.css
+++ b/addons/fix-editor-comments/scroll.css
@@ -3,4 +3,5 @@
  */
 .scratchCommentTextarea {
   overflow-y: auto;
+  background-color: transparent;
 }

--- a/addons/fix-editor-comments/scroll.css
+++ b/addons/fix-editor-comments/scroll.css
@@ -1,0 +1,6 @@
+/*
+ * Adds a vertical scroll bar to comments that overflow.
+ */
+.scratchCommentTextarea {
+  overflow-y: auto;
+}

--- a/addons/fix-editor-comments/standalone-edit.css
+++ b/addons/fix-editor-comments/standalone-edit.css
@@ -1,0 +1,7 @@
+/* 
+ * On comments not attached to blocks, allows direct selection of text instead
+ * needing to gain focus first.
+ */
+rect.blocklyDraggable.scratchCommentTarget {
+  display: none;
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2475 (https://github.com/LLK/scratch-blocks/issues/1566 with duplicates https://github.com/LLK/scratch-gui/issues/4776 and https://github.com/LLK/scratch-gui/issues/5948)

### Changes

<!-- Please describe the changes you've made. -->
In vanilla Scratch, when dragging a block with a comment attached to it, the position of the comment is not saved correctly, causing it to jump back to its original position when the sprite or project is reloaded. This addon fixes this bug.

Also, when the contents of comments are clipped due to the comment bubble's size, a scroll bar does not appear on the comment. This addon implements this scroll bar.

In addition, comments not attached to blocks cannot be edited directly -- the user must click the comment for it to gain focus, and only then can it be directly edited. This addon makes it so that the cursor can interact with the text without having to select the comment first.

This addon does NOT implement the comment previews that I recently showcased. Those will be part of a separate addon.

All three of these adjustments already exist in TurboWarp.

### Reason for changes

<!-- Why should these changes be made? -->
Usage of comments on Scratch has sharply declined since the debut of Scratch 3.0 due to bugginess and incompleteness. It is frequently suggested to fix these bugs. Some users even make custom blocks as stand-ins for comments, which has a negative impact on project performance.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested using
- browser w/ Chromium 95
- Firefox 93.0