### PR TITLE
dark-www: fix stage monitor colors

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -9,13 +9,6 @@ body {
   background-color: var(--darkWww-page);
   color: var(--darkWww-page-text);
 }
-div[class*="stage-wrapper_"] {
-  /*
-    Revert the color specified above. Editor dark mode provides its own CSS.
-    See also: #4560 and LLK/scratch-gui#5797
-  */
-  color: #575e75;
-}
 .subactions .share-date,
 .conf2019-description {
   color: var(--darkWww-page-text);
@@ -806,7 +799,7 @@ p {
   border-radius: 8px;
 }
 
-.project-info-alert {
+.guiPlayer {
   color: #575e75;
 }
 

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -9,6 +9,13 @@ body {
   background-color: var(--darkWww-page);
   color: var(--darkWww-page-text);
 }
+div[class*="stage-wrapper_"] {
+  /*
+    Revert the color specified above. Editor dark mode provides its own CSS.
+    See also: #4560 and LLK/scratch-gui#5797
+  */
+  color: #575e75;
+}
 .subactions .share-date,
 .conf2019-description {
   color: var(--darkWww-page-text);

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -580,8 +580,7 @@ img[src="/static/assets/26255153f92ea41df149a58d3c3fe2cf.svg"] /* record modal s
 }
 
 /* Miscellaneous styles */
-.monitor_label_ci1ok,
-.monitor_list-empty_1UKsB {
+[class*="stage-wrapper_"] {
   color: #575e75;
 }
 .sprite-selector_sprite-selector_2KgCX {


### PR DESCRIPTION
Resolves #4560 
Sadly there is no CSS keyword that reverts to previously defined non-inherited style. Also this is not a prio-2.