### PR TITLE
Error with not showing loading message

### DIFF
--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -226,7 +226,7 @@ export default async ({ addon, msg, safeMsg }) => {
       stMessages: [],
       messages: [],
       comments: {},
-      error: "loadingPage",
+      error: "notReady",
       hasCustomError: false,
 
       username: null,

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -226,7 +226,7 @@ export default async ({ addon, msg, safeMsg }) => {
       stMessages: [],
       messages: [],
       comments: {},
-      error: null,
+      error: "loadingPage",
       hasCustomError: false,
 
       username: null,


### PR DESCRIPTION
Resolves #4215

### Changes

`After the messaging refactor, the "Loading messages..." text no longer appears when opening the messaging popup, which makes loading seem much slower. `
So now it works 😄 
