### PR TITLE
editor-comment-previews: add featured tag

### DIFF
--- a/addons/editor-comment-previews/addon.json
+++ b/addons/editor-comment-previews/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Editor comment previews",
   "description": "Allows you to preview the contents of comments by hovering over collapsed comments and blocks. You can use this to view comments that are off-screen, identify a loop block from the bottom by its preview, fit many long comments in a small space, and more.",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "credits": [
     {
       "name": "lisa_wolfgang",


### PR DESCRIPTION
Reasons for featured tag:
1. Very useful
2. Well-made (not buggy or hacky, unlikely to break)
3. Well-tested