### PR TITLE
Clickable forum mentions

### DIFF
--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "More links",
-  "description": "Adds links for URLs pointing outside scratch.mit.edu.",
+  "description": "Adds links for URLs pointing outside scratch.mit.edu and makes most mentions on the forums clickable.",
   "credits": [
     {
       "name": "Hans5958"
@@ -12,7 +12,8 @@
       "matches": [
         "https://scratch.mit.edu/projects/*",
         "https://scratch.mit.edu/studios/*",
-        "https://scratch.mit.edu/users/*"
+        "https://scratch.mit.edu/users/*",
+        "https://scratch.mit.edu/discuss/*"
       ]
     }
   ],

--- a/addons/more-links/userscript.js
+++ b/addons/more-links/userscript.js
@@ -1,4 +1,4 @@
-import { linkifyTextNode, linkifyTag } from "../../libraries/common/cs/fast-linkify.js";
+import { linkifyTextNode, pingifyTextNode, linkifyTag } from "../../libraries/common/cs/fast-linkify.js";
 
 export default async function ({ addon, console }) {
   const pageType = document.location.pathname.substr(1).split("/")[0];
@@ -41,10 +41,17 @@ export default async function ({ addon, console }) {
 
   (async () => {
     if (addon.tab.clientVersion === "scratchr2") {
-      while (true) {
-        let comment = await addon.tab.waitForElement(".comment .content", { markAsSeen: true });
-        // scratchr2 comment is a simple linkifyTextNode.
-        linkifyTextNode(comment);
+      if (pageType === "discuss") {
+        while (true) {
+          let post = await addon.tab.waitForElement(".post_body_html", { markAsSeen: true });
+          pingifyTextNode(post);
+        }
+      } else {
+        while (true) {
+          let comment = await addon.tab.waitForElement(".comment .content", { markAsSeen: true });
+          // scratchr2 comment is a simple linkifyTextNode.
+          linkifyTextNode(comment);
+        }
       }
     } else {
       while (true) {


### PR DESCRIPTION
Resolves #1445

### Changes

Makes mentions on the forums clickable when the more links addon is enbled.

### Reason for changes

Clickable links are always nice.

### Tests

Tested on Chromium 103. Right now it only linkifies mentions that aren't in BBCode.
