### PR TITLE
Add notice to `editor-stage-left` and change description

### DIFF
--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -1,6 +1,12 @@
 {
   "name": "Display stage on left side",
-  "description": "Moves the stage to the left side of the editor.",
+  "description": "Moves the stage to the left side of the editor, like in Scratch 2.0.",
+  "info": [
+    {
+      "id": "reverseOrder",
+      "text": "To change the position of buttons above the stage, use the \"reverse order of project controls\" addon."
+    }
+  ],
   "credits": [
     {
       "name": "NitroCipher/ZenithRogue"


### PR DESCRIPTION
### Changes

![image](https://user-images.githubusercontent.com/51849865/179945557-54c0e5d4-3317-46ac-b162-1bf504a41894.png)

### Reason for changes

* The addon now appears when searching for "scratch 2" or "scratch 2.0".
* People who enable this addon probably also want the old button order.