### PR TITLE
progress-bar: Set height limits

### DIFF
--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -31,7 +31,7 @@
       "id": "height",
       "type": "integer",
       "min": 3,
-      "max": 120,
+      "max": 25,
       "default": 5
     }
   ],

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -31,7 +31,7 @@
       "id": "height",
       "type": "integer",
       "min": 3,
-      "max" 120,
+      "max": 120,
       "default": 5
     }
   ],

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -29,7 +29,9 @@
     {
       "name": "Progress bar height (px)",
       "id": "height",
-      "type": "positive_integer",
+      "type": "integer",
+      "min": 3,
+      "max" 120,
       "default": 5
     }
   ],


### PR DESCRIPTION
Resolves #2412.

### Changes

- Sets the minimum progress bar height to 3.
- Sets the maximum progress bar height to 25.

### Reason for changes

Any progress bar height lower than 3 causes it to be unreadable because of the 1px border and any height higher than about 26 pixels causes it to overflow the menu bar when saving the project.

### Tests

Tested on Edge 96.