### PR TITLE
fix(addon): `customize-avatar-border` - hide `Outline color` when `Hide outline` is off

### DIFF
--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -58,7 +58,12 @@
       "id": "outline-color",
       "type": "color",
       "allowTransparency": true,
-      "default": "#4d97ff40"
+      "default": "#4d97ff40",
+      "if": {
+        "settings": {
+          "hide-outline": false
+        }
+      }
     }
   ],
   "tags": ["community", "theme"],


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/819307061493760031/913834834156199976/unknown.png