### PR TITLE
forum-time-zones: use mobile forums instead of scratchdb

### DIFF
--- a/addons/forum-time-zones/addon.json
+++ b/addons/forum-time-zones/addon.json
@@ -4,7 +4,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/discuss/topic/*"],
+      "matches": ["topics"],
       "runAtComplete": false
     }
   ],

--- a/addons/forum-time-zones/addon.json
+++ b/addons/forum-time-zones/addon.json
@@ -8,6 +8,8 @@
       "runAtComplete": false
     }
   ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
   "versionAdded": "1.0.0",
   "tags": ["forums", "community"],
   "enabledByDefault": false

--- a/addons/forum-time-zones/userscript.js
+++ b/addons/forum-time-zones/userscript.js
@@ -34,7 +34,7 @@ export default async function ({ addon, global, console }) {
       }
     }
   };
-  const pageNumber = /page=(\d+)/.exec(location.search)?.[1];
+  const pageNumber = new URLSearchParams(location.search).get("page");
 
   addon.self.addEventListener("disabled", () => {
     for (const c of cache) {


### PR DESCRIPTION
### Changes
Leaves the ScratchDB deprecated v2 APIs and get UTC dates using the mobile forums
Also fixes bug when you're on a big topic and you're on the first page (we don't specify a "page" to scratchdb)
And dynamic enable/disable
<!-- Please describe the changes you've made. -->

### Reason for changes
Less bytes sent to client
<!-- Why should these changes be made? -->

### Tests
Firefox
<!-- If applicable. Have you tested this pull request? If so, how? -->
