### PR TITLE
Compute addon.tab.clientVersion only when the addon needs it

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -23,14 +23,18 @@ export default class Tab extends Listenable {
   constructor(info) {
     super();
     this._addonId = info.id;
-    this.clientVersion = document.querySelector("meta[name='format-detection']")
-      ? "scratch-www"
-      : document.querySelector("script[type='text/javascript']")
-      ? "scratchr2"
-      : null;
     this.traps = new Trap(this);
     this.redux = new ReduxHandler();
     this._waitForElementSet = new WeakSet();
+  }
+  get clientVersion() {
+    if (!this._clientVersion)
+      this._clientVersion = document.querySelector("meta[name='format-detection']")
+        ? "scratch-www"
+        : document.querySelector("script[type='text/javascript']")
+        ? "scratchr2"
+        : null;
+    return this._clientVersion;
   }
   addBlock(...a) {
     blocks.init(this);

--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -8,8 +8,8 @@ export default class Trap extends Listenable {
   constructor(tab) {
     super();
     this._react_internal_key = undefined;
-    this._isWWW = tab.clientVersion === "scratch-www";
-    this._getEditorMode = () => this._isWWW && tab.editorMode;
+    this._isWWW = () => tab.clientVersion === "scratch-www";
+    this._getEditorMode = () => this._isWWW() && tab.editorMode;
     this._waitForElement = tab.waitForElement.bind(tab);
     this._cache = Object.create(null);
   }


### PR DESCRIPTION
Mitigates #4212

Note: commit name is inaccurate, every addon will compute clientVersion when requested for the first time, and it will be cached only for the addon that requested it.