### PR TITLE
better-quoter: #reply instead of scrollIntoView()

### DIFF
--- a/addons/better-quoter/userscript.js
+++ b/addons/better-quoter/userscript.js
@@ -155,7 +155,7 @@ export default async function ({ addon, global, console }) {
           blockpost.querySelector(".black.username").innerText
         }]${getSelectionBBCode()}[/quote]`;
       else copy_paste(blockpost.id);
-      textarea.scrollIntoView(false);
+      window.location.hash = "#reply";
       textarea.focus();
     });
   }


### PR DESCRIPTION
Resolves #2018

### Changes

Uses `#reply` instead of `scrollIntoView()` in `better-quoter`: 

### Reason for changes

It allows navigating back to the post being quoted and is consistent with Scratch.

### Tests

Tested on Chromium 103