### PR TITLE
animated-thumb: add community tag

### DIFF
--- a/addons/animated-thumb/addon.json
+++ b/addons/animated-thumb/addon.json
@@ -15,7 +15,7 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "tags": ["editor", "editorMenuBar", "recommended"],
+  "tags": ["community", "projectPage", "recommended"],
   "versionAdded": "1.3.0",
   "enabledByDefault": true
 }


### PR DESCRIPTION
Resolves #2334 (makes `animated-thumb` a community addon)

### Changes

Adds the `community` & `projectPage` tags and removes the `editor` & `menuBar` tags from `animated-thumb`.

### Reason for changes

> This should be a "community" addon, not an "editor" addon - editor addons are about the project itself, and thumbnails are only a concept as part of the community site.

_Originally posted by @WorldLanguages in #2334._

Even though the set thumbnail button moved to the project page, it was still found under the editor category on the settings page. If this was done for a reason, just close the PR.

### Tests

None.