### PR TITLE
`emoji-picker`: fix Unicode emojis and button in Chrome

### DIFF
--- a/addons/emoji-picker/userscript.js
+++ b/addons/emoji-picker/userscript.js
@@ -176,7 +176,7 @@ export default async function ({ addon, global, console, msg }) {
     } else {
       emojiButtonText = document.createElement("a");
     }
-    emojiButtonText.textContent = "🙂";
+    emojiButtonText.textContent = "🙂︎";
     emojiButtonText.classList.add("sa-emoji-button");
     emojiButton.appendChild(emojiButtonText);
     addon.tab.displayNoneWhileDisabled(emojiButton, { display: "inline-block" });

--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -13,8 +13,7 @@
   overflow: hidden;
   line-height: 0px;
   font-size: 15px;
-}
-.sa-emoji-picker {
+  font-weight: normal;
   right: -7px;
 }
 
@@ -54,6 +53,7 @@
 .sa-emoji-button {
   padding: 0.74rem 0.99rem;
   vertical-align: middle;
+  font-weight: bold;
 }
 .button.small.sa-emoji-button-container {
   user-select: none;
@@ -65,9 +65,6 @@
 .comments-container .sa-emoji-button-container,
 .studio-compose-container .sa-emoji-button-container {
   margin-left: 1em;
-}
-.sa-emoji-button-container, .sa-emoji-button {
-  font-weight: normal;
 }
 .sa-emoji-picker-divider {
   height: 1px;

--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -66,6 +66,9 @@
 .studio-compose-container .sa-emoji-button-container {
   margin-left: 1em;
 }
+.sa-emoji-button-container {
+  font-weight: normal;
+}
 .sa-emoji-picker-divider {
   height: 1px;
   margin: 5px;

--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -66,7 +66,7 @@
 .studio-compose-container .sa-emoji-button-container {
   margin-left: 1em;
 }
-.sa-emoji-button-container {
+.sa-emoji-button-container, .sa-emoji-button {
   font-weight: normal;
 }
 .sa-emoji-picker-divider {


### PR DESCRIPTION
Resolves #3843
Related to #3840

### Changes

Makes the font of the emoji picker button and its Unicode emojis normal-weight.

### Reason for changes

Google made an amazing new ""feature"" in Chrome where bold emojs are outlined for absolutely zero reason.

### Tests

Tested in Chrome. Should work in Firefox.
![](https://user-images.githubusercontent.com/68464103/143178752-89b58527-e085-4511-bba0-e00ca0d56164.png)
