### PR TITLE
Fix thumbnail setter preview aspect ratio

### DIFF
--- a/addons/animated-thumb/userscript.js
+++ b/addons/animated-thumb/userscript.js
@@ -85,7 +85,7 @@ export default async function ({ addon, global, console, msg }) {
     );
     const thumbImage = Object.assign(document.createElement("img"), {
       alt: "",
-      width: 360,
+      width: 320,
       height: 240,
     });
     const thumbImageWrapper = Object.assign(document.createElement("p"), {


### PR DESCRIPTION
Resolves #4049

### Changes

Changes the width of the image preview in the animated-thumb modal to make sure the aspect ratio is 4:3.