### PR TITLE
editor-searchable-dropdowns: check that editingTarget isn't null

### DIFF
--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -74,7 +74,7 @@ export default async function ({ addon, global, console, msg }) {
   Blockly.FieldDropdown.prototype.getOptions = function () {
     const options = oldFieldDropdownGetOptions.call(this);
     const block = this.sourceBlock_;
-    const isStage = vm.editingTarget.isStage;
+    const isStage = vm.editingTarget && vm.editingTarget.isStage;
     if (block) {
       if (block.category_ === "data") {
         options.push(getMenuItemMessage("createGlobalVariable"));


### PR DESCRIPTION
vm.editingTarget can be null while the project is still loading. This adds a check to fix an error introduced by #4096