### PR TITLE
Remove sareferer when unnecessary

### DIFF
--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -89,7 +89,7 @@ export async function fetchMessageCount(username) {
  */
 export async function fetchMessages(username, xToken, offset) {
   const resp = await fetch(
-    `https://api.scratch.mit.edu/users/${username}/messages?limit=40&offset=${offset}&sareferer`,
+    `https://api.scratch.mit.edu/users/${username}/messages?limit=40&offset=${offset}`,
     {
       headers: {
         "x-token": xToken,

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -88,14 +88,11 @@ export async function fetchMessageCount(username) {
  * @throws {HTTPError} when fetching fails
  */
 export async function fetchMessages(username, xToken, offset) {
-  const resp = await fetch(
-    `https://api.scratch.mit.edu/users/${username}/messages?limit=40&offset=${offset}`,
-    {
-      headers: {
-        "x-token": xToken,
-      },
-    }
-  );
+  const resp = await fetch(`https://api.scratch.mit.edu/users/${username}/messages?limit=40&offset=${offset}`, {
+    headers: {
+      "x-token": xToken,
+    },
+  });
   if (!resp.ok) {
     if (resp.status === 404) return [];
     throw HTTPError.fromResponse(`Fetching message offset ${offset} for ${username} failed`, resp);

--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -143,19 +143,19 @@ export async function fetchMigratedComments(
 ) {
   let projectAuthor;
   if (resourceType === "project") {
-    const projectRes = await fetch(`https://api.scratch.mit.edu/projects/${resourceId}?sareferer`);
+    const projectRes = await fetch(`https://api.scratch.mit.edu/projects/${resourceId}`);
     if (!projectRes.ok) return commentsObj; // empty
     const projectJson = await projectRes.json();
     projectAuthor = projectJson.author.username;
   }
   const getCommentUrl = (commId) =>
     resourceType === "project"
-      ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}?sareferer`
-      : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}?sareferer`;
+      ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}`
+      : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}`;
   const getRepliesUrl = (commId, offset) =>
     resourceType === "project"
-      ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}&sareferer`
-      : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}&sareferer`;
+      ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}`
+      : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}`;
   for (const commentId of commentIds) {
     if (commentsObj[`${resourceType[0]}_${commentId}`]) continue;
 

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -137,10 +137,10 @@ export default async ({ addon, msg, safeMsg }) => {
                   mins: Math.max(Math.ceil((e.details.muteStatus.muteExpiresAt - Date.now() / 1000) / 60), 1),
                 });
               } else {
-                errorMsg = msg(errorCodes[e.details.error] || "send-error");
+                errorMsg = msg(errorCodes[e.details?.error] || "send-error");
               }
             } else if (e instanceof API.HTTPError) {
-              errorMsg = msg(errorCodes[e.details.code] || "send-error");
+              errorMsg = msg(errorCodes[e.code] || "send-error");
             } else {
               errorMsg = e.toString();
             }

--- a/webpages/popup-loader.js
+++ b/webpages/popup-loader.js
@@ -75,7 +75,7 @@ async function refetchSession(addon) {
   scratchAddons.isFetchingSession = true;
   addon.auth._refresh();
   try {
-    res = await fetch("https://scratch.mit.edu/session/?sareferer", {
+    res = await fetch("https://scratch.mit.edu/session/", {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
       },


### PR DESCRIPTION
Referer is unnecessary when fetching from migrated API. Still required for r2 or proxy APIs. Also fixes a potential crash when a comment could not be sent.