### PR TITLE
New "bugfix" tag for addons

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -192,7 +192,7 @@
     "message": "Keep in mind that this addon might have bugs."
   },
   "bugfixTooltip": {
-    "message": "This addon fix Scratch's bugs!"
+    "message": "This addon fixes a Scratch bug."
   },
   "forumsTooltip": {
     "message": "This addon applies to Scratch's Discussion Forums."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -50,6 +50,9 @@
   "beta": {
     "message": "Beta"
   },
+  "bugfix": {
+    "message": "Bugfix"
+  },
   "danger": {
     "message": "Dangerous"
   },
@@ -187,6 +190,9 @@
   },
   "betaTooltip": {
     "message": "Keep in mind that this addon might have bugs."
+  },
+  "bugfixTooltip": {
+    "message": "This addon fix Scratch's bugs!"
   },
   "forumsTooltip": {
     "message": "This addon applies to Scratch's Discussion Forums."

--- a/addons/block-duplicate/addon.json
+++ b/addons/block-duplicate/addon.json
@@ -22,6 +22,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.21.0",
-  "tags": ["editor", "codeEditor", "featured", "bugfix"],
+  "tags": ["editor", "codeEditor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/block-duplicate/addon.json
+++ b/addons/block-duplicate/addon.json
@@ -22,6 +22,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.21.0",
-  "tags": ["editor", "codeEditor", "featured"],
+  "tags": ["editor", "codeEditor", "featured", "bugfix"],
   "enabledByDefault": false
 }

--- a/addons/fix-pasted-scripts/addon.json
+++ b/addons/fix-pasted-scripts/addon.json
@@ -23,7 +23,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "recommended", "codeEditor"],
+  "tags": ["editor", "recommended", "codeEditor", "bugfix"],
   "versionAdded": "1.15.0",
   "enabledByDefault": false
 }

--- a/addons/fix-uploaded-svgs/addon.json
+++ b/addons/fix-uploaded-svgs/addon.json
@@ -9,6 +9,6 @@
     }
   ],
   "versionAdded": "1.4.0",
-  "tags": ["editor", "costumeEditor"],
+  "tags": ["editor", "costumeEditor", "bugfix"],
   "enabledByDefault": false
 }

--- a/webpages/settings/data/addon-groups.js
+++ b/webpages/settings/data/addon-groups.js
@@ -92,4 +92,12 @@ export default [
     iframeShow: false,
     fullscreenShow: true,
   },
+  {
+    id: "bugfix",
+    name: "bugfix",
+    addonIds: [],
+    expanded: false,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
 ];

--- a/webpages/settings/data/tags.js
+++ b/webpages/settings/data/tags.js
@@ -57,4 +57,11 @@ export default [
       theme: true,
     },
   },
+  {
+    name: "bugfix",
+    tooltipText: "bugfixTooltip",
+    matchName: "bugfix",
+    color: "yellow",
+    iframeAlwaysShow: true,
+  },
 ];


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves https://github.com/ScratchAddons/ScratchAddons/pull/2568#issuecomment-876833246

### Changes

<!-- Please describe the changes you've made. -->
Adds new tag to addons: `don't run duplicated blocks` and `fix SVG upload`
![file](https://user-images.githubusercontent.com/89837724/163985576-3b6c4428-27af-448f-8b95-d9d8905d489c.png)

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Firefox newest.

### Merge before: https://github.com/ScratchAddons/manifest-schema/pull/59

