### PR TITLE
folders: optimize folder preview generation 

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1,3 +1,5 @@
+import { escapeHTML } from "../../libraries/common/cs/autoescaper.js";
+
 export default async function ({ addon, global, console, msg }) {
   // The basic premise of how this addon works is relative simple.
   // scratch-gui renders the sprite selectors and asset selectors in a hierarchy like this:
@@ -16,8 +18,6 @@ export default async function ({ addon, global, console, msg }) {
   // We touch some things on the VM to make dragging items work properly.
 
   const REACT_INTERNAL_PREFIX = "__reactInternalInstance$";
-
-  const SVG_NS = "http://www.w3.org/2000/svg";
 
   const TYPE_SPRITES = 1;
   const TYPE_ASSETS = 2;
@@ -370,26 +370,29 @@ export default async function ({ addon, global, console, msg }) {
     ];
 
     const createFolderPreview = (items) => {
-      const svg = document.createElementNS(SVG_NS, "svg");
-      svg.setAttribute("width", PREVIEW_SIZE);
-      svg.setAttribute("height", PREVIEW_SIZE);
+      // Directly generate a string instead of using DOM API for performance as we deal with very large inlined images
+      // Because the result is only used as an img src, XSS shouldn't be a concern
+      let result = `data:image/svg+xml;,<svg xmlns="http://www.w3.org/2000/svg" width="${PREVIEW_SIZE}" height="${PREVIEW_SIZE}">`;
       for (let i = 0; i < Math.min(PREVIEW_POSITIONS.length, items.length); i++) {
         const item = items[i];
-        const image = document.createElementNS(SVG_NS, "image");
-        image.setAttribute("width", PREVIEW_SIZE / 2);
-        image.setAttribute("height", PREVIEW_SIZE / 2);
-        image.setAttribute("x", PREVIEW_POSITIONS[i][0]);
-        image.setAttribute("y", PREVIEW_POSITIONS[i][1]);
+        const width = PREVIEW_SIZE / 2;
+        const height = PREVIEW_SIZE / 2;
+        const [x, y] = PREVIEW_POSITIONS[i];
+        let src;
         if (item.asset) {
-          image.setAttribute("href", item.asset.encodeDataURI());
+          // escaping shouldn't be necessary here but we'll do it anyways for safety
+          src = escapeHTML(item.asset.encodeDataURI());
         } else if (item.costume && item.costume.asset) {
-          image.setAttribute("href", item.costume.asset.encodeDataURI());
+          src = escapeHTML(item.costume.asset.encodeDataURI());
         } else if (item.url) {
-          image.setAttribute("href", soundIconHref);
+          src = soundIconHref;
         }
-        svg.appendChild(image);
+        if (src) {
+          result += `<image width="${width}" height="${height}" x="${x}" y="${y}" href="${src}"/>`;
+        }
       }
-      return "data:image/svg+xml;," + new XMLSerializer().serializeToString(svg);
+      result += '</svg>';
+      return result;
     };
 
     const getUniqueIdOfFolderItems = (items) => {

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -391,7 +391,7 @@ export default async function ({ addon, global, console, msg }) {
           result += `<image width="${width}" height="${height}" x="${x}" y="${y}" href="${src}"/>`;
         }
       }
-      result += '</svg>';
+      result += "</svg>";
       return result;
     };
 


### PR DESCRIPTION
DOM API is very slow when dealing with very large attributes like inline image sources. Manually generating a string is much faster.

On a test project, generating a very large folder preview used to take 20ms, now takes 3ms. Could be further reduced to almost zero if escaping is removed which doesn't sound like a great idea (even though I'm pretty sure it would be completely safe).