### PR TITLE
Attempt to fix broken profile layout on macOS

### DIFF
--- a/addons/better-featured-project/userstyle.css
+++ b/addons/better-featured-project/userstyle.css
@@ -131,6 +131,10 @@
 #lfp-change-featured {
   display: none !important;
 }
+#bio,
+#bio-readonly {
+  margin-bottom: 0;
+}
 #bio-readonly,
 #status-readonly {
   width: 285px;

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -71,7 +71,7 @@
   margin-bottom: 8px;
   color: var(--darkWww-page-text, #575e75);
   font-size: 16px;
-  line-height: normal;
+  line-height: 18px;
 }
 #profile-box .about {
   width: 303px;
@@ -138,7 +138,7 @@
 }
 #bio-readonly,
 #bio {
-  margin-bottom: 12px;
+  margin-bottom: 13px;
 }
 #bio-readonly,
 #status-readonly {


### PR DESCRIPTION
Resolves #4154

### Changes

This should fix an issue on profile pages that happens consistently on macOS and on specific zoom levels on Windows when both Scratch 2.0 → 3.0 and profile page banner are enabled.

### Tests

Tested in Edge on Windows. Someone who uses macOS would need to check if this fixes the problem there as well.