### PR TITLE
block-cherry-picking: bug fixes

### DIFF
--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -22,6 +22,8 @@ export default async function ({ addon, global, console }) {
           ScratchBlocks.Events.setGroup(true);
         }
         this.draggingBlock_.unplug(true);
+        // A separate field has to be updated to avoid dragging comments attached to blocks underneath this block.
+        this.dragIconData_ = this.dragIconData_.filter((i) => i.icon.block_ === this.draggingBlock_);
       }
     }
     return originalStartBlockDrag.call(this, ...args);

--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -24,6 +24,10 @@ export default async function ({ addon, global, console }) {
         this.draggingBlock_.unplug(true);
         // A separate field has to be updated to avoid dragging comments attached to blocks underneath this block.
         this.dragIconData_ = this.dragIconData_.filter((i) => i.icon.block_ === this.draggingBlock_);
+        // And we also have to make sure Scratch will never try to drag a block on top of itself, which crashes the editor.
+        // That can happen when you cherry-pick the top block of a script and drop it where it started.
+        this.draggedConnectionManager_.availableConnections_ =
+          this.draggedConnectionManager_.initAvailableConnections_();
       }
     }
     return originalStartBlockDrag.call(this, ...args);


### PR DESCRIPTION
 - Don't drag comments attached to blocks underneath the cherry-picked block
   
   https://user-images.githubusercontent.com/33787854/143664568-b8ebdfb8-c597-4392-989f-b2e00fdc7ace.mp4

 - Fix editor breaking when you start cherry-picking the top block of a script, drag it away from where it started, then drop it in the same place where it started
