### PR TITLE
Live forum post preview addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -116,6 +116,7 @@
   "search-sprites",
   "hide-signatures",
   "disable-sprite-wobble",
+  "forum-live-preview",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -22,5 +22,6 @@
       "matches": ["editingScreens"]
     }
   ],
-  "tags": ["community", "forums"]
+  "tags": ["community", "forums"],
+  "versionAdded": "1.25.0"
 }

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -1,0 +1,26 @@
+{
+  "name": "Live forum post preview",
+  "description": "Automatically shows a preview when you stop typing while writing or editing a forum post.",
+  "credits": [
+    {
+      "name": "Maximouse",
+      "link": "https://scratch.mit.edu/users/Maximouse/"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["editingScreens"],
+      "runAtComplete": false
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "style.css",
+      "matches": ["editingScreens"]
+    }
+  ],
+  "tags": ["community", "forums"]
+}

--- a/addons/forum-live-preview/style.css
+++ b/addons/forum-live-preview/style.css
@@ -1,0 +1,3 @@
+.markItUpButton.preview {
+  display: none;
+}

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -1,0 +1,31 @@
+export default async function({ addon, console }) {
+  const textarea = await addon.tab.waitForElement(".markItUpEditor");
+  const previewButton = await addon.tab.waitForElement(".markItUpButton.preview");
+  let previewIframe;
+  addon.tab.waitForElement(".markItUpPreviewFrame").then(iframe => previewIframe = iframe);
+
+  const showPreview = () => {
+    if (previewIframe) previewIframe.style.removeProperty("display");
+  }
+  const hidePreview = () => {
+    if (previewIframe) previewIframe.style.display = "none";
+  }
+  const updatePreview = () => {
+    if (addon.self.disabled) return;
+    previewButton.dispatchEvent(new MouseEvent("mousedown"));
+    if (textarea.value) {
+      showPreview();
+    } else {
+      hidePreview();
+    }
+  }
+
+  let timeout;
+  textarea.addEventListener("input", () => {
+    if (timeout !== undefined) clearTimeout(timeout);
+    timeout = setTimeout(updatePreview, 1000);
+  });
+  addon.self.addEventListener("disabled", () => {
+    showPreview();
+  });
+}

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -28,4 +28,6 @@ export default async function ({ addon, console }) {
   addon.self.addEventListener("disabled", () => {
     showPreview();
   });
+
+  if (addon.self.enabledLate) updatePreview();
 }

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -1,15 +1,15 @@
-export default async function({ addon, console }) {
+export default async function ({ addon, console }) {
   const textarea = await addon.tab.waitForElement(".markItUpEditor");
   const previewButton = await addon.tab.waitForElement(".markItUpButton.preview");
   let previewIframe;
-  addon.tab.waitForElement(".markItUpPreviewFrame").then(iframe => previewIframe = iframe);
+  addon.tab.waitForElement(".markItUpPreviewFrame").then((iframe) => (previewIframe = iframe));
 
   const showPreview = () => {
     if (previewIframe) previewIframe.style.removeProperty("display");
-  }
+  };
   const hidePreview = () => {
     if (previewIframe) previewIframe.style.display = "none";
-  }
+  };
   const updatePreview = () => {
     if (addon.self.disabled) return;
     previewButton.dispatchEvent(new MouseEvent("mousedown"));
@@ -18,7 +18,7 @@ export default async function({ addon, console }) {
     } else {
       hidePreview();
     }
-  }
+  };
 
   let timeout;
   textarea.addEventListener("input", () => {


### PR DESCRIPTION
Resolves #2395

### Changes

Adds an addon that removes the preview button in the forums and instead automatically shows the preview when the user stops typing for a second (exactly a second right now, but that delay could be changed or made configurable).