### PR TITLE
Improve layout of table rows with only one field

### DIFF
--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -358,6 +358,9 @@
     margin: 10px 0px;
   }
   .setting-table-row-settings {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     background: var(--navigation-background);
     border-radius: 10px;
   }

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -361,11 +361,13 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    padding-bottom: 10px;
     background: var(--navigation-background);
     border-radius: 10px;
   }
   .setting-table-row-settings .addon-setting {
     margin-inline-end: 10px;
+    margin-bottom: 0;
     flex-wrap: wrap;
   }
   .setting-table-options {


### PR DESCRIPTION
### Changes

Makes settings inside table rows vertically centered.

### Tests

Before:
![image](https://user-images.githubusercontent.com/51849865/179943817-ba3e3a3b-b1ef-47bc-be2d-3a0b218df9c8.png)

After:
![image](https://user-images.githubusercontent.com/51849865/179943783-ed7f99cf-e035-44c8-aedc-df1649be1682.png)

Rows with more than one setting aren't changed.