### PR TITLE
`hide-flyout`: suppress flyout on workspace drag

### DIFF
--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -17,15 +17,22 @@ export default async function ({ addon, global, console }) {
     };
     return data[addon.settings.get("speed")];
   }
-  function onmouseenter(speed = {}) {
-    speed = typeof speed === "object" ? getSpeedValue() : speed;
-    flyOut.classList.remove("sa-flyoutClose");
-    flyOut.style.transitionDuration = `${speed}s`;
-    scrollBar.classList.remove("sa-flyoutClose");
-    scrollBar.style.transitionDuration = `${speed}s`;
-    lockDisplay.classList.remove("sa-flyoutClose");
-    lockDisplay.style.transitionDuration = `${speed}s`;
-    setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
+  function onmouseenter(e, speed = {}) {
+    // If a mouse event was passed, only open flyout if the workspace isn't being dragged
+    if (
+      !e ||
+      (e &&
+        (e.buttons === 0 || document.querySelector(".blocklyToolboxDiv").className.includes("blocklyToolboxDelete")))
+    ) {
+      speed = typeof speed === "object" ? getSpeedValue() : speed;
+      flyOut.classList.remove("sa-flyoutClose");
+      flyOut.style.transitionDuration = `${speed}s`;
+      scrollBar.classList.remove("sa-flyoutClose");
+      scrollBar.style.transitionDuration = `${speed}s`;
+      lockDisplay.classList.remove("sa-flyoutClose");
+      lockDisplay.style.transitionDuration = `${speed}s`;
+      setTimeout(() => Blockly.getMainWorkspace().recordCachedAreas(), speed * 1000);
+    }
   }
   function onmouseleave(e, speed = getSpeedValue()) {
     // If we go behind the flyout or the user has locked it, let's return
@@ -55,7 +62,7 @@ export default async function ({ addon, global, console }) {
           lockDisplay.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
           placeHolderDiv.style.display = e.detail.action.activeTabIndex === 0 ? "block" : "none";
           if (e.detail.action.activeTabIndex === 0) {
-            onmouseenter(0);
+            onmouseenter(null, 0);
             toggle = true;
           }
           break;
@@ -121,9 +128,10 @@ export default async function ({ addon, global, console }) {
     if (toggleSetting === "hover") tabs.appendChild(lockDisplay);
 
     if (toggleSetting === "hover") {
-      placeHolderDiv.onmouseenter = onmouseenter;
-      document.querySelector(".blocklyToolboxDiv").onmouseenter = onmouseenter; // for columns
-      blocklySvg.onmouseenter = onmouseleave;
+      placeHolderDiv.onmouseenter = (e) => onmouseenter(e);
+      placeHolderDiv.onmousedown = (e) => onmouseenter();
+      document.querySelector(".blocklyToolboxDiv").onmouseenter = (e) => onmouseenter(e); // for columns
+      blocklySvg.onmouseenter = (e) => onmouseleave(e);
     }
 
     if (toggleSetting === "cathover") {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -129,7 +129,7 @@ export default async function ({ addon, global, console }) {
 
     if (toggleSetting === "hover") {
       placeHolderDiv.onmouseenter = (e) => onmouseenter(e);
-      placeHolderDiv.onmousedown = (e) => onmouseenter();
+      placeHolderDiv.onmouseup = (e) => onmouseenter();
       document.querySelector(".blocklyToolboxDiv").onmouseenter = (e) => onmouseenter(e); // for columns
       blocklySvg.onmouseenter = (e) => onmouseleave(e);
     }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #3736

### Changes

<!-- Please describe the changes you've made. -->
In hover mode, when the workspace is dragged and the mouse enters the flyout area, the flyout no longer opens.
The flyout still opens when a block is being dragged for deletion.
When the mouse is released while still hovering over the flyout area, the flyout will reappear.

The category hover and category click modes are unaffected.

### Reason for changes

<!-- Why should these changes be made? -->
The user does not intend for the flyout to open when the workspace is being dragged.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested in browser w/ Chromium 95 and Firefox 94.0.1.