### PR TITLE
"View settings" button on settings page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -290,7 +290,7 @@
   "import": {
     "message": "Import Settings"
   },
-  "view":{
+  "view": {
     "message": "View settings file"
   },
   "fileNotSelected": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -290,6 +290,9 @@
   "import": {
     "message": "Import Settings"
   },
+  "view":{
+    "message": "View settings file"
+  },
   "fileNotSelected": {
     "message": "Please select a settings file."
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -290,7 +290,7 @@
   "import": {
     "message": "Import Settings"
   },
-  "view": {
+  "viewSettings": {
     "message": "View settings file"
   },
   "fileNotSelected": {

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -254,7 +254,7 @@
                   <button class="large-button hidden-button" id="confirmImport">{{ msg("confirmImport") }}</button>
                 </div>
                 <div class="filter-selector" style="margin-left: 16px">
-                  <button class="large-button" @click="viewSettings()">{{ msg("view") }}</button>
+                  <button class="large-button" @click="viewSettings()">{{ msg("viewSettings") }}</button>
                 </div>
               </div>
             </div>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -253,6 +253,9 @@
                   <button class="large-button" @click="importSettings()">{{ msg("import") }}</button>
                   <button class="large-button hidden-button" id="confirmImport">{{ msg("confirmImport") }}</button>
                 </div>
+                <div class="filter-selector">
+                  <button class="large-button" @click="viewSettings()">{{ msg("view") }}</button>
+                </div>
               </div>
             </div>
           </div>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -253,7 +253,7 @@
                   <button class="large-button" @click="importSettings()">{{ msg("import") }}</button>
                   <button class="large-button hidden-button" id="confirmImport">{{ msg("confirmImport") }}</button>
                 </div>
-                <div class="filter-selector">
+                <div class="filter-selector" style="margin-left: 16px">
                   <button class="large-button" @click="viewSettings()">{{ msg("view") }}</button>
                 </div>
               </div>

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -300,9 +300,10 @@ let fuse;
         });
       },
       viewSettings() {
+        const openedWindow = window.open("about:blank");
         serializeSettings().then((serialized) => {
           const blob = new Blob([serialized], { type: "text/plain" });
-          window.open(URL.createObjectURL(blob));
+          openedWindow.location.replace(URL.createObjectURL(blob));
         });
       },
       importSettings() {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -299,6 +299,14 @@ let fuse;
           downloadBlob("scratch-addons-settings.json", blob);
         });
       },
+      
+      viewSettings(){
+        serializeSettings().then((serialized) => {
+          const blob = new Blob([serialized], { type: "text/plain" });
+          window.open(URL.createObjectURL(blob));
+        });
+      },
+
       importSettings() {
         const inputElem = Object.assign(document.createElement("input"), {
           hidden: true,

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -299,14 +299,12 @@ let fuse;
           downloadBlob("scratch-addons-settings.json", blob);
         });
       },
-      
-      viewSettings(){
+      viewSettings() {
         serializeSettings().then((serialized) => {
           const blob = new Blob([serialized], { type: "text/plain" });
           window.open(URL.createObjectURL(blob));
         });
       },
-
       importSettings() {
         const inputElem = Object.assign(document.createElement("input"), {
           hidden: true,


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #4360

### Changes

Adds a button to view the raw settings file in the Settings page.

### Reason for changes

#4360

### Tests

Like this

https://user-images.githubusercontent.com/97374054/157168220-b648ad40-b6ff-4cb1-9710-55684647f64a.mov

### Drawbacks?
Well this is currently using `window.open()` so it counts as a pop-up, according to the user's browser settings, they may or may not see this message when they click the button

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/97374054/157168400-08d901aa-537b-4fed-8763-1d4ec31c2c6a.png">

In vanilla JS, under a user event, pop-ups are allowed to be made (like when a button is clicked), but since this is using Vue, I don't think it works that way.
