### PR TITLE
onion-skinning: fix vector layers being a couple pixels off

### DIFF
--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -274,8 +274,8 @@ export default async function ({ addon, global, console, msg }) {
         canvas.height = scaledHeight;
 
         this._size = new paper.Size(scaledWidth, scaledHeight);
-        const topLeft = bounds.getTopLeft().floor();
-        const bottomRight = bounds.getBottomRight().ceil();
+        const topLeft = bounds.getTopLeft();
+        const bottomRight = bounds.getBottomRight();
         const size = new paper.Size(bottomRight.subtract(topLeft));
         const matrix = new paper.Matrix().scale(newScale).translate(topLeft.negate());
         ctx.save();


### PR DESCRIPTION
Remove unnecessary rounding so that vector onion layers aren't shifted a pixel or two from their true position. Most noticeable when zoomed in on small costumes.