### PR TITLE
Fix featured project selection

### DIFF
--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -535,6 +535,10 @@ h4 {
   border: none;
   background: #fff;
 }
+#featured-project-modal .project.thumb.selected {
+  background-color: #ddd;
+  box-shadow: inset 0 0 0 2px var(--scratchr2-primaryColor);
+}
 .modal-footer {
   border-radius: 0 0 16px 16px;
   border: none;

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -532,12 +532,12 @@ h4 {
   background: rgba(77, 151, 255, 0.1);
 }
 #featured-project-modal .project.thumb {
-  border: none;
+  border: 1px solid transparent;
   background: #fff;
 }
 #featured-project-modal .project.thumb.selected {
-  background-color: #ddd;
-  box-shadow: inset 0 0 0 2px var(--scratchr2-primaryColor);
+  border: 1px solid #4d97ff !important;
+  box-shadow: 0 0 0 4px rgba(77, 151, 255, 0.35);
 }
 .modal-footer {
   border-radius: 0 0 16px 16px;


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

### Resolves
Currently, the 2.0 --> 3.0 addon breaks project selection in the `featured-project-modal` modal on profile pages. This fixes that.

**Steps to Reproduce:**
1) Enable the 2.0 --> 3.0 addon
2) Go to your profile page
3) Try changing the featured project

### Changes
Current:
<img width="553" alt="image" src="https://user-images.githubusercontent.com/83728060/143673911-927eb29d-bea5-436b-a4e4-064ca37eb9b8.png">

After:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/83728060/143673550-0a425ae0-9f11-4365-82a1-6a0940522bfa.png">

### Tests
Tested on Firefox 95 and Edge 97
