### PR TITLE
hide-stage: Fix renderer crashes

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -66,7 +66,7 @@
   justify-content: flex-end;
 }
 
-[dir="rtl"] .sa-stage-hidden [class*="stage-header_stage-size-row"] {
+.sa-stage-hidden [dir="rtl"] [class*="stage-header_stage-size-row"] {
   left: auto;
   right: 0.5rem;
 }

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -40,7 +40,7 @@
   align-items: center;
 }
 
-[dir="rtl"] .sa-stage-hidden [class*="stage-header_stage-size-row"] {
+.sa-stage-hidden [dir="rtl"] [class*="stage-header_stage-size-row"] {
   right: auto;
   left: 0.5rem;
 }

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -52,3 +52,7 @@
   /* makes small and large stage buttons appear unselected */
   filter: var(--editorDarkMode-accent-desaturateFilter, saturate(0));
 }
+
+.sa-stage-hidden .scratchEyedropper {
+  display: none;
+}

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -44,7 +44,9 @@ export default async function ({ addon, console, msg }) {
     return result;
   };
 
-  // Used by stage color pickers.
+  // Used by code editor eye droppers.
+  // We already hide the button with CSS but just in case it somehow gets called anyways, we'll still fix
+  // this method.
   const originalExtractColor = renderer.extractColor;
   renderer.extractColor = function patchedExtractColor(...args) {
     if (stageHidden) {

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -7,23 +7,20 @@ export default async function ({ addon, console, msg }) {
   });
 
   let stageHidden = false;
-  let bodyWrapper;
   let smallStageButton;
   let largeStageButton;
   let hideStageButton;
 
   function hideStage() {
     stageHidden = true;
-    if (!bodyWrapper) return;
-    bodyWrapper.classList.add("sa-stage-hidden");
+    document.documentElement.classList.add("sa-stage-hidden");
     hideStageButton.classList.remove(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
   }
 
   function unhideStage(e) {
     stageHidden = false;
-    if (!bodyWrapper) return;
-    bodyWrapper.classList.remove("sa-stage-hidden");
+    document.documentElement.classList.remove("sa-stage-hidden");
     hideStageButton.classList.add(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
   }
@@ -72,7 +69,6 @@ export default async function ({ addon, console, msg }) {
       markAsSeen: true,
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
-    bodyWrapper = document.querySelector("[class*='gui_body-wrapper_']");
     smallStageButton = stageControls.firstChild;
     smallStageButton.classList.add("sa-stage-button-middle");
     largeStageButton = stageControls.lastChild;

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -59,8 +59,8 @@ export default async function ({ addon, console, msg }) {
           r: 0,
           g: 0,
           b: 0,
-          a: 0
-        }
+          a: 0,
+        },
       };
     }
     return originalExtractColor.apply(this, args);

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -36,7 +36,7 @@ export default async function ({ addon, console, msg }) {
   renderer.clientSpaceToScratchBounds = function patchedClientSpaceToScratchBounds(...args) {
     const result = originalClientSpaceToScratchBounds.apply(this, args);
     if (stageHidden) {
-      // We'll just say that the stage is very far offscreen so that we shouldn't be touching anything
+      // We'll just say that the mouse is very far offscreen so that it shouldn't be touching anything
       const BIG_NUMBER = 1000000;
       // left, right, bottom, top
       result.initFromBounds(BIG_NUMBER, BIG_NUMBER, BIG_NUMBER, BIG_NUMBER);

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, console, msg }) {
-  // Can't access renderer until project has loaded
+  // Wait until the project is loaded so that the renderer will definitely exist.
   const vm = addon.tab.traps.vm;
   await new Promise((resolve) => {
     if (vm.editingTarget) return resolve();


### PR DESCRIPTION
A hidden stage is interpreted as 0x0 in some parts of the renderer which can cause infinite loops or crashes.

 - Fixes https://github.com/ScratchAddons/ScratchAddons/issues/4857 (infinite loop in "touching mouse pointer" block)
 - Hides code editor eye droppers when the stage is hidden because the user has no way to hover over the stage anyways. Previously attempting to use these would crash the editor.
