### PR TITLE
Add CMD key notice

### DIFF
--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -7,6 +7,13 @@
       "link": "https://scratch.mit.edu/users/TheColaber"
     }
   ],
+  "info": [
+    {
+      "type": "notice",
+      "text": "On macOS, you can also use the Cmd key.",
+      "id": "macOS"
+    }
+  ],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -10,7 +10,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "On macOS, you can also use the Cmd key.",
+      "text": "On macOS, use the \"Cmd\" key instead of the \"Ctrl\" key",
       "id": "macOS"
     }
   ],

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -6,7 +6,7 @@ export default async function ({ addon, global, console }) {
   icon.loading = "lazy";
   icon.style.display = "none";
   const toggleMute = (e) => {
-    if (e.ctrlKey) {
+    if (e.ctrlKey || e.metaKey) {
       e.cancelBubble = true;
       e.preventDefault();
       muted = !muted;


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves [issuecomment-1050049569](https://github.com/ScratchAddons/ScratchAddons/pull/4320#issuecomment-1050049569)

### Changes
Added notice from ctrl-enter-post addon.json

### Reason for changes
So Mac users can know they use CMD

### Tests

Tested on Windows 10, Firefox 97.0.1
