### PR TITLE
Fix _step trap race affecting clones and variable-manager

### DIFF
--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -52,8 +52,8 @@ export default async function ({ addon, global, console, msg }) {
     // Fix bug with inaccurate clone counter
     if (t.isOriginal) vm.runtime.changeCloneCounter(1);
   });
-  const oldStep = vm.runtime.constructor.prototype._step;
-  vm.runtime.constructor.prototype._step = function (...args) {
+  const oldStep = vm.runtime._step;
+  vm.runtime._step = function (...args) {
     const ret = oldStep.call(this, ...args);
     doCloneChecks();
     return ret;

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -320,8 +320,8 @@ export default async function ({ addon, global, console, msg }) {
     }
   });
 
-  const oldStep = vm.runtime.constructor.prototype._step;
-  vm.runtime.constructor.prototype._step = function (...args) {
+  const oldStep = vm.runtime._step;
+  vm.runtime._step = function (...args) {
     const ret = oldStep.call(this, ...args);
     try {
       quickReload();


### PR DESCRIPTION
Some addons trapped `vm.runtime._step` while some other addons trapped `vm.runtime.constructor.prototype._step`. If an addon that used the first approach ran first, any addons that used the second approach would not work. This converts everything to use the first approach.

Fixes #4184 and another instance of the same issue in variable-manager