### PR TITLE
Improve popup loading

### DIFF
--- a/addons-l10n/en/cloud-games.json
+++ b/addons-l10n/en/cloud-games.json
@@ -1,7 +1,7 @@
 {
   "cloud-games/popup-title": "Scratch Addons - Cloud games",
   "cloud-games/no-users": "No users currently playing",
-  "cloud-games/loading": "Loading... ({done}/{amount})",
+  "cloud-games/loading": "Loading...",
   "cloud-games/general-error": "Could not load projects from the studio.",
   "cloud-games/server-error": "It seems like the Scratch server is having a problem.",
   "cloud-games/no-projects": "There are no projects to display.",

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -2,10 +2,41 @@ body {
   padding-bottom: 1px; /* show margin below last game */
 }
 
+.fade-transition {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter,
+.fade-leave {
+  opacity: 0;
+}
+
 .loading {
+  position: fixed;
+  top: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 15px 20px;
+  overflow: hidden;
+  background-color: var(--tooltip-background);
+  border-radius: 10px;
+  box-shadow: var(--large-shadow);
+  font-weight: 600;
+}
+
+.loading-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 4px;
+  background-color: var(--brand-orange);
+}
+
+.error {
   text-align: center;
   font-size: 1rem;
-  padding-top: 10px;
+  padding-top: 20px;
   font-weight: 600;
   margin: 0 2rem;
 }

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -54,6 +54,15 @@ body {
   color: var(--content-text);
 }
 
+.title-placeholder {
+  display: inline-block;
+  vertical-align: middle;
+  width: 150px;
+  height: 8px;
+  background-color: var(--gray-text);
+  border-radius: 3px;
+}
+
 .small-icon {
   height: 14px;
   vertical-align: text-bottom;

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -65,6 +65,7 @@ body {
 
 .project-details {
   padding: 8px;
+  color: var(--description-text);
   font-size: 12px;
 }
 .username-list > a {

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -15,15 +15,15 @@
     <script src="../../webpages/popup-loader.js" type="module"></script>
   </head>
 
-  <body v-cloak>
-    <div class="loading" v-show="!error && (projects.length === 0 || projects.length !== projectsChecked)">
+  <body>
+    <div v-cloak class="loading" v-show="!error && (projects.length === 0 || projects.length !== projectsChecked)">
       {{ loadingMsg }}
     </div>
-    <div class="loading" v-show="error">
+    <div v-cloak class="loading" v-show="error">
       {{ errorMessage }}
       <span v-if="error !== 'server-error'">{{{ settingsHTML() }}}</span>
     </div>
-    <div v-show="projectsVisible">
+    <div v-cloak v-show="projectsVisible">
       <div class="games" v-for="project of projectsSorted">
         <div class="title">
           <a class="project-name nolink" :href="'https://scratch.mit.edu/projects/' + project.id" target="_blank"
@@ -45,6 +45,12 @@
           </div>
           <div class="username-list" v-show="project.amt === 0">{{ messages.noUsersMsg }}</div>
         </div>
+      </div>
+    </div>
+    <div v-else>
+      <div class="games" v-for="_ of (this.projects.length / 2)">
+        <div class="title"><span class="title-placeholder"></span><br /></div>
+        <div class="project-details"></div>
       </div>
     </div>
   </body>

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -53,7 +53,7 @@
         </div>
       </div>
     </div>
-    <div v-else>
+    <div v-cloak v-else>
       <div class="games" v-for="_ of (this.projects.length / 2)">
         <div class="title"><span class="title-placeholder"></span><br /></div>
         <div class="project-details"></div>

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -16,10 +16,16 @@
   </head>
 
   <body>
-    <div v-cloak class="loading" v-show="!error && (projects.length === 0 || projects.length !== projectsChecked)">
-      {{ loadingMsg }}
+    <div
+      v-cloak
+      class="loading"
+      transition="fade"
+      v-show="!error && (projects.length === 0 || projects.length !== projectsChecked)"
+    >
+      {{ messages.loadingMsg }}
+      <div class="loading-progress" :style="{ width: (100 * projectsChecked / projects.length) + '%' }"></div>
     </div>
-    <div v-cloak class="loading" v-show="error">
+    <div v-cloak class="error" v-show="error">
       {{ errorMessage }}
       <span v-if="error !== 'server-error'">{{{ settingsHTML() }}}</span>
     </div>

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -23,7 +23,7 @@
       {{ errorMessage }}
       <span v-if="error !== 'server-error'">{{{ settingsHTML() }}}</span>
     </div>
-    <div v-show="loaded">
+    <div v-show="projectsVisible">
       <div class="games" v-for="project of projectsSorted">
         <div class="title">
           <a class="project-name nolink" :href="'https://scratch.mit.edu/projects/' + project.id" target="_blank"

--- a/popups/cloud-games/popup.js
+++ b/popups/cloud-games/popup.js
@@ -8,7 +8,10 @@ export default async ({ addon, msg, safeMsg }) => {
     data: {
       projects: [],
       projectsVisible: false,
-      messages: { noUsersMsg: msg("no-users") },
+      messages: {
+        loadingMsg: msg("loading"),
+        noUsersMsg: msg("no-users"),
+      },
       projectsChecked: 0,
       error: shouldFailEarly ? "general-error" : null,
     },
@@ -18,9 +21,6 @@ export default async ({ addon, msg, safeMsg }) => {
           if (a.amt !== b.amt) return a.amt - b.amt;
           return a.timestamp - b.timestamp;
         });
-      },
-      loadingMsg() {
-        return msg("loading", { done: this.projectsChecked, amount: this.projects.length || "?" });
       },
       errorMessage() {
         return this.error && msg(this.error);

--- a/popups/cloud-games/popup.js
+++ b/popups/cloud-games/popup.js
@@ -7,7 +7,7 @@ export default async ({ addon, msg, safeMsg }) => {
     el: "body",
     data: {
       projects: [],
-      loaded: false,
+      projectsVisible: false,
       messages: { noUsersMsg: msg("no-users") },
       projectsChecked: 0,
       error: shouldFailEarly ? "general-error" : null,
@@ -46,7 +46,7 @@ export default async ({ addon, msg, safeMsg }) => {
             this.projectsChecked++;
             if (this.projectsChecked / this.projects.length > 0.5) {
               // Show UI even tho it's not ready, if a majority of projects loaded
-              this.loaded = true;
+              this.projectsVisible = true;
             }
             resolve();
           }, i * 125);

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -287,6 +287,7 @@ a.message-type-title-text {
   font-weight: 600;
   text-align: center;
 }
+.status-container p,
 .status-empty {
   display: block;
   margin-block: 10px;

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -449,7 +449,7 @@
     </div>
 
     <!-- Bottom bar-->
-    <div id="bottom-bar" v-show="messagesReady">
+    <div id="bottom-bar">
       <a v-cloak @click="markAsRead()" v-show="!markedAsRead">{{ uiMessages.markAsReadMsg }}</a>
       <span v-cloak v-show="markedAsRead" class="marked-as-read"
         ><img class="small-icon" src="../../images/icons/read.svg" /> {{ uiMessages.markedAsReadMsg }}</span


### PR DESCRIPTION
### Changes

* Changes the spacing around "Loading messages..." to match "No unread messages". It currently moves slightly when the loading is complete.
* Doesn't wait until messages are loaded before showing the bottom bar.
* Shows a placeholder similar to that on the settings page while cloud games are loading.
* Changes to the loading message for cloud games:
  * It's now in front of the project list (not above it) to avoid layout shift
  * Replaces numbers with a progress bar to make it easier to see the progress

![Screenshot of Games popup](https://user-images.githubusercontent.com/51849865/173186055-effe9c3f-08c3-482f-a69f-2ba4c6589d05.png)