### PR TITLE
`script-snap`: remove the default preset

### DIFF
--- a/addons/script-snap/addon.json
+++ b/addons/script-snap/addon.json
@@ -45,13 +45,6 @@
       "values": {
         "grid": 24
       }
-    },
-    {
-      "name": "Default",
-      "id": "default",
-      "values": {
-        "grid": 40
-      }
     }
   ],
   "dynamicEnable": true,


### PR DESCRIPTION
Resolves #3864

### Changes

Removes the `Default` preset from `script-snap`.

### Reason for changes

Most add-ons don't have a default preset and the reset button does the same thing.

### Tests

I didn't test it because I'm on mobile right now.