### PR TITLE
`editor-devtools`: Shortcut to not close the floating find bar

### DIFF
--- a/addons-l10n/en/editor-devtools.json
+++ b/addons-l10n/en/editor-devtools.json
@@ -2,7 +2,7 @@
   "editor-devtools/help-title": "Scratch 3 Developer Tools",
   "editor-devtools/help-by": "by {url} and Scratch Addons contributors & translators",
   "editor-devtools/ctrl-space": "Ctrl + Space, Middle Click, or Shift + Click",
-  "editor-devtools/ctrl-space-desc": "Pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there. Hold Shift to avoid closing the popup, to add multiple blocks at one time.",
+  "editor-devtools/ctrl-space-desc": "Pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there. Hold Shift while dragging to avoid closing the box when adding multiple blocks at once.",
   "editor-devtools/code-tab-features": "Code Tab Features",
   "editor-devtools/interactive-find-bar": "Interactive Find Bar (Ctrl + F)",
   "editor-devtools/interactive-find-bar-desc": "Quickly find and jump to any Custom Block, Variable, Event, or Hat block defined in a sprite by clicking on the new find bar located to the right of the Code, Costumes and Sounds tabs. Begin typing to filter down the list. Use the up and down arrow keys to switch between the possible entries, and the left and right arrows to cycle between all found instances of that block.",

--- a/addons-l10n/en/editor-devtools.json
+++ b/addons-l10n/en/editor-devtools.json
@@ -2,7 +2,7 @@
   "editor-devtools/help-title": "Scratch 3 Developer Tools",
   "editor-devtools/help-by": "by {url} and Scratch Addons contributors & translators",
   "editor-devtools/ctrl-space": "Ctrl + Space, Middle Click, or Shift + Click",
-  "editor-devtools/ctrl-space-desc": "Pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there. Hold Ctrl (Cmd on Mac) to avoid closing the popup, to add multiple blocks at one time.",
+  "editor-devtools/ctrl-space-desc": "Pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there. Hold Shift to avoid closing the popup, to add multiple blocks at one time.",
   "editor-devtools/code-tab-features": "Code Tab Features",
   "editor-devtools/interactive-find-bar": "Interactive Find Bar (Ctrl + F)",
   "editor-devtools/interactive-find-bar-desc": "Quickly find and jump to any Custom Block, Variable, Event, or Hat block defined in a sprite by clicking on the new find bar located to the right of the Code, Costumes and Sounds tabs. Begin typing to filter down the list. Use the up and down arrow keys to switch between the possible entries, and the left and right arrows to cycle between all found instances of that block.",

--- a/addons-l10n/en/editor-devtools.json
+++ b/addons-l10n/en/editor-devtools.json
@@ -2,7 +2,7 @@
   "editor-devtools/help-title": "Scratch 3 Developer Tools",
   "editor-devtools/help-by": "by {url} and Scratch Addons contributors & translators",
   "editor-devtools/ctrl-space": "Ctrl + Space, Middle Click, or Shift + Click",
-  "editor-devtools/ctrl-space-desc": "Pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there.",
+  "editor-devtools/ctrl-space-desc": "Pops up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code to make use of it right there. Hold Ctrl (Cmd on Mac) to avoid closing the popup, to add multiple blocks at one time.",
   "editor-devtools/code-tab-features": "Code Tab Features",
   "editor-devtools/interactive-find-bar": "Interactive Find Bar (Ctrl + F)",
   "editor-devtools/interactive-find-bar-desc": "Quickly find and jump to any Custom Block, Variable, Event, or Hat block defined in a sprite by clicking on the new find bar located to the right of the Code, Costumes and Sounds tabs. Begin typing to filter down the list. Use the up and down arrow keys to switch between the possible entries, and the left and right arrows to cycle between all found instances of that block.",

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1507,9 +1507,12 @@ export default class DevTools {
     if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
       if (
         !e.shiftKey ||
+		// Clicking on the code area should always make multi-inject work
         (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
+		// Focused inputs are not part of the injectionDiv to the user they are part of the code area so make multi-inject work there
           !e.target.classList.contains("blocklyHtmlInput")) ||
-        e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
+		  // This selection targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
+		  e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
       ) {
         // If we click outside the dropdown, then instigate the hide code...
         this.hideFloatDropDown();

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1509,7 +1509,7 @@ export default class DevTools {
         !e.shiftKey ||
         // Clicking on the code area should always make multi-inject work
         (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
-          // Focused inputs are not part of the injectionDiv to the user they are part of the code area so make multi-inject work there
+          // Focused inputs are not part of the injectionDiv, but to the user they are part of the code area so make multi-inject work there
           !e.target.classList.contains("blocklyHtmlInput")) ||
         // This selection targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
         e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1507,12 +1507,12 @@ export default class DevTools {
     if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
       if (
         !e.shiftKey ||
-		// Clicking on the code area should always make multi-inject work
+        // Clicking on the code area should always make multi-inject work
         (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
-		// Focused inputs are not part of the injectionDiv to the user they are part of the code area so make multi-inject work there
+          // Focused inputs are not part of the injectionDiv to the user they are part of the code area so make multi-inject work there
           !e.target.classList.contains("blocklyHtmlInput")) ||
-		  // This selection targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
-		  e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
+        // This selection targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
+        e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
       ) {
         // If we click outside the dropdown, then instigate the hide code...
         this.hideFloatDropDown();

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1511,7 +1511,7 @@ export default class DevTools {
         (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
           // Focused inputs are not part of the injectionDiv, but to the user they are part of the code area so make multi-inject work there
           !e.target.classList.contains("blocklyHtmlInput")) ||
-        // This selector targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
+        // This selector targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly trigger a popup window so always close the dropdown
         e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
       ) {
         // If we click outside the dropdown, then instigate the hide code...

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1511,7 +1511,7 @@ export default class DevTools {
         (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
           // Focused inputs are not part of the injectionDiv, but to the user they are part of the code area so make multi-inject work there
           !e.target.classList.contains("blocklyHtmlInput")) ||
-        // This selection targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
+        // This selector targets workspace buttons (Make a Block etc.) and the extension (!) buttons, which most commonly triggers a popup window so always close the dropdown
         e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
       ) {
         // If we click outside the dropdown, then instigate the hide code...

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -460,7 +460,7 @@ export default class DevTools {
       this.hideFloatDropDown();
       return;
     }
-
+	
     let float = document.getElementById("s3devFloatingBar");
     if (float) {
       float.remove();
@@ -1498,16 +1498,19 @@ export default class DevTools {
 
   eventMouseDown(e) {
     this.updateMousePosition(e);
-
-    if (this.ddOut && this.ddOut.classList.contains("vis") && !e.target.closest("#s3devDDOut")) {
-      // If we click outside the dropdown, then instigate the hide code...
-      this.hideDropDown();
-    }
-
-    if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
-      // If we click outside the dropdown, then instigate the hide code...
-      this.hideFloatDropDown();
-    }
+	
+	if (this.ddOut && this.ddOut.classList.contains("vis") && !e.target.closest("#s3devDDOut")) {
+	  // If we click outside the dropdown, then instigate the hide code...
+	  this.hideDropDown();
+	}
+	
+	let ctrlKey = e.ctrlKey || e.metaKey;
+	if (!ctrlKey || !document.getElementsByClassName("injectionDiv")[0].contains(e.target)) {
+		if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
+		  // If we click outside the dropdown, then instigate the hide code...
+		  this.hideFloatDropDown();
+		}
+	}
 
     if (e.button === 1 || e.shiftKey) {
       // Wheel button...
@@ -1602,7 +1605,7 @@ export default class DevTools {
 
     e.cancelBubble = true;
     e.preventDefault();
-
+	
     let floatBar = document.getElementById("s3devFloatingBar");
     if (floatBar) {
       floatBar.remove();
@@ -2042,8 +2045,12 @@ export default class DevTools {
     x.appendChild(option.dom);
 
     let ids = Blockly.Xml.domToWorkspace(x, wksp);
-
-    this.reallyHideFloatDropDown(true);
+	
+	let ctrlKey = e.ctrlKey || e.metaKey;
+	
+	if (!ctrlKey) {
+		this.reallyHideFloatDropDown(true);
+	}
 
     let block = wksp.getBlockById(ids[0]);
 
@@ -2057,7 +2064,11 @@ export default class DevTools {
       }
     }
 
-    this.domHelpers.triggerDragAndDrop(block.svgPath_, null, { x: this.mouseXY.x, y: this.mouseXY.y });
+    this.domHelpers.triggerDragAndDrop(block.svgPath_, null, { x: this.mouseXY.x, y: this.mouseXY.y }, ctrlKey);
+	
+	if (ctrlKey) {
+		document.getElementById("s3devIInp").focus();
+	}
 
     this.blockCursor = block;
   }

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1505,9 +1505,8 @@ export default class DevTools {
     }
 
     if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
-      let ctrlKey = e.ctrlKey || e.metaKey;
       if (
-        !ctrlKey ||
+        !e.shiftKey ||
         (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
           !e.target.classList.contains("blocklyHtmlInput")) ||
         e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
@@ -2051,9 +2050,7 @@ export default class DevTools {
 
     let ids = Blockly.Xml.domToWorkspace(x, wksp);
 
-    let ctrlKey = e.ctrlKey || e.metaKey;
-
-    if (!ctrlKey) {
+    if (!e.shiftKey) {
       this.reallyHideFloatDropDown(true);
     }
 
@@ -2069,9 +2066,9 @@ export default class DevTools {
       }
     }
 
-    this.domHelpers.triggerDragAndDrop(block.svgPath_, null, { x: this.mouseXY.x, y: this.mouseXY.y }, ctrlKey);
+    this.domHelpers.triggerDragAndDrop(block.svgPath_, null, { x: this.mouseXY.x, y: this.mouseXY.y }, e.shiftKey);
 
-    if (ctrlKey) {
+    if (e.shiftKey) {
       document.getElementById("s3devIInp").focus();
     }
 

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1505,17 +1505,15 @@ export default class DevTools {
     }
 
     if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
-		let ctrlKey = e.ctrlKey || e.metaKey;
-		if (
-			!ctrlKey
-			|| (
-				!document.getElementsByClassName("injectionDiv")[0].contains(e.target)
-				&& !e.target.classList.contains("blocklyHtmlInput")
-				)
-			|| e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
-		) {
-			// If we click outside the dropdown, then instigate the hide code...
-			this.hideFloatDropDown();
+      let ctrlKey = e.ctrlKey || e.metaKey;
+      if (
+        !ctrlKey ||
+        (!document.getElementsByClassName("injectionDiv")[0].contains(e.target) &&
+          !e.target.classList.contains("blocklyHtmlInput")) ||
+        e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
+      ) {
+        // If we click outside the dropdown, then instigate the hide code...
+        this.hideFloatDropDown();
       }
     }
 

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -460,7 +460,7 @@ export default class DevTools {
       this.hideFloatDropDown();
       return;
     }
-	
+
     let float = document.getElementById("s3devFloatingBar");
     if (float) {
       float.remove();
@@ -1498,19 +1498,19 @@ export default class DevTools {
 
   eventMouseDown(e) {
     this.updateMousePosition(e);
-	
-	if (this.ddOut && this.ddOut.classList.contains("vis") && !e.target.closest("#s3devDDOut")) {
-	  // If we click outside the dropdown, then instigate the hide code...
-	  this.hideDropDown();
-	}
-	
-	let ctrlKey = e.ctrlKey || e.metaKey;
-	if (!ctrlKey || !document.getElementsByClassName("injectionDiv")[0].contains(e.target)) {
-		if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
-		  // If we click outside the dropdown, then instigate the hide code...
-		  this.hideFloatDropDown();
-		}
-	}
+
+    if (this.ddOut && this.ddOut.classList.contains("vis") && !e.target.closest("#s3devDDOut")) {
+      // If we click outside the dropdown, then instigate the hide code...
+      this.hideDropDown();
+    }
+
+    let ctrlKey = e.ctrlKey || e.metaKey;
+    if (!ctrlKey || !document.getElementsByClassName("injectionDiv")[0].contains(e.target)) {
+      if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
+        // If we click outside the dropdown, then instigate the hide code...
+        this.hideFloatDropDown();
+      }
+    }
 
     if (e.button === 1 || e.shiftKey) {
       // Wheel button...
@@ -1605,7 +1605,7 @@ export default class DevTools {
 
     e.cancelBubble = true;
     e.preventDefault();
-	
+
     let floatBar = document.getElementById("s3devFloatingBar");
     if (floatBar) {
       floatBar.remove();
@@ -2045,12 +2045,12 @@ export default class DevTools {
     x.appendChild(option.dom);
 
     let ids = Blockly.Xml.domToWorkspace(x, wksp);
-	
-	let ctrlKey = e.ctrlKey || e.metaKey;
-	
-	if (!ctrlKey) {
-		this.reallyHideFloatDropDown(true);
-	}
+
+    let ctrlKey = e.ctrlKey || e.metaKey;
+
+    if (!ctrlKey) {
+      this.reallyHideFloatDropDown(true);
+    }
 
     let block = wksp.getBlockById(ids[0]);
 
@@ -2065,10 +2065,10 @@ export default class DevTools {
     }
 
     this.domHelpers.triggerDragAndDrop(block.svgPath_, null, { x: this.mouseXY.x, y: this.mouseXY.y }, ctrlKey);
-	
-	if (ctrlKey) {
-		document.getElementById("s3devIInp").focus();
-	}
+
+    if (ctrlKey) {
+      document.getElementById("s3devIInp").focus();
+    }
 
     this.blockCursor = block;
   }

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -1504,11 +1504,18 @@ export default class DevTools {
       this.hideDropDown();
     }
 
-    let ctrlKey = e.ctrlKey || e.metaKey;
-    if (!ctrlKey || !document.getElementsByClassName("injectionDiv")[0].contains(e.target)) {
-      if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
-        // If we click outside the dropdown, then instigate the hide code...
-        this.hideFloatDropDown();
+    if (this.floatInp && !e.target.closest("#s3devIDDOut")) {
+		let ctrlKey = e.ctrlKey || e.metaKey;
+		if (
+			!ctrlKey
+			|| (
+				!document.getElementsByClassName("injectionDiv")[0].contains(e.target)
+				&& !e.target.classList.contains("blocklyHtmlInput")
+				)
+			|| e.target.matches(".blocklyFlyoutButton, .blocklyFlyoutButton *, .blocklyTouchTargetBackground")
+		) {
+			// If we click outside the dropdown, then instigate the hide code...
+			this.hideFloatDropDown();
       }
     }
 

--- a/addons/editor-devtools/DomHelpers.js
+++ b/addons/editor-devtools/DomHelpers.js
@@ -13,15 +13,15 @@ export default class DomHelpers {
    * @param selectorDrag
    * @param selectorDrop
    * @param mouseXY
-   * @param [ctrlKey=false]
+   * @param [shiftKey=false]
    * @returns {boolean}
    */
-  triggerDragAndDrop(selectorDrag, selectorDrop, mouseXY, ctrlKey) {
+  triggerDragAndDrop(selectorDrag, selectorDrop, mouseXY, shiftKey) {
     // function for triggering mouse events
-    ctrlKey = ctrlKey || false;
+    shiftKey = shiftKey || false;
     let fireMouseEvent = function (type, elem, centerX, centerY) {
       let evt = document.createEvent("MouseEvents");
-      evt.initMouseEvent(type, true, true, window, 1, 1, 1, centerX, centerY, ctrlKey, false, false, false, 0, elem);
+      evt.initMouseEvent(type, true, true, window, 1, 1, 1, centerX, centerY, shiftKey, false, false, false, 0, elem);
       elem.dispatchEvent(evt);
     };
 

--- a/addons/editor-devtools/DomHelpers.js
+++ b/addons/editor-devtools/DomHelpers.js
@@ -13,13 +13,15 @@ export default class DomHelpers {
    * @param selectorDrag
    * @param selectorDrop
    * @param mouseXY
+   * @param [ctrlKey=false]
    * @returns {boolean}
    */
-  triggerDragAndDrop(selectorDrag, selectorDrop, mouseXY) {
+  triggerDragAndDrop(selectorDrag, selectorDrop, mouseXY, ctrlKey) {
     // function for triggering mouse events
+	ctrlKey = ctrlKey || false;
     let fireMouseEvent = function (type, elem, centerX, centerY) {
       let evt = document.createEvent("MouseEvents");
-      evt.initMouseEvent(type, true, true, window, 1, 1, 1, centerX, centerY, false, false, false, false, 0, elem);
+      evt.initMouseEvent(type, true, true, window, 1, 1, 1, centerX, centerY, ctrlKey, false, false, false, 0, elem);
       elem.dispatchEvent(evt);
     };
 

--- a/addons/editor-devtools/DomHelpers.js
+++ b/addons/editor-devtools/DomHelpers.js
@@ -18,7 +18,7 @@ export default class DomHelpers {
    */
   triggerDragAndDrop(selectorDrag, selectorDrop, mouseXY, ctrlKey) {
     // function for triggering mouse events
-	ctrlKey = ctrlKey || false;
+    ctrlKey = ctrlKey || false;
     let fireMouseEvent = function (type, elem, centerX, centerY) {
       let evt = document.createEvent("MouseEvents");
       evt.initMouseEvent(type, true, true, window, 1, 1, 1, centerX, centerY, ctrlKey, false, false, false, 0, elem);

--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -440,7 +440,7 @@ div.s3devDDOut.vis ul.s3devDD {
   border-radius: 4px;
   box-shadow: rgba(0, 0, 0, 0.3) 0 0 3px, rgba(0, 0, 0, 0.2) 0 3px 10px;
 
-  z-index: 1000001;
+  z-index: 999;
 }
 
 #s3devInsertLabel {


### PR DESCRIPTION
### Changes

If ~~Ctrl~~ Shift is held while clicking on the workspace or dragging a block from the middle-click find bar, it will not  be closed. The layer of the floating find bar is also lowered so that it appears below dragged blocks.

### Reason for changes

A little quality-of-life feature to allow rapid creation of scripts.

### Tests

Tested.
![](https://user-images.githubusercontent.com/68464103/138583630-0941761e-cd44-4523-93e2-40d4e41e3493.gif)

~~This might have some issues combined with block cherry picking, but hopefully it should be fine.~~