### PR TITLE
editor-stepping: Don't spew errors if workspace is null

### DIFF
--- a/addons/editor-stepping/highlighter.js
+++ b/addons/editor-stepping/highlighter.js
@@ -106,25 +106,27 @@ class Highlighter {
     const elementsToHighlight = new Set();
     const workspace = Blockly.getMainWorkspace();
 
-    for (const thread of threads) {
-      thread.stack.forEach((blockId) => {
-        const block = workspace.getBlockById(blockId);
-        if (!block) {
-          return;
-        }
-        const childblock = thread.stack.find((i) => {
-          let b = block;
-          while (b.childBlocks_.length) {
-            b = b.childBlocks_[b.childBlocks_.length - 1];
-            if (i === b.id) return true;
+    if (workspace) {
+      for (const thread of threads) {
+        thread.stack.forEach((blockId) => {
+          const block = workspace.getBlockById(blockId);
+          if (!block) {
+            return;
           }
-          return false;
+          const childblock = thread.stack.find((i) => {
+            let b = block;
+            while (b.childBlocks_.length) {
+              b = b.childBlocks_[b.childBlocks_.length - 1];
+              if (i === b.id) return true;
+            }
+            return false;
+          });
+          if (!childblock && block.svgPath_) {
+            const svgPath = block.svgPath_;
+            elementsToHighlight.add(svgPath);
+          }
         });
-        if (!childblock && block.svgPath_) {
-          const svgPath = block.svgPath_;
-          elementsToHighlight.add(svgPath);
-        }
-      });
+      }
     }
 
     for (const element of this.previousElements) {


### PR DESCRIPTION
Fixes editor-stepping spewing errors when the editor hasn't been opened. I don't think this actually broke anything. It could've broken some other editor addons, but the error wouldn't happen when the editor is open anyways.

https://discord.com/channels/751206349614088204/758464349768515604/939767789902762014

https://scratch.mit.edu/projects/579616012/#comments-249378616
