### PR TITLE
Fix `(addon-id/@credits-undefined)` in non-English

### DIFF
--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -23,7 +23,7 @@
       }
       if (manifest.credits) {
         for (const credit of manifest.credits || []) {
-          credit.note = scratchAddons.l10n.get(`${folderName}/@credits-${credit.id}`, {}, credit.note);
+          if (credit.note) credit.note = scratchAddons.l10n.get(`${folderName}/@credits-${credit.id}`, {}, credit.note);
         }
       }
       if (manifest.popup) {


### PR DESCRIPTION
Code could use logical nullish assignment (`??=`) but Chrome 84 and below would break