### PR TITLE
2.0 → 3.0 forum username fixes

### DIFF
--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -278,7 +278,8 @@ body > #pagewrapper {
 .djangobb .username:hover {
   width: fit-content;
 }
-.forum-search-list .postleft .username {
+.forum-search-list .postleft .username,
+.forum-search-list .postleft .username:visited:not(:hover) {
   color: var(--darkWww-gray-text, #575e75);
 }
 .searchposts .postleft a {


### PR DESCRIPTION
### Changes

* Fixes visited usernames being white
* Restrict the width of the clickable area to the text itself
* Makes very long usernames cover the post text when hovered