### PR TITLE
Add icons to project-info

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -21,7 +21,8 @@ body {
 .project-loves::before,
 .project-favorites::before,
 .project-remixes::before,
-.project-views::before {
+.project-views::before,
+.sa-project-info img {
   filter: var(--darkWww-page-filter);
 }
 .project-loves.loved::before,

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -53,5 +53,9 @@
       "default": "both"
     }
   ],
-  "versionAdded": "1.4.0"
+  "versionAdded": "1.4.0",
+    "latestUpdate": {
+    "version": "1.27.0",
+    "newSettings": ["show"]
+  }
 }

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -50,7 +50,7 @@
           "name": "Text only"
         }
       ],
-    "default": "both"
+      "default": "both"
     }
   ],
   "versionAdded": "1.4.0"

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -54,7 +54,7 @@
     }
   ],
   "versionAdded": "1.4.0",
-    "latestUpdate": {
+  "latestUpdate": {
     "version": "1.27.0",
     "newSettings": ["show"]
   }

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -10,6 +10,8 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "injectAsStyleElt": true,
+  "updateUserstylesOnSettingsChange": true,
   "userscripts": [
     {
       "url": "projectstats.js",
@@ -20,6 +22,35 @@
     {
       "url": "userscript.css",
       "matches": ["projects"]
+    },
+    {
+      "url": "text-only.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": { "show": "text" }
+      }
+    }
+  ],
+  "settings": [
+    {
+      "name": "Show",
+      "id": "show",
+      "type": "select",
+      "potentialValues": [
+        {
+          "id": "both",
+          "name": "Icon and text"
+        },
+        {
+          "id": "icon",
+          "name": "Icon only"
+        },
+        {
+          "id": "text",
+          "name": "Text only"
+        }
+      ],
+    "default": "both"
     }
   ],
   "versionAdded": "1.4.0"

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -33,7 +33,7 @@
   ],
   "settings": [
     {
-      "name": "Show",
+      "name": "Show...",
       "id": "show",
       "type": "select",
       "potentialValues": [

--- a/addons/project-info/projectstats.js
+++ b/addons/project-info/projectstats.js
@@ -32,14 +32,14 @@ export default async function ({ addon, console, msg }) {
       addon.tab.displayNoneWhileDisabled(container, { display: "inline-block" });
       addon.tab.appendToSharedSpace({ space: "beforeRemixButton", element: container, order: 0 });
       let projectInfo = getBlockCount();
-      let spriteImg = document.createElement("img")
-      spriteImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/sprite-count.svg")
-      container.appendChild(spriteImg)
+      let spriteImg = document.createElement("img");
+      spriteImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/sprite-count.svg");
+      container.appendChild(spriteImg);
       container.appendChild(document.createTextNode(msg("sprite", { num: projectInfo.spriteCount })));
       container.appendChild(document.createElement("br"));
-      let scriptImg = document.createElement("img")
-      scriptImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/block-count.svg")
-      container.appendChild(scriptImg)
+      let scriptImg = document.createElement("img");
+      scriptImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/block-count.svg");
+      container.appendChild(scriptImg);
       container.appendChild(document.createTextNode(msg("script", { num: projectInfo.scriptCount })));
     }
   };

--- a/addons/project-info/projectstats.js
+++ b/addons/project-info/projectstats.js
@@ -31,22 +31,34 @@ export default async function ({ addon, console, msg }) {
       container.className = "sa-project-info";
       addon.tab.displayNoneWhileDisabled(container, { display: "inline-block" });
       addon.tab.appendToSharedSpace({ space: "beforeRemixButton", element: container, order: 0 });
-      let projectInfo = getBlockCount();
       let spriteImg = document.createElement("img");
       spriteImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/sprite-count.svg");
       container.appendChild(spriteImg);
-      container.appendChild(document.createTextNode(msg("sprite", { num: projectInfo.spriteCount })));
+      let spriteLbl = document.createElement("span");
+      spriteLbl.id = "spriteLabel";
+      container.appendChild(spriteLbl);
       container.appendChild(document.createElement("br"));
       let scriptImg = document.createElement("img");
       scriptImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/block-count.svg");
       container.appendChild(scriptImg);
-      container.appendChild(document.createTextNode(msg("script", { num: projectInfo.scriptCount })));
+      let scriptLbl = document.createElement("span");
+      scriptLbl.id = "scriptLabel";
+      container.appendChild(scriptLbl);
+      updateLabels()
     }
   };
+  
+  function updateLabels() {
+    let setting = addon.settings.get("show");
+    let projectInfo = getBlockCount();
+    document.querySelector("#spriteLabel").innerText = (setting === "icon") ? projectInfo.spriteCount : msg("sprite", { num: projectInfo.spriteCount });
+    document.querySelector("#scriptLabel").innerText = (setting === "icon") ? projectInfo.scriptCount : msg("script", { num: projectInfo.scriptCount });
+  }
 
   // addProjectPageStats either when the project is loaded through the project page or when the user goes from the editor to the project page
   vm.runtime.on("PROJECT_LOADED", async () => addProjectPageStats());
   addon.tab.addEventListener("urlChange", (e) => addProjectPageStats());
   // The addon ran late, so PROJECT_LOADED already happened.
   if (addon.self.enabledLate) addProjectPageStats();
+  addon.settings.addEventListener("change", (e) => updateLabels());
 }

--- a/addons/project-info/projectstats.js
+++ b/addons/project-info/projectstats.js
@@ -44,15 +44,17 @@ export default async function ({ addon, console, msg }) {
       let scriptLbl = document.createElement("span");
       scriptLbl.id = "scriptLabel";
       container.appendChild(scriptLbl);
-      updateLabels()
+      updateLabels();
     }
   };
-  
+
   function updateLabels() {
     let setting = addon.settings.get("show");
     let projectInfo = getBlockCount();
-    document.querySelector("#spriteLabel").innerText = (setting === "icon") ? projectInfo.spriteCount : msg("sprite", { num: projectInfo.spriteCount });
-    document.querySelector("#scriptLabel").innerText = (setting === "icon") ? projectInfo.scriptCount : msg("script", { num: projectInfo.scriptCount });
+    document.querySelector("#spriteLabel").innerText =
+      setting === "icon" ? projectInfo.spriteCount : msg("sprite", { num: projectInfo.spriteCount });
+    document.querySelector("#scriptLabel").innerText =
+      setting === "icon" ? projectInfo.scriptCount : msg("script", { num: projectInfo.scriptCount });
   }
 
   // addProjectPageStats either when the project is loaded through the project page or when the user goes from the editor to the project page

--- a/addons/project-info/projectstats.js
+++ b/addons/project-info/projectstats.js
@@ -32,8 +32,14 @@ export default async function ({ addon, console, msg }) {
       addon.tab.displayNoneWhileDisabled(container, { display: "inline-block" });
       addon.tab.appendToSharedSpace({ space: "beforeRemixButton", element: container, order: 0 });
       let projectInfo = getBlockCount();
+      let spriteImg = document.createElement("img")
+      spriteImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/sprite-count.svg")
+      container.appendChild(spriteImg)
       container.appendChild(document.createTextNode(msg("sprite", { num: projectInfo.spriteCount })));
       container.appendChild(document.createElement("br"));
+      let scriptImg = document.createElement("img")
+      scriptImg.setAttribute("src", "https://scratch.mit.edu/svgs/project/block-count.svg")
+      container.appendChild(scriptImg)
       container.appendChild(document.createTextNode(msg("script", { num: projectInfo.scriptCount })));
     }
   };

--- a/addons/project-info/text-only.css
+++ b/addons/project-info/text-only.css
@@ -5,4 +5,3 @@
 .sa-project-info img {
   display: none;
 }
-

--- a/addons/project-info/text-only.css
+++ b/addons/project-info/text-only.css
@@ -1,0 +1,8 @@
+.preview .sa-project-info {
+  text-align: right;
+}
+
+.sa-project-info img {
+  display: none;
+}
+

--- a/addons/project-info/userscript.css
+++ b/addons/project-info/userscript.css
@@ -2,8 +2,13 @@
   margin-left: 1rem;
   margin-bottom: 0.5rem;
   font-size: 0.875rem;
-  text-align: right;
 }
+
+.sa-project-info img {
+  height: 0.875rem;
+  margin-right: 0.5rem;
+}
+
 .preview .project-buttons > * {
   vertical-align: middle;
 }

--- a/addons/project-info/userscript.css
+++ b/addons/project-info/userscript.css
@@ -1,14 +1,18 @@
 .preview .sa-project-info {
-  margin-left: 1rem;
   margin-bottom: 0.5rem;
   font-size: 0.875rem;
+  text-align: left;
 }
 
 .sa-project-info img {
   height: 0.875rem;
-  margin-right: 0.5rem;
+  vertical-align: bottom;
 }
 
-.preview .project-buttons > * {
+.sa-project-info > * {
+  padding: 0.1rem;
+}
+
+.sa-project-info, .preview .project-buttons > * {
   vertical-align: middle;
 }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -187,10 +187,6 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
             delete scratchr2.linkColor;
           }
         }
-        if (addonId == "project-info") {
-          madeChangesToAddon = madeAnyChanges = true;
-          settings.show = "text";
-        }
       }
 
       if (addonsEnabled[addonId] === undefined) addonsEnabled[addonId] = !!manifest.enabledByDefault;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -187,6 +187,10 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
             delete scratchr2.linkColor;
           }
         }
+        if (addonId == "project-info") {
+          madeChangesToAddon = madeAnyChanges = true;
+          settings.show = "text";
+        }
       }
 
       if (addonsEnabled[addonId] === undefined) addonsEnabled[addonId] = !!manifest.enabledByDefault;


### PR DESCRIPTION
Resolves #3378

### Changes

Adds an option to add icons next to the `project-info` labels or remove the labels entirely.

![image](https://user-images.githubusercontent.com/81489795/176067219-819d08a1-2511-4fbd-8bfe-0307c61b966c.png)
![image](https://user-images.githubusercontent.com/81489795/176543039-3ba9b31e-51a8-4883-bf04-27ecd067da5b.png)

### Reason for changes

It looks a little better with the icons and they were already available on Scratch's servers.

### Tests

Tested on Chromium 103.