### PR TITLE
Change the capitalization of Export/Import Settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -279,7 +279,7 @@
     "description": "Used as a category name for enabled addons"
   },
   "exportAndImportSettings": {
-    "message": "Export and Import Settings"
+    "message": "Export and import settings"
   },
   "exportAndImportSettingsDescription": {
     "message": "Export settings as a JSON file for use on other computers."
@@ -288,10 +288,10 @@
     "message": "You can also enable your browser's built-in sync options to automatically synchronize the settings between devices."
   },
   "export": {
-    "message": "Export Settings"
+    "message": "Export settings"
   },
   "import": {
-    "message": "Import Settings"
+    "message": "Import settings"
   },
   "viewSettings": {
     "message": "View settings file"


### PR DESCRIPTION
Resolves #4520

### Changes

* Changes the title "Export and Import Settings" to "Export and import settings" to match "Scratch Addons theme" above
* Changes "Export Settings" and "Import Settings" to "Export/Import settings" to match all other buttons.