### PR TITLE
Fix ocular reaction buttons when both dark mode and 2.0 → 3.0 are enabled

### DIFF
--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -180,12 +180,11 @@
   padding: 8px;
 }
 .my-ocular-reaction-button {
-  background-color: #f2f2f2;
   box-shadow: 0 0 2px #0fbd8c;
 }
 .my-ocular-reaction-button.selected {
   background-color: #0fbd8c;
 }
 .my-ocular-popup {
-  color: #575e75;
+  color: var(--darkWww-input-text, #575e75);
 }


### PR DESCRIPTION
### Changes

Text on ocular reaction buttons was unreadable when website dark mode and Scratch 2.0 → 3.0 were enabled. This fixes it.