### PR TITLE
Add selected category name to no results message

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -331,6 +331,9 @@
   "searchNotFound": {
     "message": "No results found. Perhaps try different keywords?"
   },
+  "searchNotFoundInCategory": {
+    "message": "No results found in \"$1\". Perhaps try different keywords?"
+  },
   "captureCommentError": {
     "message": "Message added by Scratch Addons: it appears that your comment doesn't follow $1, which asks Scratchers not to advertise or name browser extensions. This comment wasn't posted because it will probably result in your account getting muted from commenting for 5 minutes."
   },

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -180,7 +180,9 @@
 
         <div class="addons-container" :class="{placeholder: !loaded}" v-cloak>
           <template v-if="searchInput && hasNoResults">
-            <p id="search-not-found" v-if="selectedCategory === 'all' || !selectedCategoryName">{{ msg("searchNotFound") }}</p>
+            <p id="search-not-found" v-if="selectedCategory === 'all' || !selectedCategoryName">
+              {{ msg("searchNotFound") }}
+            </p>
             <p id="search-not-found" v-else>{{ msg("searchNotFoundInCategory", selectedCategoryName) }}</p>
           </template>
           <template v-for="addon of addonList">

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -179,7 +179,10 @@
         </div>
 
         <div class="addons-container" :class="{placeholder: !loaded}" v-cloak>
-          <p id="search-not-found" v-show="searchInput && hasNoResults">{{ msg("searchNotFound") }}</p>
+          <template v-if="searchInput && hasNoResults">
+            <p id="search-not-found" v-if="selectedCategory === 'all' || !selectedCategoryName">{{ msg("searchNotFound") }}</p>
+            <p id="search-not-found" v-else>{{ msg("searchNotFoundInCategory", selectedCategoryName) }}</p>
+          </template>
           <template v-for="addon of addonList">
             <div
               id="iframe-fullscreen-suggestion"

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -229,7 +229,7 @@ let fuse;
         return `${Math.floor(this.manifests.length / 5) * 5}+`;
       },
       selectedCategoryName() {
-        return this.categories.find(category => category.id === this.selectedCategory)?.name;
+        return this.categories.find((category) => category.id === this.selectedCategory)?.name;
       },
     },
 

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -228,6 +228,9 @@ let fuse;
       addonAmt() {
         return `${Math.floor(this.manifests.length / 5) * 5}+`;
       },
+      selectedCategoryName() {
+        return this.categories.find(category => category.id === this.selectedCategory)?.name;
+      },
     },
 
     methods: {


### PR DESCRIPTION
Resolves #4442

### Changes

Adds a new "no results" message that is displayed when searching in a category other than "All". This doesn't work in the `easterEgg` category because it doesn't have a name.