### PR TITLE
Fix some bugs from #4627

### DIFF
--- a/addons/data-category-tweaks-v2/userscript.js
+++ b/addons/data-category-tweaks-v2/userscript.js
@@ -196,10 +196,27 @@ export default async function ({ addon, global, console, msg, safeMsg }) {
     }
   });
 
+  const dynamicEnableOrDisable = () => {
+    // Enabling/disabling is similar to changing settings.
+    // If separate list category is enabled, a workspace update is needed.
+    // If any other setting is enabled, refresh the toolbox.
+    if (addon.settings.get("separateListCategory")) {
+      if (vm.editingTarget) {
+        vm.emitWorkspaceUpdate();
+      }
+    }
+    if (addon.settings.get("separateLocalVariables") || addon.settings.get("moveReportersDown")) {
+      const workspace = Blockly.getMainWorkspace();
+      if (workspace) {
+        workspace.refreshToolboxSelection_();
+      }
+    }
+  };
+
   addon.self.addEventListener("disabled", () => {
-    vm.emitWorkspaceUpdate();
+    dynamicEnableOrDisable();
   });
   addon.self.addEventListener("reenabled", () => {
-    vm.emitWorkspaceUpdate();
+    dynamicEnableOrDisable();
   });
 }

--- a/addons/full-signature/addon.json
+++ b/addons/full-signature/addon.json
@@ -45,21 +45,16 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "updateUserstylesOnSettingsChange": true,
   "userscripts": [
     {
       "url": "working.js",
-      "matches": ["https://scratch.mit.edu/users/*"],
-      "if": {
-        "settings": { "whatworkingon": true }
-      }
+      "matches": ["https://scratch.mit.edu/users/*"]
     },
     {
       "url": "happen.js",
       "matches": ["https://scratch.mit.edu/"],
-      "runAtComplete": false,
-      "if": {
-        "settings": { "whathappen": true }
-      }
+      "runAtComplete": false
     }
   ],
   "userstyles": [

--- a/addons/full-signature/happen.css
+++ b/addons/full-signature/happen.css
@@ -11,5 +11,6 @@
 }
 
 .load-more-wh-container {
+  display: block !important;
   text-align: center;
 }

--- a/addons/full-signature/happen.js
+++ b/addons/full-signature/happen.js
@@ -36,15 +36,13 @@ export default async function ({ addon, global, console, msg }) {
       updateRedux();
     });
     async function updateRedux() {
-      displayedFetch = fetched.slice(0, dataLoaded);
+      displayedFetch = fetched.slice(0, addon.self.disabled ? 5 : dataLoaded);
       await addon.tab.redux.dispatch({ type: "SET_ROWS", rowType: "activity", rows: displayedFetch });
       document.querySelector(".activity-ul").appendChild(container);
       if (dataLoaded > fetched.length) container.remove();
     }
     addon.tab.displayNoneWhileDisabled(loadMore);
-    addon.self.addEventListener("disabled", () => {
-      dataLoaded = 5;
-      updateRedux();
-    });
+    addon.self.addEventListener("disabled", updateRedux);
+    addon.self.addEventListener("reenabled", updateRedux)
   }
 }

--- a/addons/full-signature/happen.js
+++ b/addons/full-signature/happen.js
@@ -4,6 +4,7 @@ export default async function ({ addon, global, console, msg }) {
   if (activityStream.length) {
     let container = document.querySelector(".activity-ul").appendChild(document.createElement("div"));
     container.classList.add("load-more-wh-container");
+    container.style.display = "none"; // overridden by userstyle if the setting is enabled
     let loadMore = container.appendChild(document.createElement("button"));
     loadMore.className = "load-more-wh button";
     loadMore.innerText = msg("load-more");
@@ -36,13 +37,13 @@ export default async function ({ addon, global, console, msg }) {
       updateRedux();
     });
     async function updateRedux() {
-      displayedFetch = fetched.slice(0, addon.self.disabled ? 5 : dataLoaded);
+      displayedFetch = fetched.slice(0, !addon.self.disabled && addon.settings.get("whathappen") ? dataLoaded : 5);
       await addon.tab.redux.dispatch({ type: "SET_ROWS", rowType: "activity", rows: displayedFetch });
       document.querySelector(".activity-ul").appendChild(container);
       if (dataLoaded > fetched.length) container.remove();
     }
-    addon.tab.displayNoneWhileDisabled(loadMore);
     addon.self.addEventListener("disabled", updateRedux);
-    addon.self.addEventListener("reenabled", updateRedux)
+    addon.self.addEventListener("reenabled", updateRedux);
+    addon.settings.addEventListener("change", updateRedux);
   }
 }

--- a/addons/full-signature/happen.js
+++ b/addons/full-signature/happen.js
@@ -37,6 +37,7 @@ export default async function ({ addon, global, console, msg }) {
       updateRedux();
     });
     async function updateRedux() {
+      if (!fetched.length) return; // load more hasn't been clicked yet: just use the data loaded by Scratch
       displayedFetch = fetched.slice(0, !addon.self.disabled && addon.settings.get("whathappen") ? dataLoaded : 5);
       await addon.tab.redux.dispatch({ type: "SET_ROWS", rowType: "activity", rows: displayedFetch });
       document.querySelector(".activity-ul").appendChild(container);

--- a/addons/full-signature/working.css
+++ b/addons/full-signature/working.css
@@ -11,5 +11,6 @@ ul.activity-stream div {
 }
 
 .load-more-wibd-container {
+  display: block !important;
   text-align: center;
 }

--- a/addons/full-signature/working.js
+++ b/addons/full-signature/working.js
@@ -3,6 +3,7 @@ export default async function ({ addon, global, console, msg }) {
   if (activityStream.length) {
     let container = document.querySelector(".activity-stream").appendChild(document.createElement("div"));
     container.classList.add("load-more-wibd-container");
+    container.style.display = "none"; // overridden by userstyle if the setting is enabled
     let loadMore = container.appendChild(document.createElement("button"));
     loadMore.classList.add("load-more-wibd");
     loadMore.innerText = msg("load-more");
@@ -36,6 +37,5 @@ export default async function ({ addon, global, console, msg }) {
       },
       { once: true }
     );
-    addon.tab.displayNoneWhileDisabled(loadMore);
   }
 }

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -60,10 +60,10 @@ const vue = new Vue({
 });
 
 let manifests = null;
+// If order unspecified, addon goes first. All new popups should be added here.
 const TAB_ORDER = ["scratch-messaging", "cloud-games", "__settings__"];
 
 chrome.runtime.sendMessage("getSettingsInfo", (res) => {
-  // If order unspecified, addon goes first. All new popups should be added here.
   manifests = res.manifests;
   const popupObjects = Object.keys(res.addonsEnabled)
     .filter((addonId) => res.addonsEnabled[addonId] === true)


### PR DESCRIPTION
### Changes

Bug fixes:
* Data category tweaks: dynamic enable/disable didn't work correctly if any setting other than separate list category was enabled.
* Full areas: disabling the addon when the What's Happening load more button hasn't been clicked yet removed all items.
* An outdated comment in `webpages/popup/index.js`.

Other changes:
* Full areas now has dynamic setting changes. Interacting with an addon that has dynamic enable/disable but requires a reload to change settings can be confusing.
* Reenabling full areas now shows all items that were previously loaded so that the user doesn't have to click "Load more" again if they accidentally disable the addon.

### Tests

Tested all changed addons.