### PR TITLE
Hide Studio Outlines

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -118,6 +118,7 @@
   "hide-signatures",
   "disable-sprite-wobble",
   "forum-live-preview",
+  "hide-studio-outlines",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/hide-studio-outlines/addon.json
+++ b/addons/hide-studio-outlines/addon.json
@@ -12,7 +12,7 @@
   "userscripts": [
     {
       "url": "script.js",
-      "matches": ["profiles"]
+      "matches": ["users"]
     }
   ]
 }

--- a/addons/hide-studio-outlines/addon.json
+++ b/addons/hide-studio-outlines/addon.json
@@ -1,0 +1,18 @@
+
+{
+  "name": "Hide studio outlines",
+  "description": "Hides the ugly outlines that studidos have on Scratch 2.0 profiles.",
+  "credits": [
+    {
+      "name": "rgantzos",
+      "link": "https://scratch.mit.edu/users/rgantzos/"
+    }
+  ],
+  "tags": ["studios"],
+  "userscripts": [
+    {
+      "url": "script.js",
+      "matches": ["profiles"]
+    }
+  ]
+}

--- a/addons/hide-studio-outlines/addon.json
+++ b/addons/hide-studio-outlines/addon.json
@@ -12,7 +12,7 @@
   "userscripts": [
     {
       "url": "script.js",
-      "matches": ["users"]
+      "matches": ["https://scratch.mit.edu/users/*"]
     }
   ]
 }

--- a/addons/hide-studio-outlines/script.js
+++ b/addons/hide-studio-outlines/script.js
@@ -1,12 +1,12 @@
 function checkforstudio() {
     if (document.querySelector('.lazy') === null) {
-window.setTimeout(checkforstudio(), 100)
+        window.setTimeout(checkforstudio(), 100)
     } else {
-const highlightedItems = document.querySelectorAll('.image')
+        const highlightedItems = document.querySelectorAll('.image')
 
-highlightedItems.forEach(function(item) {
-item.style.border = '0px'
-})
-}
+        highlightedItems.forEach(function(item) {
+            item.style.border = '0px'
+        })
+    }
 }
 checkforstudio()

--- a/addons/hide-studio-outlines/script.js
+++ b/addons/hide-studio-outlines/script.js
@@ -1,0 +1,12 @@
+function checkforstudio() {
+    if (document.querySelector('.lazy') === null) {
+window.setTimeout(checkforstudio(), 100)
+    } else {
+const highlightedItems = document.querySelectorAll('.image')
+
+highlightedItems.forEach(function(item) {
+item.style.border = '0px'
+})
+}
+}
+checkforstudio()


### PR DESCRIPTION
On profiles, studios have an **EXTREMELY** ugly outline. This addon would remove it, and make the UI on the profile pages _much_ nicer.
### Before:
<img width="443" alt="Screen Shot 2022-03-13 at 9 58 12 AM" src="https://user-images.githubusercontent.com/86856959/158070426-a888ffbb-2c8d-4516-a401-671702fdc15f.png">

### After:
<img width="443" alt="Screen Shot 2022-03-13 at 10 00 56 AM" src="https://user-images.githubusercontent.com/86856959/158070543-6262e41c-e653-4c3a-a8b0-7b61439c34d0.png">