### PR TITLE
Confirm removing project in mystuff

### DIFF
--- a/addons-l10n/en/confirm-actions.json
+++ b/addons-l10n/en/confirm-actions.json
@@ -11,6 +11,6 @@
   "confirm-actions/closetopic": "Are you sure you want to close this topic?",
   "confirm-actions/cancelcomment-title": "Discard Comment",
   "confirm-actions/cancelcomment": "Are you sure you want to discard your comment?",
-  "confirm-actions/removeproject-title": "Remove Project",
-  "confirm-actions/removeproject": "Are you sure you want to remove this project?"
+  "confirm-actions/removeproject-title": "Delete Project",
+  "confirm-actions/removeproject": "Are you sure you want to delete this project?"
 }

--- a/addons-l10n/en/confirm-actions.json
+++ b/addons-l10n/en/confirm-actions.json
@@ -13,6 +13,8 @@
   "confirm-actions/cancelcomment": "Are you sure you want to discard your comment?",
   "confirm-actions/leavestudio-title": "Leave Studio",
   "confirm-actions/leavestudio": "Are you sure you want to leave this studio?",
+  "confirm-actions/deletestudio-title": "Delete Studio",
+  "confirm-actions/deletestudio": "Are you sure you want to delete this studio?",
   "confirm-actions/removeproject-title": "Remove Project",
   "confirm-actions/removeproject": "Are you sure you want to remove this project?"
 }

--- a/addons-l10n/en/confirm-actions.json
+++ b/addons-l10n/en/confirm-actions.json
@@ -10,5 +10,9 @@
   "confirm-actions/closetopic-title": "Close Topic",
   "confirm-actions/closetopic": "Are you sure you want to close this topic?",
   "confirm-actions/cancelcomment-title": "Discard Comment",
-  "confirm-actions/cancelcomment": "Are you sure you want to discard your comment?"
+  "confirm-actions/cancelcomment": "Are you sure you want to discard your comment?",
+  "confirm-actions/leavestudio-title": "Leave Studio",
+  "confirm-actions/leavestudio": "Are you sure you want to leave this studio?",
+  "confirm-actions/removeproject-title": "Remove Project",
+  "confirm-actions/removeproject": "Are you sure you want to remove this project?"
 }

--- a/addons-l10n/en/confirm-actions.json
+++ b/addons-l10n/en/confirm-actions.json
@@ -11,10 +11,6 @@
   "confirm-actions/closetopic": "Are you sure you want to close this topic?",
   "confirm-actions/cancelcomment-title": "Discard Comment",
   "confirm-actions/cancelcomment": "Are you sure you want to discard your comment?",
-  "confirm-actions/leavestudio-title": "Leave Studio",
-  "confirm-actions/leavestudio": "Are you sure you want to leave this studio?",
-  "confirm-actions/deletestudio-title": "Delete Studio",
-  "confirm-actions/deletestudio": "Are you sure you want to delete this studio?",
   "confirm-actions/removeproject-title": "Remove Project",
   "confirm-actions/removeproject": "Are you sure you want to remove this project?"
 }

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -31,6 +31,12 @@
       "default": true
     },
     {
+      "name": "Confirm deleting projects",
+      "id": "removingprojects",
+      "type": "boolean",
+      "default": true
+    },
+    {
       "name": "Confirm cancelling comments",
       "id": "cancelcomment",
       "type": "boolean",
@@ -51,12 +57,6 @@
     {
       "name": "Confirm closing forum topics",
       "id": "closingtopic",
-      "type": "boolean",
-      "default": false
-    },
-    {
-      "name": "Confirm removing projects",
-      "id": "removingprojects",
       "type": "boolean",
       "default": false
     }

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -49,7 +49,7 @@
       "default": false
     },
     {
-      "name": "Confirm leaving studios",
+      "name": "Confirm leaving or deleting studios",
       "id": "leavingstudio",
       "type": "boolean",
       "default": false
@@ -68,8 +68,8 @@
     }
   ],
   "latestUpdate": {
-    "version": "1.27.0",
-    "newSettings": ["cancelcomment"]
+    "version": "1.28.0",
+    "newSettings": ["closingtopic", "removingprojects"]
   },
   "tags": ["community", "recommended"],
   "enabledByDefault": false

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -49,12 +49,6 @@
       "default": false
     },
     {
-      "name": "Confirm leaving or deleting studios",
-      "id": "leavingstudio",
-      "type": "boolean",
-      "default": false
-    },
-    {
       "name": "Confirm closing forum topics",
       "id": "closingtopic",
       "type": "boolean",
@@ -69,7 +63,7 @@
   ],
   "latestUpdate": {
     "version": "1.28.0",
-    "newSettings": ["closingtopic", "removingprojects"]
+    "newSettings": ["removingprojects"]
   },
   "tags": ["community", "recommended"],
   "enabledByDefault": false

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -49,8 +49,20 @@
       "default": false
     },
     {
+      "name": "Confirm leaving studios",
+      "id": "leavingstudio",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "Confirm closing forum topics",
       "id": "closingtopic",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "name": "Confirm removing projects",
+      "id": "removingprojects",
       "type": "boolean",
       "default": false
     }

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -11,15 +11,13 @@ export default async function ({ addon, console, msg }) {
 
       let title = null;
       let cancelMessage = null;
-      let isInStudios = document.querySelector("#tabs > :nth-child(4).active");
-
       if (
         addon.settings.get("projectsharing") &&
         e.target.closest("[class*='share-button_share-button']:not([class*='is-shared']), .banner-button")
       ) {
         title = addon.tab.scratchMessage("project.share.shareButton"); // "Share"
         cancelMessage = msg("share");
-      } else if (addon.settings.get("projectunsharing") && e.target.closest(".media-stats a.unshare") && !isInStudios) {
+      } else if (addon.settings.get("projectunsharing") && e.target.closest(".media-stats a.unshare") && location.hash !== "#galleries") {
         title = e.target.closest(".media-stats a.unshare").textContent; // "Unshare"
         cancelMessage = msg("unshare");
       } else if (addon.settings.get("followinguser") && e.target.closest("#profile-data .follow-button")) {

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -52,14 +52,6 @@ export default async function ({ addon, console, msg }) {
         if (e.target.closest("form").querySelector("textarea").value === "") return;
         title = msg("cancelcomment-title");
         cancelMessage = msg("cancelcomment");
-      } else if (addon.settings.get("leavingstudio") && e.target.closest("a.unshare") && isInStudios) {
-        if (e.target.closest("[data-control='trash']")) {
-          title = msg("deletestudio-title");
-          cancelMessage = msg("deletestudio");
-        } else {
-          title = msg("leavestudio-title");
-          cancelMessage = msg("leavestudio");
-        }
       } else if (addon.settings.get("removingprojects") && e.target.closest(".media-trash")) {
         title = msg("removeproject-title");
         cancelMessage = msg("removeproject");

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -52,20 +52,13 @@ export default async function ({ addon, console, msg }) {
         if (e.target.closest("form").querySelector("textarea").value === "") return;
         title = msg("cancelcomment-title");
         cancelMessage = msg("cancelcomment");
-      } else if (
-        addon.settings.get("leavingstudio") &&
-        e.target.closest("a.unshare") && isInStudios
-      ) {
+      } else if (addon.settings.get("leavingstudio") && e.target.closest("a.unshare") && isInStudios) {
         title = msg("leavestudio-title");
         cancelMessage = msg("leavestudio");
-      } else if (
-        addon.settings.get("removingprojects") &&
-        e.target.closest(".media-trash")
-      ) {
+      } else if (addon.settings.get("removingprojects") && e.target.closest(".media-trash")) {
         title = msg("removeproject-title");
         cancelMessage = msg("removeproject");
       }
-      
 
       if (cancelMessage !== null) {
         e.preventDefault();

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -17,7 +17,11 @@ export default async function ({ addon, console, msg }) {
       ) {
         title = addon.tab.scratchMessage("project.share.shareButton"); // "Share"
         cancelMessage = msg("share");
-      } else if (addon.settings.get("projectunsharing") && e.target.closest(".media-stats a.unshare") && location.hash !== "#galleries") {
+      } else if (
+        addon.settings.get("projectunsharing") &&
+        e.target.closest(".media-stats a.unshare") &&
+        location.hash !== "#galleries"
+      ) {
         title = e.target.closest(".media-stats a.unshare").textContent; // "Unshare"
         cancelMessage = msg("unshare");
       } else if (addon.settings.get("followinguser") && e.target.closest("#profile-data .follow-button")) {

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -11,6 +11,7 @@ export default async function ({ addon, console, msg }) {
 
       let title = null;
       let cancelMessage = null;
+      let isInStudios = document.querySelector("#tabs > :nth-child(4).active");
 
       if (
         addon.settings.get("projectsharing") &&
@@ -18,7 +19,7 @@ export default async function ({ addon, console, msg }) {
       ) {
         title = addon.tab.scratchMessage("project.share.shareButton"); // "Share"
         cancelMessage = msg("share");
-      } else if (addon.settings.get("projectunsharing") && e.target.closest(".media-stats a.unshare")) {
+      } else if (addon.settings.get("projectunsharing") && e.target.closest(".media-stats a.unshare") && !isInStudios) {
         title = e.target.closest(".media-stats a.unshare").textContent; // "Unshare"
         cancelMessage = msg("unshare");
       } else if (addon.settings.get("followinguser") && e.target.closest("#profile-data .follow-button")) {
@@ -51,7 +52,20 @@ export default async function ({ addon, console, msg }) {
         if (e.target.closest("form").querySelector("textarea").value === "") return;
         title = msg("cancelcomment-title");
         cancelMessage = msg("cancelcomment");
+      } else if (
+        addon.settings.get("leavingstudio") &&
+        e.target.closest("a.unshare") && isInStudios
+      ) {
+        title = msg("leavestudio-title");
+        cancelMessage = msg("leavestudio");
+      } else if (
+        addon.settings.get("removingprojects") &&
+        e.target.closest(".media-trash")
+      ) {
+        title = msg("removeproject-title");
+        cancelMessage = msg("removeproject");
       }
+      
 
       if (cancelMessage !== null) {
         e.preventDefault();

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -53,8 +53,13 @@ export default async function ({ addon, console, msg }) {
         title = msg("cancelcomment-title");
         cancelMessage = msg("cancelcomment");
       } else if (addon.settings.get("leavingstudio") && e.target.closest("a.unshare") && isInStudios) {
-        title = msg("leavestudio-title");
-        cancelMessage = msg("leavestudio");
+        if (e.target.closest("[data-control='trash']")) {
+          title = msg("deletestudio-title");
+          cancelMessage = msg("deletestudio");
+        } else {
+          title = msg("leavestudio-title");
+          cancelMessage = msg("leavestudio");
+        }
       } else if (addon.settings.get("removingprojects") && e.target.closest(".media-trash")) {
         title = msg("removeproject-title");
         cancelMessage = msg("removeproject");


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #4884

### Changes

- Fix bug with showing "unshare project" when leaving/deleting studio in mystuff
- Show new delete confirmation when user is deleting project in mystuff (in trash, and in projects tab)

### Tests

Firefox 95.