### PR TITLE
Settings page - CSS tweaks - Clickable controls now use pointer cursor

### DIFF
--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -74,7 +74,6 @@ body {
   font-size: 12px;
   padding-inline-start: 10.5px;
   padding-inline-end: 12px;
-  cursor: pointer;
   background-color: var(--button-background);
   border: 1px solid var(--control-border);
   border-bottom: none;
@@ -83,6 +82,9 @@ body {
 }
 .popup-name:hover {
   background-color: var(--button-hover-background);
+}
+.popup-name:not(.sel):hover {
+  cursor: pointer;
 }
 .popup-name:not(:last-child) {
   border-inline-end: none;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -127,6 +127,7 @@ h1 {
 }
 .large-button:hover:not([disabled]) {
   background: var(--button-hover-background);
+  cursor: pointer;
 }
 .large-button:focus-visible {
   outline: none;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -396,6 +396,9 @@ button.setting-input.color.open {
   display: flex;
   position: relative;
 }
+.color-container .setting-input.color {
+  cursor: pointer;
+}
 
 .action-disabled {
   pointer-events: none;

--- a/webpages/styles/components/filter.css
+++ b/webpages/styles/components/filter.css
@@ -28,6 +28,9 @@
 .filter-option:hover {
   background: var(--button-hover-background);
 }
+.filter-option:not(.sel):hover {
+  cursor: pointer;
+}
 .filter-option:last-child {
   border-inline-end: none;
 }


### PR DESCRIPTION
## Reason for changes

It adds more consistency and better accessibility to the controls used in the settings page.
All the controls (buttons, reset input buttons, open color picker button, etc.) now show a pointer mouse cursor (pointing hand) when hovered.
It's now clearer that those controls are clickable.
It is basically the point of that cursor, so we might as well use it.

Suggested those changes back in August this year.
Didn't get a lot of feedback, but was mainly positive overall.
Even if this was never really requested, it's still a nice quality of life addition and doesn't hurt.



