### PR TITLE
Revert now unnecessary April Fools fix

### DIFF
--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -16,43 +16,6 @@ function injectPrototype() {
       onceMap.vm = args[0];
       // After finding the VM, return to previous Function.prototype.bind
       Function.prototype.bind = oldBind;
-
-      const vm = args[0];
-
-      const getStyleFixer = () => {
-        const cssVariables = document.documentElement
-          .getAttribute("style")
-          .split(";")
-          .filter((s) => s.trimStart().startsWith("--"))
-          .join(";");
-        return () => {
-          document.documentElement.setAttribute("style", cssVariables);
-        };
-      };
-
-      const originalsetWorldStageMode = vm.setWorldStageMode;
-      vm.setWorldStageMode = function () {
-        const fixStyles = getStyleFixer();
-        const returnValue = originalsetWorldStageMode.apply(vm, args);
-        fixStyles();
-        return returnValue;
-      };
-
-      (async () => {
-        await new Promise((resolve) => {
-          if (vm.editingTarget) return resolve();
-          vm.runtime.once("PROJECT_LOADED", resolve);
-        });
-        const renderedTargetPrototype = Object.getPrototypeOf(vm.runtime.getTargetForStage());
-        const originalClearEffects = renderedTargetPrototype.clearEffects;
-        renderedTargetPrototype.clearEffects = function () {
-          const fixStyles = getStyleFixer();
-          const returnValue = originalClearEffects.apply(this, args);
-          fixStyles();
-          return returnValue;
-        };
-      })();
-
       return oldBind.apply(this, args);
     } else {
       return oldBind.apply(this, args);


### PR DESCRIPTION
"All the world's a stage" mode, which would clear the `style` attribute of the `<html>` element, was removed: https://github.com/LLK/scratch-gui/commit/9a0200e0bb1e6d1b034cabf514db6fee588fc01d

So we can also remove our own fix that restored CSS variables to avoid issues with editor-dark-mode and other addons.