### PR TITLE
Fixed z-index property

### DIFF
--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -2,6 +2,7 @@
   display: flex;
   white-space: nowrap;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  z-index: 1;
 }
 
 .s3devLabel {


### PR DESCRIPTION
Resolves: Problem with search bar showing in front of new easter egg layer with for example, torch:
![Screenshot from 2022-04-01 20-41-36](https://user-images.githubusercontent.com/89837724/161324631-9166a6aa-bf04-4b1a-beeb-df34920baf9c.png)


### Changes

Just simple added `z-index`

### Tests

Yep. It looks nice, and everything works normally:
![Screenshot from 2022-04-01 20-42-06](https://user-images.githubusercontent.com/89837724/161324763-cb887224-68a4-4ada-a4b2-6d74e3980fc5.png)

### Info

Just today we have this torch, but when SA or ST will add new things in front layer, we will need to fix it. So why just not fix it now?
