### PR TITLE
Add partial dynamicEnable/dynamicDisable for userstyles

### DIFF
--- a/background/declare-scratchaddons-object.js
+++ b/background/declare-scratchaddons-object.js
@@ -9,7 +9,7 @@ scratchAddons.localEvents = new EventTarget();
 
 // Load manifests into memory
 scratchAddons.manifests = [];
-// addonId to array of addon IDs that has the addon inside userstyle's settings.if.addonEnabled
+// addonId to set of addon IDs that has the addon inside userstyle's settings.if.addonEnabled
 scratchAddons.dependents = {};
 
 // Other files may add their own global methods here so that addon-api files can access them

--- a/background/declare-scratchaddons-object.js
+++ b/background/declare-scratchaddons-object.js
@@ -9,6 +9,8 @@ scratchAddons.localEvents = new EventTarget();
 
 // Load manifests into memory
 scratchAddons.manifests = [];
+// addonId to array of addon IDs that has the addon inside userstyle's settings.if.addonEnabled
+scratchAddons.dependents = {};
 
 // Other files may add their own global methods here so that addon-api files can access them
 scratchAddons.methods = {};

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -30,7 +30,7 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
               // Handle partial dynamic enable (PDE)
               // Userscripts currently cannot be PDEd
               // Note: this can still result in userstyles being empty
-              // if a userstyle depends on multple addons
+              // if a userstyle depends on multiple addons
               // If no running userstyles depend on the provided dependency,
               // this means no new userstyles are loaded, thus early return.
               // We still need to send the whole array.

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -18,7 +18,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 });
 
 scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) => {
-  const { addonId, manifest } = detail;
+  const { addonId, manifest, partialDynamicEnableBy } = detail;
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
       if (tab.url || (!tab.url && typeof browser !== "undefined")) {
@@ -26,7 +26,19 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
           void chrome.runtime.lastError;
           if (res) {
             (async () => {
-              const { userscripts, userstyles, cssVariables } = await getAddonData({ addonId, url: res, manifest });
+              let { userscripts, userstyles, cssVariables } = await getAddonData({ addonId, url: res, manifest });
+              // Handle partial dynamic enable (PDE)
+              // Userscripts currently cannot be PDEd
+              // Note: this can still result in userstyles being empty
+              // if a userstyle depends on multple addons
+              // If no running userstyles depend on the provided dependency,
+              // this means no new userstyles are loaded, thus early return.
+              // We still need to send the whole array.
+              if (partialDynamicEnableBy) {
+                // NOR(a userstyle has a dependency on the newly enabled addon), RETURN
+                if (!userstyles.some((injectable) => injectable.if?.addonEnabled?.includes(partialDynamicEnableBy)))
+                  return;
+              }
               if (userscripts.length || userstyles.length) {
                 chrome.tabs.sendMessage(
                   tab.id,
@@ -40,6 +52,7 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
                       index: scratchAddons.manifests.findIndex((addon) => addon.addonId === addonId),
                       dynamicEnable: Boolean(manifest.dynamicEnable),
                       dynamicDisable: Boolean(manifest.dynamicDisable),
+                      partial: !!partialDynamicEnableBy,
                     },
                   },
                   { frameId: 0 }
@@ -53,13 +66,24 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
   );
 });
 scratchAddons.localEvents.addEventListener("addonDynamicDisable", ({ detail }) => {
-  const { addonId } = detail;
+  const { addonId, manifest, partialDynamicDisableBy } = detail;
+  let partialDynamicDisabledStyles;
+  if (partialDynamicDisableBy) {
+    partialDynamicDisabledStyles = manifest.userstyles
+      ?.filter((injectable) => injectable.if?.addonEnabled?.includes(partialDynamicDisableBy))
+      .map((style) => chrome.runtime.getURL(`/addons/${addonId}/${style.url}`));
+  }
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
       if (tab.url || (!tab.url && typeof browser !== "undefined")) {
         chrome.tabs.sendMessage(
           tab.id,
-          { dynamicAddonDisable: { addonId } },
+          {
+            dynamicAddonDisable: {
+              addonId,
+              partialDynamicDisabledStyles,
+            },
+          },
           { frameId: 0 },
           () => void chrome.runtime.lastError
         );
@@ -116,19 +140,23 @@ async function getAddonData({ addonId, manifest, url }) {
         // Reserve index in array to avoid race conditions (#700)
         const arrLength = userstyles.push(null);
         const indexToUse = arrLength - 1;
+        const styleHref = chrome.runtime.getURL(`/addons/${addonId}/${style.url}`);
         promises.push(
-          fetch(chrome.runtime.getURL(`/addons/${addonId}/${style.url}`))
+          fetch(styleHref)
             .then((res) => res.text())
             .then((text) => {
               // Replace %addon-self-dir% for relative URLs
               text = text.replace(/\%addon-self-dir\%/g, chrome.runtime.getURL(`addons/${addonId}`));
               // Provide source url
               text += `\n/*# sourceURL=${style.url} */`;
-              userstyles[indexToUse] = text;
+              userstyles[indexToUse] = {
+                href: styleHref,
+                text,
+              };
             })
         );
       } else {
-        userstyles.push(chrome.runtime.getURL(`/addons/${addonId}/${style.url}`));
+        userstyles.push({ href: chrome.runtime.getURL(`/addons/${addonId}/${style.url}`) });
       }
   }
   await Promise.all(promises);

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -26,7 +26,7 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
           void chrome.runtime.lastError;
           if (res) {
             (async () => {
-              let { userscripts, userstyles, cssVariables } = await getAddonData({ addonId, url: res, manifest });
+              const { userscripts, userstyles, cssVariables } = await getAddonData({ addonId, url: res, manifest });
               // Handle partial dynamic enable (PDE)
               // Userscripts currently cannot be PDEd
               // Note: this can still result in userstyles being empty

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -134,7 +134,8 @@ async function getAddonData({ addonId, manifest, url }) {
       });
   }
   const userstyles = [];
-  for (const style of manifest.userstyles || []) {
+  for (let i = 0; i < manifest.userstyles?.length; i++) {
+    const style = manifest.userstyles[i];
     if (userscriptMatches({ url }, style, addonId))
       if (manifest.injectAsStyleElt) {
         // Reserve index in array to avoid race conditions (#700)
@@ -152,11 +153,15 @@ async function getAddonData({ addonId, manifest, url }) {
               userstyles[indexToUse] = {
                 href: styleHref,
                 text,
+                index: i,
               };
             })
         );
       } else {
-        userstyles.push({ href: chrome.runtime.getURL(`/addons/${addonId}/${style.url}`) });
+        userstyles.push({
+          href: chrome.runtime.getURL(`/addons/${addonId}/${style.url}`),
+          index: i,
+        });
       }
   }
   await Promise.all(promises);

--- a/background/imports/change-addon-state.js
+++ b/background/imports/change-addon-state.js
@@ -30,7 +30,7 @@ export default (addonId, newState) => {
   if (scratchAddons.dependents[addonId]?.size) {
     for (const dependentAddonId of scratchAddons.dependents[addonId]) {
       // Ignore disabled addons
-      if (!scratchAddons.localState.addonsEnabled[addonId]) continue;
+      if (!scratchAddons.localState.addonsEnabled[dependentAddonId]) continue;
       const dependentManifest = scratchAddons.manifests.find(
         (manifest) => manifest.addonId === dependentAddonId
       ).manifest;

--- a/background/imports/change-addon-state.js
+++ b/background/imports/change-addon-state.js
@@ -25,4 +25,40 @@ export default (addonId, newState) => {
     }
   }
   if (addonId === "msg-count-badge") updateBadge(scratchAddons.cookieStoreId);
+  // Partial dynamicEnable (PDE)/Partial dynamicDisable (PDD)
+  // See #4188 - for now, userstyles only.
+  if (scratchAddons.dependents[addonId]?.length) {
+    for (const dependentAddonId of scratchAddons.dependents[addonId]) {
+      // Ignore disabled addons
+      if (!scratchAddons.localState.addonsEnabled[addonId]) continue;
+      const dependentManifest = scratchAddons.manifests.find(
+        (manifest) => manifest.addonId === dependentAddonId
+      ).manifest;
+      // Require dynamicEnable/dynamicDisable since this is a type of dynamic enable/disable
+      // and it might cause problems if applied to addons without support
+      if (newState && dependentManifest.dynamicEnable) {
+        // Dependent might have a userstyle that needs to be activated
+        scratchAddons.localEvents.dispatchEvent(
+          new CustomEvent("addonDynamicEnable", {
+            detail: {
+              addonId: dependentAddonId,
+              manifest: dependentManifest,
+              partialDynamicEnableBy: addonId,
+            },
+          })
+        );
+      } else if (!newState && dependentManifest.dynamicDisable) {
+        // Dependent might have a userstyle that needs to be deactivated
+        scratchAddons.localEvents.dispatchEvent(
+          new CustomEvent("addonDynamicDisable", {
+            detail: {
+              addonId: dependentAddonId,
+              manifest: dependentManifest,
+              partialDynamicDisableBy: addonId,
+            },
+          })
+        );
+      }
+    }
+  }
 };

--- a/background/imports/change-addon-state.js
+++ b/background/imports/change-addon-state.js
@@ -27,7 +27,7 @@ export default (addonId, newState) => {
   if (addonId === "msg-count-badge") updateBadge(scratchAddons.cookieStoreId);
   // Partial dynamicEnable (PDE)/Partial dynamicDisable (PDD)
   // See #4188 - for now, userstyles only.
-  if (scratchAddons.dependents[addonId]?.length) {
+  if (scratchAddons.dependents[addonId]?.size) {
     for (const dependentAddonId of scratchAddons.dependents[addonId]) {
       // Ignore disabled addons
       if (!scratchAddons.localState.addonsEnabled[addonId]) continue;

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -100,8 +100,8 @@ const localizeSettings = (addonId, setting, tableId) => {
             injectable.if.addonEnabled = [injectable.if.addonEnabled];
           }
           for (const dependency of injectable.if.addonEnabled) {
-            if (!scratchAddons.dependents[dependency]) scratchAddons.dependents[dependency] = [];
-            scratchAddons.dependents[dependency].push(addonId);
+            if (!scratchAddons.dependents[dependency]) scratchAddons.dependents[dependency] = new Set();
+            scratchAddons.dependents[dependency].add(addonId);
           }
         }
       }

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -88,6 +88,22 @@ const localizeSettings = (addonId, setting, tableId) => {
             }
           }
         }
+        // Cache dependents
+        // if A has addonEnabled: C
+        // A's dependency is C
+        // C's dependent is A
+        // Only handle userstyles because userscript support is complicated
+        if (propName === "userstyles" && injectable.if?.addonEnabled?.length) {
+          // Convert string shortcut to Array
+          // might as well remove this in the future
+          if (typeof injectable.if.addonEnabled === "string") {
+            injectable.if.addonEnabled = [injectable.if.addonEnabled];
+          }
+          for (const dependency of injectable.if.addonEnabled) {
+            if (!scratchAddons.dependents[dependency]) scratchAddons.dependents[dependency] = [];
+            scratchAddons.dependents[dependency].push(addonId);
+          }
+        }
       }
     }
     if (!useDefault) {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -454,7 +454,7 @@ async function onInfoAvailable({ globalState: globalStateMsg, addonsWithUserscri
       disabledDynamicAddons.add(addonId);
 
       if (scriptIndex !== -1) addonsWithUserscripts.splice(scriptIndex, 1);
-      if (scriptIndex !== -1) addonsWithUserstyles.splice(scriptIndex, 1);
+      if (styleIndex !== -1) addonsWithUserstyles.splice(styleIndex, 1);
 
       _page_.fireEvent({ name: "disabled", addonId, target: "self" });
       setCssVariables(globalState.addonSettings, addonsWithUserstyles);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -187,7 +187,7 @@ function addStyle(addon) {
   }
   for (let i = 0; i < addon.styles.length; i++) {
     const userstyle = addon.styles[i];
-    const styleIndex = addon.index * MAX_USERSTYLES_PER_ADDON + i;
+    const styleIndex = addon.index * MAX_USERSTYLES_PER_ADDON + userstyle.index;
     if (addon.injectAsStyleElt) {
       // If an existing style is already appended, just enable it instead
       const existingEl = addonStyles.find((style) => style.dataset.styleHref === userstyle.href);
@@ -199,7 +199,7 @@ function addStyle(addon) {
       const style = document.createElement("style");
       style.classList.add("scratch-addons-style");
       style.setAttribute("data-addon-id", addon.addonId);
-      style.setAttribute("data-addon-index", addon.index);
+      style.setAttribute("data-addon-index", styleIndex);
       style.setAttribute("data-style-href", userstyle.href);
       style.textContent = userstyle.text;
       appendByIndex(style, styleIndex);
@@ -213,7 +213,7 @@ function addStyle(addon) {
       const link = document.createElement("link");
       link.rel = "stylesheet";
       link.setAttribute("data-addon-id", addon.addonId);
-      link.setAttribute("data-addon-index", addon.index);
+      link.setAttribute("data-addon-index", styleIndex);
       link.classList.add("scratch-addons-style");
       link.href = userstyle.href;
       appendByIndex(link, styleIndex);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -399,7 +399,7 @@ async function onInfoAvailable({ globalState: globalStateMsg, addonsWithUserscri
       if (partial) {
         // Partial: part of userstyle was (re-)enabled.
         // No need to deal with userscripts here.
-        const addonsWithUserstylesEntry = addonsWithUserscripts.find((entry) => entry.addonId === addonId);
+        const addonsWithUserstylesEntry = addonsWithUserstyles.find((entry) => entry.addonId === addonId);
         if (addonsWithUserstylesEntry) {
           addonsWithUserstylesEntry.styles = userstyles;
         } else {
@@ -438,7 +438,7 @@ async function onInfoAvailable({ globalState: globalStateMsg, addonsWithUserscri
         removeAddonStylesPartial(addonId, partialDynamicDisabledStyles);
         if (styleIndex > -1) {
           // This should exist... right? Safeguarding anyway
-          const userstylesEntry = addonsWithUserscripts[styleIndex];
+          const userstylesEntry = addonsWithUserstyles[styleIndex];
           userstylesEntry.styles = userstylesEntry.styles.filter(
             (style) => !partialDynamicDisabledStyles.includes(style.href)
           );


### PR DESCRIPTION
Resolves #4188

Took 3 hours to implement and 30 minutes to write this.

# Major Changes
- `scratchAddons.dependents`: `object<Set<string>>` - set of addon IDs that declare the addon as `addonEnabled` dependency for userstyles.
- `getAddonData` and other places that handle an array of userstyles now receive an array of objects instead of strings. The object always has `href` (absolute URL to the style) and `index` (index in manifest, does not change if userstyle gets enabled/disabled), and additional `text` for `injectAsStyleElt` addons.
- Due to internal code changes, there's a maximum limit of userstyles per addon. Exceeding this won't throw error, but may cause unreliable style priority on some situations. Currently this is 100. If this is ever reached, a warning will be logged to the page console.
- `disabledDynamicAddons` and `everLoadedAddons` are now sets of addon IDs, which should fix issues with duplicate IDs. This should also make has/delete calls faster.
- And the big one, introducing partial dynamicEnable/dynamicDisable! This is like dynamicEnable (PDE)/dynamicDisable (PDD) but for part of the addon (specifically userstyles). See below

## PDE
PDE occurs when a dynamicEnable addon (A)'s userstyle depends on addon B, and B gets enabled while A is enabled. PDE doesn't emit reenabled event on addons. Note that PDE only occurs when enabling such addons caused a new userstyle to load. (For example, if A had two styles, X and Y, and X is always enabled while Y depends on (both disabled) addon B and C - if B is enabled, PDE attempt occurs at `change-addon-state.js`, but since C is disabled the style Y is still disabled. Thus, there are no new styles (since X is already enabled) and no PDE occurs. This is `get-userscripts.js` L39)

## PDD
PDD is a type of autism... wait no, not that.

PDD is the opposite of PDE, that occurs when a dynamicDisable addon (A)'s userstyle depends on addon B, and B gets disabled while A is enabled. PDD doesn't emit events. If there are remaining styles or loaded scripts, it just disables affected styles, removes them from the array, and early returns. (`cs.js` L448) However, if there are no scripts or styles left after disabling the affected styles, the addon is considered entirely disabled and is removed from `addonsWithUserstyles`, etc.

Normal dynamicDisable may follow PDD if someone disabled B and then A. To not "double disable" an addon, we first check if it's currently entirely disabled via PDD, and early-returns if so. (`cs.js` L431)