### PR TITLE
Change minimum supported Firefox version, remove unused code

### DIFF
--- a/addon-api/popup/Popup.js
+++ b/addon-api/popup/Popup.js
@@ -23,10 +23,7 @@ export default class Popup {
     return new Promise((resolve) => {
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         if (tabs.length === 0) return resolve(null);
-        chrome.tabs.sendMessage(tabs[0].id, "getLocationHref", { frameId: 0 }, (url) => {
-          if (chrome.runtime.lastError) return resolve(null);
-          resolve(url);
-        });
+        return resolve(tabs[0]?.url || null);
       });
     });
   }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -21,7 +21,7 @@ scratchAddons.localEvents.addEventListener("addonDynamicEnable", ({ detail }) =>
   const { addonId, manifest } = detail;
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
-      if (tab.url || (!tab.url && typeof browser !== "undefined")) {
+      if (tab.url) {
         chrome.tabs.sendMessage(tab.id, "getInitialUrl", { frameId: 0 }, (res) => {
           void chrome.runtime.lastError;
           if (res) {
@@ -56,7 +56,7 @@ scratchAddons.localEvents.addEventListener("addonDynamicDisable", ({ detail }) =
   const { addonId } = detail;
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
-      if (tab.url || (!tab.url && typeof browser !== "undefined")) {
+      if (tab.url) {
         chrome.tabs.sendMessage(
           tab.id,
           { dynamicAddonDisable: { addonId } },
@@ -71,7 +71,7 @@ scratchAddons.localEvents.addEventListener("updateUserstylesSettingsChange", ({ 
   const { addonId, manifest } = detail;
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
-      if (tab.url || (!tab.url && typeof browser !== "undefined")) {
+      if (tab.url) {
         chrome.tabs.sendMessage(tab.id, "getInitialUrl", { frameId: 0 }, (res) => {
           if (res) {
             (async () => {
@@ -288,7 +288,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // we notify them they can resend the contentScriptInfo message
 chrome.tabs.query({}, (tabs) =>
   tabs.forEach((tab) => {
-    if (tab.url || (!tab.url && typeof browser !== "undefined")) {
+    if (tab.url) {
       chrome.tabs.sendMessage(tab.id, "backgroundListenerReady", () => void chrome.runtime.lastError);
     }
   })

--- a/background/handle-unsupported-version.js
+++ b/background/handle-unsupported-version.js
@@ -6,7 +6,7 @@ const checkIfUnsupported = () => {
   };
 
   let { browser, version } = getVersion();
-  return (browser === "Chrome" && version < 80) || (browser === "Firefox" && version < 74);
+  return (browser === "Chrome" && version < 80) || (browser === "Firefox" && version < 86);
 };
 
 if (checkIfUnsupported()) {

--- a/background/imports/global-state.js
+++ b/background/imports/global-state.js
@@ -44,7 +44,7 @@ function messageForAllTabs(message) {
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach(
       (tab) =>
-        (tab.url || (!tab.url && typeof browser !== "undefined")) &&
+        (tab.url) &&
         chrome.tabs.sendMessage(tab.id, message, () => void chrome.runtime.lastError)
     )
   );

--- a/background/imports/global-state.js
+++ b/background/imports/global-state.js
@@ -42,11 +42,7 @@ class StateProxy {
 
 function messageForAllTabs(message) {
   chrome.tabs.query({}, (tabs) =>
-    tabs.forEach(
-      (tab) =>
-        (tab.url) &&
-        chrome.tabs.sendMessage(tab.id, message, () => void chrome.runtime.lastError)
-    )
+    tabs.forEach((tab) => tab.url && chrome.tabs.sendMessage(tab.id, message, () => void chrome.runtime.lastError))
   );
   scratchAddons.sendToPopups(message);
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -156,8 +156,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   console.log("[Message from background]", request);
   if (request === "getInitialUrl") {
     sendResponse(pseudoUrl || initialUrl);
-  } else if (request === "getLocationHref") {
-    sendResponse(location.href);
   }
 });
 


### PR DESCRIPTION
Resolves #4334 

Firefox 86 gives us access to the URL of tabs we already have a host permission for, so we can avoid sending messages to all tabs in Firefox, and instead do the same thing we've always done in Chrome, which is only messaging scratch.mit.edu tabs.