### PR TITLE
Fix uncentered block-pallate-icons

### DIFF
--- a/addons/block-palette-icons/userstyle.css
+++ b/addons/block-palette-icons/userstyle.css
@@ -1,7 +1,7 @@
 .scratchCategoryItemBubble {
   background-position: center;
   background-repeat: no-repeat;
-  background-size: 17px 17px;
+  background-size: cover;
 }
 
 .scratchCategoryId-motion .scratchCategoryItemBubble {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves https://discord.com/channels/806602307750985799/806602307750985803/936692119454744666

### Changes

<!-- Please describe the changes you've made. -->

changed `backgound-size: 17px 17px;` to `background: cover;`

### Reason for changes

<!-- Why should these changes be made? -->

the icons were offcenter

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
inspect element