### PR TITLE
Don't send message if fallback is set

### DIFF
--- a/libraries/common/cs/l10n.js
+++ b/libraries/common/cs/l10n.js
@@ -31,7 +31,8 @@ export default class LocalizationProvider extends EventTarget {
       const message = messageHandler(rawMessage.string || rawMessage);
       return this.formatter.format(message, placeholders);
     }
-    console.warn("Key missing:", key);
+    if (fallback == "")
+      console.warn("Key missing:", key);
     return fallback || key;
   }
 

--- a/libraries/common/cs/l10n.js
+++ b/libraries/common/cs/l10n.js
@@ -31,8 +31,7 @@ export default class LocalizationProvider extends EventTarget {
       const message = messageHandler(rawMessage.string || rawMessage);
       return this.formatter.format(message, placeholders);
     }
-    if (fallback == "")
-      console.warn("Key missing:", key);
+    if (fallback == "") console.warn("Key missing:", key);
     return fallback || key;
   }
 


### PR DESCRIPTION

### Changes

Send message "key missing", when fallback is not set. 

### Reason for changes

Scratch has a lot of spam in console. We don't want to make it worse.
*I am talking about debbuger's name*

### Tests

Firefox 95, everything works great.
