### PR TITLE
Remove beta tag from swap-local-global

### DIFF
--- a/addons/swap-local-global/addon.json
+++ b/addons/swap-local-global/addon.json
@@ -18,7 +18,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "codeEditor", "featured", "beta"],
+  "tags": ["editor", "codeEditor", "featured"],
   "versionAdded": "1.22.0",
   "dynamicEnable": true,
   "dynamicDisable": true,


### PR DESCRIPTION
This addon is pretty robust and we haven't found a bug for months. Great job garbo!