### PR TITLE
Fix editor-unshare-button bug

### DIFF
--- a/addons/editor-unshare-button/userscript.js
+++ b/addons/editor-unshare-button/userscript.js
@@ -8,11 +8,7 @@ export default async function ({ addon, msg, global, console }) {
 
     button.classList.add("sa-unshare-button");
     button.querySelector("span").innerText = msg("unshare-button");
-    button.addEventListener("click", async (e) => {
-      // Don't do anything if the button is now a "Share" button
-      // This can happen if the "Unshare" button was clicked previously
-      if (!button.className.includes("is-shared")) return;
-
+    button.addEventListener("click", async function thisFunction(e) {
       if (!(await addon.tab.confirm(msg("unshare-button"), msg("unshare-msg"), { useEditorClasses: true }))) return;
       redux.dispatch({
         type: "SET_COMMENT_FETCH_STATUS",
@@ -46,6 +42,8 @@ export default async function ({ addon, msg, global, console }) {
         });
 
         button.classList.remove("sa-unshare-button");
+        button.removeEventListener("click", thisFunction);
+
         redux.dispatch({
           type: "UPDATE_PROJECT_INFO",
           info: {

--- a/addons/editor-unshare-button/userscript.js
+++ b/addons/editor-unshare-button/userscript.js
@@ -9,6 +9,10 @@ export default async function ({ addon, msg, global, console }) {
     button.classList.add("sa-unshare-button");
     button.querySelector("span").innerText = msg("unshare-button");
     button.addEventListener("click", async (e) => {
+      // Don't do anything if the button is now a "Share" button
+      // This can happen if the "Unshare" button was clicked previously
+      if (!button.className.includes("is-shared")) return;
+
       if (!(await addon.tab.confirm(msg("unshare-button"), msg("unshare-msg"), { useEditorClasses: true }))) return;
       redux.dispatch({
         type: "SET_COMMENT_FETCH_STATUS",


### PR DESCRIPTION
Resolves the bug that @Norbiros commented over here: https://github.com/ScratchAddons/ScratchAddons/pull/4639#discussion_r906731593

To repro the bug on master:
1. Go to a shared project you own
2. Click the unshare button
3. Confirm the action
4. Click the share button
5. The editor-unshare-button addon thinks the "unshare" button was clicked, and asks to confirm
6. If the confirmations addon is set up to confirm sharing projects, it will also ask to confirm.

Bug was fixed by removing the confirmation described on number 5 - this addon shouldn't do anything if the "share" button was clicked after using the "unshared" button.