### PR TITLE
turbowarp-button: add setting to automatically open/replace with TurboWarp

### DIFF
--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -22,7 +22,8 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects"]
+      "matches": ["projects"],
+      "runAtComplete": false
     }
   ],
   "userstyles": [
@@ -49,6 +50,12 @@
       "default": "link"
     },
     {
+      "name": "Automatically open/replace",
+      "id": "auto",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "Enable addons",
       "id": "addons",
       "type": "boolean",
@@ -59,5 +66,9 @@
     }
   ],
   "versionAdded": "1.18.0",
+  "latestUpdate": {
+    "version": "1.24.0",
+    "newSettings": ["auto"]
+  },
   "tags": ["community", "projectPage", "featured"]
 }

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -16,7 +16,12 @@ export default async function ({ addon, console, msg }) {
 
   const button = document.createElement("button");
   button.className = "button sa-tw-button";
-  button.title = "TurboWarp";
+  if (addon.settings.get("auto")) {
+    button.title = "Scratch";
+    button.classList.add("scratch");
+  } else {
+    button.title = "TurboWarp";
+  }
 
   function removeIframe() {
     twIframeContainer.remove();
@@ -26,7 +31,7 @@ export default async function ({ addon, console, msg }) {
     button.title = "TurboWarp";
   }
 
-  button.onclick = async () => {
+  const buttonAction = async () => {
     if (action === "player") {
       playerToggled = !playerToggled;
       if (playerToggled) {
@@ -40,6 +45,7 @@ export default async function ({ addon, console, msg }) {
         }
         const iframeUrl = `https://turbowarp.org/${projectId}/embed?${usp}`;
         twIframe.src = "";
+        scratchStage = await addon.tab.waitForElement(".guiPlayer");
         scratchStage.parentElement.prepend(twIframeContainer);
         // Use location.replace to avoid creating a history entry
         twIframe.contentWindow.location.replace(iframeUrl);
@@ -54,6 +60,10 @@ export default async function ({ addon, console, msg }) {
     }
   };
 
+  if (addon.settings.get("auto")) buttonAction();
+
+  button.onclick = buttonAction;
+
   let showAlert = true;
   while (true) {
     const seeInside = await addon.tab.waitForElement(".see-inside-button", {
@@ -62,9 +72,16 @@ export default async function ({ addon, console, msg }) {
     });
 
     seeInside.addEventListener("click", function seeInsideClick(event) {
-      if (!playerToggled || !showAlert) return;
+      if (!playerToggled) return;
+      if (!showAlert) {
+        button.title = "TurboWarp";
+        button.classList.remove("scratch");
+        return;
+      }
 
       if (confirm(msg("confirmation"))) {
+        button.title = "TurboWarp";
+        button.classList.remove("scratch");
         showAlert = false;
       } else {
         event.stopPropagation();


### PR DESCRIPTION
Resolves #5480

### Changes

<!-- Please describe the changes you've made. -->
A new setting has been added. When enabled, as soon as the addon loads, the TurboWarp player will immediately either open in a new tab or replace the Scratch player based on the `action` setting. This new setting is disabled by default.

Even when this setting is disabled, the TurboWarp button is now able to be toggled before the project finishes loading.

Also fixed a bug where the button would display the incorrect mode after exiting the editor.

### Reason for changes

<!-- Why should these changes be made? -->
For frequent users of TurboWarp, it is time-consuming to wait for large projects to load before using the TurboWarp button. In some cases, it may actually be faster to just copy the link and open TurboWarp manually, defeating the whole purpose of this addon.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested in browser w/ Chromium 96 and Firefox 95.0.2.

One potential further optimization is blocking Scratch from loading the regular project while the TurboWarp project is loading. However, the user is already loading two projects in succession with the current addon, so this shouldn't be a merge blocker, in my opinion.