### PR TITLE
`editor-buttons-reverse-order`: add `theme` tag

### DIFF
--- a/addons/editor-buttons-reverse-order/addon.json
+++ b/addons/editor-buttons-reverse-order/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Reverse order of project controls",
   "description": "Moves the green flag and stop buttons to the right and the full screen button to the left, like in Scratch 2.0.",
-  "tags": ["editor", "projectPlayer", "featured"],
+  "tags": ["editor", "projectPlayer", "theme", "featured"],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "userstyles": [


### PR DESCRIPTION
### Changes

<!-- Please describe the changes you've made. -->
Adds the theme tag to the `editor-buttons-reverse-order` (reverse order of project controls) addon.

### Reason for changes

<!-- Why should these changes be made? -->
The addon only makes visual changes and doesn't provide in-editor functionality to toggle or change them; therefore, it is a theme and should be labelled as such.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Works on browsers with Chromium 103.

![image](https://user-images.githubusercontent.com/43426138/179602395-1388c0ab-fe47-44bd-806b-4ad0721f5b66.png)