### PR TITLE
block-switching: fix custom block arg switching bugs

### DIFF
--- a/addons/block-switching/userscript.js
+++ b/addons/block-switching/userscript.js
@@ -831,7 +831,7 @@ export default async function ({ addon, global, console, msg }) {
         const stringArgs = [];
         const boolArgs = [];
         for (let i = 0; i < argumentNames.length; i++) {
-          if (parsedArguments[i] === '%b') {
+          if (parsedArguments[i] === "%b") {
             boolArgs.push(argumentNames[i]);
           } else {
             stringArgs.push(argumentNames[i]);
@@ -839,7 +839,7 @@ export default async function ({ addon, global, console, msg }) {
         }
         customBlocks[procCode] = {
           stringArgs,
-          boolArgs
+          boolArgs,
         };
       });
     return customBlocks;

--- a/addons/block-switching/userscript.js
+++ b/addons/block-switching/userscript.js
@@ -1,7 +1,7 @@
 import blockToDom from "./blockToDom.js";
 
 export default async function ({ addon, global, console, msg }) {
-  const blockly = await addon.tab.traps.getBlockly();
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
   const vm = addon.tab.traps.vm;
 
   let blockSwitches = {};
@@ -816,7 +816,7 @@ export default async function ({ addon, global, console, msg }) {
 
         if (addon.settings.get("border") && (block.type === "data_variable" || block.type === "data_listcontents")) {
           // Add top border to first variable (if it exists)
-          const delBlockIndex = items.findIndex((item) => item.text === blockly.Msg.DELETE_BLOCK);
+          const delBlockIndex = items.findIndex((item) => item.text === ScratchBlocks.Msg.DELETE_BLOCK);
           // firstVariableItem might be undefined, a variable to switch to,
           // or an item added by editor-devtools (or any addon before this one)
           const firstVariableItem = items[delBlockIndex + 1];

--- a/addons/block-switching/userscript.js
+++ b/addons/block-switching/userscript.js
@@ -736,6 +736,8 @@ export default async function ({ addon, global, console, msg }) {
     }, 0);
   };
 
+  const uniques = (array) => [...new Set(array)];
+
   addon.tab.createBlockContextMenu(
     (items, block) => {
       if (!addon.self.disabled) {
@@ -777,7 +779,7 @@ export default async function ({ addon, global, console, msg }) {
             }
           }
           const currentValue = block.getFieldValue("VALUE");
-          switches = switches.map((i) => ({
+          switches = uniques(switches).map((i) => ({
             isNoop: i === currentValue,
             fieldValue: i,
             msg: i,


### PR DESCRIPTION
 - Fixes custom block arg switching misbehaving after deleting and adding arguments of varying types (root cause appears to have been a Scratch bug where argumentdefaults is not updated properly)
   Should resolve https://discord.com/channels/751206349614088204/755131743136383107/907390137330176000
 - Show each unique argument name at most once
 - Clean up some old code

Compare with & without patch on https://scratch.mit.edu/projects/597673801/
