### PR TITLE
 fix-pasted-scripts: don't break the flyout 

### DIFF
--- a/addons/fix-pasted-scripts/userscript.js
+++ b/addons/fix-pasted-scripts/userscript.js
@@ -2,7 +2,7 @@ export default async function ({ addon, global, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
   const originalGetGesture = ScratchBlocks.WorkspaceSvg.prototype.getGesture;
   ScratchBlocks.WorkspaceSvg.prototype.getGesture = function (e) {
-    if (!addon.self.disabled && e.type === 'mousedown' && this.isDragging()) {
+    if (!addon.self.disabled && e.type === "mousedown" && this.isDragging()) {
       return null;
     }
     return originalGetGesture.call(this, e);

--- a/addons/fix-pasted-scripts/userscript.js
+++ b/addons/fix-pasted-scripts/userscript.js
@@ -1,29 +1,10 @@
 export default async function ({ addon, global, console }) {
-  const BlocklyInstance = await addon.tab.traps.getBlockly();
-  const originalBlockMouseDown = BlocklyInstance.BlockSvg.prototype.onMouseDown_;
-  const originalFieldMouseDown = BlocklyInstance.Field.prototype.onMouseDown_;
-
-  BlocklyInstance.BlockSvg.prototype.onMouseDown_ = function (e) {
-    if (!addon.self.disabled && this.workspace && this.workspace.isDragging()) {
-      return;
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const originalGetGesture = ScratchBlocks.WorkspaceSvg.prototype.getGesture;
+  ScratchBlocks.WorkspaceSvg.prototype.getGesture = function (e) {
+    if (!addon.self.disabled && e.type === 'mousedown' && this.isDragging()) {
+      return null;
     }
-    return originalBlockMouseDown.call(this, e);
+    return originalGetGesture.call(this, e);
   };
-  BlocklyInstance.Field.prototype.onMouseDown_ = function (e) {
-    if (
-      !addon.self.disabled &&
-      this.sourceBlock_ &&
-      this.sourceBlock_.workspace &&
-      this.sourceBlock_.workspace.isDragging()
-    ) {
-      return;
-    }
-    return originalFieldMouseDown.call(this, e);
-  };
-
-  // Because of how Scratch adds event listeners, we might have to redraw if the editor already has something
-  const vm = addon.tab.traps.vm;
-  if (vm.editingTarget) {
-    vm.emitWorkspaceUpdate();
-  }
 }


### PR DESCRIPTION
This should be safer and faster; it won't trigger a workspace update

Fixes https://discord.com/channels/751206349614088204/751207339545198682/946687781265113119

Fixes https://discord.com/channels/806602307750985799/944919791477620746/945042894849474562

>repro steps:
>1) be logged out and use Chrome, go to /projects/editor/ with fix-pasted-scripts enabled
>2) create new variable
>3) neither toolbox block nor monitor appears
>4) refresh workspace (e.g. by switching tabs or sprites)
>5) toolbox updated, monitor still missing
