### PR TITLE
disable-stage-drag-select: more reliable shift key detection

### DIFF
--- a/addons/disable-stage-drag-select/userscript.js
+++ b/addons/disable-stage-drag-select/userscript.js
@@ -1,13 +1,16 @@
 export default async ({ addon, console }) => {
   const vm = addon.tab.traps.vm;
-  let shiftKeyPressed = false;
 
-  document.addEventListener("keydown", (event) => {
-    shiftKeyPressed = event.shiftKey;
-  });
-  document.addEventListener("keyup", (event) => {
-    shiftKeyPressed = event.shiftKey;
-  });
+  let shiftKeyPressed = false;
+  document.addEventListener(
+    "mousedown",
+    function (e) {
+      shiftKeyPressed = e.shiftKey;
+    },
+    {
+      capture: true,
+    }
+  );
 
   // Do not focus sprite after dragging it
   const oldStopDrag = vm.stopDrag;


### PR DESCRIPTION
Alt+tabbing while holding shift will no longer cause problems

Very similar to #3513 
