### PR TITLE
Remove use of InstallTrigger for UA detection

### DIFF
--- a/addon-api/common/Self.js
+++ b/addon-api/common/Self.js
@@ -13,7 +13,7 @@ export default class Self extends Listenable {
     this._addonId = info.id; // In order to receive fireEvent messages from background
     this.id = info.id;
     this._addonObj = addonObj;
-    this.browser = typeof InstallTrigger !== "undefined" ? "firefox" : "chrome";
+    this.browser = /Chrom/.test(navigator.userAgent) ? "chrome" : "firefox";
     this.disabled = false;
     this.addEventListener("disabled", () => (this.disabled = true));
     this.addEventListener("reenabled", () => (this.disabled = false));

--- a/libraries/common/notification-util.js
+++ b/libraries/common/notification-util.js
@@ -7,7 +7,7 @@ export default function create(opts) {
   if (scratchAddons.muted) return Promise.resolve(null);
   const notifId = `${opts.base}__${Date.now()}_${id++}`;
   let newOpts;
-  if (typeof InstallTrigger !== "undefined") {
+  if (!/Chrom/.test(navigator.userAgent)) {
     newOpts = JSON.parse(JSON.stringify(opts));
     // On Firefox, remove notification properties that throw.
     delete newOpts.buttons;


### PR DESCRIPTION
An intent-to-deprecate was issued, replacing them with general User-Agent detection.