### PR TITLE
debugger: Fix some bugs

### DIFF
--- a/addons/debugger/logs.js
+++ b/addons/debugger/logs.js
@@ -14,6 +14,9 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
 
   const getInputOfBlock = (targetId, blockId) => {
     const target = vm.runtime.getTargetById(targetId);
+    if (!target) {
+      return null;
+    }
     const block = target.blocks.getBlock(blockId);
     if (!block) {
       return null;

--- a/addons/debugger/logs.js
+++ b/addons/debugger/logs.js
@@ -105,7 +105,7 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
             /\{(sprite|type|content)\}/g,
             (_, match) =>
               ({
-                sprite: targetInfo ? targetInfo.name : msg('unknown-sprite'),
+                sprite: targetInfo ? targetInfo.name : msg("unknown-sprite"),
                 type,
                 content: text,
               }[match])

--- a/addons/debugger/logs.js
+++ b/addons/debugger/logs.js
@@ -44,10 +44,11 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
     repeats.style.display = "none";
     root.appendChild(repeats);
 
-    if (row.preview && row.blockId && row.targetId) {
-      const inputBlock = getInputOfBlock(row.targetId, row.blockId);
+    if (row.preview && row.blockId && row.targetInfo) {
+      const originalId = row.targetInfo.originalId;
+      const inputBlock = getInputOfBlock(originalId, row.blockId);
       if (inputBlock) {
-        const preview = debug.createBlockPreview(row.targetId, inputBlock);
+        const preview = debug.createBlockPreview(originalId, inputBlock);
         if (preview) {
           root.appendChild(preview);
         }
@@ -65,8 +66,8 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
     }
     root.appendChild(text);
 
-    if (row.targetId && row.blockId) {
-      root.appendChild(debug.createBlockLink(row.targetId, row.blockId));
+    if (row.targetInfo && row.blockId) {
+      root.appendChild(debug.createBlockLink(row.targetInfo, row.blockId));
     }
 
     return {
@@ -98,13 +99,13 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
       : defaultFormat;
     if (!exportFormat) return;
     const file = logView.rows
-      .map(({ text, targetId, type, count }) =>
+      .map(({ text, targetInfo, type, count }) =>
         (
           exportFormat.replace(
             /\{(sprite|type|content)\}/g,
             (_, match) =>
               ({
-                sprite: debug.getTargetInfoById(targetId).name,
+                sprite: targetInfo ? targetInfo.name : msg('unknown-sprite'),
                 type,
                 content: text,
               }[match])
@@ -139,7 +140,9 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
     };
     if (thread) {
       log.blockId = thread.peekStack();
-      log.targetId = thread.target.id;
+      const targetId = thread.target.id;
+      log.targetId = targetId;
+      log.targetInfo = debug.getTargetInfoById(targetId);
     }
     if (type === "internal") {
       log.internal = true;

--- a/addons/debugger/logs.js
+++ b/addons/debugger/logs.js
@@ -17,7 +17,7 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
     if (!target) {
       return null;
     }
-    const block = target.blocks.getBlock(blockId);
+    const block = debug.getBlock(target, blockId);
     if (!block) {
       return null;
     }

--- a/addons/debugger/threads.js
+++ b/addons/debugger/threads.js
@@ -156,14 +156,14 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
         return result;
       };
 
-      const topBlock = thread.target.blocks.getBlock(thread.topBlock);
+      const topBlock = debug.getBlock(thread.target, thread.topBlock);
       const result = [cacheInfo.headerItem];
       if (topBlock) {
         concatInPlace(result, createBlockInfo(topBlock, 0));
         for (let i = 0; i < thread.stack.length; i++) {
           const blockId = thread.stack[i];
           if (blockId === topBlock.id) continue;
-          const block = thread.target.blocks.getBlock(blockId);
+          const block = debug.getBlock(thread.target, blockId);
           if (block) {
             concatInPlace(result, createBlockInfo(block, i));
           }

--- a/addons/debugger/threads.js
+++ b/addons/debugger/threads.js
@@ -63,7 +63,7 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
     }
 
     if (row.targetId && row.blockId) {
-      root.appendChild(debug.createBlockLink(row.targetId, row.blockId));
+      root.appendChild(debug.createBlockLink(debug.getTargetInfoById(row.targetId), row.blockId));
     }
 
     return {

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -238,6 +238,8 @@ export default async function ({ addon, global, console, msg }) {
     afterStepCallbacks.push(cb);
   };
 
+  const getBlock = (target, id) => target.blocks.getBlock(id) || vm.runtime.flyoutBlocks.getBlock(id);
+
   const getTargetInfoById = (id) => {
     const target = vm.runtime.getTargetById(id);
     if (target) {
@@ -372,7 +374,7 @@ export default async function ({ addon, global, console, msg }) {
       return null;
     }
 
-    const block = target.blocks.getBlock(blockId);
+    const block = getBlock(target, blockId);
     if (!block || block.opcode === "text") {
       return null;
     }
@@ -408,7 +410,7 @@ export default async function ({ addon, global, console, msg }) {
       }
     } else if (block.opcode === "procedures_definition") {
       const prototypeBlockId = block.inputs.custom_block.block;
-      const prototypeBlock = target.blocks.getBlock(prototypeBlockId);
+      const prototypeBlock = getBlock(target, prototypeBlockId);
       const proccode = prototypeBlock.mutation.proccode;
       text = ScratchBlocks.ScratchMsgs.translate("PROCEDURES_DEFINITION", "define %1").replace(
         "%1",
@@ -489,6 +491,7 @@ export default async function ({ addon, global, console, msg }) {
       createHeaderTab,
       setHasUnreadMessage,
       addAfterStepCallback,
+      getBlock,
       getTargetInfoById,
       createBlockLink,
       createBlockPreview,

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -262,11 +262,11 @@ export default async function ({ addon, global, console, msg }) {
     };
   };
 
-  const createBlockLink = (targetId, blockId) => {
+  const createBlockLink = (targetInfo, blockId) => {
     const link = document.createElement("a");
     link.className = "sa-debugger-log-link";
 
-    const { exists, name, originalId } = getTargetInfoById(targetId);
+    const { exists, name, originalId } = targetInfo;
     link.textContent = name;
     if (exists) {
       // We use mousedown instead of click so that you can still go to blocks when logs are rapidly scrolling


### PR DESCRIPTION
 - Fix logs tab breaking when trying to generate a block preview for a deleted sprite or clone.
 - The logs tab now records the name of the sprite when the log happens, not when it's displayed. This makes block links not display "(unknown sprite)" when a sprite or clone is deleted. This also makes links not update when a sprite is renamed which didn't happen reliably before anyways.
 - Fix threads tab for blocks in flyout

Part of https://github.com/TurboWarp/scratch-gui/issues/537

Can be tested in https://scratch.mit.edu/projects/703936251/
