### PR TITLE
scratch-messaging: hide Delete when inapplicable

### DIFF
--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -238,6 +238,7 @@ export async function fetchMigratedComments(
         childOf: `${resourceType[0]}_${parentId}`,
         replyingTo,
         scratchTeam: reply.author.scratchteam,
+        projectAuthor,
       };
     }
     for (const childCommentId of Object.keys(childrenComments)) {
@@ -253,6 +254,7 @@ export async function fetchMigratedComments(
       childOf: null,
       replyingTo: "",
       scratchTeam: parentComment.author.scratchteam,
+      projectAuthor,
     };
   }
   return commentsObj;

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -39,7 +39,12 @@
             <img src="../../images/icons/popout.svg" class="popout-comment" title="{{ messages.openNewTabMsg }}" />
           </a>
         </span>
-        <a @click="deleteComment()" class="delete-btn" :class="{'bold': deleteStep === 1}" v-show="!deleted"
+        <a
+          @click="deleteComment()"
+          class="delete-btn"
+          :class="{'bold': deleteStep === 1}"
+          v-show="!deleted"
+          v-if="canDeleteComment"
           >{{ deleteStep === 0 ? messages.deleteMsg : messages.deleteConfirmMsg }}
         </a>
         <bdo dir="ltr">

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -122,6 +122,7 @@ export default async ({ addon, msg, safeMsg }) => {
               date: new Date().toISOString(),
               children: null,
               childOf: parent_pseudo_id,
+              projectAuthor: this.thisComment.projectAuthor,
             });
             this.commentsObj[parent_pseudo_id].children.push(newCommentPseudoId);
             this.replyBoxValue = "";

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -179,6 +179,16 @@ export default async ({ addon, msg, safeMsg }) => {
       },
     },
     computed: {
+      canDeleteComment() {
+        switch (this.resourceType) {
+          case "user":
+            return this.resourceId === this.username;
+          case "project":
+            return this.thisComment.projectAuthor === this.username;
+          default:
+            return true; // Studio comment deletion is complex, just assume we can
+        }
+      },
       thisComment() {
         return this.commentsObj[this.commentId];
       },


### PR DESCRIPTION
Hides Delete button for comments in others' profile/project. Not doing this for studio comments, since that'll require an additional API request just for that.