### PR TITLE
Add `font-variant: tabular-nums` to the number of remaining characters

### DIFF
--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -265,6 +265,7 @@ a.message-type-title-text {
 .comment-chars {
   margin-inline-start: auto;
   font-weight: normal;
+  font-variant: tabular-nums;
 }
 
 .status-container {


### PR DESCRIPTION
### Changes

Adds `font-variant: tabular-nums` to the number of remaining characters when replying to a comment in the Messaging popup. This prevents the width of the number from changing.

Before: ![chars_left_old](https://user-images.githubusercontent.com/51849865/177115005-9aee62e5-7e57-4dd3-8a7d-7ed4ac6286a4.gif)

After: ![chars_left_new](https://user-images.githubusercontent.com/51849865/177115351-28b28a78-9cc2-4004-b0d6-eda1e522d9e4.gif)