### PR TITLE
Refresh setting for forum-live-preview

### DIFF
--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -28,20 +28,20 @@
       "id": "refresh",
       "type": "select",
       "potentialValues": [
-       {
-           "name": "fast",
-           "id": "250"
-         },
-         {
-           "name": "normal",
-           "id": "1000"
-         },
-         {
-           "name": "slow",
-           "id": "3000"
-         }
-       ],
-       "default": "normal"
+        {
+          "name": "fast",
+          "id": "250"
+        },
+        {
+          "name": "normal",
+          "id": "1000"
+        },
+        {
+          "name": "slow",
+          "id": "3000"
+        }
+      ],
+      "default": "normal"
     }
   ],
   "tags": ["community", "forums"],

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -27,9 +27,9 @@
       "name": "Refresh rate (ms)",
       "id": "refresh",
       "type": "integer",
-      "min": "250",
-      "max": "10000",
-      "default": "1000"
+      "min": 250,
+      "max": 10000,
+      "default": 1000
     }
   ],
   "tags": ["community", "forums"],

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -22,6 +22,16 @@
       "matches": ["editingScreens"]
     }
   ],
+  "settings": [
+    {
+      "name": "Refresh rate (ms)",
+      "id": "refresh",
+      "type": "integer",
+      "min": "250",
+      "max": "10000",
+      "default": "1000"
+    }
+  ],
   "tags": ["community", "forums"],
   "versionAdded": "1.25.0"
 }

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -25,23 +25,23 @@
   "settings": [
     {
       "name": "Refresh rate",
-      "id": "refresh",
+      "id": "rate",
       "type": "select",
       "potentialValues": [
         {
-          "name": "fast",
-          "id": "250"
+          "id": "fast",
+          "name": "Fast"
         },
         {
-          "name": "normal",
-          "id": "1000"
+          "id": "default",
+          "name": "Default"
         },
         {
-          "name": "slow",
-          "id": "3000"
+          "id": "slow",
+          "name": "Slow"
         }
       ],
-      "default": "normal"
+      "default": "default"
     }
   ],
   "tags": ["community", "forums"],

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -24,12 +24,24 @@
   ],
   "settings": [
     {
-      "name": "Refresh rate (ms)",
+      "name": "Refresh rate",
       "id": "refresh",
-      "type": "integer",
-      "min": 250,
-      "max": 10000,
-      "default": 1000
+      "type": "select",
+      "potentialValues": [
+       {
+           "name": "fast",
+           "id": "250"
+         },
+         {
+           "name": "normal",
+           "id": "1000"
+         },
+         {
+           "name": "slow",
+           "id": "3000"
+         }
+       ],
+       "default": "normal"
     }
   ],
   "tags": ["community", "forums"],

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -29,16 +29,16 @@
       "type": "select",
       "potentialValues": [
         {
-          "id": "fast",
-          "name": "Fast"
+          "id": "slow",
+          "name": "Slow"
         },
         {
           "id": "default",
           "name": "Default"
         },
         {
-          "id": "slow",
-          "name": "Slow"
+          "id": "fast",
+          "name": "Fast"
         }
       ],
       "default": "default"

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -23,7 +23,7 @@ export default async function ({ addon, console }) {
   let timeout;
   textarea.addEventListener("input", () => {
     if (timeout !== undefined) clearTimeout(timeout);
-    timeout = setTimeout(updatePreview, 1000);
+    timeout = setTimeout(updatePreview, addon.settings.get("refresh"));
   });
   addon.self.addEventListener("disabled", () => {
     showPreview();

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, console }) {
   const textarea = await addon.tab.waitForElement(".markItUpEditor");
   const previewButton = await addon.tab.waitForElement(".markItUpButton.preview");
-  const delay = addon.settings.get("refresh");
+  const delay = Number(addon.settings.get("refresh"));
   let previewIframe;
   addon.tab.waitForElement(".markItUpPreviewFrame").then((iframe) => (previewIframe = iframe));
 

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -1,6 +1,7 @@
 export default async function ({ addon, console }) {
   const textarea = await addon.tab.waitForElement(".markItUpEditor");
   const previewButton = await addon.tab.waitForElement(".markItUpButton.preview");
+  const delay = addon.settings.get("refresh");
   let previewIframe;
   addon.tab.waitForElement(".markItUpPreviewFrame").then((iframe) => (previewIframe = iframe));
 
@@ -23,7 +24,7 @@ export default async function ({ addon, console }) {
   let timeout;
   textarea.addEventListener("input", () => {
     if (timeout !== undefined) clearTimeout(timeout);
-    timeout = setTimeout(updatePreview, addon.settings.get("refresh"));
+    timeout = setTimeout(updatePreview, delay);
   });
   addon.self.addEventListener("disabled", () => {
     showPreview();

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -1,8 +1,18 @@
 export default async function ({ addon, console }) {
   const textarea = await addon.tab.waitForElement(".markItUpEditor");
   const previewButton = await addon.tab.waitForElement(".markItUpButton.preview");
-  const delay = Number(addon.settings.get("refresh"));
   let previewIframe;
+  let delay;
+  switch (addon.settings.get("rate")) {
+    case "slow":
+      delay = 2500;
+      break;
+    case "fast":
+      delay = 250;
+      break;
+    default:
+      delay = 1000;
+  }
   addon.tab.waitForElement(".markItUpPreviewFrame").then((iframe) => (previewIframe = iframe));
 
   const showPreview = () => {


### PR DESCRIPTION
Resolves #4782

### Changes

Adds a setting to `forum-live-preview` for adjusting the refresh rate.

### Reason for changes

Some people might want to configure the refresh rate.

### Tests

Tested on Chromium 103.