### PR TITLE
Support loading Structured JSON translations

### DIFF
--- a/libraries/common/cs/l10n.js
+++ b/libraries/common/cs/l10n.js
@@ -26,7 +26,9 @@ export default class LocalizationProvider extends EventTarget {
   _get(key, placeholders, messageHandler, fallback) {
     messageHandler = messageHandler || ((m) => m);
     if (Object.prototype.hasOwnProperty.call(this.messages, key)) {
-      const message = messageHandler(this.messages[key]);
+      const rawMessage = this.messages[key];
+      // English source file may use Structured JSON, non-English files use keyvalue JSON
+      const message = messageHandler(rawMessage.string || rawMessage);
       return this.formatter.format(message, placeholders);
     }
     console.warn("Key missing:", key);


### PR DESCRIPTION
Support loading Structured JSON translations. Note that this PR does not introduce the new format. Structured JSON is specified at https://docs.transifex.com/formats/json/structured-json.

Future plans:

- `addons-l10n/en` will use a mix of key-value json and structured json; current syntax works fine, but you can also specify an object that meets the structured json spec.
- Since key-value json is not a valid structure json syntax, the script will convert that to actual structured json.
- After pulling the translated strings as structured json, the script will convert them to key-value json to save some bytes. Translations on this repository do not need developer comments, etc.