### PR TITLE
Fix some bugs in the pause and debugger shared module

### DIFF
--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -44,7 +44,7 @@ const pauseThread = (thread) => {
   }
 };
 
-const setSteppingThred = (thread) => {
+const setSteppingThread = (thread) => {
   steppingThread = thread;
   steppingThreadIndex = vm.runtime.threads.indexOf(steppingThread);
 };
@@ -218,7 +218,7 @@ export const singleStep = () => {
 
   // If we don't have a thread, than we are between VM steps and should search for a new thread
   if (!steppingThread) {
-    setSteppingThred(findNewSteppingThread(0));
+    setSteppingThread(findNewSteppingThread(0));
 
     // End of VM step, emulate one frame of time passing.
     vm.runtime.ioDevices.clock._pausedTime += vm.runtime.currentStepTime;
@@ -283,7 +283,7 @@ export const setup = (_vm) => {
     if (pausedThreadState.has(thread)) {
       const threadPauseState = pausedThreadState.get(thread);
 
-      setSteppingThred(thread);
+      setSteppingThread(thread);
 
       Object.defineProperty(thread, "status", {
         value: threadPauseState.status,

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -295,7 +295,7 @@ export const setup = (_vm) => {
 
   const originalStepThreads = vm.runtime.sequencer.stepThreads;
   vm.runtime.sequencer.stepThreads = function () {
-    // If we where half way through a vm step and have unpaused, pick up were we left off.
+    // If we were half way through a vm step and have unpaused, pick up were we left off.
     if (steppingThread && !paused) {
       const threads = vm.runtime.threads;
       const startingIndex = threads.indexOf(steppingThread);

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -147,9 +147,8 @@ const singleStepThread = (thread) => {
       if (err !== throwMsg) throw err;
     }
 
-    // TODO: this and below = currentBlockId can be simplified
     Object.defineProperty(thread, "blockGlowInFrame", {
-      value: null,
+      value: currentBlockId,
       configurable: true,
       enumerable: true,
       writable: true,
@@ -157,7 +156,6 @@ const singleStepThread = (thread) => {
 
     vm.runtime.sequencer.activeThread = null;
     pauseNewThreads = false;
-    thread.blockGlowInFrame = currentBlockId;
 
     if (thread.status === STATUS_YIELD) {
       thread.status = STATUS_RUNNING;

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -168,6 +168,12 @@ const singleStepThread = (thread) => {
   try {
     thread.status = STATUS_RUNNING;
 
+    // Restart the warp timer on each step.
+    // If we don't do this, Scratch will think a lot of time has passed and may yield this thread.
+    if (thread.warpTimer) {
+      thread.warpTimer.start();
+    }
+
     try {
       vm.runtime.sequencer.stepThread(thread);
     } catch (err) {

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -15,7 +15,7 @@ let steppingThread = null;
 let isInSingleStep = false;
 let steppingThreadIndex = -1;
 
-let eventTarget = new EventTarget();
+const eventTarget = new EventTarget();
 
 export const isPaused = () => paused;
 
@@ -109,7 +109,7 @@ const singleStepThread = (thread) => {
   isInSingleStep = true;
 
   try {
-    let currentBlockId = thread.peekStack();
+    const currentBlockId = thread.peekStack();
 
     if (!currentBlockId) {
       thread.popStack();

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -35,9 +35,11 @@ const pauseThread = (thread) => {
   Object.defineProperty(thread, "status", {
     get() {
       if (isInSingleStep && steppingThread === thread) {
+        // Must report true status when this thread is being single stepped so that Scratch can execute it.
         return pauseState.status;
       }
       if (pauseState.status === STATUS_DONE) {
+        // Done threads should report their true status so that they can be removed.
         return STATUS_DONE;
       }
       return STATUS_PROMISE_WAIT;
@@ -128,9 +130,7 @@ export const onSingleStep = (listener) => {
   eventTarget.addEventListener("step", listener);
 };
 
-export const getRunningThread = () => {
-  return steppingThread;
-};
+export const getRunningThread = () => steppingThread;
 
 // A modified version of this function
 // https://github.com/LLK/scratch-vm/blob/0e86a78a00db41af114df64255e2cd7dd881329f/src/engine/sequencer.js#L179

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -199,10 +199,10 @@ const singleStepThread = (thread) => {
       const stackFrame = thread.peekStackFrame();
 
       if (stackFrame.isLoop) {
-        if (!thread.isWarpMode) {
-          return false;
-        } else {
+        if (thread.peekStackFrame().warpMode) {
           continue;
+        } else {
+          return false;
         }
       } else if (stackFrame.waitingReporter) {
         return false;

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -239,15 +239,18 @@ const getRealStatus = (thread) => {
   return thread.status;
 };
 
-// You can't just use vm.runtime.threads.indexOf(thread) because threads can be restarted.
-// This can happens when, for example, a "when I receive message1" script broadcasts message1.
-// The Thread in runtime.threads is replaced when this happens.
-const getThreadIndex = (thread) => vm.runtime.threads.findIndex((otherThread) => (
-  otherThread.target === thread.target &&
-  otherThread.topBlock === thread.topBlock &&
-  otherThread.stackClick === thread.stackClick &&
-  otherThread.updateMonitor === thread.updateMonitor
-));
+const getThreadIndex = (thread) => {
+  // We can't use vm.runtime.threads.indexOf(thread) because threads can be restarted.
+  // This can happens when, for example, a "when I receive message1" script broadcasts message1.
+  // The object in runtime.threads is replaced when this happens.
+  if (!thread) return -1;
+  return vm.runtime.threads.findIndex((otherThread) => (
+    otherThread.target === thread.target &&
+    otherThread.topBlock === thread.topBlock &&
+    otherThread.stackClick === thread.stackClick &&
+    otherThread.updateMonitor === thread.updateMonitor
+  ));
+};
 
 const findNewSteppingThread = (startingIndex) => {
   const threads = vm.runtime.threads;

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -298,7 +298,7 @@ export const setup = (_vm) => {
     }
   };
 
-  const ogStepThreads = vm.runtime.sequencer.stepThreads;
+  const originalStepThreads = vm.runtime.sequencer.stepThreads;
   vm.runtime.sequencer.stepThreads = function () {
     // If we where half way through a vm step and have unpaused, pick up were we left off.
     if (steppingThread && !paused) {
@@ -321,7 +321,7 @@ export const setup = (_vm) => {
       steppingThread = null;
     }
 
-    return ogStepThreads.call(this);
+    return originalStepThreads.call(this);
   };
 
   // Unpause when green flag

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -6,7 +6,6 @@ const STATUS_YIELD_TICK = 3;
 const STATUS_DONE = 4;
 
 let vm;
-let sequencerStepThread; // The unmodified sequencer.stepThread function
 
 let paused = false;
 let pausedThreadState = new WeakMap();
@@ -147,7 +146,7 @@ const singleStepThread = (thread) => {
       });
 
       try {
-        sequencerStepThread.call(vm.runtime.sequencer, thread);
+        vm.runtime.sequencer.stepThread(thread);
       } catch (err) {
         if (err !== throwMsg) throw err;
       }
@@ -298,11 +297,6 @@ export const setup = (_vm) => {
   }
 
   vm = _vm;
-
-  sequencerStepThread = vm.runtime.sequencer.stepThread;
-  vm.runtime.sequencer.stepThread = function (thread) {
-    sequencerStepThread.call(this, thread);
-  };
 
   const originalStepThreads = vm.runtime.sequencer.stepThreads;
   vm.runtime.sequencer.stepThreads = function () {

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -110,15 +110,15 @@ const singleStepThread = (thread) => {
     vm.runtime.sequencer.retireThread(thread);
   } else {
     /*
-          We need to call execute(this, thread) like the original sequencer. We don't
-          have access to that method, so we need to force the original stepThread to run
-          execute for us then exit before it tries to run more blocks.
-          So, we make `thread.blockGlowInFrame = ...` throw an exception, so this line:
-          https://github.com/LLK/scratch-vm/blob/bb352913b57991713a5ccf0b611fda91056e14ec/src/engine/sequencer.js#L214
-          will end the function early. We then have to set it back to normal afterward.
+      We need to call execute(this, thread) like the original sequencer. We don't
+      have access to that method, so we need to force the original stepThread to run
+      execute for us then exit before it tries to run more blocks.
+      So, we make `thread.blockGlowInFrame = ...` throw an exception, so this line:
+      https://github.com/LLK/scratch-vm/blob/bb352913b57991713a5ccf0b611fda91056e14ec/src/engine/sequencer.js#L214
+      will end the function early. We then have to set it back to normal afterward.
 
-          Why are we here just to suffer?
-         */
+      Why are we here just to suffer?
+    */
     const throwMsg = ["special error used by Scratch Addons for implementing single-stepping"];
 
     Object.defineProperty(thread, "blockGlowInFrame", {

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -123,42 +123,37 @@ const singleStepThread = (thread) => {
     vm.runtime.sequencer.activeThread = thread;
     pauseNewThreads = true;
 
-    if (!thread.target) {
-      // TODO: is this needed?
-      vm.runtime.sequencer.retireThread(thread);
-    } else {
-      /*
-        We need to call execute(this, thread) like the original sequencer. We don't
-        have access to that method, so we need to force the original stepThread to run
-        execute for us then exit before it tries to run more blocks.
-        So, we make `thread.blockGlowInFrame = ...` throw an exception, so this line:
-        https://github.com/LLK/scratch-vm/blob/bb352913b57991713a5ccf0b611fda91056e14ec/src/engine/sequencer.js#L214
-        will end the function early. We then have to set it back to normal afterward.
+    /*
+      We need to call execute(this, thread) like the original sequencer. We don't
+      have access to that method, so we need to force the original stepThread to run
+      execute for us then exit before it tries to run more blocks.
+      So, we make `thread.blockGlowInFrame = ...` throw an exception, so this line:
+      https://github.com/LLK/scratch-vm/blob/bb352913b57991713a5ccf0b611fda91056e14ec/src/engine/sequencer.js#L214
+      will end the function early. We then have to set it back to normal afterward.
 
-        Why are we here just to suffer?
-      */
-      const throwMsg = ["special error used by Scratch Addons for implementing single-stepping"];
+      Why are we here just to suffer?
+    */
+    const throwMsg = ["special error used by Scratch Addons for implementing single-stepping"];
 
-      Object.defineProperty(thread, "blockGlowInFrame", {
-        set(block) {
-          throw throwMsg;
-        },
-      });
+    Object.defineProperty(thread, "blockGlowInFrame", {
+      set(block) {
+        throw throwMsg;
+      },
+    });
 
-      try {
-        vm.runtime.sequencer.stepThread(thread);
-      } catch (err) {
-        if (err !== throwMsg) throw err;
-      }
-
-      // TODO: this can below = currentBlockId can be simplified
-      Object.defineProperty(thread, "blockGlowInFrame", {
-        value: null,
-        configurable: true,
-        enumerable: true,
-        writable: true,
-      });
+    try {
+      vm.runtime.sequencer.stepThread(thread);
+    } catch (err) {
+      if (err !== throwMsg) throw err;
     }
+
+    // TODO: this and below = currentBlockId can be simplified
+    Object.defineProperty(thread, "blockGlowInFrame", {
+      value: null,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
 
     vm.runtime.sequencer.activeThread = null;
     pauseNewThreads = false;

--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -26,7 +26,7 @@ const pauseThread = (thread) => {
 
   const pauseState = {
     time: vm.runtime.currentMSecs,
-    status: thread.status
+    status: thread.status,
   };
   pausedThreadState.set(thread, pauseState);
 
@@ -89,7 +89,7 @@ export const setPaused = (_paused) => {
     const activeThread = vm.runtime.sequencer.activeThread;
     if (activeThread) {
       setSteppingThread(activeThread);
-      eventTarget.dispatchEvent(new CustomEvent('step'));
+      eventTarget.dispatchEvent(new CustomEvent("step"));
     }
   } else {
     vm.runtime.audioEngine.audioContext.resume();
@@ -98,11 +98,11 @@ export const setPaused = (_paused) => {
       const pauseState = pausedThreadState.get(thread);
       if (pauseState) {
         compensateForTimePassedWhilePaused(thread, pauseState);
-        Object.defineProperty(thread, 'status', {
+        Object.defineProperty(thread, "status", {
           value: pauseState.status,
           configurable: true,
           enumerable: true,
-          writable: true,  
+          writable: true,
         });
       }
     }
@@ -244,12 +244,13 @@ const getThreadIndex = (thread) => {
   // This can happens when, for example, a "when I receive message1" script broadcasts message1.
   // The object in runtime.threads is replaced when this happens.
   if (!thread) return -1;
-  return vm.runtime.threads.findIndex((otherThread) => (
-    otherThread.target === thread.target &&
-    otherThread.topBlock === thread.topBlock &&
-    otherThread.stackClick === thread.stackClick &&
-    otherThread.updateMonitor === thread.updateMonitor
-  ));
+  return vm.runtime.threads.findIndex(
+    (otherThread) =>
+      otherThread.target === thread.target &&
+      otherThread.topBlock === thread.topBlock &&
+      otherThread.stackClick === thread.stackClick &&
+      otherThread.updateMonitor === thread.updateMonitor
+  );
 };
 
 const findNewSteppingThread = (startingIndex) => {
@@ -355,7 +356,7 @@ export const setup = (_vm) => {
   vm.runtime.startHats = function (...args) {
     const hat = args[0];
     // These hats can be manually started by the user when paused or while single stepping.
-    const isUserInitiated = hat === 'event_whenbroadcastreceived' || hat === 'control_start_as_clone';
+    const isUserInitiated = hat === "event_whenbroadcastreceived" || hat === "control_start_as_clone";
     if (pauseNewThreads) {
       if (!isUserInitiated && !this.getIsEdgeActivatedHat(hat)) {
         return [];


### PR DESCRIPTION
 - Fix performance regression where pausing a project will make Scratch's sequencer do 25ms of unnecessary work every frame.
 - Fix some bugs where breakpoints and single stepping could affect script execution order
 - Fix error when you pause project with no threads -> start new thread -> try to single step

I've tested this on quite a few projects and haven't found any regressions so far (but have found many bug fixes), but with how complex the debugger is I wouldn't be surprised if there's something. I have verified that #4210 and #4281 are still fixed.

