### PR TITLE
Change updated message to "New settings"

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -256,7 +256,7 @@
     "description": "Tag for addons. Singular."
   },
   "updated": {
-    "message": "New features",
+    "message": "New settings",
     "description": "Tag for addons with new features. Singular."
   },
   "newGroup": {


### PR DESCRIPTION
Imo #4104 is an issue, so I guess it's resolved by this PR.

I specifically called it "new options" because that phrasing implies that the user needs to take action in order to enable the new functionality, as opposed to "updated" or "new features" which implies that the new functionality is enabled by default. I did a test in the community server when implementing this -- people simply thought that "updated" meant bugfixes or things they didn't need to worry about.

That being said, I do agree with W_L that "settings" is better for consistency, and it has the same effect as "options" here.

We could also do a hybrid approach where we have separate "updated" and "new settings" tags, or an arrow prompt (simply adding `→`?) to open settings.