### PR TITLE
initialise-sprite-position: run on sprite duplication

### DIFF
--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -42,11 +42,11 @@
       "id": "duplicate",
       "name": "Behaviour when duplicating sprites",
       "type": "select",
-      "default": "keep",
+      "default": "randomize",
       "potentialValues": [
         {
           "id": "custom",
-          "name": "Send to custom x/y values"
+          "name": "Send to specified x/y values"
         },
         {
           "id": "keep",

--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -60,6 +60,10 @@
     }
   ],
   "versionAdded": "1.13.0",
+  "latestUpdate": {
+    "version": "1.28.0",
+    "newSettings": ["duplicate"]
+  },
   "tags": ["editor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -37,6 +37,26 @@
       "name": "Randomize the position of library sprites",
       "type": "boolean",
       "default": false
+    },
+    {
+      "id": "duplicate",
+      "name": "Behaviour when duplicating sprites",
+      "type": "select",
+      "default": "keep",
+      "potentialValues": [
+        {
+          "id": "custom",
+          "name": "Send to custom x/y values"
+        },
+        {
+          "id": "keep",
+          "name": "Keep the same as the original sprite"
+        },
+        {
+          "id": "randomize",
+          "name": "Randomize"
+        }
+      ]
     }
   ],
   "versionAdded": "1.13.0",

--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -40,7 +40,7 @@
     },
     {
       "id": "duplicate",
-      "name": "Behaviour when duplicating sprites",
+      "name": "Behavior when duplicating sprites",
       "type": "select",
       "default": "randomize",
       "potentialValues": [

--- a/addons/initialise-sprite-position/userscript.js
+++ b/addons/initialise-sprite-position/userscript.js
@@ -1,6 +1,6 @@
 export default async function ({ addon }) {
   const vm = addon.tab.traps.vm;
-    
+
   const oldAddSprite = vm.constructor.prototype.addSprite;
   vm.constructor.prototype.addSprite = function (input) {
     let spriteObj,
@@ -20,26 +20,26 @@ export default async function ({ addon }) {
     }
     return oldAddSprite.call(this, stringify ? JSON.stringify(spriteObj) : spriteObj);
   };
-  
+
   const registerDupPrototype = () => {
     const targetPrototype = vm.runtime.getTargetForStage().constructor.prototype;
     const oldDuplicate = targetPrototype.duplicate;
     targetPrototype.duplicate = function () {
-        return oldDuplicate.call(this).then(newSprite => {
-            if (!addon.self.disabled) {
-                switch (addon.settings.get('duplicate')) {
-                  case 'custom':
-                    newSprite.setXY(addon.settings.get('x'), addon.settings.get('y'));
-                    break;
-                  case 'keep':
-                    newSprite.setXY(this.x, this.y);
-                }
-            }
-            return newSprite;
-        });
+      return oldDuplicate.call(this).then((newSprite) => {
+        if (!addon.self.disabled) {
+          switch (addon.settings.get("duplicate")) {
+            case "custom":
+              newSprite.setXY(addon.settings.get("x"), addon.settings.get("y"));
+              break;
+            case "keep":
+              newSprite.setXY(this.x, this.y);
+          }
+        }
+        return newSprite;
+      });
     };
   };
-  
+
   if (vm.runtime.getTargetForStage()) {
     registerDupPrototype();
   } else {

--- a/addons/initialise-sprite-position/userscript.js
+++ b/addons/initialise-sprite-position/userscript.js
@@ -43,6 +43,6 @@ export default async function ({ addon }) {
   if (vm.runtime.getTargetForStage()) {
     registerDupPrototype();
   } else {
-    vm.runtime.on(vm.runtime.constructor.PROJECT_LOADED, registerDupPrototype);
+    vm.runtime.once("PROJECT_LOADED", registerDupPrototype);
   }
 }

--- a/addons/initialise-sprite-position/userscript.js
+++ b/addons/initialise-sprite-position/userscript.js
@@ -1,12 +1,13 @@
 export default async function ({ addon }) {
-  let vm = addon.tab.traps.vm;
-  let oldAddSprite = vm.constructor.prototype.addSprite;
+  const vm = addon.tab.traps.vm;
+    
+  const oldAddSprite = vm.constructor.prototype.addSprite;
   vm.constructor.prototype.addSprite = function (input) {
     let spriteObj,
       stringify = true;
     if (typeof input === "object") [spriteObj, stringify] = [input, false];
     else spriteObj = JSON.parse(input);
-    let isEmpty = spriteObj.costumes?.[0]?.baseLayerMD5 === "cd21514d0531fdffb22204e0ec5ed84a.svg";
+    const isEmpty = spriteObj.costumes?.[0]?.baseLayerMD5 === "cd21514d0531fdffb22204e0ec5ed84a.svg";
     if (!addon.self.disabled && (isEmpty || !spriteObj.tags || !addon.settings.get("library"))) {
       if (spriteObj.scratchX) {
         spriteObj.scratchX = addon.settings.get("x");
@@ -19,4 +20,29 @@ export default async function ({ addon }) {
     }
     return oldAddSprite.call(this, stringify ? JSON.stringify(spriteObj) : spriteObj);
   };
+  
+  const registerDupPrototype = () => {
+    const targetPrototype = vm.runtime.getTargetForStage().constructor.prototype;
+    const oldDuplicate = targetPrototype.duplicate;
+    targetPrototype.duplicate = function () {
+        return oldDuplicate.call(this).then(newSprite => {
+            if (!addon.self.disabled) {
+                switch (addon.settings.get('duplicate')) {
+                  case 'custom':
+                    newSprite.setXY(addon.settings.get('x'), addon.settings.get('y'));
+                    break;
+                  case 'keep':
+                    newSprite.setXY(this.x, this.y);
+                }
+            }
+            return newSprite;
+        });
+    };
+  };
+  
+  if (vm.runtime.getTargetForStage()) {
+    registerDupPrototype();
+  } else {
+    vm.runtime.on(vm.runtime.constructor.PROJECT_LOADED, registerDupPrototype);
+  }
 }


### PR DESCRIPTION
Resolves #4786

### Changes

- adds a setting for how to handle duplication: either randomise (scratch's default), go to custom x/y values, or stay in the same position as the original sprite; setting & option names & orders should probably be reconsidered
- uses `const` instead of `let` in a few places

### Reason for changes

- it's a bug, and users should choose the behaviour they want
- `const` is love, `const` is life

### Tests

tested on chromium (kiwi) 101 with all 3 settings + dynamic enable/disable
