### PR TITLE
Fix crash on initial install

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -34,7 +34,7 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
       madeAnyChanges = true;
     }
 
-    if (addonSettings["editor-dark-mode"].textShadow === true && addonsEnabled["custom-block-text"] === undefined) {
+    if (addonSettings["editor-dark-mode"]?.textShadow === true && addonsEnabled["custom-block-text"] === undefined) {
       // Transition v1.23 to v1.24
       // Moved text shadow option to the custom-block-text addon
       madeAnyChanges = true;


### PR DESCRIPTION
Who approved this code 🤔 (yes, this is the one bug we can solve by typechecking. Or maybe not. We don't want an enum of addon IDs just for this, and it still wouldn't solve this issue because it can be partially initialized. But we don't want to mark every usage of addonSettings as potentially fallible. Hmmm)