### PR TITLE
Capitalize "Account Settings" in editor

### DIFF
--- a/addons/account-settings-capitalize/addon.json
+++ b/addons/account-settings-capitalize/addon.json
@@ -7,6 +7,8 @@
       "matches": ["https://scratch.mit.edu/*"]
     }
   ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
   "tags": ["easterEgg", "community"],
   "versionAdded": "1.9.0"
 }

--- a/addons/account-settings-capitalize/style.css
+++ b/addons/account-settings-capitalize/style.css
@@ -1,4 +1,5 @@
 .account-nav .dropdown > li:nth-child(3),
-ul.user-nav > li:nth-child(3) {
+ul.user-nav > li:nth-child(3),
+[class*="menu-bar_account-info-group_"] [class*="menu_menu_"] > [class*="menu_menu-item_"]:nth-child(3) {
   text-transform: capitalize;
 }


### PR DESCRIPTION
Resolves #3808

### Changes

Makes the "Capitalized Account Settings" addon work in the editor.