### PR TITLE
hide-stage: Fix hidden stage on project page regression and other errors

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -66,7 +66,7 @@
   justify-content: flex-end;
 }
 
-.sa-stage-hidden [dir="rtl"] [class*="stage-header_stage-size-row"] {
+[dir="rtl"] .sa-stage-hidden [class*="stage-header_stage-size-row"] {
   left: auto;
   right: 0.5rem;
 }

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -52,7 +52,3 @@
   /* makes small and large stage buttons appear unselected */
   filter: var(--editorDarkMode-accent-desaturateFilter, saturate(0));
 }
-
-.sa-stage-hidden .scratchEyedropper {
-  display: none;
-}

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -40,7 +40,7 @@
   align-items: center;
 }
 
-.sa-stage-hidden [dir="rtl"] [class*="stage-header_stage-size-row"] {
+[dir="rtl"] .sa-stage-hidden [class*="stage-header_stage-size-row"] {
   right: auto;
   left: 0.5rem;
 }

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -25,11 +25,18 @@
 .sa-stage-hidden
   [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"])
   [class*="controls_controls-container_"],
-.sa-stage-hidden
-  [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"])
-  [class*="stage-wrapper_stage-canvas-wrapper_"],
 .sa-stage-hidden [class*="gui_target-wrapper_"] {
   display: none;
+}
+.sa-stage-hidden
+  [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"])
+  [class*="stage-wrapper_stage-canvas-wrapper_"] {
+  /* can't use display: none here because that causes the canvas's size to become 0x0 and causes crashes */
+  visibility: hidden;
+  position: absolute;
+  /* this puts the stage fully offscreen it can't be hovered over */
+  right: 100vw;
+  z-index: -9999;
 }
 
 .sa-stage-hidden [class*="stage-header_stage-size-row"] {

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -37,6 +37,8 @@
   z-index: -9999;
   /* move the stage to avoid a horizontal scroll bar */
   right: 0;
+  /* and move it up so that the mouse can't hover over the stage while its hidden */
+  bottom: 100%;
 }
 [dir="rtl"]
   .sa-stage-hidden

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -52,3 +52,7 @@
   /* makes small and large stage buttons appear unselected */
   filter: var(--editorDarkMode-accent-desaturateFilter, saturate(0));
 }
+
+.sa-stage-hidden-outer .scratchEyedropper {
+  display: none;
+}

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -31,12 +31,19 @@
 .sa-stage-hidden
   [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"])
   [class*="stage-wrapper_stage-canvas-wrapper_"] {
-  /* can't use display: none here because that causes the canvas's size to become 0x0 and causes crashes */
+  /* can't use display: none because that causes the canvas's clientWidth/Height to become 0 which causes crashes */
   visibility: hidden;
   position: absolute;
-  /* this puts the stage fully offscreen it can't be hovered over */
-  right: 100vw;
   z-index: -9999;
+  /* move the stage to avoid a horizontal scroll bar */
+  right: 0;
+}
+[dir="rtl"]
+  .sa-stage-hidden
+  [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"])
+  [class*="stage-wrapper_stage-canvas-wrapper_"] {
+  right: initial;
+  left: 0;
 }
 
 .sa-stage-hidden [class*="stage-header_stage-size-row"] {

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -76,6 +76,20 @@ export default async function ({ addon, console, msg }) {
     return result;
   };
 
+  // Scratch might try to resize the canvas to 0x0 when you leave fullscreen with the stage hidden.
+  // This can cause crashes in things like text bubble rendering, so we'll force it to be at least 1x1.
+  const originalResize = renderer.resize;
+  renderer.resize = function patchedResize (width, height) {
+    if (stageHidden) {
+      return originalResize.call(
+        this,
+        Math.max(1, width),
+        Math.max(1, height)
+      );
+    }
+    return originalResize.call(this, width, height);
+  };
+
   while (true) {
     const stageControls = await addon.tab.waitForElement("[class*='stage-header_stage-size-toggle-group_']", {
       markAsSeen: true,

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -77,15 +77,10 @@ export default async function ({ addon, console, msg }) {
   };
 
   // Scratch might try to resize the canvas to 0x0 when you leave fullscreen with the stage hidden.
-  // This can cause crashes in things like text bubble rendering, so we'll force it to be at least 1x1.
   const originalResize = renderer.resize;
   renderer.resize = function patchedResize (width, height) {
-    if (stageHidden) {
-      return originalResize.call(
-        this,
-        Math.max(1, width),
-        Math.max(1, height)
-      );
+    if (stageHidden && (width === 0 || height === 0)) {
+      return originalResize.call(this, this._nativeSize[0], this._nativeSize[1]);
     }
     return originalResize.call(this, width, height);
   };

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -7,20 +7,23 @@ export default async function ({ addon, console, msg }) {
   });
 
   let stageHidden = false;
+  let bodyWrapper;
   let smallStageButton;
   let largeStageButton;
   let hideStageButton;
 
   function hideStage() {
     stageHidden = true;
-    document.documentElement.classList.add("sa-stage-hidden");
+    if (!bodyWrapper) return;
+    bodyWrapper.classList.add("sa-stage-hidden");
     hideStageButton.classList.remove(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
   }
 
   function unhideStage(e) {
     stageHidden = false;
-    document.documentElement.classList.remove("sa-stage-hidden");
+    if (!bodyWrapper) return;
+    bodyWrapper.classList.remove("sa-stage-hidden");
     hideStageButton.classList.add(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
   }
@@ -69,6 +72,7 @@ export default async function ({ addon, console, msg }) {
       markAsSeen: true,
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
+    bodyWrapper = document.querySelector("[class*='gui_body-wrapper_']");
     smallStageButton = stageControls.firstChild;
     smallStageButton.classList.add("sa-stage-button-middle");
     largeStageButton = stageControls.lastChild;

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -1,11 +1,4 @@
 export default async function ({ addon, console, msg }) {
-  // Wait until the project is loaded so that the renderer will definitely exist.
-  const vm = addon.tab.traps.vm;
-  await new Promise((resolve) => {
-    if (vm.editingTarget) return resolve();
-    vm.runtime.once("PROJECT_LOADED", resolve);
-  });
-
   let stageHidden = false;
   let bodyWrapper;
   let smallStageButton;
@@ -32,58 +25,6 @@ export default async function ({ addon, console, msg }) {
   }
 
   addon.self.addEventListener("disabled", () => unhideStage());
-
-  // Some places in Scratch's renderer use canvas.clientWidth and canvas.clientHeight.
-  // When the stage is hidden these will return 0 which can cause infinite loops or crashes.
-  const renderer = vm.renderer;
-
-  // Used by "touching mouse pointer" block and hovered sprite detection.
-  const originalClientSpaceToScratchBounds = renderer.clientSpaceToScratchBounds;
-  renderer.clientSpaceToScratchBounds = function patchedClientSpaceToScratchBounds(...args) {
-    const result = originalClientSpaceToScratchBounds.apply(this, args);
-    // Hidden stage causes left, right, bottom, top to be all Infinity.
-    if (stageHidden && result.left === Infinity) {
-      // Pretend the mouse is very far offscreen so that it shouldn't be touching anything
-      const BIG_NUMBER = 1000000;
-      // left, right, bottom, top
-      result.initFromBounds(BIG_NUMBER, BIG_NUMBER, BIG_NUMBER, BIG_NUMBER);
-    }
-    return result;
-  };
-
-  // Used by code editor eye droppers.
-  // We already hide the button with CSS but just in case it somehow gets called anyways, we'll still fix
-  // this method.
-  const originalExtractColor = renderer.extractColor;
-  renderer.extractColor = function patchedExtractColor(...args) {
-    const result = originalExtractColor.apply(this, args);
-    // Hidden stage causes NaN width/height, empty data array, color object with all undefined
-    if (stageHidden && isNaN(result.width)) {
-      // Pretend the canvas is transparent. The user has no way to hover over the stage anyways.
-      return {
-        // 4 bytes for 1 RGBA pixel
-        data: new Uint8ClampedArray(4),
-        width: 1,
-        height: 1,
-        color: {
-          r: 0,
-          g: 0,
-          b: 0,
-          a: 0,
-        },
-      };
-    }
-    return result;
-  };
-
-  // Scratch might try to resize the canvas to 0x0 when you leave fullscreen with the stage hidden.
-  const originalResize = renderer.resize;
-  renderer.resize = function patchedResize(width, height) {
-    if (stageHidden && (width < 1 || height < 1)) {
-      return originalResize.call(this, this._nativeSize[0], this._nativeSize[1]);
-    }
-    return originalResize.call(this, width, height);
-  };
 
   while (true) {
     const stageControls = await addon.tab.waitForElement("[class*='stage-header_stage-size-toggle-group_']", {

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -15,6 +15,7 @@ export default async function ({ addon, console, msg }) {
   function hideStage() {
     stageHidden = true;
     if (!bodyWrapper) return;
+    document.body.classList.add("sa-stage-hidden-outer");
     bodyWrapper.classList.add("sa-stage-hidden");
     hideStageButton.classList.remove(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
@@ -23,6 +24,7 @@ export default async function ({ addon, console, msg }) {
   function unhideStage(e) {
     stageHidden = false;
     if (!bodyWrapper) return;
+    document.body.classList.remove("sa-stage-hidden-outer");
     bodyWrapper.classList.remove("sa-stage-hidden");
     hideStageButton.classList.add(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -79,7 +79,7 @@ export default async function ({ addon, console, msg }) {
   // Scratch might try to resize the canvas to 0x0 when you leave fullscreen with the stage hidden.
   const originalResize = renderer.resize;
   renderer.resize = function patchedResize(width, height) {
-    if (stageHidden && (width === 0 || height === 0)) {
+    if (stageHidden && (width < 1 || height < 1)) {
       return originalResize.call(this, this._nativeSize[0], this._nativeSize[1]);
     }
     return originalResize.call(this, width, height);

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -44,9 +44,7 @@ export default async function ({ addon, console, msg }) {
     return result;
   };
 
-  // Used by code editor eye droppers.
-  // We already hide the button with CSS but just in case it somehow gets called anyways, we'll still fix
-  // this method.
+  // Used by stage color pickers.
   const originalExtractColor = renderer.extractColor;
   renderer.extractColor = function patchedExtractColor(...args) {
     if (stageHidden) {

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -49,7 +49,9 @@ export default async function ({ addon, console, msg }) {
     return result;
   };
 
-  // Used by stage color pickers.
+  // Used by code editor eye droppers.
+  // We already hide the button with CSS but just in case it somehow gets called anyways, we'll still fix
+  // this method.
   const originalExtractColor = renderer.extractColor;
   renderer.extractColor = function patchedExtractColor(...args) {
     if (stageHidden) {

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -78,7 +78,7 @@ export default async function ({ addon, console, msg }) {
 
   // Scratch might try to resize the canvas to 0x0 when you leave fullscreen with the stage hidden.
   const originalResize = renderer.resize;
-  renderer.resize = function patchedResize (width, height) {
+  renderer.resize = function patchedResize(width, height) {
     if (stageHidden && (width === 0 || height === 0)) {
       return originalResize.call(this, this._nativeSize[0], this._nativeSize[1]);
     }

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -16,6 +16,7 @@ export default async function ({ addon, console, msg }) {
     stageHidden = true;
     if (!bodyWrapper) return;
     document.body.classList.add("sa-stage-hidden-outer");
+    // Inner class is applied to body wrapper so that it won't affect the project page.
     bodyWrapper.classList.add("sa-stage-hidden");
     hideStageButton.classList.remove(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas


### PR DESCRIPTION
 - Fixes https://github.com/ScratchAddons/ScratchAddons/issues/4866. sa-stage-hidden is now once again applied to the body wrapper, not the root element. A different class is now applied to the root element to style something that isn't inside the body wrapper.
 - Fixes an editor crash when rendering a text bubble after entering and leaving fullscreen with the stage hidden
