### PR TITLE
Use solid border in editor-searchable-dropdowns

### DIFF
--- a/addons/editor-searchable-dropdowns/userscript.css
+++ b/addons/editor-searchable-dropdowns/userscript.css
@@ -4,7 +4,7 @@
   /* based on styles for the title input */
   color: white;
   background-color: hsla(0, 100%, 100%, 0.25);
-  border: 1px dashed hsla(0, 0%, 0%, 0.15);
+  border: 1px solid hsla(0, 0%, 0%, 0.15);
   padding: 0.5rem;
   outline: none;
   transition: 0.25s ease-out;


### PR DESCRIPTION
Resolves #3806

### Changes

Makes the searchable drop-down borders solid instead of dashed.

### Tests

Tested briefly on Edge.
