### PR TITLE
editor-devtools: add missing reduxEvents and reduxCondition

### DIFF
--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -38,7 +38,11 @@ export default class DevTools {
   async init() {
     this.addContextMenus();
     while (true) {
-      const root = await this.addon.tab.waitForElement("ul[class*=gui_tab-list_]", { markAsSeen: true });
+      const root = await this.addon.tab.waitForElement("ul[class*=gui_tab-list_]", {
+        markAsSeen: true,
+        reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+        reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
+      });
       this.initInner(root);
     }
   }

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -40,7 +40,11 @@ export default class DevTools {
     while (true) {
       const root = await this.addon.tab.waitForElement("ul[class*=gui_tab-list_]", {
         markAsSeen: true,
-        reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+        reduxEvents: [
+          "scratch-gui/mode/SET_PLAYER",
+          "fontsLoaded/SET_FONTS_LOADED",
+          "scratch-gui/locales/SELECT_LOCALE",
+        ],
         reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
       });
       this.initInner(root);


### PR DESCRIPTION
Very minor optimization.

The standalone devtools extension doesn't support these, but that's fine. It's not particularly important.