### PR TITLE
Remove reference to `experimental_forums.css` from dark-www userscript

### DIFF
--- a/addons/dark-www/experimental_forums_preview.js
+++ b/addons/dark-www/experimental_forums_preview.js
@@ -56,7 +56,6 @@ export default async function ({ addon, console }) {
           }
           if (node.tagName === "LINK" && node.href.endsWith("djangobb_forum/css/pygments.css")) {
             preview.contentDocument.head.appendChild(createStyle(addon.self.dir + "/experimental_scratchr2.css"));
-            preview.contentDocument.head.appendChild(createStyle(addon.self.dir + "/experimental_forums.css"));
             preview.contentDocument.head.appendChild(
               createStyle(addon.self.dir + "/pygments.css", !addon.settings.get("darkForumCode"))
             );


### PR DESCRIPTION
### Changes

Removes a reference to a file that no longer exist.

### Reason for changes

It was showing errors in the console.