### PR TITLE
Fix outlined reaction menu button icon in Chromium

### DIFF
--- a/addons/my-ocular/reactions.css
+++ b/addons/my-ocular/reactions.css
@@ -72,6 +72,7 @@
 }
 
 .my-ocular-reaction-menu-button {
+  font-weight: normal;
   cursor: pointer;
   filter: grayscale(100%);
   transition: filter 0.2s ease;


### PR DESCRIPTION
### Changes

Chromium recently started using outlined emojis in bold text (I'm not sure if that happens everywhere or just on Windows). The ocular reaction menu button icon isn't meant to be outlined, so this fixes it:
![image](https://user-images.githubusercontent.com/51849865/142825764-0caa4b26-2a28-4cf1-b421-5bfbdbf26bef.png)
![image](https://user-images.githubusercontent.com/51849865/142825582-98f3b6b4-67ee-404c-94bd-ca833f4f9bbd.png)
I'm not sure if the ocular icon should be changed or not because it's part of a link.