### PR TITLE
Improve install from source for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ After downloading the extension to your computer, just load it by following thes
   3. Click the `Load unpacked` button on the top and select the extension directory which has the `manifest.json` file in it. 
 
 - Mozilla Firefox
-  1. Open `about:debugging` to open the add-ons page by typing it into your address bar.
-  2. Click `This Firefox` on the right-hand menu.
+  1. Open `about:debugging` to open the debugging page by typing it into your address bar.
+  2. Click `This Firefox` on the left-hand menu.
   3. Click `Load Temporary Add-on...` and select the `manifest.json` file.
 
 ## Contribute


### PR DESCRIPTION
### Improves install from source steps for Firefox in the README.

### Changes
Changes the wording for step 1 a bit, and changes `right-hand` to `left-hand` in step 2.
The instructions for Firefox in the [README](https://github.com/ScratchAddons/ScratchAddons#from-source) tells users to click a button the the right-hand menu, but it actually is in the left now. 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/97374054/152821836-4372547f-1619-40f4-887d-f2eb6069881d.png">


### Reason for changes
Improving instructions to install the addon from source.

### Tests
This doesn't change any file except `README.md`, so I haven't tested it. 