### PR TITLE
2.0 → 3.0: fix delete account confirmation page

### DIFF
--- a/addons/dark-www/blue_banners_scratchr2.css
+++ b/addons/dark-www/blue_banners_scratchr2.css
@@ -1,4 +1,3 @@
-body:not(.beta-opt-in, .password-change, .email-change) #content > .cols > .col-12 > .box,
-#content > .cols > .col-12 > .box .box-head {
-  background-color: var(--darkWww-button-banner);
+#content > .cols > .col-12 > .box > .box-head {
+  background-color: var(--darkWww-button-banner) !important;
 }

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -75,7 +75,7 @@
       "url": "v_tabs.css",
       "matches": [
         "https://scratch.mit.edu/mystuff/",
-        "https://scratch.mit.edu/accounts/settings/",
+        "https://scratch.mit.edu/accounts/settings/*",
         "https://scratch.mit.edu/accounts/password_change/",
         "https://scratch.mit.edu/accounts/email_change/"
       ]
@@ -87,7 +87,7 @@
     {
       "url": "settings.css",
       "matches": [
-        "https://scratch.mit.edu/accounts/settings/",
+        "https://scratch.mit.edu/accounts/settings/*",
         "https://scratch.mit.edu/accounts/password_change/",
         "https://scratch.mit.edu/accounts/email_change/"
       ]

--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -7,9 +7,6 @@
 #content > .cols > .col-12 {
   width: 662px;
 }
-body:not(.beta-opt-in, .password-change, .email-change) #content > .cols > .col-12 > .box {
-  background-color: var(--darkWww-page, #fcfcfc);
-}
 .ajax-loader {
   background-color: transparent;
   background-image: none;
@@ -34,10 +31,10 @@ body:not(.beta-opt-in, .password-change, .email-change) #content > .cols > .col-
   animation-delay: 0s, 0.25s;
   animation-iteration-count: 1, infinite;
 }
-.box .box-head {
+#content > .cols > .col-12 > .box > .box-head {
   padding-bottom: 20px;
 }
-.box .box-head .buttons {
+#content > .cols > .col-12 > .box > .box-head .buttons {
   position: static;
   width: 942px;
   margin: auto;

--- a/addons/scratchr2/v_tabs.css
+++ b/addons/scratchr2/v_tabs.css
@@ -6,7 +6,7 @@
   padding-top: 40px;
   padding-inline: 10px;
 }
-.box .box-head {
+#content > .cols > .col-12 > .box > .box-head {
   position: absolute;
   top: 50px;
   left: 0;
@@ -18,7 +18,7 @@
   background: #4d97ff;
   border: none;
 }
-.box .box-head h2 {
+#content > .cols > .col-12 > .box > .box-head h2 {
   width: 942px;
   margin: auto;
   margin-bottom: 16px;
@@ -79,7 +79,7 @@
   margin: 0;
   width: 722px;
 }
-#content > .cols > .col-12 .box,
+#content > .cols > .col-12 > .box,
 #main-content {
   padding: 0;
   border: none;


### PR DESCRIPTION
Resolves #4211

### Changes

Makes the delete account confirmation page look not broken (which doesn't mean good, but it isn't a page people would use very often) if Scratch 2.0 → 3.0 is enabled.