### PR TITLE
Avoid using spaces in manifest credit.id

### DIFF
--- a/addons/scratch-notifier/addon.json
+++ b/addons/scratch-notifier/addon.json
@@ -11,7 +11,7 @@
     {
       "name": "notificationsounds.com",
       "note": "Scratch Addons ping",
-      "id": "Scratch Addons ping"
+      "id": "scratchAddonsPing"
     }
   ],
   "permissions": ["notifications"],


### PR DESCRIPTION
My bad, ids shouldn't have spaces