### PR TITLE
scratch-messaging: fail soft when missing replies

### DIFF
--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -220,10 +220,13 @@ export async function fetchMigratedComments(
     }
 
     if (json.parent_id && replies.length === 0) {
-      // Something went wrong, we didn't get the replies
-      throw new Error(
+      // Something went wrong, we didn't get the replies (likely API failure)
+      // Add the comment as a reply - better than crashing, because apparently it's
+      // more common than I thought!
+      console.error(
         `No replies found on comment ${resourceType}/${resourceId}/${commentId} with parents ${json.parent_id}`
       );
+      replies.push(json);
     }
 
     for (const reply of replies) {


### PR DESCRIPTION
This doesn't fix the underlying bug, it just means it will show the message without other replies when it fails.