### PR TITLE
Use declarativeNetRequestWithHostAccess when possible

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -1,3 +1,6 @@
+const PERMISSIONS_IGNORED_IN_CHROME = ["clipboardWrite"];
+const PERMISSIONS_IGNORED_IN_FIREFOX = ["declarativeNetRequestWithHostAccess"];
+
 /**
  * Generates a manifest for specific browsers.
  * Called by packer-script.
@@ -13,12 +16,14 @@ export default (env, manifest) => {
       delete manifest.browser_specific_settings;
       // manifest.incognito = "split";
       manifest.optional_permissions = manifest.optional_permissions.filter(
-        (permission) => permission !== "clipboardWrite"
+        (permission) => !PERMISSIONS_IGNORED_IN_CHROME.includes(permission)
       );
       break;
     }
     case "firefox": {
-      // Currently none
+      manifest.optional_permissions = manifest.optional_permissions.filter(
+        (permission) => !PERMISSIONS_IGNORED_IN_FIREFOX.includes(permission)
+      );
       break;
     }
   }

--- a/background/handle-fetch.js
+++ b/background/handle-fetch.js
@@ -1,59 +1,62 @@
-const extraInfoSpec = ["blocking", "requestHeaders"];
-if (Object.prototype.hasOwnProperty.call(chrome.webRequest.OnBeforeSendHeadersOptions, "EXTRA_HEADERS"))
-  extraInfoSpec.push("extraHeaders");
+if (chrome.declarativeNetRequest) {
+  // DNR available, use this instead
+  chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: [1],
+    addRules: [
+      {
+        id: 1,
+        priority: 1,
+        action: {
+          type: "modifyHeaders",
+          requestHeaders: [
+            {
+              header: "Referer",
+              operation: "set",
+              value: "https://scratch.mit.edu/",
+            },
+          ],
+        },
+        condition: {
+          domains: [chrome.runtime.id],
+          regexFilter: "^https:\\/\\/(api\\.|clouddata\\.|)scratch\\.mit\\.edu\\/.*(\\?|\\&)sareferer",
+          resourceTypes: ["xmlhttprequest"],
+        },
+      },
+    ],
+  });
+} else {
+  // DNR unavailable, falling back to webRequestBlocking
+  // Used in Chrome < 96 (lacks DNRWithHostAccess) and Firefox
+  const extraInfoSpec = ["blocking", "requestHeaders"];
+  if (Object.prototype.hasOwnProperty.call(chrome.webRequest.OnBeforeSendHeadersOptions, "EXTRA_HEADERS"))
+    extraInfoSpec.push("extraHeaders");
 
-chrome.webRequest.onBeforeSendHeaders.addListener(
-  function (details) {
-    if (details.originUrl) {
-      // Firefox
-      const origin = new URL(details.originUrl).origin;
-      if (origin !== chrome.runtime.getURL("").slice(0, -1)) return;
-    } else if (
-      // Chrome
-      details.initiator !== chrome.runtime.getURL("").slice(0, -1)
-    )
-      return;
+  chrome.webRequest.onBeforeSendHeaders.addListener(
+    function (details) {
+      if (details.originUrl) {
+        // Firefox
+        const origin = new URL(details.originUrl).origin;
+        if (origin !== chrome.runtime.getURL("").slice(0, -1)) return;
+      } else if (
+        // Chrome
+        details.initiator !== chrome.runtime.getURL("").slice(0, -1)
+      )
+        return;
 
-    if (details.url.endsWith("?sareferer") || details.url.endsWith("&sareferer")) {
-      details.requestHeaders.push({
-        name: "Referer",
-        value: "https://scratch.mit.edu/",
-      });
-      return {
-        requestHeaders: details.requestHeaders,
-      };
-    }
-  },
-  {
-    urls: ["https://scratch.mit.edu/*", "https://api.scratch.mit.edu/*", "https://clouddata.scratch.mit.edu/*"],
-    types: ["xmlhttprequest"],
-  },
-  extraInfoSpec
-);
-
-/*
-
-// declarativeNetRequest alternative
-
-chrome.declarativeNetRequest.updateDynamicRules({
-  removeRuleIds: [1],
-  addRules: [{
-    id: 1,
-    priority: 1,
-    action: {
-      type: "modifyHeaders",
-      requestHeaders: [{
-        header: "Referer",
-        operation: "set",
-        value: "https://scratch.mit.edu/"
-      }]
+      if (details.url.endsWith("?sareferer") || details.url.endsWith("&sareferer")) {
+        details.requestHeaders.push({
+          name: "Referer",
+          value: "https://scratch.mit.edu/",
+        });
+        return {
+          requestHeaders: details.requestHeaders,
+        };
+      }
     },
-    condition: {
-      domains: [chrome.runtime.id],
-      regexFilter: "^https:\\/\\/(api\\.|clouddata\\.|)scratch\\.mit\\.edu\\/.*(\\?|\\&)sareferer",
-      resourceTypes: ["xmlhttprequest"]
-    }
-  }]
-});
-
-*/
+    {
+      urls: ["https://scratch.mit.edu/*", "https://api.scratch.mit.edu/*", "https://clouddata.scratch.mit.edu/*"],
+      types: ["xmlhttprequest"],
+    },
+    extraInfoSpec
+  );
+}

--- a/manifest.json
+++ b/manifest.json
@@ -45,6 +45,7 @@
     "cookies",
     "webRequest",
     "webRequestBlocking",
+    "declarativeNetRequestWithHostAccess",
     "storage",
     "contextMenus",
     "alarms"


### PR DESCRIPTION
Progress on #3615

### Changes
Uses declarativeNetRequestWithHostAccess when possible. Users running Chrome 95 and below, plus Firefox users, will still use webRequestBlocking. Packer script now automatically removes DNR permission from Firefox build.

Note that `domains` condition was renamed to `initiatorDomains`, but this is not shipped yet.

Tested that requests using sareferer still works in Chrome and Firefox.

Next step would be to drop all Chrome versions without DNR support and implement a way to ask for non-WHA DNR permission in browsers that require those. Not sure how to test that though.