### PR TITLE
Expose VM

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -113,6 +113,7 @@
   "hi-res-thumbnails",
   "block-count",
   "script-snap",
+  "expose-vm",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/expose-vm/addon.json
+++ b/addons/expose-vm/addon.json
@@ -1,0 +1,14 @@
+{
+  "name": "Expose VM",
+  "description": "Stores a reference to scratch-vm at window.vm",
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "tags": ["editor"],
+  "enabledByDefault": false
+}

--- a/addons/expose-vm/userscript.js
+++ b/addons/expose-vm/userscript.js
@@ -1,0 +1,5 @@
+export default async function ({ addon }) {
+  window.vm = addon.tab.traps.vm;
+  addon.self.addEventListener("disabled", () => {delete window.vm});
+  addon.self.addEventListener("reenabled", () => {window.vm = addon.tab.traps.vm});
+}

--- a/addons/expose-vm/userscript.js
+++ b/addons/expose-vm/userscript.js
@@ -1,5 +1,9 @@
 export default async function ({ addon }) {
   window.vm = addon.tab.traps.vm;
-  addon.self.addEventListener("disabled", () => {delete window.vm});
-  addon.self.addEventListener("reenabled", () => {window.vm = addon.tab.traps.vm});
+  addon.self.addEventListener("disabled", () => {
+    delete window.vm;
+  });
+  addon.self.addEventListener("reenabled", () => {
+    window.vm = addon.tab.traps.vm;
+  });
 }


### PR DESCRIPTION
### Changes

Adds an addon that exposes scratch-vm at window.vm like turbowarp does.

### Reason for changes

It makes messing with scratch-vm easier.

### Tests

It works, including the dynamic enable/disable.
