### PR TITLE
`editor-comment-previews`: fix `editor-dark-mode` support

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -491,6 +491,17 @@
       }
     },
     {
+      "name": "input-transparent90",
+      "value": {
+        "type": "multiply",
+        "source": {
+          "type": "settingValue",
+          "settingId": "input"
+        },
+        "a": 0.90
+      }
+    },
+    {
       "name": "input-transparent75",
       "value": {
         "type": "multiply",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -498,7 +498,7 @@
           "type": "settingValue",
           "settingId": "input"
         },
-        "a": 0.90
+        "a": 0.9
       }
     },
     {

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -602,9 +602,15 @@ img[src="/static/assets/26255153f92ea41df149a58d3c3fe2cf.svg"] /* record modal s
   color-scheme: dark;
 }
 /* For `editor-comment-previews` */
-.sa-comment-preview {
+.sa-comment-preview-inner {
   color: var(--editorDarkMode-input-text);
-  background-color: var(--editorDarkMode-input-transparent75);
+  background-color: var(--editorDarkMode-input-transparent90);
+}
+@supports (backdrop-filter: blur(16px)) {
+  .sa-comment-preview-inner {
+    background-color: var(--editorDarkMode-input-transparent75);
+    backdrop-filter: blur(16px);
+  }
 }
 .sa-comment-preview-reduce-transparency {
   background-color: var(--editorDarkMode-input);


### PR DESCRIPTION
Fixes a bug where `editor-dark-mode` could not apply its styling to `editor-comment-previews` because a recent refactor of the latter changed the class names.
Also adds the Firefox fallback behavior to this styling.

Tested on Chromium 97 and Firefox 96.0.2.