### PR TITLE
add cmd key support

### DIFF
--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -6,7 +6,7 @@ export default async function ({ addon, global, console }) {
   icon.loading = "lazy";
   icon.style.display = "none";
   const toggleMute = (e) => {
-    if (e.ctrlKey) {
+    if (e.ctrlKey || e.metaKey) {
       e.cancelBubble = true;
       e.preventDefault();
       muted = !muted;


### PR DESCRIPTION

<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #4299

### Changes

basically just used what was in /addons/ctrl-enter-post/forums.js

### Reason for changes

So Mac users can use the CMD key.

### Tests
can't test since I don't have a Mac
