### PR TITLE
Handle settings change effectively changing addon state

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -91,7 +91,7 @@ scratchAddons.localEvents.addEventListener("addonDynamicDisable", ({ detail }) =
   );
 });
 scratchAddons.localEvents.addEventListener("updateUserstylesSettingsChange", ({ detail }) => {
-  const { addonId, manifest } = detail;
+  const { addonId, manifest, newSettings } = detail;
   chrome.tabs.query({}, (tabs) =>
     tabs.forEach((tab) => {
       if (tab.url) {
@@ -107,8 +107,11 @@ scratchAddons.localEvents.addEventListener("updateUserstylesSettingsChange", ({ 
                     userstyles,
                     cssVariables,
                     addonId,
+                    addonSettings: newSettings,
                     injectAsStyleElt: !!manifest.injectAsStyleElt,
                     index: scratchAddons.manifests.findIndex((addon) => addon.addonId === addonId),
+                    dynamicEnable: manifest.dynamicEnable,
+                    dynamicDisable: manifest.dynamicDisable,
                   },
                 },
                 { frameId: 0 }

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -34,7 +34,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const { updateUserstylesOnSettingsChange } = manifest;
     if (updateUserstylesOnSettingsChange)
       scratchAddons.localEvents.dispatchEvent(
-        new CustomEvent("updateUserstylesSettingsChange", { detail: { addonId, manifest } })
+        new CustomEvent("updateUserstylesSettingsChange", { detail: { addonId, manifest, newSettings } })
       );
     if (addonId === "msg-count-badge") updateBadge(scratchAddons.cookieStoreId);
   }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -473,6 +473,13 @@ async function onInfoAvailable({ globalState: globalStateMsg, addonsWithUserscri
           // should always be executed but listen to settings change event. Thus this
           // "dynamic disable" does not fire disable event, because userscripts aren't disabled.
         }
+        if (addonIndex > -1 && (dynamicDisable || dynamicEnable)) {
+          // Userstyles enabled when there are already enabled ones, or
+          // userstyles partially disabled. do not call
+          // removeAddonStylesPartial as we remove and re-add instead.
+          const userstylesEntry = addonsWithUserstyles[addonIndex];
+          userstylesEntry.styles = userstyles;
+        }
         if (addonIndex === -1 && userstyles.length > 0 && dynamicEnable) {
           // This is actually dynamicEnable condition, but since this does not involve
           // toggling addon state, this is not considered one by the code.


### PR DESCRIPTION
Resolves #4665

Addon state (whether addon was enabled or disabled) was previously only changed by enabling or disabling an addon directly. #4289 changed this by introducing partial dynamic enable and disable. However, there existed another way for userstyle addons to get enabled, involving a setting condition. Due to implementation quirks this actually added the style previously as well, but other effects normally achieved by (dynamically-)enabling addons weren't applied; this included addonsWithUserstyles array and custom CSS variables. This also applied to disabling.

The change consists of four parts:

- Warn if updateUserstylesOnSettingsChange was used without either dynamicEnable or dynamicDisable, and if a userstyle had a settings condition. This causes the described bug.
- If dynamicEnable is available and changing the setting causes a new userstyle to load, perform the steps done for normal dynamic enable, except for userscript related steps as they are inapplicable due to conditional userscript being unsupported.
- If dynamicDisable is available and changing the setting causes an existing userstyle to be disabled, perform the steps done for normal dynamic disable, except for userscript related steps.
- Small changes to background to pass necessary information.
