### PR TITLE
Fix command key not working on `ctrl-enter-post`

### DIFF
--- a/addons/ctrl-enter-post/comments.js
+++ b/addons/ctrl-enter-post/comments.js
@@ -18,7 +18,7 @@ export default async function ({ addon, global, console, msg }) {
       button = textbox.parentNode.parentNode.parentNode.querySelector(".compose-bottom-row .compose-post");
     }
 
-    textbox.addEventListener("keyup", (e) => {
+    textbox.addEventListener("keydown", (e) => {
       if ((e.ctrlKey || e.metaKey) && (e.code === "Enter" || e.code === "NumpadEnter")) {
         button.click();
       }

--- a/addons/ctrl-enter-post/forums.js
+++ b/addons/ctrl-enter-post/forums.js
@@ -5,7 +5,7 @@ export default async function ({ addon }) {
   let postButton = document.querySelector(type === "topic" ? ".button.grey:nth-child(1)" : "button");
 
   if (!textarea) return;
-  textarea.addEventListener("keyup", (e) => {
+  textarea.addEventListener("keydown", (e) => {
     if ((e.ctrlKey || e.metaKey) && (e.code === "Enter" || e.code === "NumpadEnter")) {
       postButton.click();
     }


### PR DESCRIPTION
Resolves #4451

### Changes
Changes event listener to listen on `keydown` instead of `keyup`

### Reason for changes
`keyup` doesn't seem to work for the command key on Macs

### Tests

Command key now seems to work on Firefox, macOS Big Sur, on both the forums  (posting a new post and editing)  and comments (scratchr2 + scratch-www). Also tested ctrl key on the forums and comments, works fine. 