### PR TITLE
Add Cmd Key notice to mute-project

### DIFF
--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -4,7 +4,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "On macOS, use the \"Cmd\" key instead of the \"Ctrl\" key.",
+      "text": "On macOS, use the Cmd key instead of the Ctrl key.",
       "id": "macOS"
     }
   ],

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -1,6 +1,14 @@
 {
   "name": "Muted project player mode",
   "description": "Ctrl+Click the green flag to mute/unmute the project.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "On macOS, you can also use the Cmd key.",
+      "text": "On macOS, use the \"Cmd\" key instead of the \"Ctrl\" key",
+      "id": "macOS"
+    }
+  ],
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -4,8 +4,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "On macOS, you can also use the Cmd key.",
-      "text": "On macOS, use the \"Cmd\" key instead of the \"Ctrl\" key",
+      "text": "On macOS, use the \"Cmd\" key instead of the \"Ctrl\" key.",
       "id": "macOS"
     }
   ],


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves [issuecomment-1050049569](https://github.com/ScratchAddons/ScratchAddons/pull/4320#issuecomment-1050049569)

### Changes
Added notice to use CMD key on Mac.

### Reason for changes
So Mac users can know they use CMD

### Tests

Tested on Windows 10, Firefox 97.0.1