### PR TITLE
Compare datetime_created when checking for new messages

### DIFF
--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -171,13 +171,13 @@ export async function updateMessages(cookieStoreId, forceClear, username, xToken
   const db = await openDatabase();
   try {
     const messages = await db.get("cache", cookieStoreId);
-    const firstId = messages[0]?.id;
+    const firstTimestamp = messages[0] ? new Date(messages[0].datetime_created).getTime() : 0;
     const newlyAdded = [];
     const knownIds = new Set();
     fetching: for (let i = 0; i < maxPages; i++) {
       const pageMessages = await fetchMessages(username, xToken, i * 40);
       for (const pageMessage of pageMessages) {
-        if (pageMessage.id <= firstId) break fetching;
+        if (new Date(pageMessage.datetime_created).getTime() <= firstTimestamp) break fetching;
         if (knownIds.has(pageMessage.id)) continue;
         newlyAdded.push(pageMessage);
         knownIds.add(pageMessage.id);


### PR DESCRIPTION
because `id` can be arbitrary and does not have to be in order