### PR TITLE
New "orange" color preset for msg count badge

### DIFF
--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -40,6 +40,14 @@
       "values": {
         "color": "#000000"
       }
+    },
+    {
+      "name": "Orange",
+      "id": "orange",
+      "description": "The same color as the Scratch Addons logo.",
+      "values": {
+        "color": "#FF7B26"
+      }
     }
   ],
   "credits": [
@@ -53,6 +61,9 @@
     {
       "name": "lisa_wolfgang",
       "link": "https://scratch.mit.edu/users/lisa_wolfgang"
-    }
+    },
+    {
+      "name": "Xan"
+      "link": "https://scratch.mit.edu/users/-Xanimation-"
   ]
 }

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -65,5 +65,6 @@
     {
       "name": "Xan"
       "link": "https://scratch.mit.edu/users/-Xanimation-"
+    }
   ]
 }

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -61,10 +61,6 @@
     {
       "name": "lisa_wolfgang",
       "link": "https://scratch.mit.edu/users/lisa_wolfgang"
-    },
-    {
-      "name": "Xan"
-      "link": "https://scratch.mit.edu/users/-Xanimation-"
     }
   ]
 }


### PR DESCRIPTION
Resolves the issue of the message count badge looking wrong. 

### Changes
Added "Orange" preset to message count badge

### Reason for changes
- The badge doesn't match the extension logo 
	- Other extensions with badges on my device use colors similar to their logos(/icons).
- This adds an SA-color orange preset to make the logo and badge look good together.

### Tests
It works. ☑️ 
