### PR TITLE
fix(addon): `customize-avatar-border` - don't hide `Outline color` when `Fill transparent profile pictures` is on

### DIFF
--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -62,7 +62,7 @@
       "if": {
         "settings": {
           "hide-outline": false,
-		  "fill-transparent": true
+          "fill-transparent": true
         }
       }
     }

--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -61,7 +61,8 @@
       "default": "#4d97ff40",
       "if": {
         "settings": {
-          "hide-outline": false
+          "hide-outline": false,
+		  "fill-transparent": true
         }
       }
     }


### PR DESCRIPTION
Response to #3866

### Changes

In the "Customizable profile picture border" addon, also shows the "Outline color" option when the "Fill transparent profile pictures" option is on.

### Reason for changes

The "Fill transparent profile pictures" option also uses the "Outline color" option for its color, so it doesn't make sense to hide it when that option's on.

### Tests

Works.
![](https://user-images.githubusercontent.com/68464103/145688574-b140f3af-64b5-4034-9823-e75970e4033a.png)
