### PR TITLE
Scratch Avocados (April Fools)

### DIFF
--- a/libraries/common/global-theme.js
+++ b/libraries/common/global-theme.js
@@ -1,6 +1,7 @@
 export default function () {
   const now = Date.now() / 1000;
-  if (now < 1648911600 && now > 1648738800) document.documentElement.style.setProperty("--brand-orange", "#568203");
+  if (now < 1648911600 && now > 1648738800 && ["settings", "popup"].includes(location.pathname.split("/")[2]))
+    document.documentElement.style.setProperty("--brand-orange", "#568203");
 
   const lightThemeLink = document.createElement("link");
   lightThemeLink.setAttribute("rel", "stylesheet");

--- a/libraries/common/global-theme.js
+++ b/libraries/common/global-theme.js
@@ -1,4 +1,7 @@
 export default function () {
+  const now = Date.now() / 1000;
+  if (now < 1648911600 && now > 1648738800) document.documentElement.style.setProperty("--brand-orange", "#568203");
+
   const lightThemeLink = document.createElement("link");
   lightThemeLink.setAttribute("rel", "stylesheet");
   lightThemeLink.setAttribute("href", chrome.runtime.getURL("/webpages/styles/colors-light.css"));

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -26,6 +26,8 @@ const vue = new Vue({
   },
   methods: {
     msg(message, ...params) {
+      const now = Date.now() / 1000;
+      if (message === "extensionName" && now < 1648911600 && now > 1648738800) return "Scratch Avocados";
       return chrome.i18n.getMessage(message, ...params);
     },
     direction() {

--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -24,6 +24,8 @@
     cursor: pointer;
     display: flex;
     align-items: center;
+
+    --brand-orange: #ff7b26;
   }
   .category.category-small {
     padding: 15px 20px 15px 20px;

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -118,7 +118,7 @@
     <div class="navbar">
       <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
       <img src="../../images/icon.svg" class="logo" alt="Logo" />
-      <h1 v-cloak>{{ msg("settings") }}</h1>
+      <h1 v-cloak>{{ msg("settings") }}{{ aprilFoolsAvocado }}</h1>
       <img v-cloak @click="setTheme(!theme)" class="theme-switch" :src="themePath" />
     </div>
     <div class="main">

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -176,6 +176,11 @@ let fuse;
             changelog: `https://scratchaddons.com/${localeSlash}changelog?${utm}`,
           };
         })(),
+        aprilFoolsAvocado: (() => {
+          const now = Date.now() / 1000;
+          if (now < 1648911600 && now > 1648738800) return " 🥑";
+          else return "";
+        })(),
       };
     },
     computed: {


### PR DESCRIPTION
Our April Fools, from March 31st 12:00:00 UTC+0 to April 2nd 12:00:00 UTC+0.

Took avocado hex color from [Wikipedia](https://en.wikipedia.org/wiki/List_of_colors:_A%E2%80%93F).

Popup changes: brand color, extension name (note that real extension name does not change, only this header). "Scratch Avocados" is not localized.
![image](https://user-images.githubusercontent.com/17484114/159814770-014d0883-eb1a-4585-904c-5afa6d87583d.png)

Settings page changes: brand color, avocado emoji on header next to "settings"
![image](https://user-images.githubusercontent.com/17484114/159814799-48ecb6ca-5c1e-4961-a893-7bbee70de1fc.png)
