### PR TITLE
editor-devtools: Fix find bar style bugs

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -150,7 +150,7 @@ img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
 .slider_handle_3f0xk,
 .sound-editor_button_1_6Li,
 .library-item_library-item_1DcMO,
-div.s3devDDOut.vis,
+.s3devDDOut.vis,
 .prompt_body_18Z-I,
 .custom-procedures_body_SQBv6,
 #s3devHelpContent,

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -2192,19 +2192,19 @@ export default class DevTools {
         "beforeend",
         `
                 <div id="s3devToolBar">
-                    <label class='title s3devLabel' id=s3devFindLabel>
-                        <span>${this.m("find")} ${
+                    <div class='title s3devLabel' id=s3devFindLabel>
+                        <label for="s3devInp">${this.m("find")} ${
           this.addon.self._isDevtoolsExtension
             ? ""
             : '<a href="#" class="s3devAction" id="s3devHelp" style="/*s-a*/ margin-left: 0; font-size: 10px; /*s-a*/">(?)</a>'
-        } </span>
+        } </label>
                         <span id=s3devFind class="s3devWrap">
-                            <div id='s3devDDOut' class="s3devDDOut">
+                            <label id='s3devDDOut' class="s3devDDOut">
                                 <input id='s3devInp' class="${this.addon.tab.scratchClass("input_input-form", {
                                   others: "s3devInp",
                                 })}" type='search' placeholder='${this.m("find-placeholder")}' autocomplete='off'>
                                 <ul id='s3devDD' class="s3devDD"></ul>
-                            </div>
+                            </label>
                         </span>
                         <a id="s3devDeep" class="s3devAction s3devHide" href="#">${this.m("deep")}</a>
                         <div ${
@@ -2213,7 +2213,7 @@ export default class DevTools {
                         <a href="https://www.youtube.com/griffpatch" class="s3devAction" target="_blank" id="s3devHelp" rel="noreferrer noopener">${this.m(
                           "tutorials"
                         )}</a></div>
-                    </label>
+                    </div>
                 </div>
             `
       );

--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -389,9 +389,6 @@ div.s3devDDOut.vis ul.s3devDD {
 
 .s3devAction {
   margin-left: 2em;
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 2;
 }
 
 @media screen and (max-width: 1180px) {

--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -10,9 +10,10 @@
   width: 100%;
 }
 
-.s3devLabel > span:first-child {
-  margin-left: 1.5em;
-  margin-right: 1em;
+.s3devLabel > label {
+  /* padding instead of margin so clicking on the empty area will select the input */
+  padding-left: 1.5em;
+  padding-right: 1em;
   font-weight: bold;
   font-size: 0.625rem;
   user-select: none;
@@ -21,9 +22,9 @@
   padding-top: 2px;
 }
 
-[dir="rtl"] .s3devLabel > span:first-child {
-  margin-right: 1.5em;
-  margin-left: 1em;
+[dir="rtl"] .s3devLabel > label {
+  padding-right: 1.5em;
+  padding-left: 1em;
 }
 
 .s3devAction {
@@ -77,6 +78,7 @@ input.s3devInp:focus {
 
 /* Drop down from find button */
 .s3devDDOut {
+  display: block;
   top: -6px;
   z-index: 100;
   width: 100%;
@@ -101,7 +103,7 @@ ul.s3devDD {
   max-width: 100%;
 }
 
-div.s3devDDOut.vis {
+.s3devDDOut.vis {
   position: absolute;
   width: 16em;
   /*box-shadow: 0 2px 3px rgba(0,0,0,0.3), 0 5px 8px rgba(0,0,0,0.2);*/
@@ -111,7 +113,7 @@ div.s3devDDOut.vis {
   border-radius: 4px;
 }
 
-div.s3devDDOut.vis ul.s3devDD {
+.s3devDDOut.vis ul.s3devDD {
   display: block;
   border: none;
 }

--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -2,16 +2,12 @@
   display: flex;
   white-space: nowrap;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  width: 100%;
 }
 
 .s3devLabel {
   display: flex;
-  padding-right: 2em;
-}
-
-[dir="rtl"] .s3devLabel {
-  padding-right: 0;
-  padding-left: 2em;
+  width: 100%;
 }
 
 .s3devLabel > span:first-child {
@@ -49,11 +45,21 @@
 
 #s3devFind {
   height: 2rem;
+  width: 100%;
+}
+
+/* We need to modify Scratch styles so that the place where the find bar is injected */
+/* has actually correct size information, which is used to make the find bar not cover up controls */
+[class*="gui_tab-list_"] {
+  width: 100%;
+}
+[class*="gui_tab_"] {
+  flex-grow: 0;
 }
 
 /* Find Input Box */
 input.s3devInp {
-  min-width: 100%;
+  width: 100%;
   box-sizing: border-box !important;
   /* !important required for extension, because CSS injection method (and hence order) differs from addon */
   height: 1.5rem;
@@ -70,15 +76,11 @@ input.s3devInp:focus {
 }
 
 /* Drop down from find button */
-#s3devDDOut {
+.s3devDDOut {
   top: -6px;
-}
-
-/* Drop down from find button */
-div.s3devDDOut {
   z-index: 100;
-  left: 0;
-  width: 16em;
+  width: 100%;
+  max-width: 16em;
   position: relative;
   /*padding: 2.2em 0 0;*/
   /*background-color: white;*/
@@ -100,6 +102,8 @@ ul.s3devDD {
 }
 
 div.s3devDDOut.vis {
+  position: absolute;
+  width: 16em;
   /*box-shadow: 0 2px 3px rgba(0,0,0,0.3), 0 5px 8px rgba(0,0,0,0.2);*/
   box-shadow: 0px 0px 8px 1px rgba(0, 0, 0, 0.3);
   background-color: white;


### PR DESCRIPTION
 - Fixes #1881
 - Fixes "Find" moving vertically when you resize the window so that "(?)" toggles visibility

When the find bar is focused, it will always grow to a minimum size to make sure that it's actually usable. It may still cover up the controls when that happens, but that's okay because you're interacting with the input when that happens.

Tested in LTR and RTL languages.
