### PR TITLE
Fix blue scrollbars on Firefox

### DIFF
--- a/addons/dark-www/darker_banners.css
+++ b/addons/dark-www/darker_banners.css
@@ -29,8 +29,6 @@
 .gradient1 {
   background-image: linear-gradient(#004099, black);
 }
-html,
-body,
 .parents .title-banner.masthead,
 .information-page .title-banner.masthead,
 .download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,

--- a/addons/dark-www/desaturated_banners.css
+++ b/addons/dark-www/desaturated_banners.css
@@ -29,8 +29,6 @@
 .gradient1 {
   background-image: linear-gradient(#334766, black);
 }
-html,
-body,
 .parents .title-banner.masthead,
 .information-page .title-banner.masthead,
 .download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -1,4 +1,6 @@
 /* Page background */
+html,
+body,
 #view,
 .crash-container,
 .semicolon {

--- a/addons/dark-www/experimental_scratchwww_white_bg.css
+++ b/addons/dark-www/experimental_scratchwww_white_bg.css
@@ -1,3 +1,5 @@
+html,
+body,
 #view {
   background-color: var(--darkWww-box);
   color: var(--darkWww-box-text);

--- a/addons/dark-www/experimental_search.css
+++ b/addons/dark-www/experimental_search.css
@@ -1,3 +1,5 @@
+html,
+body,
 #view {
   background-color: var(--darkWww-gray);
 }

--- a/addons/dark-www/scrollbar.css
+++ b/addons/dark-www/scrollbar.css
@@ -4,9 +4,6 @@ body:not(.sa-body-editor) ::-webkit-scrollbar {
   height: 17px;
   background: transparent;
 }
-body:not(.sa-body-editor)::-webkit-scrollbar {
-  background: var(--darkWww-page);
-}
 body:not(.sa-body-editor)::-webkit-scrollbar-thumb,
 body:not(.sa-body-editor) ::-webkit-scrollbar-thumb {
   width: 8px;


### PR DESCRIPTION
Resolves #3939

### Changes

Makes scrollbars on Firefox gray instead of blue. This also affects overscroll background on Edge and background of the window while a Scratch page is loading on all browsers.