### PR TITLE
Not intengers labels on graph

### DIFF
--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -114,7 +114,14 @@ export default async function ({ addon, msg, console }) {
                   },
                 },
                 y: {
-                  stepSize,
+                  precision: 0,
+                  ticks: {
+                    callback: function(stepSize) {
+                       if (!(stepSize%1)) {
+                         return new Intl.NumberFormat().format(Number(stepSize).toFixed(0));
+                       }
+                    }
+                  }
                 },
               },
               plugins: {

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -116,12 +116,12 @@ export default async function ({ addon, msg, console }) {
                 y: {
                   precision: 0,
                   ticks: {
-                    callback: function(stepSize) {
-                       if (!(stepSize%1)) {
-                         return new Intl.NumberFormat().format(Number(stepSize).toFixed(0));
-                       }
-                    }
-                  }
+                    callback: function (stepSize) {
+                      if (!(stepSize % 1)) {
+                        return new Intl.NumberFormat().format(Number(stepSize).toFixed(0));
+                      }
+                    },
+                  },
                 },
               },
               plugins: {


### PR DESCRIPTION
Resolves #4270

### Changes

It hides not integer labels, also I parsed numbers (number with comma) for all American people out there...

### Tests

Downloaded and tested on Firefox.
