### PR TITLE
[Pending docs PR] Update `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,10 @@ Also, feel free to ask questions, suggest new features, and more.
 
 ## Creating [pull requests](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
 
-Contributions are welcome! Be sure to file an issue first (see above). If you know a fix for that issue, or you know a fix for a different one, you can create a pull request. Fork this repository, create a new branch from the 'master' branch, and make your changes on the new branch. Now, create a pull request on the origin repository (ScratchAddons/ScratchAddons). We will review your pull request.
+Contributions are welcome! Be sure to file an issue first (see above). If you know a fix for that issue, or you know a fix for a different one, you can create a pull request. Fork this repository, create a new branch from the 'master' branch, and make your changes on the new branch. Now, create a pull request on the origin repository (ScratchAddons/ScratchAddons). We will review your pull request. When it receives two approvals, it is eligible to be merged.
+
+### Quality guidelines
+View our quality guidelines here: https://scratchaddons.com/docs/develop/getting-started/quality-guidelines/
+
+### Documentation
+View our documentation here: https://scratchaddons.com/docs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Also, feel free to ask questions, suggest new features, and more.
 
 ## Creating [pull requests](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
 
-Contributions are welcome! Be sure to file an issue first (see above). If you know a fix for that issue, or you know a fix for a different one, you can create a pull request. Fork this repository, create a new branch from the 'master' branch, and make your changes on the new branch. Now, create a pull request on the origin repository (ScratchAddons/ScratchAddons). We will review your pull request. When it receives two approvals, it is eligible to be merged.
+Contributions are welcome! Be sure to file an issue first (see above). If you know a fix for that issue, or you know a fix for a different one, you can create a pull request. Fork this repository, create a new branch from the 'master' branch, and make your changes on the new branch. Now, create a pull request on the origin repository (ScratchAddons/ScratchAddons). We will review your pull request.
 
 ### Quality guidelines
 View our quality guidelines here: https://scratchaddons.com/docs/develop/getting-started/quality-guidelines/


### PR DESCRIPTION
### Changes

<!-- Please describe the changes you've made. -->
Updates the review policy in `CONTRIBUTING.md` to mention the two-approval process and include a link to the quality guidelines page in the docs. Obviously, this part is dependent on said docs page being merged into the website: https://github.com/ScratchAddons/website-v2/pull/219
Also adds a link to the docs in general.

### Reason for changes

<!-- Why should these changes be made? -->
This is part of the overhauled PR merge process. The guidelines are being posted in the docs, but they also need to be posted somewhere prominent in the main repo.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
N/A