### PR TITLE
dark-www: fix banned response page

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -332,6 +332,7 @@ ul.pagination span /* mobile forums */,
   background-color: var(--darkWww-gray-scratchr2SelectedTab);
 }
 .box .box-content .action-bar .inner,
+.contact #block-message,
 .djangobb th,
 .post-content blockquote /* mobile forums */,
 .post-content div.code /* mobile forums */ {


### PR DESCRIPTION
Resolves #2106

### Changes

Makes the ban message readable.

### Tests

See screenshots below.