### PR TITLE
editor-comment-previews: fix some bugs

### DIFF
--- a/addons/editor-comment-previews/addon.json
+++ b/addons/editor-comment-previews/addon.json
@@ -6,6 +6,9 @@
     {
       "name": "lisa_wolfgang",
       "link": "https://scratch.mit.edu/users/lisa_wolfgang"
+    },
+    {
+      "name": "GarboMuffin"
     }
   ],
   "userstyles": [

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -85,15 +85,24 @@ export default async function ({ addon, global, console }) {
       return;
     }
 
-    let el = null;
+    const el = e.target.closest('.blocklyBubbleCanvas g, .blocklyBlockCanvas .blocklyDraggable[data-id]');
+    if (el === hoveredElement) {
+      // Nothing to do.
+      return;
+    }
+    if (!el) {
+      hidePreview();
+      return;
+    }
+
     let text = null;
-    if (addon.settings.get("hover-view") && (el = e.target.closest('.blocklyBubbleCanvas g'))) {
+    if (addon.settings.get("hover-view") && e.target.closest('.blocklyBubbleCanvas g')) {
       const collapsedText = el.querySelector('text.scratchCommentText');
       if (collapsedText.getAttribute('display') !== 'none') {
         const textarea = el.querySelector('textarea');
         text = textarea.value;
       }
-    } else if ((el = e.target.closest('.blocklyBlockCanvas .blocklyDraggable[data-id]'))) {
+    } else if (e.target.closest('.blocklyBlockCanvas .blocklyDraggable[data-id]')) {
       const id = el.dataset.id;
       const block = getBlock(id);
       const comment = getComment(block);
@@ -109,15 +118,13 @@ export default async function ({ addon, global, console }) {
       }
     }
 
-    if (hoveredElement !== el) {
-      if (text !== null && text.trim() !== '') {
-        showTimeout = afterDelay(() => {
-          hoveredElement = el;
-          setText(text);
-        });
-      } else {
-        hidePreview();
-      }
+    if (text !== null && text.trim() !== '') {
+      showTimeout = afterDelay(() => {
+        hoveredElement = el;
+        setText(text);
+      });
+    } else {
+      hidePreview();
     }
   });
 

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -1,20 +1,5 @@
 export default async function ({ addon, global, console }) {
-  // Get VM
   const vm = addon.tab.traps.vm;
-  await new Promise((resolve, reject) => {
-    if (vm.editingTarget) return resolve();
-    vm.runtime.once("PROJECT_LOADED", resolve);
-  });
-
-  // Get Blockly and handle flyout safely
-  const Blockly = await addon.tab.traps.getBlockly();
-  const workspace = await Blockly.getMainWorkspace();
-  if (vm.editingTarget) vm.emitWorkspaceUpdate();
-  const flyout = await workspace.getFlyout();
-  const flyoutWorkspace = flyout.getWorkspace();
-  Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);
-  workspace.getToolbox().refreshSelection();
-  workspace.toolboxRefreshEnabled_ = true;
 
   // Create comment preview element (initially hidden)
   const previewElement = document.createElement("div");
@@ -54,7 +39,7 @@ export default async function ({ addon, global, console }) {
           if (elementType === "component") element = element.parentElement;
           // Find this exact block instance in the database (checks both workspace and flyout)
           let blocks;
-          if (element.matches(".blocklyFlyout *")) blocks = flyout.workspace_.blockDB_;
+          if (element.matches(".blocklyFlyout *")) blocks = vm.runtime.flyoutBlocks._blocks;
           else blocks = vm.editingTarget.blocks._blocks;
           let block = blocks[element.getAttribute("data-id")];
           if (block) {

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -1,195 +1,125 @@
 export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
 
-  // Create comment preview element (initially hidden)
+  const updateStyles = () => {
+    previewElement.classList.toggle('sa-comment-preview-delay', addon.settings.get('delay') !== 'none');
+    previewElement.classList.toggle('sa-comment-preview-reduce-transparency', addon.settings.get('reduce-transparency'));
+    previewElement.classList.toggle('sa-comment-preview-fade', !addon.settings.get('reduce-animation'));
+  };
+
+  const afterDelay = (cb) => {
+    if (!previewElement.classList.contains('sa-comment-preview-hidden')) {
+      // If not hidden, updating immediately is preferred
+      cb();
+      return;
+    }
+    const delay = addon.settings.get("delay");
+    if (delay === 'long') return setTimeout(cb, 500);
+    if (delay === 'short') return setTimeout(cb, 300);
+    cb();
+  };
+
+  let hoveredElement = null;
+  let showTimeout = null;
+  let mouseX = 0;
+  let mouseY = 0;
+  let doNotShowUntilMoveMouse = false;
+
   const previewElement = document.createElement("div");
   previewElement.classList.add("sa-comment-preview");
   previewElement.classList.add("sa-comment-preview-hidden");
-  document.querySelector("body").appendChild(previewElement);
-  setAppearance();
-  addon.settings.addEventListener("change", setAppearance);
+  updateStyles();
+  addon.settings.addEventListener("change", updateStyles);
+  document.body.appendChild(previewElement);
 
-  /** Tracks the text content of the comment associated with what the mouse is hovered over. */
-  let mouseOver = null;
+  const getBlockAndComment = (id) => {
+    const block = vm.editingTarget.blocks.getBlock(id) || vm.runtime.flyoutBlocks.getBlock(id);
+    const comment = block && block.comment && vm.editingTarget.comments[block.comment];
+    return {
+      block,
+      comment
+    };
+  };
 
-  /**
-   * When the mouse enters a new element, check if that element is a collapsed comment, a block with a comment attached,
-   * or a custom block with a definition that has a comment attached.
-   * If so, then show the comment preview element.
-   * If not, then dismiss the comment preview element.
-   */
-  document.addEventListener("mouseover", (e) => {
-    if (!addon.self.disabled) {
-      /** The element with which this `mouseover` event is concerned. */
-      let element = e.target.parentElement;
-      const elementType = isBlockElement(element);
-      if (elementType !== false) {
-        if (elementType === "comment") {
-          // If the element is a collapsed comment
-          if (
-            addon.settings.get("hover-view") &&
-            element.querySelector("text.scratchCommentText") &&
-            element.querySelector("text.scratchCommentText").getAttribute("display") === null &&
-            element.querySelector("text.scratchCommentText").innerText !== ""
-          ) {
-            setPreview(element.querySelector("textarea").value);
-          }
-        } else {
-          // Ensure that `element` is a block at this point
-          if (elementType === "component") element = element.parentElement;
-          // Find this exact block instance in the database (checks both workspace and flyout)
-          let blocks;
-          if (element.matches(".blocklyFlyout *")) blocks = vm.runtime.flyoutBlocks._blocks;
-          else blocks = vm.editingTarget.blocks._blocks;
-          let block = blocks[element.getAttribute("data-id")];
-          if (block) {
-            // Find this block's comment in the VM, or figure out that it doesn't have one
-            const comments = vm.editingTarget.comments;
-            let commentObject = comments[block.comment];
-            if (commentObject && commentObject.text === "") {
-              // If the comment exists but is blank, don't show a preview
-              previewElement.classList.add("sa-comment-preview-hidden");
-              mouseOver = null;
-            } else if (commentObject && addon.settings.get("hover-view-block")) {
-              // If the comment exists and block comment previews are enabled, show the preview
-              // (overrides any definition comments)
-              setPreview(commentObject.text);
-            } else if (
-              addon.settings.get("hover-view-procedure") &&
-              (block.opcode === "procedures_call" || block.procCode_)
-            ) {
-              // The block doesn't have its own comment, but if it's a custom block,
-              // check if the definition block has one using VM shenanigans
-              let blockName;
-              if (block.mutation) blockName = block.mutation.proccode;
-              else blockName = block.procCode_;
-              const blockEntry = Object.entries(vm.editingTarget.blocks._blocks).find((i) => {
-                return i[1].opcode === "procedures_prototype" && i[1].mutation.proccode === blockName;
-              });
-              if (!blockEntry) {
-                // Orphaned blocks/debugger blocks do not have definition
-                previewElement.classList.add("sa-comment-preview-hidden");
-                mouseOver = null;
-                return;
-              }
-              const prototypeBlock = vm.editingTarget.blocks._blocks[blockEntry[0]];
-              const definitionBlock = vm.editingTarget.blocks._blocks[prototypeBlock.parent];
-              commentObject = comments[definitionBlock.comment];
-              if (commentObject && commentObject.text !== "") {
-                // If the comment exists and isn't blank, show the preview
-                setPreview(commentObject.text);
-              } else {
-                // Since no comment was found to display, dismiss the preview
-                previewElement.classList.add("sa-comment-preview-hidden");
-                mouseOver = null;
-              }
-            } else {
-              // Definition comment previews are disabled, so since no block comment was found, dismiss the preview
-              previewElement.classList.add("sa-comment-preview-hidden");
-              mouseOver = null;
-            }
-          }
-        }
-      } else {
-        // The currently hovered element is not a block or comment, so dismiss the preview
-        previewElement.classList.add("sa-comment-preview-hidden");
-        mouseOver = null;
-      }
-    }
-  });
-
-  /**
-   * When the mouse moves, if the comment preview is visible, update its position.
-   */
-  document.addEventListener("mousemove", (e) => {
-    if (
-      !addon.self.disabled &&
-      (addon.settings.get("follow-mouse") === true ||
-        (previewElement.classList.contains("sa-comment-preview-hidden") &&
-          window.getComputedStyle(previewElement).opacity < 0.001))
-    ) {
-      previewElement.style.left = e.clientX + 8 + "px";
-      previewElement.style.top = e.clientY + 8 + "px";
-    }
-  });
-
-  /**
-   * When the mouse is clicked, dismiss the comment preview.
-   */
-  document.addEventListener("click", () => {
-    previewElement.classList.add("sa-comment-preview-hidden");
-    mouseOver = null;
-  });
-
-  /**
-   * Calculates the block/comment type of an element.
-   * @param element An element from the `document`.
-   * @returns `block` if the element is a block, `component` if the element is a component of a block (such as text or
-   * an icon), `comment` if the element is a comment, and `false` if the element is none of the above.
-   */
-  function isBlockElement(element) {
-    if (
-      element &&
-      (element.matches(".blocklyBlockCanvas g.blocklyDraggable") ||
-        element.matches(".blocklyBlockCanvas g.blocklyDraggable *") ||
-        element.matches("g.blocklyBubbleCanvas *"))
-    ) {
-      if (element.matches("g.blocklyBubbleCanvas *")) {
-        // We are directly hovering over a comment
-        return "comment";
-      } else if (element.matches(".blocklyBlockCanvas g.blocklyDraggable")) {
-        // We are directly hovering over one of the block's elements
-        return "block";
-      } else {
-        // We are hovering over an icon or numeric input nested inside one of the block's elements
-        return "component";
-      }
-    } else {
-      // We aren't hovering over a block or a comment
-      return false;
-    }
-  }
-
-  /**
-   * Shows the comment preview element after the delay specified in the settings.
-   * @param text The text to display in the comment preview.
-   */
-  function setPreview(text) {
-    // Set the delay time, if any
-    let timeout;
-    if (addon.settings.get("delay") === "long") timeout = 500;
-    else if (addon.settings.get("delay") === "short") timeout = 300;
-    else timeout = 0;
-    // Set the comment preview's contents and track them
+  const setText = (text) => {
     previewElement.innerText = text;
-    mouseOver = text;
-    setTimeout(() => {
-      // Ensures that the element the mouse is hovering AFTER the delay has not changed
-      if (mouseOver === text) {
-        previewElement.classList.remove("sa-comment-preview-hidden");
-      }
-    }, timeout);
-  }
+    previewElement.classList.remove('sa-comment-preview-hidden');
+    updateMousePosition();
+  };
 
-  /**
-   * Reads the addon settings, then sets the delay, transparency, and fade effects of the comment preview by setting
-   * the corresponding CSS classes on the comment preview element.
-   */
-  function setAppearance() {
-    if (addon.settings.get("delay") === "none") {
-      previewElement.classList.remove("sa-comment-preview-delay");
-    } else {
-      previewElement.classList.add("sa-comment-preview-delay");
+  const updateMousePosition = () => {
+    previewElement.style.top = `${mouseY + 8}px`;
+    previewElement.style.left = `${mouseX + 8}px`;
+  };
+
+  const hidePreview = () => {
+    if (hoveredElement) {
+      hoveredElement = null;
+      previewElement.classList.add('sa-comment-preview-hidden');
     }
-    if (addon.settings.get("reduce-transparency")) {
-      previewElement.classList.add("sa-comment-preview-reduce-transparency");
-    } else {
-      previewElement.classList.remove("sa-comment-preview-reduce-transparency");
+  };
+
+  document.addEventListener("mouseover", (e) => {
+    if (addon.self.disabled) {
+      return;
     }
-    if (addon.settings.get("reduce-animation")) {
-      previewElement.classList.remove("sa-comment-preview-fade");
-    } else {
-      previewElement.classList.add("sa-comment-preview-fade");
+
+    clearTimeout(showTimeout);
+    if (doNotShowUntilMoveMouse) {
+      return;
     }
-  }
+
+    let el = null;
+    let text = null;
+    if (addon.settings.get("hover-view") && (el = e.target.closest('.blocklyBubbleCanvas g'))) {
+      const collapsedText = el.querySelector('text.scratchCommentText');
+      if (collapsedText.getAttribute('display') !== 'none') {
+        const textarea = el.querySelector('textarea');
+        text = textarea.value;
+      }
+    } else if ((el = e.target.closest('.blocklyBlockCanvas .blocklyDraggable[data-id]'))) {
+      const id = el.dataset.id;
+      const {block, comment} = getBlockAndComment(id);
+      if (addon.settings.get("hover-view-block") && comment) {
+        text = comment.text;
+      } else if (block && block.opcode === 'procedures_call' && addon.settings.get("hover-view-procedure")) {
+        const procCode = block.mutation.proccode;
+        const procedurePrototype = Object.values(vm.editingTarget.blocks._blocks).find((i) => {
+          return i.opcode === "procedures_prototype" && i.mutation.proccode === procCode;
+        });
+        const procedureDefinition = procedurePrototype && procedurePrototype.parent;
+        const procedureComment = getBlockAndComment(procedureDefinition).comment;
+        if (procedureComment) {
+          text = procedureComment.text;
+        }
+      }
+    }
+
+    if (hoveredElement !== el) {
+      if (text !== null && text.trim() !== '') {
+        showTimeout = afterDelay(() => {
+          hoveredElement = el;
+          setText(text);
+        });
+      } else {
+        hidePreview();
+      }
+    }
+  });
+
+  document.addEventListener("mousemove", (e) => {
+    mouseX = e.clientX;
+    mouseY = e.clientY;
+    doNotShowUntilMoveMouse = false;
+    if (addon.settings.get("follow-mouse")) {
+      updateMousePosition();
+    }
+  });
+
+  document.addEventListener("mousedown", () => {
+    hidePreview();
+    doNotShowUntilMoveMouse = true;
+  }, {
+    capture: true
+  });
 }

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -2,13 +2,13 @@ export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
 
   const updateStyles = () => {
-    previewElement.classList.toggle('sa-comment-preview-delay', addon.settings.get('delay') !== 'none');
-    previewElement.classList.toggle('sa-comment-preview-reduce-transparency', addon.settings.get('reduce-transparency'));
-    previewElement.classList.toggle('sa-comment-preview-fade', !addon.settings.get('reduce-animation'));
+    previewInner.classList.toggle('sa-comment-preview-delay', addon.settings.get('delay') !== 'none');
+    previewInner.classList.toggle('sa-comment-preview-reduce-transparency', addon.settings.get('reduce-transparency'));
+    previewInner.classList.toggle('sa-comment-preview-fade', !addon.settings.get('reduce-animation'));
   };
 
   const afterDelay = (cb) => {
-    if (!previewElement.classList.contains('sa-comment-preview-hidden')) {
+    if (!previewInner.classList.contains('sa-comment-preview-hidden')) {
       // If not hidden, updating immediately is preferred
       cb();
       return;
@@ -25,12 +25,17 @@ export default async function ({ addon, global, console }) {
   let mouseY = 0;
   let doNotShowUntilMoveMouse = false;
 
-  const previewElement = document.createElement("div");
-  previewElement.classList.add("sa-comment-preview");
-  previewElement.classList.add("sa-comment-preview-hidden");
+  const previewOuter = document.createElement('div');
+  previewOuter.classList.add('sa-comment-preview-outer');
+
+  const previewInner = document.createElement("div");
+  previewInner.classList.add("sa-comment-preview-inner");
+  previewInner.classList.add("sa-comment-preview-hidden");
   updateStyles();
   addon.settings.addEventListener("change", updateStyles);
-  document.body.appendChild(previewElement);
+
+  previewOuter.appendChild(previewInner);
+  document.body.appendChild(previewOuter);
 
   const getBlock = (id) => vm.editingTarget.blocks.getBlock(id) || vm.runtime.flyoutBlocks.getBlock(id);
   const getComment = (block) => block && block.comment && vm.editingTarget.comments[block.comment];
@@ -54,20 +59,19 @@ export default async function ({ addon, global, console }) {
   };
 
   const setText = (text) => {
-    previewElement.innerText = text;
-    previewElement.classList.remove('sa-comment-preview-hidden');
+    previewInner.innerText = text;
+    previewInner.classList.remove('sa-comment-preview-hidden');
     updateMousePosition();
   };
 
   const updateMousePosition = () => {
-    previewElement.style.top = `${mouseY + 8}px`;
-    previewElement.style.left = `${mouseX + 8}px`;
+    previewOuter.style.transform = `translate(${mouseX + 8}px, ${mouseY + 8}px)`;
   };
 
   const hidePreview = () => {
     if (hoveredElement) {
       hoveredElement = null;
-      previewElement.classList.add('sa-comment-preview-hidden');
+      previewInner.classList.add('sa-comment-preview-hidden');
     }
   };
 
@@ -121,7 +125,7 @@ export default async function ({ addon, global, console }) {
     mouseX = e.clientX;
     mouseY = e.clientY;
     doNotShowUntilMoveMouse = false;
-    if (addon.settings.get("follow-mouse")) {
+    if (addon.settings.get("follow-mouse") && !previewInner.classList.contains('sa-comment-preview-hidden')) {
       updateMousePosition();
     }
   });

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -2,20 +2,20 @@ export default async function ({ addon, global, console }) {
   const vm = addon.tab.traps.vm;
 
   const updateStyles = () => {
-    previewInner.classList.toggle('sa-comment-preview-delay', addon.settings.get('delay') !== 'none');
-    previewInner.classList.toggle('sa-comment-preview-reduce-transparency', addon.settings.get('reduce-transparency'));
-    previewInner.classList.toggle('sa-comment-preview-fade', !addon.settings.get('reduce-animation'));
+    previewInner.classList.toggle("sa-comment-preview-delay", addon.settings.get("delay") !== "none");
+    previewInner.classList.toggle("sa-comment-preview-reduce-transparency", addon.settings.get("reduce-transparency"));
+    previewInner.classList.toggle("sa-comment-preview-fade", !addon.settings.get("reduce-animation"));
   };
 
   const afterDelay = (cb) => {
-    if (!previewInner.classList.contains('sa-comment-preview-hidden')) {
+    if (!previewInner.classList.contains("sa-comment-preview-hidden")) {
       // If not hidden, updating immediately is preferred
       cb();
       return;
     }
     const delay = addon.settings.get("delay");
-    if (delay === 'long') return setTimeout(cb, 500);
-    if (delay === 'short') return setTimeout(cb, 300);
+    if (delay === "long") return setTimeout(cb, 500);
+    if (delay === "short") return setTimeout(cb, 300);
     cb();
   };
 
@@ -25,42 +25,38 @@ export default async function ({ addon, global, console }) {
   let mouseY = 0;
   let doNotShowUntilMoveMouse = false;
 
-  const previewOuter = document.createElement('div');
-  previewOuter.classList.add('sa-comment-preview-outer');
-
+  const previewOuter = document.createElement("div");
+  previewOuter.classList.add("sa-comment-preview-outer");
   const previewInner = document.createElement("div");
   previewInner.classList.add("sa-comment-preview-inner");
   previewInner.classList.add("sa-comment-preview-hidden");
   updateStyles();
   addon.settings.addEventListener("change", updateStyles);
-
   previewOuter.appendChild(previewInner);
   document.body.appendChild(previewOuter);
 
   const getBlock = (id) => vm.editingTarget.blocks.getBlock(id) || vm.runtime.flyoutBlocks.getBlock(id);
   const getComment = (block) => block && block.comment && vm.editingTarget.comments[block.comment];
   const getProcedureDefinitionBlock = (procCode) => {
-    const procedurePrototype = Object.values(vm.editingTarget.blocks._blocks).find((i) => (
-      i.opcode === "procedures_prototype" && i.mutation.proccode === procCode
-    ));
+    const procedurePrototype = Object.values(vm.editingTarget.blocks._blocks).find(
+      (i) => i.opcode === "procedures_prototype" && i.mutation.proccode === procCode
+    );
     if (procedurePrototype) {
       // Usually `parent` will exist but sometimes it doesn't
       if (procedurePrototype.parent) {
         return getBlock(procedurePrototype.parent);
       }
       const id = procedurePrototype.id;
-      return Object.values(vm.editingTarget.blocks._blocks).find((i) => (
-        i.opcode === 'procedures_definition' &&
-        i.inputs.custom_block &&
-        i.inputs.custom_block.block === id
-      ));
+      return Object.values(vm.editingTarget.blocks._blocks).find(
+        (i) => i.opcode === "procedures_definition" && i.inputs.custom_block && i.inputs.custom_block.block === id
+      );
     }
     return null;
   };
 
   const setText = (text) => {
     previewInner.innerText = text;
-    previewInner.classList.remove('sa-comment-preview-hidden');
+    previewInner.classList.remove("sa-comment-preview-hidden");
     updateMousePosition();
   };
 
@@ -71,7 +67,7 @@ export default async function ({ addon, global, console }) {
   const hidePreview = () => {
     if (hoveredElement) {
       hoveredElement = null;
-      previewInner.classList.add('sa-comment-preview-hidden');
+      previewInner.classList.add("sa-comment-preview-hidden");
     }
   };
 
@@ -79,13 +75,12 @@ export default async function ({ addon, global, console }) {
     if (addon.self.disabled) {
       return;
     }
-
     clearTimeout(showTimeout);
     if (doNotShowUntilMoveMouse) {
       return;
     }
 
-    const el = e.target.closest('.blocklyBubbleCanvas g, .blocklyBlockCanvas .blocklyDraggable[data-id]');
+    const el = e.target.closest(".blocklyBubbleCanvas g, .blocklyBlockCanvas .blocklyDraggable[data-id]");
     if (el === hoveredElement) {
       // Nothing to do.
       return;
@@ -96,19 +91,19 @@ export default async function ({ addon, global, console }) {
     }
 
     let text = null;
-    if (addon.settings.get("hover-view") && e.target.closest('.blocklyBubbleCanvas g')) {
-      const collapsedText = el.querySelector('text.scratchCommentText');
-      if (collapsedText.getAttribute('display') !== 'none') {
-        const textarea = el.querySelector('textarea');
+    if (addon.settings.get("hover-view") && e.target.closest(".blocklyBubbleCanvas g")) {
+      const collapsedText = el.querySelector("text.scratchCommentText");
+      if (collapsedText.getAttribute("display") !== "none") {
+        const textarea = el.querySelector("textarea");
         text = textarea.value;
       }
-    } else if (e.target.closest('.blocklyBlockCanvas .blocklyDraggable[data-id]')) {
+    } else if (e.target.closest(".blocklyBlockCanvas .blocklyDraggable[data-id]")) {
       const id = el.dataset.id;
       const block = getBlock(id);
       const comment = getComment(block);
       if (addon.settings.get("hover-view-block") && comment) {
         text = comment.text;
-      } else if (block && block.opcode === 'procedures_call' && addon.settings.get("hover-view-procedure")) {
+      } else if (block && block.opcode === "procedures_call" && addon.settings.get("hover-view-procedure")) {
         const procCode = block.mutation.proccode;
         const procedureDefinitionBlock = getProcedureDefinitionBlock(procCode);
         const procedureComment = getComment(procedureDefinitionBlock);
@@ -118,7 +113,7 @@ export default async function ({ addon, global, console }) {
       }
     }
 
-    if (text !== null && text.trim() !== '') {
+    if (text !== null && text.trim() !== "") {
       showTimeout = afterDelay(() => {
         hoveredElement = el;
         setText(text);
@@ -132,15 +127,19 @@ export default async function ({ addon, global, console }) {
     mouseX = e.clientX;
     mouseY = e.clientY;
     doNotShowUntilMoveMouse = false;
-    if (addon.settings.get("follow-mouse") && !previewInner.classList.contains('sa-comment-preview-hidden')) {
+    if (addon.settings.get("follow-mouse") && !previewInner.classList.contains("sa-comment-preview-hidden")) {
       updateMousePosition();
     }
   });
 
-  document.addEventListener("mousedown", () => {
-    hidePreview();
-    doNotShowUntilMoveMouse = true;
-  }, {
-    capture: true
-  });
+  document.addEventListener(
+    "mousedown",
+    () => {
+      hidePreview();
+      doNotShowUntilMoveMouse = true;
+    },
+    {
+      capture: true,
+    }
+  );
 }

--- a/addons/editor-comment-previews/userstyle.css
+++ b/addons/editor-comment-previews/userstyle.css
@@ -3,6 +3,7 @@
   top: 0;
   left: 0;
   z-index: 100000000;
+  pointer-events: none;
 }
 
 .sa-comment-preview-inner {

--- a/addons/editor-comment-previews/userstyle.css
+++ b/addons/editor-comment-previews/userstyle.css
@@ -1,10 +1,15 @@
-.sa-comment-preview {
+.sa-comment-preview-outer {
   position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100000000;
+}
+
+.sa-comment-preview-inner {
   width: calc(200px - 16px);
   max-height: calc(132px - 8px);
   padding: 8px;
   overflow: hidden;
-  z-index: 100000000;
 
   font-size: 12px;
   white-space: pre-wrap;
@@ -20,7 +25,7 @@
 }
 
 @supports (backdrop-filter: blur(16px)) {
-  .sa-comment-preview {
+  .sa-comment-preview-inner {
     background-color: rgb(255 255 255 / 75%);
     backdrop-filter: blur(16px);
   }

--- a/addons/editor-comment-previews/userstyle.css
+++ b/addons/editor-comment-previews/userstyle.css
@@ -11,13 +11,19 @@
   pointer-events: none;
 
   color: rgb(87, 94, 117);
-  background-color: rgb(255 255 255 / 75%);
+  background-color: rgb(255 255 255 / 90%);
   border-style: none;
   border-radius: 8px;
   filter: drop-shadow(0px 5px 5px rgb(0 0 0 / 10%));
-  backdrop-filter: blur(16px);
 
   transform: perspective(200px);
+}
+
+@supports (backdrop-filter: blur(16px)) {
+  .sa-comment-preview {
+    background-color: rgb(255 255 255 / 75%);
+    backdrop-filter: blur(16px);
+  }
 }
 
 .sa-comment-preview-fade {


### PR DESCRIPTION
 - Don't needlessy force the flyout to completely rerender
 - Various other minor optimizations
 - Fix comment previews in the flyout not working after leaving & entering editor
 - Don't show preview for comments that only contain whitespace
 - Right clicking should hide preview as left clicking already did
 - Improve preview readability in browsers that don't support backdrop-filter (Firefox)
 - Hovering over a text input will now show the comment attached to the block that the input is in (previously it would show nothing, don't know if that was intentional)
 - Fix various other bugs
