### PR TITLE
Confirm object deletion

### DIFF
--- a/addons-l10n/en/remove-sprite-confirm.json
+++ b/addons-l10n/en/remove-sprite-confirm.json
@@ -1,3 +1,9 @@
 {
-  "remove-sprite-confirm/confirm": "Do you want to delete the sprite?"
+  "remove-sprite-confirm/confirm-title": "Remove {object}",
+  "remove-sprite-confirm/confirm-message": "Do you want to delete this {object}?",
+  "remove-sprite-confirm/sprite": "sprite",
+  "remove-sprite-confirm/costume": "costume",
+  "remove-sprite-confirm/sound": "sound",
+  "remove-sprite-confirm/yes": "Yes",
+  "remove-sprite-confirm/no": "No"
 }

--- a/addons-l10n/en/remove-sprite-confirm.json
+++ b/addons-l10n/en/remove-sprite-confirm.json
@@ -3,6 +3,8 @@
   "remove-sprite-confirm/delete-sprite-message": "Do you want to delete this sprite?",
   "remove-sprite-confirm/delete-costume-title": "Delete Costume",
   "remove-sprite-confirm/delete-costume-message": "Do you want to delete this costume?",
+  "remove-sprite-confirm/delete-backdrop-title": "Delete Backdrop",
+  "remove-sprite-confirm/delete-backdrop-message": "Do you want to delete this backdrop?",
   "remove-sprite-confirm/delete-sound-title": "Delete Sound",
   "remove-sprite-confirm/delete-sound-message": "Do you want to delete this sound?",
   "remove-sprite-confirm/delete": "Delete"

--- a/addons-l10n/en/remove-sprite-confirm.json
+++ b/addons-l10n/en/remove-sprite-confirm.json
@@ -5,6 +5,5 @@
   "remove-sprite-confirm/delete-costume-message": "Do you want to delete this costume?",
   "remove-sprite-confirm/delete-sound-title": "Delete Sound",
   "remove-sprite-confirm/delete-sound-message": "Do you want to delete this sound?",
-  "remove-sprite-confirm/delete": "Delete",
-  "remove-sprite-confirm/cancel": "Cancel"
+  "remove-sprite-confirm/delete": "Delete"
 }

--- a/addons-l10n/en/remove-sprite-confirm.json
+++ b/addons-l10n/en/remove-sprite-confirm.json
@@ -5,6 +5,6 @@
   "remove-sprite-confirm/delete-costume-message": "Do you want to delete this costume?",
   "remove-sprite-confirm/delete-sound-title": "Delete Sound",
   "remove-sprite-confirm/delete-sound-message": "Do you want to delete this sound?",
-  "remove-sprite-confirm/yes": "Yes",
-  "remove-sprite-confirm/no": "No"
+  "remove-sprite-confirm/delete": "Delete",
+  "remove-sprite-confirm/cancel": "Cancel"
 }

--- a/addons-l10n/en/remove-sprite-confirm.json
+++ b/addons-l10n/en/remove-sprite-confirm.json
@@ -1,9 +1,10 @@
 {
-  "remove-sprite-confirm/confirm-title": "Remove {object}",
-  "remove-sprite-confirm/confirm-message": "Do you want to delete this {object}?",
-  "remove-sprite-confirm/sprite": "sprite",
-  "remove-sprite-confirm/costume": "costume",
-  "remove-sprite-confirm/sound": "sound",
+  "remove-sprite-confirm/delete-sprite-title": "Delete Sprite",
+  "remove-sprite-confirm/delete-sprite-message": "Do you want to delete this sprite?",
+  "remove-sprite-confirm/delete-costume-title": "Delete Costume",
+  "remove-sprite-confirm/delete-costume-message": "Do you want to delete this costume?",
+  "remove-sprite-confirm/delete-sound-title": "Delete Sound",
+  "remove-sprite-confirm/delete-sound-message": "Do you want to delete this sound?",
   "remove-sprite-confirm/yes": "Yes",
   "remove-sprite-confirm/no": "No"
 }

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Editor confirmations",
-  "description": "Asks if you're sure when deleting a sprite/costume/sound inside a project.",
+  "description": "Asks if you're sure when deleting a sprite, costume, or sound inside a project.",
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -18,13 +18,13 @@
       "name": "Costumes and backdrops",
       "id": "costumes",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     {
       "name": "Sounds",
       "id": "sounds",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   ],
   "userstyles": [

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -44,5 +44,4 @@
     "temporaryNotice": "You can now select, to ask for confirmations when deleting costumes and sounds.",
     "newSettings": ["sprites", "costumes", "sounds"]
   }
-
 }

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -1,9 +1,35 @@
 {
-  "name": "Sprite deletion confirmation",
-  "description": "Asks if you're sure when deleting a sprite inside a project.",
+  "name": "Editor confirmations",
+  "description": "Asks if you're sure when deleting a sprite/costume/sound inside a project.",
   "userscripts": [
     {
       "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "settings": [
+    {
+      "name": "Sprites",
+      "id": "sprites",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Costumes and backdrops",
+      "id": "costumes",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Sounds",
+      "id": "sounds",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "fix-z-index.css",
       "matches": ["projects"]
     }
   ],
@@ -11,5 +37,12 @@
   "dynamicDisable": true,
   "versionAdded": "1.0.0",
   "tags": ["editor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": false,
+  "latestUpdate": {
+    "version": "1.28.0",
+    "isMajor": true,
+    "temporaryNotice": "You can now select, to ask for confirmations when deleting costumes and sounds.",
+    "newSettings": ["sprites", "costumes", "sounds"]
+  }
+
 }

--- a/addons/remove-sprite-confirm/fix-z-index.css
+++ b/addons/remove-sprite-confirm/fix-z-index.css
@@ -1,3 +1,3 @@
-nav[class*='context-menu_context-menu_'] {
-   z-index: 510 !important;
+nav[class*="context-menu_context-menu_"] {
+  z-index: 510 !important;
 }

--- a/addons/remove-sprite-confirm/fix-z-index.css
+++ b/addons/remove-sprite-confirm/fix-z-index.css
@@ -1,3 +1,3 @@
 nav[class*="context-menu_context-menu_"] {
-  z-index: 510 !important;
+  z-index: 510;  /* It can't be smaller than 510 */
 }

--- a/addons/remove-sprite-confirm/fix-z-index.css
+++ b/addons/remove-sprite-confirm/fix-z-index.css
@@ -1,0 +1,3 @@
+nav[class*='context-menu_context-menu_'] {
+   z-index: 510 !important;
+}

--- a/addons/remove-sprite-confirm/fix-z-index.css
+++ b/addons/remove-sprite-confirm/fix-z-index.css
@@ -1,3 +1,3 @@
 nav[class*="context-menu_context-menu_"] {
-  z-index: 510;  /* It can't be smaller than 510 */
+  z-index: 510; /* It can't be smaller than 510 */
 }

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -11,21 +11,26 @@ export default async function ({ addon, console, msg }) {
       }
 
       let type = null;
-      
-      if ( addon.settings.get("sprites") && 
-        (e.target.closest("[class*='sprite-selector_sprite_'] > nav[class*='context-menu_context-menu_'] > :nth-child(3)") || 
-        e.target.closest("div[class*='sprite-selector_sprite-wrapper_'] div[class*='delete-button_delete-button_']")))
-      {
+
+      if (
+        addon.settings.get("sprites") &&
+        (e.target.closest(
+          "[class*='sprite-selector_sprite_'] > nav[class*='context-menu_context-menu_'] > :nth-child(3)"
+        ) ||
+          e.target.closest("div[class*='sprite-selector_sprite-wrapper_'] div[class*='delete-button_delete-button_']"))
+      ) {
         type = msg("sprite");
-      } else if (addon.settings.get("sounds") &&
-        (e.target.closest("[data-tabs] > :nth-child(4) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
-        e.target.closest("[data-tabs] > :nth-child(4) div[class*='delete-button_delete-button_']"))
-      {
+      } else if (
+        (addon.settings.get("sounds") &&
+          e.target.closest("[data-tabs] > :nth-child(4) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
+        e.target.closest("[data-tabs] > :nth-child(4) div[class*='delete-button_delete-button_']")
+      ) {
         type = msg("sound");
-      } else if (addon.settings.get("costumes") &&
-        (e.target.closest("[data-tabs] > :nth-child(3) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
-        e.target.closest("[data-tabs] > :nth-child(3) div[class*='delete-button_delete-button_']"))
-      {
+      } else if (
+        (addon.settings.get("costumes") &&
+          e.target.closest("[data-tabs] > :nth-child(3) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
+        e.target.closest("[data-tabs] > :nth-child(3) div[class*='delete-button_delete-button_']")
+      ) {
         type = msg("costume");
       }
 
@@ -33,11 +38,15 @@ export default async function ({ addon, console, msg }) {
         e.preventDefault();
         e.stopPropagation();
         addon.tab
-          .confirm(msg("confirm-title", {object: type.charAt(0).toUpperCase() + type.slice(1)}), msg("confirm-message", {object: msg(type)}), {
-            okButtonLabel: msg("yes"),
-            cancelButtonLabel: msg("no"),
-            useEditorClasses: true,
-          })
+          .confirm(
+            msg("confirm-title", { object: type.charAt(0).toUpperCase() + type.slice(1) }),
+            msg("confirm-message", { object: msg(type) }),
+            {
+              okButtonLabel: msg("yes"),
+              cancelButtonLabel: msg("no"),
+              useEditorClasses: true,
+            }
+          )
           .then((confirmed) => {
             if (confirmed) {
               override = true;

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -19,19 +19,19 @@ export default async function ({ addon, console, msg }) {
         ) ||
           e.target.closest("div[class*='sprite-selector_sprite-wrapper_'] div[class*='delete-button_delete-button_']"))
       ) {
-        type = msg("sprite");
+        type = "sprite";
       } else if (
         (addon.settings.get("sounds") &&
           e.target.closest("[data-tabs] > :nth-child(4) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
         e.target.closest("[data-tabs] > :nth-child(4) div[class*='delete-button_delete-button_']")
       ) {
-        type = msg("sound");
+        type = "sound";
       } else if (
         (addon.settings.get("costumes") &&
           e.target.closest("[data-tabs] > :nth-child(3) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
         e.target.closest("[data-tabs] > :nth-child(3) div[class*='delete-button_delete-button_']")
       ) {
-        type = msg("costume");
+        type = "costume";
       }
 
       if (type !== null) {
@@ -39,8 +39,8 @@ export default async function ({ addon, console, msg }) {
         e.stopPropagation();
         addon.tab
           .confirm(
-            msg("confirm-title", { object: type.charAt(0).toUpperCase() + type.slice(1) }),
-            msg("confirm-message", { object: msg(type) }),
+            msg("delete-" + type + "-title"),
+            msg("delete-" + type + "-message"),
             {
               okButtonLabel: msg("yes"),
               cancelButtonLabel: msg("no"),

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -39,8 +39,8 @@ export default async function ({ addon, console, msg }) {
         e.stopPropagation();
         addon.tab
           .confirm(msg("delete-" + type + "-title"), msg("delete-" + type + "-message"), {
-            okButtonLabel: msg("yes"),
-            cancelButtonLabel: msg("no"),
+            okButtonLabel: msg("delete"),
+            cancelButtonLabel: msg("cancel"),
             useEditorClasses: true,
           })
           .then((confirmed) => {

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -1,4 +1,5 @@
 export default async function ({ addon, console, msg }) {
+  const vm = addon.tab.traps.vm;
   // Thanks to confirm-actions addon!
   let override = false;
 
@@ -31,7 +32,8 @@ export default async function ({ addon, console, msg }) {
           e.target.closest("[data-tabs] > :nth-child(3) nav[class*='context-menu_context-menu_'] > :nth-child(3)")) ||
         e.target.closest("[data-tabs] > :nth-child(3) div[class*='delete-button_delete-button_']")
       ) {
-        type = "costume";
+        if (vm.runtime.getEditingTarget().isStage === true) type = "backdrop";
+        else type = "costume";
       }
 
       if (type !== null) {

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -38,15 +38,11 @@ export default async function ({ addon, console, msg }) {
         e.preventDefault();
         e.stopPropagation();
         addon.tab
-          .confirm(
-            msg("delete-" + type + "-title"),
-            msg("delete-" + type + "-message"),
-            {
-              okButtonLabel: msg("yes"),
-              cancelButtonLabel: msg("no"),
-              useEditorClasses: true,
-            }
-          )
+          .confirm(msg("delete-" + type + "-title"), msg("delete-" + type + "-message"), {
+            okButtonLabel: msg("yes"),
+            cancelButtonLabel: msg("no"),
+            useEditorClasses: true,
+          })
           .then((confirmed) => {
             if (confirmed) {
               override = true;

--- a/addons/remove-sprite-confirm/userscript.js
+++ b/addons/remove-sprite-confirm/userscript.js
@@ -40,7 +40,6 @@ export default async function ({ addon, console, msg }) {
         addon.tab
           .confirm(msg("delete-" + type + "-title"), msg("delete-" + type + "-message"), {
             okButtonLabel: msg("delete"),
-            cancelButtonLabel: msg("cancel"),
             useEditorClasses: true,
           })
           .then((confirmed) => {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #4822
Resolves #4848

### Changes

Change remove-sprite-confirm addon, adds confirmations to costume and sound deletion. 

### Tests

Everything works on Firefox 95.
