### PR TITLE
Fix monitor updates in 60 FPS mode

### DIFF
--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -27,14 +27,15 @@ export default async function ({ addon, global, console }) {
         if (!monitorUpdateFixed) {
           const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name == "onMonitorsUpdate");
           if (originalListener) vm.removeListener("MONITORS_UPDATE", originalListener);
-          vm.on("MONITORS_UPDATE", monitors => addon.tab.redux.dispatch({
-            type: "scratch-gui/monitors/UPDATE_MONITORS",
-            monitors,
-          }));
+          vm.on("MONITORS_UPDATE", (monitors) =>
+            addon.tab.redux.dispatch({
+              type: "scratch-gui/monitors/UPDATE_MONITORS",
+              monitors,
+            })
+          );
           monitorUpdateFixed = true;
         }
-      }
-      else setFPS(30);
+      } else setFPS(30);
       updateFlag();
     };
     const flagListener = (e) => {

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -5,6 +5,8 @@ export default async function ({ addon, global, console }) {
   let global_fps = 30;
   const vm = addon.tab.traps.vm;
   let mode = false;
+  let monitorUpdateFixed = false;
+
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
       markAsSeen: true,
@@ -17,7 +19,21 @@ export default async function ({ addon, global, console }) {
 
     const changeMode = (_mode = !mode) => {
       mode = _mode;
-      if (mode) setFPS(addon.settings.get("framerate"));
+      if (mode) {
+        setFPS(addon.settings.get("framerate"));
+
+        // monitor updates are throttled by default
+        // https://github.com/LLK/scratch-gui/blob/ba76db7/src/reducers/monitors.js
+        if (!monitorUpdateFixed) {
+          const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name == "onMonitorsUpdate");
+          if (originalListener) vm.removeListener("MONITORS_UPDATE", originalListener);
+          vm.on("MONITORS_UPDATE", monitors => addon.tab.redux.dispatch({
+            type: "scratch-gui/monitors/UPDATE_MONITORS",
+            monitors,
+          }));
+          monitorUpdateFixed = true;
+        }
+      }
       else setFPS(30);
       updateFlag();
     };

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -25,7 +25,7 @@ export default async function ({ addon, global, console }) {
         // monitor updates are throttled by default
         // https://github.com/LLK/scratch-gui/blob/ba76db7/src/reducers/monitors.js
         if (!monitorUpdateFixed) {
-          const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name == "onMonitorsUpdate");
+          const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name === "onMonitorsUpdate");
           if (originalListener) vm.removeListener("MONITORS_UPDATE", originalListener);
           vm.on("MONITORS_UPDATE", (monitors) =>
             addon.tab.redux.dispatch({


### PR DESCRIPTION
Resolves #4523

### Changes

Makes monitors update consistently when 60 FPS mode (Alt + green flag) is enabled. This is similar to TurboWarp's solution mentioned by @apple502j.

### Tests

Tested by following the reproduction steps described in #4523.