### PR TITLE
New Addon: Self Referencing in Dropdowns ("myself" option for sensing blocks)

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -120,6 +120,7 @@
   "forum-live-preview",
   "sounds-duration",
   "default-costume-editor-color",
+  "self-referencing",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/self-referencing/addon.json
+++ b/addons/self-referencing/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "Self referencing",
+  "description": "Adds the \"myself\" option to certain block dropdowns in the sensing category. Useful when working with clones.",
+  "credits": [
+    {
+      "name": "smalllevy"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.26.1",
+  "tags": ["editor"],
+  "enabledByDefault": false
+}

--- a/addons/self-referencing/addon.json
+++ b/addons/self-referencing/addon.json
@@ -14,7 +14,7 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "versionAdded": "1.26.1",
+  "versionAdded": "1.27.0",
   "tags": ["editor"],
   "enabledByDefault": false
 }

--- a/addons/self-referencing/addon.json
+++ b/addons/self-referencing/addon.json
@@ -12,8 +12,6 @@
       "matches": ["projects"]
     }
   ],
-  "dynamicEnable": true,
-  "dynamicDisable": true,
   "versionAdded": "1.27.0",
   "tags": ["editor"],
   "enabledByDefault": false

--- a/addons/self-referencing/userscript.js
+++ b/addons/self-referencing/userscript.js
@@ -1,0 +1,18 @@
+export default async function ({ addon, global, console, msg }) {
+  const Blockly = await addon.tab.traps.getBlockly();
+  const vm = addon.tab.traps.vm;
+  //Most of this code was derived from GarboMuffin's "searchable dropdowns" addon
+  const oldFieldDropdownGetOptions = Blockly.FieldDropdown.prototype.getOptions;
+  Blockly.FieldDropdown.prototype.getOptions = function () {
+    const options = oldFieldDropdownGetOptions.call(this);
+    const block = this.sourceBlock_;
+    if(vm.editingTarget.isStage) return options;
+    const name = vm.editingTarget.sprite.name;
+    if (block) {
+      if (block.type === "sensing_touchingobjectmenu" || block.type === "sensing_of_object_menu" || block.type === "sensing_distancetomenu") {
+        options.push(["myself",name]); //Adds the "myself" option to the blocks listed above
+      }
+    }
+    return options;
+  };
+}

--- a/addons/self-referencing/userscript.js
+++ b/addons/self-referencing/userscript.js
@@ -10,7 +10,7 @@ export default async function ({ addon, global, console, msg }) {
     const name = vm.editingTarget.sprite.name;
     if (block) {
       if (block.type === "sensing_touchingobjectmenu" || block.type === "sensing_of_object_menu" || block.type === "sensing_distancetomenu") {
-        options.push(["myself",name]); //Adds the "myself" option to the blocks listed above
+        options.push([name,name]); //Adds the "myself" option to the blocks listed above
       }
     }
     return options;

--- a/addons/self-referencing/userscript.js
+++ b/addons/self-referencing/userscript.js
@@ -1,6 +1,14 @@
 export default async function ({ addon, global, console, msg }) {
   const Blockly = await addon.tab.traps.getBlockly();
   const vm = addon.tab.traps.vm;
+  const SUPPORTED_BLOCKS = [
+    "sensing_touchingobjectmenu",
+    "sensing_of_object_menu",
+    "sensing_distancetomenu",
+    "motion_pointtowards_menu",
+    "motion_goto_menu",
+    "motion_glideto_menu"
+  ];
   //Most of this code was derived from GarboMuffin's "searchable dropdowns" addon
   const oldFieldDropdownGetOptions = Blockly.FieldDropdown.prototype.getOptions;
   Blockly.FieldDropdown.prototype.getOptions = function () {
@@ -9,7 +17,7 @@ export default async function ({ addon, global, console, msg }) {
     if(vm.editingTarget.isStage) return options;
     const name = vm.editingTarget.sprite.name;
     if (block) {
-      if (block.type === "sensing_touchingobjectmenu" || block.type === "sensing_of_object_menu" || block.type === "sensing_distancetomenu") {
+      if (SUPPORTED_BLOCKS.includes(block.type)) {
         options.push([name,name]); //Adds the "myself" option to the blocks listed above
       }
     }


### PR DESCRIPTION
Resolves #3396

### Changes

Allows certain sensing block menu dropdowns ("touching []", "distance to []", and "[] of []") to select its own sprite, similar to the "myself" option for creating a clone.

![image](https://user-images.githubusercontent.com/48697325/171969955-b38bf68f-b127-4bf7-9539-1a2aabb2e00e.png)

### Reason for changes

Useful when working with clones of a sprite, especially for detecting collisions between clones.

### Tests

Tested on Chromium 102, with and without the searchable dropdowns addon. No apparent issues.
