### PR TITLE
scratchr2: fix z-index

### DIFF
--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -70,6 +70,8 @@
 }
 #comments .comment .actions-wrap {
   line-height: normal;
+  /* Needed to make the action buttons actually work; #4161 */
+  z-index: 1;
 }
 #comments .comment .info::before {
   content: "";


### PR DESCRIPTION
Resolves #4161

Adds `z-index: 1;` to `.actions-wrap` so that it is over the commenter name (but below the modals)