### PR TITLE
swap-local-global: theoretical bug fix

### DIFF
--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -222,8 +222,17 @@ export default async function ({ addon, msg, console }) {
 
   const canUserUseCloudVariables = () => {
     const blocksWrapper = document.querySelector('[class^="gui_blocks-wrapper_1ccgf"]');
-    const internalNode = blocksWrapper[addon.tab.traps.getInternalKey(blocksWrapper)];
-    return internalNode.child.pendingProps.canUseCloud;
+    let internalNode = blocksWrapper[addon.tab.traps.getInternalKey(blocksWrapper)];
+    while (true) {
+      if (!internalNode) {
+        return false;
+      }
+      const canUseCloud = internalNode.stateNode?.props?.canUseCloud;
+      if (typeof canUseCloud === 'boolean') {
+        return canUseCloud;
+      }
+      internalNode = internalNode.child;
+    }
   };
 
   const addMoreOptionsToPrompt = (variable) => {

--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -228,7 +228,7 @@ export default async function ({ addon, msg, console }) {
         return false;
       }
       const canUseCloud = internalNode.stateNode?.props?.canUseCloud;
-      if (typeof canUseCloud === 'boolean') {
+      if (typeof canUseCloud === "boolean") {
         return canUseCloud;
       }
       internalNode = internalNode.child;


### PR DESCRIPTION
The old canUserUseCloudVariables() was unreliable in certain situations, although as far as I'm aware Scratch Addons itself wasn't affected (not entirely sure, there might be some weird edge case). This makes it work reliably everywhere and should be more resistant to any Scratch changes.
