### PR TITLE
Change regex for comments that mention "scratch addons"

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -626,9 +626,9 @@ const isProject = pathArr[0] === "projects";
 
 if (isProfile || isStudio || isProject) {
   const shouldCaptureComment = (value) => {
-    const regex = / scratch[ ]?add[ ]?ons/;
+    const regex = /scratch[ ]?add[ ]?ons/;
     // Trim like scratchr2
-    const trimmedValue = " " + value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
+    const trimmedValue = value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
     const limitedValue = trimmedValue.toLowerCase().replace(/[^a-z /]+/g, "");
     return regex.test(limitedValue);
   };

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -73,9 +73,9 @@ export default async ({ addon, msg, safeMsg }) => {
       postComment() {
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js
-          const regex = / scratch[ ]?add[ ]?ons/;
+          const regex = /scratch[ ]?add[ ]?ons/;
           // Trim like scratchr2
-          const trimmedValue = " " + value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
+          const trimmedValue = value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
           const limitedValue = trimmedValue.toLowerCase().replace(/[^a-z /]+/g, "");
           return regex.test(limitedValue);
         };


### PR DESCRIPTION
This message now appears when linking to the Chrome Web Store link for scratch addons, now that the regex is more strict:

![image](https://user-images.githubusercontent.com/17484114/155417544-2ea6016e-07e2-4513-bffe-d04a0514ee26.png)
