### PR TITLE
hide-flyout: update workspace metrics when changing settings

### DIFF
--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -119,6 +119,8 @@ export default async function ({ addon, global, console, msg }) {
     }
     addon.self.addEventListener("disabled", () => {
       Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
+      // update workspace dimensions
+      Blockly.svgResize(Blockly.getMainWorkspace());
     });
     addon.self.addEventListener("reenabled", () => {
       if (getToggleSetting() === "category") {
@@ -126,6 +128,8 @@ export default async function ({ addon, global, console, msg }) {
         onmouseleave(null, 0);
         toggle = false;
       }
+      // update workspace dimensions
+      Blockly.svgResize(Blockly.getMainWorkspace());
     });
 
     addon.settings.addEventListener("change", () => {
@@ -146,6 +150,8 @@ export default async function ({ addon, global, console, msg }) {
         onmouseleave();
         Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
       }
+      // update workspace dimensions
+      Blockly.svgResize(Blockly.getMainWorkspace());
     });
 
     // category click mode


### PR DESCRIPTION
### Changes

Calls `Blockly.svgResize()` when a setting is changed or hide-flyout is disabled/reenabled.

### Reason for changes

If auto-hide block palette is enabled and the mode is set to category hover or category click, the amount of usable space in the code area is increased. This affects the horizontal scrollbar and the placement of blocks. Previously the workspace metrics were only updated when enabling the addon. When it was disabled or the mode was changed, a reload was necessary to update them.