### PR TITLE
Fix incorrect icon color on Firefox

### DIFF
--- a/libraries/common/cs/text-color.js
+++ b/libraries/common/cs/text-color.js
@@ -132,7 +132,7 @@ function recolorFilter(hex) {
   return `url("data:image/svg+xml,
     <svg xmlns='http://www.w3.org/2000/svg'>
       <filter id='recolor'>
-        <feColorMatrix values='
+        <feColorMatrix color-interpolation-filters='sRGB' values='
           0 0 0 0 ${r / 255}
           0 0 0 0 ${g / 255}
           0 0 0 0 ${b / 255}


### PR DESCRIPTION
Fixes part of #3938

### Changes

Firefox and Chromium use different default color spaces for SVG filters (Chromium doesn't follow the specification for some reason). This defines the color space explicitly to produce the same result on both browsers.