### PR TITLE
Add latestUpdate to hide-flyout, change default mode

### DIFF
--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -83,7 +83,7 @@
           "name": "Category click"
         }
       ],
-      "default": "hover"
+      "default": "cathover"
     },
     {
       "name": "Animation duration",

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -5,6 +5,10 @@
     {
       "name": "TheColaber",
       "link": "https://scratch.mit.edu/users/TheColaber"
+    },
+    {
+      "name": "Maximouse",
+      "link": "https://scratch.mit.edu/users/Maximouse/"
     }
   ],
   "info": [

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -106,5 +106,10 @@
       "default": "default"
     }
   ],
-  "tags": ["editor", "codeEditor", "recommended"]
+  "tags": ["editor", "codeEditor", "recommended"],
+  "latestUpdate": {
+    "version": "1.27.0",
+    "temporaryNotice": "This addon was revisited and many bugs were fixed.",
+    "isMajor": true
+  }
 }

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -113,7 +113,7 @@
   "tags": ["editor", "codeEditor", "recommended"],
   "latestUpdate": {
     "version": "1.27.0",
-    "temporaryNotice": "This addon was revisited and many bugs were fixed.",
+    "temporaryNotice": "This addon was revised and many bugs were fixed.",
     "isMajor": true
   }
 }


### PR DESCRIPTION
Resolves #4668

- Adds latestUpdate to addon:
![image](https://user-images.githubusercontent.com/17484114/178117098-2654754c-0e26-4c14-8959-ba8b6338a02b.png)
- Credit Maximouse for the addon
- Change default mode to category hover. There's no migration, so it will only affect new Scratch Addons users - old SA users that had this enabled will still have category hover as the default. For this reason, I'm keeping the info hoverExplanation.