### PR TITLE
onion-skinning: Improve performance and fix bugs

### DIFF
--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -261,13 +261,13 @@ export default async function ({ addon, global, console, msg }) {
 
       paper.project.importSVG(asset, {
         expandShapes: true,
+        insert: false,
         onLoad: (root) => {
           if (!root) {
             reject(new Error("could not load onion skin"));
             return;
           }
 
-          root.remove();
           root.opacity = opacity;
 
           // https://github.com/LLK/scratch-paint/blob/cdf0afc217633e6cfb8ba90ea4ae38b79882cf6c/src/containers/paper-canvas.jsx#L274-L275

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -232,6 +232,32 @@ export default async function ({ addon, global, console, msg }) {
     return Promise.all(promises);
   };
 
+  const rasterizeVector = (root) => {
+    const MAX_SIZE = 4096;
+    const bounds = root.strokeBounds;
+    let resolution = 4;
+    if (bounds.width * resolution > MAX_SIZE) {
+      resolution = MAX_SIZE / bounds.width;
+    }
+    if (bounds.height * resolution > MAX_SIZE) {
+      resolution = MAX_SIZE / bounds.height;
+    }
+
+    const raster = root.rasterize(
+      // resolution
+      72 * resolution,
+      // insert
+      false,
+      // bound rect
+      bounds
+    );
+    raster.guide = true;
+    raster.locked = true;
+    raster.position = root.position;
+
+    return raster;
+  };
+
   const makeVectorOnion = (opacity, costume, asset, isBefore) =>
     new Promise((resolve, reject) => {
       const { rotationCenterX, rotationCenterY } = costume;
@@ -306,29 +332,7 @@ export default async function ({ addon, global, console, msg }) {
           root.translate(paperCenter.subtract(root.bounds.width, root.bounds.height));
         }
 
-        const MAX_SIZE = 4096;
-        const bounds = root.strokeBounds;
-        let resolution = 5;
-        if (bounds.width * resolution > MAX_SIZE) {
-          resolution = MAX_SIZE / bounds.width;
-        }
-        if (bounds.height * resolution > MAX_SIZE) {
-          resolution = MAX_SIZE / bounds.height;
-        }
-
-        const raster = root.rasterize(
-          // resolution
-          72 * resolution,
-          // insert
-          false,
-          // bound rect
-          bounds
-        );
-        raster.guide = true;
-        raster.locked = true;
-        raster.position = root.position;
-
-        return raster;
+        return rasterizeVector(root);
       };
 
       paper.project.importSVG(asset, {

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -11,9 +11,7 @@ export default async function ({ addon, global, console, msg }) {
     // The check can technically fail when Redux isn't supported (rare cases)
     // Just ignore in this case
   }
-  const REACT_INTERNAL_PREFIX = "__reactInternalInstance$";
-  const reactInternalKey = Object.keys(paintEditorCanvasContainer).find((i) => i.startsWith(REACT_INTERNAL_PREFIX));
-  const paperCanvas = paintEditorCanvasContainer[reactInternalKey].child.child.child.stateNode;
+  const paperCanvas = paintEditorCanvasContainer[addon.tab.traps.getInternalKey(paintEditorCanvasContainer)].child.child.child.stateNode;
 
   let paperCenter;
   const storedOnionLayers = [];

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -164,27 +164,18 @@ export default async function ({ addon, global, console, msg }) {
     if (!project) {
       return;
     }
-    const onions = [];
-    for (const layer of project.layers) {
-      if (layer.data.sa_isOnionLayer) {
-        onions.push(layer);
-      }
+    const onionLayer = project.layers.find((i) => i.data.sa_isOnionLayer);
+    if (!onionLayer) {
+      return;
     }
-    onions.sort((a, b) => a.data.sa_onionIndex - b.data.sa_onionIndex);
     if (settings.layering === "front") {
-      for (const layer of onions) {
-        project.addLayer(layer);
-      }
+      project.addLayer(onionLayer);
     } else {
       const rasterLayer = project.layers.find((i) => i.data.isRasterLayer);
       if (rasterLayer.index === 0) {
-        for (const layer of onions) {
-          project.insertLayer(0, layer);
-        }
+        project.insertLayer(0, onionLayer);
       } else {
-        for (const layer of onions) {
-          project.insertLayer(1, layer);
-        }
+        project.insertLayer(1, onionLayer);
       }
     }
   };
@@ -451,9 +442,8 @@ export default async function ({ addon, global, console, msg }) {
         })
       );
 
-      for (const [index, item] of Object.entries(onions)) {
-        const layer = createOnionLayer();
-        layer.data.sa_onionIndex = index;
+      const layer = createOnionLayer();
+      for (const item of onions) {
         layer.addChild(item);
       }
 

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -249,7 +249,14 @@ export default async function ({ addon, global, console, msg }) {
     let renderedAtScale = 0;
     const originalDraw = raster.draw;
     raster.draw = function (...args) {
-      const newScale = Math.max(1, Math.min(maxScale, Math.ceil(this.getView().getZoom() * window.devicePixelRatio)));
+      const displayedSize = this.getView().getZoom() * window.devicePixelRatio;
+      const newScale = Math.max(
+        1,
+        Math.min(
+          maxScale,
+          2 ** Math.ceil(Math.log2(displayedSize))
+        )
+      );
       if (newScale > renderedAtScale) {
         renderedAtScale = newScale;
         const canvas = this.canvas;

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -372,6 +372,7 @@ export default async function ({ addon, global, console, msg }) {
         const y = height / 2 + (paperCenter.y - rotationCenterY);
         raster.position = new paper.Point(x, y);
         raster.drawImage(image, 0, 0);
+        raster.remove();
 
         if (settings.mode === "tint") {
           tintRaster(raster, isBefore);

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -320,7 +320,29 @@ export default async function ({ addon, global, console, msg }) {
             root.translate(paperCenter.subtract(root.bounds.width, root.bounds.height));
           }
 
-          layer.addChild(root);
+          const MAX_SIZE = 4096;
+          const bounds = root.strokeBounds;
+          let resolution = 5;
+          if (bounds.width * resolution > MAX_SIZE) {
+            resolution = MAX_SIZE / bounds.width;
+          }
+          if (bounds.height * resolution > MAX_SIZE) {
+            resolution = MAX_SIZE / bounds.height;
+          }
+
+          const raster = root.rasterize(
+            // resolution
+            72 * resolution,
+            // insert
+            false,
+            // bound rect
+            bounds
+          );
+          raster.parent = layer;
+          raster.guide = true;
+          raster.locked = true;
+          raster.position = root.position;
+
           resolve();
         },
       });

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -237,32 +237,27 @@ export default async function ({ addon, global, console, msg }) {
     const {width, height} = bounds;
 
     const MAX_SIZE = 4096;
-    let maxResolution = 5;
-    if (width * maxResolution > MAX_SIZE) {
-      maxResolution = MAX_SIZE / width;
-    }
-    if (height * maxResolution > MAX_SIZE) {
-      maxResolution = MAX_SIZE / height;
-    }
+    const maxScale = Math.min(MAX_SIZE / width, MAX_SIZE / height);
 
     const raster = new paper.Raster(new paper.Size(width, height));
     raster.remove();
+    raster.smoothing = true;
 
     raster.guide = true;
     raster.locked = true;
 
-    let renderedAtResolution = 0;
+    let renderedAtScale = 0;
     const originalDraw = raster.draw;
     raster.draw = function (...args) {
-      const newResolution = Math.max(1, Math.min(maxResolution, Math.ceil(this.getView().getZoom())));
-      if (newResolution > renderedAtResolution) {
-        renderedAtResolution = newResolution;
+      const newScale = Math.max(1, Math.min(maxScale, Math.ceil(this.getView().getZoom() * window.devicePixelRatio)));
+      if (newScale > renderedAtScale) {
+        renderedAtScale = newScale;
         const canvas = this.canvas;
         const ctx = this.context;
 
         // Based on https://github.com/LLK/paper.js/blob/16d5ff0267e3a0ef647c25e58182a27300afad20/src/item/Item.js#L1761
-        const scaledWidth = width * newResolution;
-        const scaledHeight = height * newResolution;
+        const scaledWidth = width * newScale;
+        const scaledHeight = height * newScale;
         canvas.width = scaledWidth;
         canvas.height = scaledHeight;
 
@@ -270,7 +265,7 @@ export default async function ({ addon, global, console, msg }) {
         const topLeft = bounds.getTopLeft().floor();
         const bottomRight = bounds.getBottomRight().ceil();
         const size = new paper.Size(bottomRight.subtract(topLeft));
-        const matrix = new paper.Matrix().scale(newResolution).translate(topLeft.negate());
+        const matrix = new paper.Matrix().scale(newScale).translate(topLeft.negate());
         ctx.save();
         matrix.applyToContext(ctx);
         root.draw(ctx, new paper.Base({
@@ -281,7 +276,7 @@ export default async function ({ addon, global, console, msg }) {
         this.transform(
           new paper.Matrix()
             .translate(topLeft.add(size.divide(2)))
-            .scale(1 / newResolution)
+            .scale(1 / newScale)
         );
       }
 

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -558,8 +558,8 @@ export default async function ({ addon, global, console, msg }) {
     return el;
   };
 
-  const createButton = () => {
-    const el = document.createElement("span");
+  const createButton = ({ useButtonTag } = {}) => {
+    const el = document.createElement(useButtonTag ? "button" : "span");
     el.className = "sa-onion-button";
     el.setAttribute("role", "button");
     return el;
@@ -690,7 +690,7 @@ export default async function ({ addon, global, console, msg }) {
   modeLabel.textContent = msg("mode");
   const modeGroup = createGroup();
   modeContainer.appendChild(modeLabel);
-  const modeMergeButton = createButton();
+  const modeMergeButton = createButton({ useButtonTag: true });
   modeMergeButton.appendChild(document.createTextNode(msg("merge")));
   modeGroup.appendChild(modeMergeButton);
   modeMergeButton.addEventListener("click", (e) => {
@@ -700,7 +700,7 @@ export default async function ({ addon, global, console, msg }) {
     settingsChanged();
   });
   modeMergeButton.dataset.enabled = settings.mode === "merge";
-  const modeTintButton = createButton();
+  const modeTintButton = createButton({ useButtonTag: true });
   modeTintButton.appendChild(document.createTextNode(msg("tint")));
   modeGroup.appendChild(modeTintButton);
   modeTintButton.addEventListener("click", (e) => {
@@ -720,7 +720,7 @@ export default async function ({ addon, global, console, msg }) {
   layeringLabel.textContent = msg("layering");
   const layeringGroup = createGroup();
   layeringContainer.appendChild(layeringLabel);
-  const layeringFrontButton = createButton();
+  const layeringFrontButton = createButton({ useButtonTag: true });
   layeringFrontButton.appendChild(document.createTextNode(msg("front")));
   layeringGroup.appendChild(layeringFrontButton);
   layeringFrontButton.addEventListener("click", (e) => {
@@ -730,7 +730,7 @@ export default async function ({ addon, global, console, msg }) {
     settingsChanged(true);
   });
   layeringFrontButton.dataset.enabled = settings.layering === "front";
-  const layeringBehindButton = createButton();
+  const layeringBehindButton = createButton({ useButtonTag: true });
   layeringBehindButton.appendChild(document.createTextNode(msg("behind")));
   layeringGroup.appendChild(layeringBehindButton);
   layeringBehindButton.addEventListener("click", (e) => {

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -126,14 +126,6 @@ export default async function ({ addon, global, console, msg }) {
     paperCanvas.importImage = PaperCanvas.prototype.importImage.bind(paperCanvas);
   };
 
-  const createCanvas = (width, height) => {
-    const canvas = document.createElement("canvas");
-    canvas.width = width;
-    canvas.height = height;
-    canvas.getContext("2d").imageSmoothingEnabled = false;
-    return canvas;
-  };
-
   const createOnionLayer = () => {
     const layer = new paper.Layer();
     layer.locked = true;
@@ -355,14 +347,13 @@ export default async function ({ addon, global, console, msg }) {
           rotationCenterY = height / 2;
         }
 
-        const raster = new paper.Raster(createCanvas(width, height));
+        const raster = new paper.Raster(image);
         raster.opacity = opacity;
         raster.guide = true;
         raster.locked = true;
         const x = width / 2 + (paperCenter.x - rotationCenterX);
         const y = height / 2 + (paperCenter.y - rotationCenterY);
         raster.position = new paper.Point(x, y);
-        raster.drawImage(image, 0, 0);
         raster.remove();
 
         if (settings.mode === "tint") {

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -610,7 +610,7 @@ export default async function ({ addon, global, console, msg }) {
 
   const layerInputs = {};
   for (const type of ["previous", "next", "opacity", "opacityStep"]) {
-    const container = document.createElement("div");
+    const container = document.createElement("label");
     container.className = "sa-onion-settings-line";
 
     const label = document.createElement("div");

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -218,10 +218,10 @@ export default async function ({ addon, global, console, msg }) {
       if (alpha === 0) {
         continue;
       }
-      const [newRed, newGreen, newBlue] = getTint(red, green, blue, isBefore);
-      data[i + 0] = newRed;
-      data[i + 1] = newGreen;
-      data[i + 2] = newBlue;
+      const newTint = getTint(red, green, blue, isBefore);
+      data[i + 0] = newTint[0];
+      data[i + 1] = newTint[1];
+      data[i + 2] = newTint[2];
     }
     context.putImageData(imageData, 0, 0);
   };

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -11,7 +11,8 @@ export default async function ({ addon, global, console, msg }) {
     // The check can technically fail when Redux isn't supported (rare cases)
     // Just ignore in this case
   }
-  const paperCanvas = paintEditorCanvasContainer[addon.tab.traps.getInternalKey(paintEditorCanvasContainer)].child.child.child.stateNode;
+  const paperCanvas =
+    paintEditorCanvasContainer[addon.tab.traps.getInternalKey(paintEditorCanvasContainer)].child.child.child.stateNode;
 
   let paperCenter;
   const storedOnionLayers = [];
@@ -230,10 +231,12 @@ export default async function ({ addon, global, console, msg }) {
     const promises = [];
     recursePaperItem(root, (item) => {
       if (item instanceof paper.Raster) {
-        promises.push(new Promise((resolve, reject) => {
-          item.on('load', () => resolve());
-          item.on('error', () => reject(new Error('Raster inside SVG failed to load')));
-        }));
+        promises.push(
+          new Promise((resolve, reject) => {
+            item.on("load", () => resolve());
+            item.on("error", () => reject(new Error("Raster inside SVG failed to load")));
+          })
+        );
       }
     });
     return Promise.all(promises);
@@ -241,7 +244,7 @@ export default async function ({ addon, global, console, msg }) {
 
   const rasterizeVector = (root) => {
     const bounds = root.strokeBounds;
-    const {width, height} = bounds;
+    const { width, height } = bounds;
 
     const MAX_SIZE = 4096;
     const maxScale = Math.min(MAX_SIZE / width, MAX_SIZE / height);
@@ -257,13 +260,7 @@ export default async function ({ addon, global, console, msg }) {
     const originalDraw = raster.draw;
     raster.draw = function (...args) {
       const displayedSize = this.getView().getZoom() * window.devicePixelRatio;
-      const newScale = Math.max(
-        1,
-        Math.min(
-          maxScale,
-          2 ** Math.ceil(Math.log2(displayedSize))
-        )
-      );
+      const newScale = Math.max(1, Math.min(maxScale, 2 ** Math.ceil(Math.log2(displayedSize))));
       if (newScale > renderedAtScale) {
         renderedAtScale = newScale;
         const canvas = this.canvas;
@@ -282,16 +279,15 @@ export default async function ({ addon, global, console, msg }) {
         const matrix = new paper.Matrix().scale(newScale).translate(topLeft.negate());
         ctx.save();
         matrix.applyToContext(ctx);
-        root.draw(ctx, new paper.Base({
-          matrices: [matrix]
-        }));
+        root.draw(
+          ctx,
+          new paper.Base({
+            matrices: [matrix],
+          })
+        );
         ctx.restore();
         this.matrix.reset();
-        this.transform(
-          new paper.Matrix()
-            .translate(topLeft.add(size.divide(2)))
-            .scale(1 / newScale)
-        );
+        this.transform(new paper.Matrix().translate(topLeft.add(size.divide(2))).scale(1 / newScale));
       }
 
       return originalDraw.call(this, ...args);
@@ -476,12 +472,12 @@ export default async function ({ addon, global, console, msg }) {
         layersToCreate.push({
           index: i,
           isBefore,
-          opacity
+          opacity,
         });
       }
 
       const onions = await Promise.all(
-        layersToCreate.map(({index, isBefore, opacity}) => {
+        layersToCreate.map(({ index, isBefore, opacity }) => {
           const onionCostume = costumes[index];
           const onionAsset = vm.getCostume(index);
 

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -344,8 +344,8 @@ export default async function ({ addon, global, console, msg }) {
 
       const image = new Image();
       image.onload = () => {
-        const width = Math.min(960, image.width);
-        const height = Math.min(720, image.height);
+        const width = Math.min(paperCenter.x * 2, image.width);
+        const height = Math.min(paperCenter.y * 2, image.height);
 
         // https://github.com/LLK/scratch-paint/blob/cdf0afc217633e6cfb8ba90ea4ae38b79882cf6c/src/containers/paper-canvas.jsx#L151-L156
         if (typeof rotationCenterX === "undefined") {


### PR DESCRIPTION
 - Fixes #1661 by converting vector onion layers to bitmap internally, which improves performance and fixes crashes. They're dynamically rendered up to 4096px wide/tall, so quality doesn't suffer unless you zoom in very far.
 - Fixes #3872. All onion layers will be displayed at the same time. Bitmap onion layers also load faster now because they're loaded in parallel.
 - Other performance improvements
