### PR TITLE
Fix missing `reduxEvents`

### DIFF
--- a/addons/editor-dark-mode/paper.js
+++ b/addons/editor-dark-mode/paper.js
@@ -120,7 +120,7 @@ export default async function ({ addon, console }) {
         "scratch-gui/navigation/ACTIVATE_TAB",
         "scratch-gui/mode/SET_PLAYER",
         "fontsLoaded/SET_FONTS_LOADED",
-        "scratch-gui/locales/SELECT_LOCALE"
+        "scratch-gui/locales/SELECT_LOCALE",
       ],
       reduxCondition: (state) => state.scratchGui.editorTab.activeTabIndex === 1 && !state.scratchGui.mode.isPlayerOnly,
     });

--- a/addons/editor-dark-mode/paper.js
+++ b/addons/editor-dark-mode/paper.js
@@ -116,7 +116,12 @@ export default async function ({ addon, console }) {
   while (true) {
     await addon.tab.waitForElement("[class^=paper-canvas_paper-canvas_]", {
       markAsSeen: true,
-      reduxEvents: ["scratch-gui/navigation/ACTIVATE_TAB", "scratch-gui/mode/SET_PLAYER"],
+      reduxEvents: [
+        "scratch-gui/navigation/ACTIVATE_TAB",
+        "scratch-gui/mode/SET_PLAYER",
+        "fontsLoaded/SET_FONTS_LOADED",
+        "scratch-gui/locales/SELECT_LOCALE"
+      ],
       reduxCondition: (state) => state.scratchGui.editorTab.activeTabIndex === 1 && !state.scratchGui.mode.isPlayerOnly,
     });
     updateColors();

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -766,7 +766,12 @@ export default async function ({ addon, global, console, msg }) {
     while (true) {
       const canvasControls = await addon.tab.waitForElement("[class^='paint-editor_canvas-controls']", {
         markAsSeen: true,
-        reduxEvents: ["scratch-gui/navigation/ACTIVATE_TAB", "scratch-gui/mode/SET_PLAYER"],
+        reduxEvents: [
+          "scratch-gui/navigation/ACTIVATE_TAB",
+          "scratch-gui/mode/SET_PLAYER",
+          "fontsLoaded/SET_FONTS_LOADED",
+          "scratch-gui/locales/SELECT_LOCALE"
+        ],
         reduxCondition: (state) =>
           state.scratchGui.editorTab.activeTabIndex === 1 && !state.scratchGui.mode.isPlayerOnly,
       });

--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -770,7 +770,7 @@ export default async function ({ addon, global, console, msg }) {
           "scratch-gui/navigation/ACTIVATE_TAB",
           "scratch-gui/mode/SET_PLAYER",
           "fontsLoaded/SET_FONTS_LOADED",
-          "scratch-gui/locales/SELECT_LOCALE"
+          "scratch-gui/locales/SELECT_LOCALE",
         ],
         reduxCondition: (state) =>
           state.scratchGui.editorTab.activeTabIndex === 1 && !state.scratchGui.mode.isPlayerOnly,


### PR DESCRIPTION
Resolves #4829

### Changes

Fixes two bugs that would happen when changing the language:
* the costume editor would lose its dark background if dark mode was enabled
* the onion skin settings would disappear