### PR TITLE
High res thumbnails: Downscaling + Special cases for larger-than-rendered dimensions

### DIFF
--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -41,10 +41,7 @@ export default async function ({ addon, console }) {
     // account browser scaling or high-DPI screens. That's good, because we
     // want to leave the actual resolution-increase factor completely up to
     // the addon user/settings!
-    let {
-      width: widthRect,
-      height: heightRect
-    } = image.getBoundingClientRect();
+    let { width: widthRect, height: heightRect } = image.getBoundingClientRect();
 
     // If we've only got partial or no apparent displayed dimensions, and
     // width/height HTML attributes are provided, fall back to those. For some

--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -54,7 +54,7 @@ export default async function ({ addon, console }) {
 
     let widthMax, heightMax;
 
-    if (image.classList.contains('studio-project-image')) {
+    if (image.classList.contains("studio-project-image")) {
       widthMax = 347;
       heightMax = 260;
     }

--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -20,7 +20,7 @@ export default async function ({ addon, console }) {
       continue main;
     }
 
-    [width, height] = fixLowRes(width, height, image);
+    [width, height] = resizeToScreenRes(width, height, image);
     [width, height] = scaleDimensions(width, height);
 
     if (cdn2) {
@@ -36,24 +36,45 @@ export default async function ({ addon, console }) {
     }
   }
 
-  function fixLowRes(width, height, image) {
+  function resizeToScreenRes(width, height, image) {
     // Note this returns a value in CSS pixel units, i.e. it doesn't take into
     // account browser scaling or high-DPI screens. That's good, because we
     // want to leave the actual resolution-increase factor completely up to
     // the addon user/settings!
     const rect = image.getBoundingClientRect();
 
-    // Use greater of both scales to choose the dimension which needs the most
-    // scaling and to maintain the ratio between the rendered and loaded
-    // dimensions.
-    const scale = Math.max(rect.width / width, rect.height / height);
+    // It's possible that the Scratch site is deliberately loading an image at
+    // a greater resolution than it displays at - because with dynamic layout,
+    // if the screen (window) resizes, the image may later be displayed larger.
+    //
+    // If there's an arbitrarily determined "maximum" size for this image, we
+    // should use that as the target dimensions instead. (Unless it's
+    // incidentally smaller, in which case, fall back to the greater [rendered]
+    // dimensions.)
 
-    if (scale > 1) {
-      width *= scale;
-      height *= scale;
+    let widthMax, heightMax;
+
+    if (image.classList.contains('studio-project-image')) {
+      widthMax = 347;
+      heightMax = 260;
     }
 
-    return [width, height];
+    // Use greater of scales across both axes to choose the dimension which
+    // needs the most scaling and to maintain the ratio between the rendered and
+    // loaded dimensions.
+    let scale = Math.max(rect.width / width, rect.height / height);
+
+    // Calculate scale for "maximum" dimensions, and use it instead - but only
+    // if it's greater than the actual scale. Theoretically, max possible
+    // always be >= actual, but if Scratch CSS changes and this addon is
+    // outdated, it's better to prefer the actual displayed dimensions as the
+    // basis we apply the resolution multiplier to later.
+    if (widthMax) {
+      const scaleMax = Math.max(widthMax / width, heightMax / height);
+      scale = Math.max(scale, scaleMax);
+    }
+
+    return [width * scale, height * scale];
   }
 
   function scaleDimensions(width, height) {

--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -14,15 +14,15 @@ export default async function ({ addon, console }) {
 
     // If the image is from uploads.scratch.mit.edu, reformat src so it looks
     // like a cdn2 URL.
-    if (src.includes('uploads.scratch.mit.edu')) {
+    if (src.includes("uploads.scratch.mit.edu")) {
       const id = src.match(/[0-9]+/);
-      if (src.includes('projects')) {
+      if (src.includes("projects")) {
         // Project thumbnails are always 480x360.
         src = `//cdn2.scratch.mit.edu/get_image/project/${id}_480x360.png`;
-      } else if (src.includes('users')) {
+      } else if (src.includes("users")) {
         // Max user avatar size is 500x500.
         src = `//cdn2.scratch.mit.edu/get_image/user/${id}_500x500.png`;
-      } else if (src.includes('galleries')) {
+      } else if (src.includes("galleries")) {
         // Max studio thumbnail size is 500x500.
         src = `//cdn2.scratch.mit.edu/get_image/gallery/${id}_500x500.png`;
       }

--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -5,9 +5,28 @@ export default async function ({ addon, console }) {
     });
 
     const lazy = image.classList.contains("lazy");
-    const src = lazy ? image.dataset.original : image.src;
+    let src = lazy ? image.dataset.original : image.src;
 
+    // Don't process data: URLs, since these are never thumbnails to be upsized,
+    // and can be lengthy strings - which really does cause issues when it comes
+    // to the cdn2 regex!
     if (src.startsWith("data:")) continue;
+
+    // If the image is from uploads.scratch.mit.edu, reformat src so it looks
+    // like a cdn2 URL.
+    if (src.includes('uploads.scratch.mit.edu')) {
+      const id = src.match(/[0-9]+/);
+      if (src.includes('projects')) {
+        // Project thumbnails are always 480x360.
+        src = `//cdn2.scratch.mit.edu/get_image/project/${id}_480x360.png`;
+      } else if (src.includes('users')) {
+        // Max user avatar size is 500x500.
+        src = `//cdn2.scratch.mit.edu/get_image/user/${id}_500x500.png`;
+      } else if (src.includes('galleries')) {
+        // Max studio thumbnail size is 500x500.
+        src = `//cdn2.scratch.mit.edu/get_image/gallery/${id}_500x500.png`;
+      }
+    }
 
     let width, height, newSrc;
 


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #3893.

**Not a blocker for release,** but would be nice to have!

### Changes

<!-- Please describe the changes you've made. -->

Two major tweaks:

1. Downscale images when the default resolution is larger than it's actually displayed at.
2. Use arbitrarily determined dimensions as the basis for images which may dynamically be displayed larger than they currently are (only current case: studio project thumbnails).

~~**Still need to do this third change before worth merging:**~~ Done!

3. Auto-replace `projects.scratch.mit.edu` images with cdn2 480x360 images as a preprocessing step—this will generally be downscaled to whatever size the image is actually displayed at (e.g. on the homepage 145x110).

### Reason for changes

Save people's network data by not loading higher resolutions than needed! But also, in doing that, don't accidentally make images look bad (when dynamically displayed at larger than initial dimensions).

### Tests

Tested manually. To address the concerns I brought up [here](https://github.com/ScratchAddons/ScratchAddons/issues/3893#issuecomment-988213266):

> Make sure containers don't have smaller dimensions before the image is loaded. I.e, if a container is 200px by 0px before its content image has loaded, we don't want to scale down to that zero height dimension!

There don't seem to be any cases of this—Scratch specifically sets images to particular sizes so that the layout doesn't "blink" before the image loads.

> Make sure we're operating before images initially load, in the first place—downscaling is pointless if it only happens after the higher resolution has loaded.

We do! See `"runAtComplete": false`. I verified this by looking at the network log (with caching disabled) and made sure it wasn't loading duplicate images (i.e. not both the initial resolution and the modified one).

> We should deliberately replace images loaded from projects.scratch.mit.edu with corresponding cdn2 URLs, with the appropriate dimensions. Otherwise, we aren't saving nearly as much network data as we could be!

~~See changes section, this is a todo for this PR (hence marked draft).~~ Done!