### PR TITLE
onion-skinning: Lower max size of rasterized vectors to improve performance

### DIFF
--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -246,7 +246,8 @@ export default async function ({ addon, global, console, msg }) {
     const bounds = root.strokeBounds;
     const { width, height } = bounds;
 
-    const MAX_SIZE = 4096;
+    // Some browsers experience extremely poor performance when this value exceeds 3840.
+    const MAX_SIZE = 3000;
     const maxScale = Math.min(MAX_SIZE / width, MAX_SIZE / height);
 
     const raster = new paper.Raster(new paper.Size(width, height));


### PR DESCRIPTION
Further testing shows some browsers have a significant performance issue when dealing with images larger than 3840px that can make the costume editor unusably slow, so lower the maximum size of rasterized vector layers to be under that.
