### PR TITLE
Fix custom block arg switching bug

### DIFF
--- a/addons/block-switching/userscript.js
+++ b/addons/block-switching/userscript.js
@@ -733,6 +733,7 @@ export default async function ({ addon, global, console, msg }) {
           !block.isShadow()
         ) {
           const customBlocks = getCustomBlocks();
+          const currentValue = block.getFieldValue("VALUE");
           if (customArgsMode === "all") {
             switch (type) {
               case "argument_reporter_string_number":
@@ -758,8 +759,8 @@ export default async function ({ addon, global, console, msg }) {
                 switches = customBlockObj.boolArgs;
                 break;
             }
+            if (!switches.includes(currentValue)) return items;
           }
-          const currentValue = block.getFieldValue("VALUE");
           switches = uniques(switches).map((i) => ({
             isNoop: i === currentValue,
             fieldValue: i,


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Fixes https://discord.com/channels/806602307750985799/938807989874360330/990211808981823528

### Changes

<!-- Please describe the changes you've made. -->
Fixes a bug where any argument could be switched, even if it didn't belong to the root custom block...
eg https://media.discordapp.net/attachments/990211808981823528/990212037680447518/unknown.png

### Reason for changes

<!-- Why should these changes be made? -->
It's unintended behaviour IMO; I didn't intend for this when originally implementing it.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested on chromium 101