### PR TITLE
fix(addon): `better-img-uploads` - scale image properly

### DIFF
--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -177,7 +177,9 @@ export default async function ({ addon, console, msg }) {
       processed.push(
         new File( //Create the svg file
           [
-            `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0,0,${dim.width},${dim.height}" width="${dim.width}" height="${dim.height}">
+            `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0,0,${
+              dim.width
+            },${dim.height}" width="${dim.width}" height="${dim.height}">
         <g>
           <g
               data-paper-data='{"isPaintingLayer":true}'

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -177,9 +177,7 @@ export default async function ({ addon, console, msg }) {
       processed.push(
         new File( //Create the svg file
           [
-            `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0,0,${
-              dim.width
-            },${dim.height}" width="${dim.width}" height="${dim.height}">
+            `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0,0,${dim.width},${dim.height}" width="${dim.width}" height="${dim.height}">
         <g>
           <g
               data-paper-data='{"isPaintingLayer":true}'

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -115,6 +115,7 @@ export default async function ({ addon, console, msg }) {
       });
 
       let dim = { width: i.width, height: i.height };
+	  const originalDim = JSON.parse(JSON.stringify(dim));
 
       if (mode === "fit") {
         //Make sure the image fits completely in the stage
@@ -192,8 +193,9 @@ export default async function ({ addon, console, msg }) {
               style="mix-blend-mode: normal;"
           >
             <image
-                width="${dim.width}"
-                height="${dim.height}"
+                width="${originalDim.width}"
+                height="${originalDim.height}"
+				transform="scale(${dim.width / originalDim.width},${dim.height / originalDim.height})"
                 xlink:href="${blob}"
             />
           </g>

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -115,7 +115,7 @@ export default async function ({ addon, console, msg }) {
       });
 
       let dim = { width: i.width, height: i.height };
-	  const originalDim = JSON.parse(JSON.stringify(dim));
+      const originalDim = JSON.parse(JSON.stringify(dim));
 
       if (mode === "fit") {
         //Make sure the image fits completely in the stage
@@ -177,7 +177,9 @@ export default async function ({ addon, console, msg }) {
       processed.push(
         new File( //Create the svg file
           [
-            `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0,0,${dim.width},${dim.height}" width="${dim.width}" height="${dim.height}">
+            `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0,0,${
+              dim.width
+            },${dim.height}" width="${dim.width}" height="${dim.height}">
         <g>
           <g
               data-paper-data='{"isPaintingLayer":true}'


### PR DESCRIPTION
Resolves [this suggestion](https://discord.com/channels/806602307750985799/806609030935740477/901762244633825330)

### Changes

In the HD image upload addon, sets the transform property to scale the image instead of setting the width and height parameters (which cause Scratch to pixelate the image, which we don't want).

### Reason for changes

This makes HD image uploads actually HD in the `Stretch to fill stage` and `Shrink to fit stage` modes.

### Tests

Tested 5 different test images in all 3 modes in Firefox. The image wasn't pixelated in any of them.
Test images used in case you want to test yourself:
* [Image 1](https://user-images.githubusercontent.com/68464103/145687920-54933d17-3ef3-4759-ad50-aa37d589fcf8.png) (1000x1000)
* [Image 2](https://user-images.githubusercontent.com/68464103/145687922-6084ff49-87ed-430e-8343-a916bbf02143.png) (300x300)
* [Image 3](https://user-images.githubusercontent.com/68464103/145687924-f4684762-b4e6-4f71-b7e7-49e49f322e3e.png) (950x710)
* [Image 4](https://user-images.githubusercontent.com/68464103/145687925-f398c3fc-5c31-4452-aa9a-7df5078fa460.png) (700x200)
* [Image 5](https://user-images.githubusercontent.com/68464103/145687926-52610c7f-5192-49f1-94ae-3451e744135b.png) (100x100; probably isn't needed as it is basically the same as image 1 but in a different size)

(Note: Due to the nature of those images, they might appear stretched in the project player and in the paint editor at default zoom. Zoom in to see the real resolution.)
