### PR TITLE
`move-to-top-bottom`: add `costumeEditor` tag

### DIFF
--- a/addons/move-to-top-bottom/addon.json
+++ b/addons/move-to-top-bottom/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Move costume to top or bottom",
   "description": "Adds a right click context menu item to move a costume or a sound to the top or the bottom of the list. Previously part of the developer tools.",
-  "tags": ["editor", "featured"],
+  "tags": ["editor", "costumeEditor", "featured"],
   "userscripts": [
     {
       "url": "userscript.js",


### PR DESCRIPTION
### Changes

<!-- Please describe the changes you've made. -->
Self-explanatory.

### Reason for changes

<!-- Why should these changes be made? -->
A user browsing the settings page for costume editor addons (via the "Costume Editor Features" subcategory) should see this addon in the category listing.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
No, but I would be very surprised if this actually broke anything.
