### PR TITLE
 My Stuff tabs have no padding on the right #4160

### DIFF
--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -208,3 +208,8 @@ body:not(.beta-opt-in, .password-change, .email-change) #content > .cols > .col-
   box-shadow: 0 0 0 4px hsla(163, 85%, 40%, 0.25);
   border-color: hsl(163, 85%, 40%);
 }
+
+#sidebar li.sub-list {
+  margin-left: 4px !important;
+  margin-right: 4px;
+}


### PR DESCRIPTION
Resolves  #4160 `My Stuff tabs have no padding on the right`

### Changes

Adds and changes margin value in css file.

### Reason for changes

Fixing error

### Tests

Download it, upload to my browser.
