### PR TITLE
Integer stepping

### DIFF
--- a/addons/custom-block-shape/addon.json
+++ b/addons/custom-block-shape/addon.json
@@ -38,6 +38,7 @@
       "type": "integer",
       "min": 50,
       "default": 100,
+      "step": 10,
       "max": 200
     },
     {
@@ -46,6 +47,7 @@
       "type": "integer",
       "min": 0,
       "default": 100,
+      "step": 10,
       "max": 300
     },
     {
@@ -54,6 +56,7 @@
       "type": "integer",
       "min": 0,
       "default": 100,
+      "step": 10,
       "max": 150
     }
   ],
@@ -75,7 +78,7 @@
       "values": {
         "paddingSize": 70,
         "cornerSize": 150,
-        "notchSize": 75
+        "notchSize": 70
       }
     },
     {

--- a/addons/custom-block-shape/addon.json
+++ b/addons/custom-block-shape/addon.json
@@ -38,7 +38,7 @@
       "type": "integer",
       "min": 50,
       "default": 100,
-      "step": 10,
+      "step": 5,
       "max": 200
     },
     {
@@ -56,7 +56,7 @@
       "type": "integer",
       "min": 0,
       "default": 100,
-      "step": 10,
+      "step": 5,
       "max": 150
     }
   ],
@@ -78,7 +78,7 @@
       "values": {
         "paddingSize": 70,
         "cornerSize": 150,
-        "notchSize": 70
+        "notchSize": 75
       }
     },
     {

--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -28,32 +28,36 @@
       "id": "maxZoom",
       "type": "integer",
       "min": 100,
-      "default": 300,
-      "max": 500
+      "max": 500,
+      "step": 10,
+      "default": 300
     },
     {
-      "name": "Minimum Zoom (1-100%)",
+      "name": "Minimum Zoom (10-100%)",
       "id": "minZoom",
       "type": "integer",
-      "min": 1,
-      "default": 30,
-      "max": 100
+      "min": 10,
+      "max": 100,
+      "step": 10,
+      "default": 30
     },
     {
       "name": "Start Zoom (50-500%)",
       "id": "startZoom",
       "type": "integer",
       "min": 50,
-      "default": 68,
-      "max": 500
+      "max": 500,
+      "step": 10,
+      "default": 70
     },
     {
       "name": "Zoom Speed (50-200%)",
       "id": "zoomSpeed",
       "type": "integer",
       "min": 50,
-      "default": 100,
-      "max": 200
+      "max": 200,
+      "step": 10,
+      "default": 100
     },
     {
       "name": "Autohide Zoom Controls",

--- a/addons/onion-skinning/addon.json
+++ b/addons/onion-skinning/addon.json
@@ -47,7 +47,8 @@
       "type": "integer",
       "min": 0,
       "max": 100,
-      "default": 25
+      "default": 25,
+      "step": 5
     },
     {
       "id": "opacityStep",
@@ -55,7 +56,8 @@
       "type": "integer",
       "min": 0,
       "max": 100,
-      "default": 10
+      "default": 10,
+      "step": 5
     },
     {
       "id": "layering",

--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -21,6 +21,7 @@
       "type": "integer",
       "min": 0,
       "max": 100,
+      "step": 5,
       "default": 0
     },
     {
@@ -29,6 +30,7 @@
       "type": "integer",
       "min": 0,
       "max": 100,
+      "step": 5,
       "default": 25
     },
     {
@@ -37,6 +39,7 @@
       "type": "integer",
       "min": 0,
       "max": 100,
+      "step": 5,
       "default": 25
     }
   ],

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -52,6 +52,7 @@
           :disabled="!addon._enabled"
           :min="setting.min"
           :max="setting.max"
+          :step="setting.step"
           :data-addon-id="addon._addonId"
           :data-setting-id="setting.id"
           number


### PR DESCRIPTION
Resolves #3860

### Changes

Allows setting the `step` property through the add-on manifest and applies it to a few add-ons.

Some other values have also been changed:

- ~~The 2.0 block notch size is now 70 (used to be 75)~~
- The minimum zoom is now 10 (used to be 1)
- The default starting zoom is now 70 (used to be 68)

### Reason for changes

It makes changing integer values with the arrows easier.

### Tests

Tested on Edge 96.