### PR TITLE
Fix editor tab ID immutability issues

### DIFF
--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -48,7 +48,7 @@ export default async function ({ addon, console, msg }) {
   while (true) {
     //Catch all upload menus as they are created
     let menu = await addon.tab.waitForElement(
-      '[class*="sprite-selector_sprite-selector_"] [class*="action-menu_more-buttons_"], #react-tabs-3 [class*="action-menu_more-buttons_"]',
+      '[class*="sprite-selector_sprite-selector_"] [class*="action-menu_more-buttons_"], [data-tabs] > :nth-child(3) [class*="action-menu_more-buttons_"]',
       { markAsSeen: true }
     );
     let button = menu.parentElement.previousElementSibling.previousElementSibling; //The base button that the popup menu is from

--- a/addons/hide-delete-button/costumes.css
+++ b/addons/hide-delete-button/costumes.css
@@ -1,3 +1,3 @@
-#react-tabs-3 div[class*="delete-button_delete-button_"] {
+[data-tabs] > :nth-child(3) div[class*="delete-button_delete-button_"] {
   display: none;
 }

--- a/addons/hide-delete-button/sounds.css
+++ b/addons/hide-delete-button/sounds.css
@@ -1,3 +1,3 @@
-#react-tabs-5 div[class*="delete-button_delete-button_"] {
+[data-tabs] > :nth-child(5) div[class*="delete-button_delete-button_"] {
   display: none;
 }

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -46,7 +46,8 @@ export default async function ({ addon, global, console, msg }) {
   const varTab = document.createElement("li");
   addon.tab.displayNoneWhileDisabled(varTab, { display: "flex" });
   varTab.classList.add(addon.tab.scratchClass("react-tabs_react-tabs__tab"), addon.tab.scratchClass("gui_tab"));
-  varTab.id = "react-tabs-7";
+  // Cannot use number due to conflict after leaving and re-entering editor
+  varTab.id = "react-tabs-sa-variable-manager";
 
   const varTabIcon = document.createElement("img");
   varTabIcon.draggable = false;


### PR DESCRIPTION
Resolves #4102 

Note that variable-manager one is not causing issues from what I know; it's just to fix duplicate IDs which should never happen in HTML. The id itself is meaningless.

Changelog:

- hide-delete-button does not hide the buttons after leaving and re-entering the editor.
- better-img-uploads button disappears after leaving and re-entering the editor.