### PR TITLE
Fix code blocks inside quotes again

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1077,6 +1077,36 @@
       }
     },
     {
+      "name": "gray-forumTransparentCode",
+      "value": {
+        "type": "ternary",
+        "source": {
+          "type": "settingValue",
+          "settingId": "darkForumCode"
+        },
+        "true": {
+          "type": "textColor",
+          "black": "#333333",
+          "white": "rgba(255, 255, 255, 0.03)",
+          "source": {
+            "type": "settingValue",
+            "settingId": "gray"
+          },
+          "threshold": 64
+        },
+        "false": {
+          "type": "textColor",
+          "black": "rgba(0, 0, 0, 0.03)",
+          "white": "#f7f7f7",
+          "source": {
+            "type": "settingValue",
+            "settingId": "gray"
+          },
+          "threshold": 204
+        }
+      }
+    },
+    {
       "name": "blue-text",
       "value": {
         "type": "textColor",

--- a/addons/forum-quote-code-beautifier/main.css
+++ b/addons/forum-quote-code-beautifier/main.css
@@ -3,7 +3,9 @@
   border: none;
   border-left: 2px solid var(--forumQuoteCodeBeautifier-bordercolor);
 }
-.postmsg blockquote blockquote,
-.postmsg blockquote .code {
+.postmsg blockquote blockquote {
   background-color: var(--darkWww-gray-forumTransparentQuote, rgba(0, 0, 0, 0.03));
+}
+.postmsg blockquote .code {
+  background-color: var(--darkWww-gray-forumTransparentCode, rgba(0, 0, 0, 0.03));
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -258,9 +258,7 @@ function setCssVariables(addonSettings, addonsWithUserstyles) {
         return addonSettings[addonId][obj.settingId];
       case "ternary":
         // this is not even a color lol
-        return getColor(addonId, obj.source) ?
-          getColor(addonId, obj.true)
-          : getColor(addonId, obj.false);
+        return getColor(addonId, obj.source) ? getColor(addonId, obj.true) : getColor(addonId, obj.false);
       case "map":
         return obj.options[getColor(addonId, obj.source)];
       case "textColor": {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -258,7 +258,9 @@ function setCssVariables(addonSettings, addonsWithUserstyles) {
         return addonSettings[addonId][obj.settingId];
       case "ternary":
         // this is not even a color lol
-        return getColor(addonId, obj.source) ? obj.true : obj.false;
+        return getColor(addonId, obj.source) ?
+          getColor(addonId, obj.true)
+          : getColor(addonId, obj.false);
       case "map":
         return obj.options[getColor(addonId, obj.source)];
       case "textColor": {


### PR DESCRIPTION
Resolves #4209

### Changes

Makes the background of code blocks inside quotes use either the gray background or default code block background color, depending on which is more appropriate, when forum-quote-code-beautifier.

`"type": "ternary"` value providers for `customCssVariables` now accept other value providers as `true` and `false` values.

### Tests

The color in the example screenshot still produces the same result because it is quite dark, but lighter colors now behave as expected.