### PR TITLE
editor-searchable-dropdowns: do not allow creating local variables in the stage

### DIFF
--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -1,5 +1,6 @@
 export default async function ({ addon, global, console, msg }) {
   const Blockly = await addon.tab.traps.getBlockly();
+  const vm = addon.tab.traps.vm;
 
   const SCRATCH_ITEMS_TO_HIDE = ["RENAME_VARIABLE_ID", "DELETE_VARIABLE_ID", "NEW_BROADCAST_MESSAGE_ID"];
   const ADDON_ITEMS = [
@@ -73,13 +74,18 @@ export default async function ({ addon, global, console, msg }) {
   Blockly.FieldDropdown.prototype.getOptions = function () {
     const options = oldFieldDropdownGetOptions.call(this);
     const block = this.sourceBlock_;
+    const isStage = vm.editingTarget.isStage;
     if (block) {
       if (block.category_ === "data") {
         options.push(getMenuItemMessage("createGlobalVariable"));
-        options.push(getMenuItemMessage("createLocalVariable"));
+        if (!isStage) {
+          options.push(getMenuItemMessage("createLocalVariable"));
+        }
       } else if (block.category_ === "data-lists") {
         options.push(getMenuItemMessage("createGlobalList"));
-        options.push(getMenuItemMessage("createLocalList"));
+        if (!isStage) {
+          options.push(getMenuItemMessage("createLocalList"));
+        }
       } else if (block.type === "event_broadcast_menu" || block.type === "event_whenbroadcastreceived") {
         options.push(getMenuItemMessage("createBroadcast"));
       }


### PR DESCRIPTION
Fixes https://github.com/ScratchAddons/ScratchAddons/issues/4095

There is no "bigger bug" as hinted by above issue. Creating a local variable in the stage set isLocal=true in the editor's version of the variables, which caused swap-local-globals to misbehave. The problem would've been fixed after saving and loading the project.
