### PR TITLE
Fix word-wrapping for Ocular Status in forums

### DIFF
--- a/addons/my-ocular/discuss.js
+++ b/addons/my-ocular/discuss.js
@@ -13,6 +13,7 @@ export default async function ({ addon, global, console, msg }) {
       let br = document.createElement("br");
       addon.tab.displayNoneWhileDisabled(br);
       let status = document.createElement("i");
+      status.setAttribute("class", "ocular-status")
       addon.tab.displayNoneWhileDisabled(status);
       status.title = msg("status-hover");
       status.innerText = userStatus;

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -375,3 +375,7 @@ body > #pagewrapper {
   color: white;
   line-height: 32px;
 }
+
+.ocular-status {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Resolves #4262 

### Changes

In the [addons/my-ocular/discuss.js](https://github.com/Chiroyce1/ScratchAddons/commit/97685481256ca1c2a61d0c9b056c581879632772#diff-822fae7015766686e1951e78da4e29c345e0ea347c2c567afaa3a7aba0def7ec) file, it adds a class to the ocular status and in [addons/my-ocular/discuss.js](https://github.com/Chiroyce1/ScratchAddons/commit/97685481256ca1c2a61d0c9b056c581879632772#diff-822fae7015766686e1951e78da4e29c345e0ea347c2c567afaa3a7aba0def7ec) it adds `word-wrap: break-word;` for the `ocular-status` class.

### Reason for changes

Resolve word wrapping issue

### Tests

Tested on Firefox, seems to work.
![image](https://user-images.githubusercontent.com/97374054/153696860-d9697ab4-ed28-4f7d-844d-65066d68c6e1.png)