### PR TITLE
Update `search-sprites` addon

### DIFF
--- a/addons/search-sprites/userscript.js
+++ b/addons/search-sprites/userscript.js
@@ -1,12 +1,3 @@
-/* (remove this before commiting!!!)
-How i'll go about fixing this:
-  - Get the OG list of sprites from the redux store
-  - Loop through it to see which sprites belong to which folder
-  - When user searches for open folder, current system works fine
-  - When user searches for closed folder, bring up the folder
-  - user can open the folder without messing up search results
-*/
-
 export default async function ({ addon, global, console, msg }) {
   let spritesContainer;
   let spriteSelectorContainer;
@@ -26,7 +17,7 @@ export default async function ({ addon, global, console, msg }) {
   // the libraries, so this fits right in.
   searchBox.type = "text";
 
-  // These functions were taken from the search sprites addon
+  // This function was taken from the search sprites addon
   const getFolderFromName = (name) => {
     const idx = name.indexOf("//");
     if (idx === -1 || idx === 0) {
@@ -35,36 +26,20 @@ export default async function ({ addon, global, console, msg }) {
     return name.substr(0, idx);
   };
 
-  const getNameWithoutFolder = (name) => {
-    const idx = name.indexOf("//");
-    if (idx === -1 || idx === 0) {
-      return name;
-    }
-    return name.substr(idx + DIVIDER.length);
-  };
-
   const search = (query, sprites) => {
     if (!spritesContainer) return;
 
     query = query.toLowerCase();
     const containsQuery = (str) => str.toLowerCase().includes(query);
 
-    console.log(typeof sprites);
-    console.log(sprites);
-
     const foldersWithMatchingSprites = [];
     for (let sprite of Object.keys(sprites)) {
       if (containsQuery(sprites[sprite].name) && getFolderFromName(sprites[sprite].name)) {
-        // matching sprite is in a folder
-        // add folder to list of folders to show
         foldersWithMatchingSprites.push(getFolderFromName(sprites[sprite].name));
       }
     }
-    console.log("Matching Folders..." + foldersWithMatchingSprites);
 
     for (const sprite of spritesContainer.children) {
-      // check if sprite is in the folder
-
       const visible =
         !query ||
         containsQuery(sprite.children[0].children[1].innerText) ||

--- a/addons/search-sprites/userscript.js
+++ b/addons/search-sprites/userscript.js
@@ -1,3 +1,12 @@
+/* (remove this before commiting!!!)
+How i'll go about fixing this:
+  - Get the OG list of sprites from the redux store
+  - Loop through it to see which sprites belong to which folder
+  - When user searches for open folder, current system works fine
+  - When user searches for closed folder, bring up the folder
+  - user can open the folder without messing up search results
+*/
+
 export default async function ({ addon, global, console, msg }) {
   let spritesContainer;
   let spriteSelectorContainer;
@@ -17,28 +26,63 @@ export default async function ({ addon, global, console, msg }) {
   // the libraries, so this fits right in.
   searchBox.type = "text";
 
-  const search = (query) => {
+  // These functions were taken from the search sprites addon
+  const getFolderFromName = (name) => {
+    const idx = name.indexOf("//");
+    if (idx === -1 || idx === 0) {
+      return null;
+    }
+    return name.substr(0, idx);
+  };
+
+  const getNameWithoutFolder = (name) => {
+    const idx = name.indexOf("//");
+    if (idx === -1 || idx === 0) {
+      return name;
+    }
+    return name.substr(idx + DIVIDER.length);
+  };
+
+  const search = (query, sprites) => {
     if (!spritesContainer) return;
 
     query = query.toLowerCase();
     const containsQuery = (str) => str.toLowerCase().includes(query);
 
+    console.log(typeof sprites);
+    console.log(sprites);
+
+    const foldersWithMatchingSprites = [];
+    for (let sprite of Object.keys(sprites)) {
+      if (containsQuery(sprites[sprite].name) && getFolderFromName(sprites[sprite].name)) {
+        // matching sprite is in a folder
+        // add folder to list of folders to show
+        foldersWithMatchingSprites.push(getFolderFromName(sprites[sprite].name));
+      }
+    }
+    console.log("Matching Folders..." + foldersWithMatchingSprites);
+
     for (const sprite of spritesContainer.children) {
+      // check if sprite is in the folder
+
       const visible =
         !query ||
         containsQuery(sprite.children[0].children[1].innerText) ||
-        (containsQuery(sprite.children[0].children[2].children[0].innerText) &&
+        ((containsQuery(sprite.children[0].children[2].children[0].innerText) ||
+          foldersWithMatchingSprites.includes(sprite.children[0].children[2].children[0].innerText)) &&
           sprite.children[0].classList.contains("sa-folders-folder"));
       sprite.style.display = visible ? "" : "none";
     }
   };
 
   searchBox.addEventListener("input", (e) => {
-    search(e.target.value);
+    const reduxState = addon.tab.redux.state;
+    const sprites = reduxState.scratchGui.targets.sprites;
+    search(e.target.value, sprites);
   });
 
   const reset = () => {
-    search("");
+    search("", addon.tab.redux.state.scratchGui.targets.sprites);
     searchBox.value = "";
   };
 


### PR DESCRIPTION
Resolves [this bug](https://discord.com/channels/806602307750985799/938807989874360330/954037558923370517)

### Changes
Earlier, the `search-sprites` addon did not return results from closed folders. Now, the search bar returns closed folders that contain matching sprites.

<img width="337" alt="citybus" src="https://user-images.githubusercontent.com/83728060/162670435-0fa9be4e-cf5f-4e60-be12-436e0294eace.png">



### Tests
I tried some basic searches and it worked fine.