### PR TITLE
Settings page - Allows closing an addon category by re-clicking on it.

### DIFF
--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -19,11 +19,11 @@ export default async function ({ template }) {
     methods: {
       onClick(event) {
         event.stopPropagation();
-        this.$root.selectedCategory = (
-          this.selectedCategory === this.category.id && !this.category.parent
-            ? this.$root.categories.find(category => category.id === "all")
-            : this.category
-        ).id;
+        if (this.selectedCategory === this.category.id && !this.category.parent) {
+          this.$root.selectedCategory = "all";
+        } else {
+          this.$root.selectedCategory = this.category.id;
+        }
       },
     },
   });

--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -21,7 +21,7 @@ export default async function ({ template }) {
     methods: {
       onClick(event) {
         event.stopPropagation();
-        if (this.selectedCategory === this.category.id && !this.category.parent && Date.now() - this.lastClick > 250) {
+        if (this.selectedCategory === this.category.id && !this.category.parent && Date.now() - this.lastClick > 350) {
           this.$root.selectedCategory = "all";
         } else {
           this.$root.selectedCategory = this.category.id;

--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -21,7 +21,7 @@ export default async function ({ template }) {
     methods: {
       onClick(event) {
         event.stopPropagation();
-        if (this.selectedCategory === this.category.id && !this.category.parent && Date.now() - this.lastClick > 500) {
+        if (this.selectedCategory === this.category.id && !this.category.parent && Date.now() - this.lastClick > 250) {
           this.$root.selectedCategory = "all";
         } else {
           this.$root.selectedCategory = this.category.id;

--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -19,7 +19,11 @@ export default async function ({ template }) {
     methods: {
       onClick(event) {
         event.stopPropagation();
-        this.$root.selectedCategory = this.category.id;
+        this.$root.selectedCategory = (
+          this.selectedCategory === this.category.id && !this.category.parent
+            ? this.$root.categories.find(category => category.id === "all")
+            : this.category
+        ).id;
       },
     },
   });

--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -3,7 +3,9 @@ export default async function ({ template }) {
     props: ["category"],
     template,
     data() {
-      return {};
+      return {
+        lastClick: 0,
+      };
     },
     computed: {
       selectedCategory() {
@@ -19,11 +21,12 @@ export default async function ({ template }) {
     methods: {
       onClick(event) {
         event.stopPropagation();
-        if (this.selectedCategory === this.category.id && !this.category.parent) {
+        if (this.selectedCategory === this.category.id && !this.category.parent && Date.now() - this.lastClick > 500) {
           this.$root.selectedCategory = "all";
         } else {
           this.$root.selectedCategory = this.category.id;
         }
+        this.lastClick = Date.now();
       },
     },
   });


### PR DESCRIPTION
When you click the the accordion category that is already opened, the category is closed and the main / default category is then opened / selected.

### Reason for changes

I know this has been debated when I originally submitted the proposal, but hear me out.

Many accordion menus behave this way.
This commit just adds a behavior that is to be expected from such kind of menu.

It doesn't change anything for the users used to the menu's current behavior,
but it's still a nice quality of life improvement for those expecting it to behave that way.
