### PR TITLE
editor-comment-previews: Fix a couple small bugs

### DIFF
--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -91,7 +91,12 @@ export default async function ({ addon, global, console }) {
     }
 
     let text = null;
-    if (addon.settings.get("hover-view") && e.target.closest(".blocklyBubbleCanvas g")) {
+    if (
+      addon.settings.get("hover-view") &&
+      e.target.closest(".blocklyBubbleCanvas g") &&
+      // Hovering over the thin line that connects comments to blocks should never show a preview
+      !e.target.closest("line")
+    ) {
       const collapsedText = el.querySelector("text.scratchCommentText");
       if (collapsedText.getAttribute("display") !== "none") {
         const textarea = el.querySelector("textarea");

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -80,7 +80,7 @@ export default async function ({ addon, global, console }) {
       return;
     }
 
-    const el = e.target.closest(".blocklyBubbleCanvas g, .blocklyBlockCanvas .blocklyDraggable[data-id]");
+    const el = e.target.closest(".blocklyBubbleCanvas > g, .blocklyBlockCanvas .blocklyDraggable[data-id]");
     if (el === hoveredElement) {
       // Nothing to do.
       return;
@@ -93,7 +93,7 @@ export default async function ({ addon, global, console }) {
     let text = null;
     if (
       addon.settings.get("hover-view") &&
-      e.target.closest(".blocklyBubbleCanvas g") &&
+      e.target.closest(".blocklyBubbleCanvas > g") &&
       // Hovering over the thin line that connects comments to blocks should never show a preview
       !e.target.closest("line")
     ) {


### PR DESCRIPTION
 - Don't display comment preview when hovering over the thin line that connects comments to their block. It was too small to be useful for actually wanting to read a preview but it was possible to accidentally trigger.
 - Fixed uncaught errors when resizing comments (didn't actually break anything)
