### PR TITLE
Exclude easter eggs from addon count

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -226,7 +226,7 @@ let fuse;
         return chrome.runtime.getManifest().version_name;
       },
       addonAmt() {
-        return `${Math.floor(this.manifests.length / 5) * 5}+`;
+        return `${Math.floor( this.manifests.filter(addon => !addon.tags.includes("easterEgg")).length / 5 ) * 5}+`;
       },
     },
 

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -226,7 +226,7 @@ let fuse;
         return chrome.runtime.getManifest().version_name;
       },
       addonAmt() {
-        return `${Math.floor( this.manifests.filter(addon => !addon.tags.includes("easterEgg")).length / 5 ) * 5}+`;
+        return `${Math.floor(this.manifests.filter((addon) => !addon.tags.includes("easterEgg")).length / 5) * 5}+`;
       },
     },
 


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #4465

### Changes

Code doesn't check for manifests length, but it filters if addon doesn't contains `easterEgg` tag.

### Tests

Now you can't see it, because it is rounded to 5, but I removed it for test and it excluded all easter eggs correctly.
