### PR TITLE
Most loves by country is comma sepperated

### DIFF
--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -59,7 +59,7 @@ export default async function ({ addon, msg, console }) {
       );
       ranksRow.appendChild(
         createItem(
-          `#${data.statistics.ranks.loves.toLocaleString()} (#${data.statistics.ranks.country.loves})`,
+          `#${data.statistics.ranks.loves.toLocaleString()} (#${data.statistics.ranks.country.loves.toLocaleString()})`,
           msg("most-loves")
         )
       );


### PR DESCRIPTION
For example, it would display 
https://ibb.co/y4vkxHW
but now it shows
https://ibb.co/VNprHNH

### Changes

Add .toLocaleString() 

### Reason for changes

Everything else is comma-separated so this just makes it consistent

### Tests
I tested this with my browser
