### PR TITLE
swap-local-global: remove hardcoded class hashes

### DIFF
--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -246,10 +246,12 @@ export default async function ({ addon, msg, console }) {
     }
 
     const headerTitle = promptBody.parentElement.querySelector('[class^="modal_header-item_"]');
-    if (variable.type === "") {
-      headerTitle.textContent = msg("edit-variable-header");
-    } else {
-      headerTitle.textContent = msg("edit-list-header");
+    if (headerTitle) {
+      if (variable.type === "") {
+        headerTitle.textContent = msg("edit-variable-header");
+      } else {
+        headerTitle.textContent = msg("edit-list-header");
+      }
     }
 
     const root = document.createElement("div");

--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -221,7 +221,7 @@ export default async function ({ addon, msg, console }) {
   };
 
   const canUserUseCloudVariables = () => {
-    const blocksWrapper = document.querySelector('[class^="gui_blocks-wrapper_1ccgf"]');
+    const blocksWrapper = document.querySelector('[class^="gui_blocks-wrapper_"]');
     let internalNode = blocksWrapper[addon.tab.traps.getInternalKey(blocksWrapper)];
     while (true) {
       if (!internalNode) {
@@ -245,7 +245,7 @@ export default async function ({ addon, msg, console }) {
       return;
     }
 
-    const headerTitle = promptBody.parentElement.querySelector('[class^="modal_header-item_2zQTd"]');
+    const headerTitle = promptBody.parentElement.querySelector('[class^="modal_header-item_"]');
     if (variable.type === "") {
       headerTitle.textContent = msg("edit-variable-header");
     } else {


### PR DESCRIPTION
Accidentally left hardcoded class hashes in some selectors. They shouldn't be there.

Old code works fine in Scratch but can break in modified environments or if/when Scratch changes prompts.