### PR TITLE
Minify stored settings data

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -1,3 +1,5 @@
+import minifySettings from "../libraries/common/minify-settings.js";
+
 /**
  Since presets can change independently of others, we have to keep track of
  the versions separately. Current versions:
@@ -197,7 +199,12 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
       }
     }
 
-    if (madeAnyChanges) chrome.storage.sync.set({ addonSettings, addonsEnabled });
+    const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
+    if (madeAnyChanges)
+      chrome.storage.sync.set({
+        addonSettings: minifySettings(addonSettings, prerelease ? null : scratchAddons.manifests),
+        addonsEnabled,
+      });
     scratchAddons.globalState.addonSettings = addonSettings;
     scratchAddons.localState.addonsEnabled = addonsEnabled;
     scratchAddons.localState.ready.addonSettings = true;

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -1,4 +1,5 @@
 import changeAddonState from "./imports/change-addon-state.js";
+import minifySettings from "../libraries/common/minify-settings.js";
 import { updateBadge } from "./message-cache.js";
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
@@ -25,9 +26,13 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   } else if (request.changeAddonSettings) {
     const { addonId, newSettings } = request.changeAddonSettings;
     scratchAddons.globalState.addonSettings[addonId] = newSettings;
+    const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
     chrome.storage.sync.set({
       // Store target so arrays don't become objects
-      addonSettings: scratchAddons.globalState.addonSettings._target,
+      addonSettings: minifySettings(
+        scratchAddons.globalState.addonSettings._target,
+        prerelease ? null : scratchAddons.manifests
+      ),
     });
 
     const manifest = scratchAddons.manifests.find((addon) => addon.addonId === addonId).manifest;

--- a/libraries/common/minify-settings.js
+++ b/libraries/common/minify-settings.js
@@ -17,7 +17,11 @@ export default (settings, manifests) => {
       delete newSettings[addonId];
     } else {
       for (const settingsKey of Object.keys(setting)) {
-        if (manifestObj && !manifestObj[addonId].settings?.some((s) => settingsKey === s.id)) {
+        if (
+          manifestObj &&
+          !settingsKey.startsWith("_") &&
+          !manifestObj[addonId].settings?.some((s) => settingsKey === s.id)
+        ) {
           delete setting[settingsKey];
         }
       }

--- a/libraries/common/minify-settings.js
+++ b/libraries/common/minify-settings.js
@@ -1,0 +1,30 @@
+/**
+ * Removes unnecessary settings entry to reduce storage size.
+ * @param {object} settings the settings object
+ * @param {?object[]} manifests the manifests, if null manifest check is not performed
+ * @return the new settings
+ */
+export default (settings, manifests) => {
+  const newSettings = JSON.parse(JSON.stringify(settings));
+  const manifestObj =
+    manifests &&
+    manifests.reduce((a, b) => {
+      a[b._addonId || b.addonId] = b.manifest || b;
+      return a;
+    }, {});
+  for (const [addonId, setting] of Object.entries(newSettings)) {
+    if (manifestObj && !manifestObj[addonId]) {
+      delete newSettings[addonId];
+    } else {
+      for (const settingsKey of Object.keys(setting)) {
+        if (manifestObj && !manifestObj[addonId].settings?.some((s) => settingsKey === s.id)) {
+          delete setting[settingsKey];
+        }
+      }
+      if (Object.keys(setting).length === 0) {
+        delete newSettings[addonId];
+      }
+    }
+  }
+  return newSettings;
+};

--- a/libraries/common/minify-settings.js
+++ b/libraries/common/minify-settings.js
@@ -14,6 +14,7 @@ export default (settings, manifests) => {
     }, {});
   for (const [addonId, setting] of Object.entries(newSettings)) {
     if (manifestObj && !manifestObj[addonId]) {
+      // Delete settings from addons that no longer exist
       delete newSettings[addonId];
     } else {
       for (const settingsKey of Object.keys(setting)) {
@@ -22,10 +23,14 @@ export default (settings, manifests) => {
           !settingsKey.startsWith("_") &&
           !manifestObj[addonId].settings?.some((s) => settingsKey === s.id)
         ) {
+          // Delete settings that no longer exist (exception: those with setting id starting with underscore)
           delete setting[settingsKey];
         }
       }
       if (Object.keys(setting).length === 0) {
+        // Delete empty settings objects, even if "manifests" arg is null
+        // One of the deletions above might have caused an object to be empty
+        // Importing settings from a JSON file also causes most objects to be empty
         delete newSettings[addonId];
       }
     }

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -8,6 +8,7 @@ import categories from "./data/categories.js";
 import exampleManifest from "./data/example-manifest.js";
 import fuseOptions from "./data/fuse-options.js";
 import globalTheme from "../../libraries/common/global-theme.js";
+import minifySettings from "../../libraries/common/minify-settings.js";
 
 let isIframe = false;
 if (window.parent !== window) {
@@ -126,10 +127,11 @@ let fuse;
           addonsEnabled[addonId] = granted;
         });
       }
+      const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
       await syncSet({
         globalTheme: !!obj.core.lightTheme,
         addonsEnabled,
-        addonSettings,
+        addonSettings: minifySettings(addonSettings, prerelease ? null : manifests),
       });
       resolvePromise();
     };


### PR DESCRIPTION
Resolves #4721

### Changes
Removes unnecessary addon settings (missing, empty, etc) from the stored settings. Missing addon/setting check is not performed in development environment.

### Reason for changes
This reduces the storage size, hopefully allowing storage errors while I work on more permanent solution.