### PR TITLE
Fix "editor-theme3 reduces size of clickable area in block dropdowns "

### DIFF
--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -15,7 +15,7 @@ g[data-shapes="c-block c-1 hat"] > g[data-shapes="stack"]:not(.blocklyDraggable)
 g[data-argument-type="dropdown"] > rect,
 g[data-argument-type="variable"] > rect {
   stroke: #0003;
-  fill: none;
+  fill: #0000;
 }
 g[data-argument-type*="text"] > path,
 [data-category] g > line {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #3702 

### Changes

<!-- Please describe the changes you've made. -->
Changed line 18 of theme3.css from `fill: none` to `fill: #0000`
### Reason for changes

<!-- Why should these changes be made? -->
To fix the bug that was in #3702
### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
I haven't actually tested it, but @awesome-llama did. See https://github.com/ScratchAddons/ScratchAddons/issues/3702#issuecomment-950198535