### PR TITLE
hide-flyout: Fix some bugs and some internal cleanup

### DIFF
--- a/addons/columns/style.css
+++ b/addons/columns/style.css
@@ -95,7 +95,3 @@
   left: 0;
   top: calc(var(--sa-flyout-y));
 }
-
-.sa-lock-image {
-  top: calc(var(--sa-flyout-y) + 4px);
-}

--- a/addons/columns/style.css
+++ b/addons/columns/style.css
@@ -88,10 +88,9 @@
 
 [class*="gui_tabs_"] {
   --sa-flyout-width: 310px;
-  --sa-toolbox-width: var(--sa-flyout-width);
+  --sa-category-width: 0;
 }
 
 .sa-flyout-placeHolder {
-  left: 0;
   top: calc(var(--sa-flyout-y));
 }

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -54,7 +54,8 @@
 }
 
 .Popover {
-  z-index: 40;
+  /* see hide-flyout */
+  z-index: 51;
 }
 
 /* hide-stage compatibility */

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -54,7 +54,7 @@
 }
 
 .Popover {
-  /* see hide-flyout */
+  /* See hide-flyout */
   z-index: 51;
 }
 

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -63,12 +63,12 @@
 
 .sa-lock-object {
   display: var(--hideFlyout-lockDisplay) !important;
-  transform: translate(calc(var(--sa-flyout-width) - 15px - 32px), 4px);
+  transform: translate(calc(var(--sa-flyout-width) - 15px - 32px), 3px);
   width: 32px;
   height: 32px;
 }
 [dir="rtl"] .sa-lock-object {
-  transform: translate(15px, 4px);
+  transform: translate(15px, 3px);
 }
 
 .sa-lock-button {

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -46,7 +46,6 @@
   margin-left: calc(var(--sa-flyout-width) + 10px);
 }
 
-
 .sa-flyout-placeHolder {
   display: var(--hideFlyout-placeholderDisplay) !important;
   position: absolute;

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -72,6 +72,7 @@
 }
 
 .sa-lock-button {
+  display: flex;
   cursor: pointer;
   width: 100%;
   height: 100%;

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -121,5 +121,6 @@
 
 /* https://github.com/ScratchAddons/ScratchAddons/issues/4896 */
 .Popover {
-  z-index: 40;
+  /* above stage wrapper and target pane */
+  z-index: 51;
 }

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -100,11 +100,18 @@
 /* Setting these styles on gui_stage-and-target-wrapper breaks full screen */
 .sa-body-editor [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen"]),
 [class*="gui_target-wrapper_"] {
-  /* must cover the hidden palette when editor-stage-left is enabled and lock icon when columns is also enabled */
   position: relative;
-  z-index: 31;
   padding-inline: 0.5rem;
   background-color: var(--editorDarkMode-page, hsl(215, 100%, 95%));
+}
+/* Both must be above hidden flyout when dragging block with editor-stage-left enabled */
+/* Both must be above category list when columns is enabled so dragged sprites appear aren't obscured */
+/* Stage wrapper must be above target pane so dragged sprites aren't obscured */
+.sa-body-editor [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen"]) {
+  z-index: 50;
+}
+[class*="gui_target-wrapper_"] {
+  z-index: 49;
 }
 
 [class*="gui_stage-and-target-wrapper_"] {

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -66,15 +66,20 @@
   right: calc(var(--sa-category-width) + 1px);
 }
 
-.sa-lock-image {
+.sa-lock-object {
   display: var(--hideFlyout-lockDisplay) !important;
-  position: absolute;
-  z-index: 20;
-  cursor: pointer;
-  top: 4px;
-  left: calc(var(--sa-toolbox-width) - 15px - 32px);
+  transform: translate(calc(var(--sa-flyout-width) - 15px - 32px), 4px);
   width: 32px;
   height: 32px;
+}
+[dir="rtl"] .sa-lock-object {
+  transform: translate(15px, 4px);
+}
+
+.sa-lock-button {
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
   padding: 0;
   justify-content: center;
   align-items: center;
@@ -83,29 +88,24 @@
   border-radius: 4px;
 }
 
-.sa-lock-image.locked {
+.sa-lock-object.locked .sa-lock-button {
   background-color: var(--editorDarkMode-primary, #4d97ff);
   border-color: var(--editorDarkMode-primary-variant, #3373cc);
 }
 
-.sa-lock-image img {
+.sa-lock-button img {
   width: 20px;
   filter: var(--editorDarkMode-accent-filter, none);
 }
 
-.sa-lock-image.locked img {
+.sa-lock-object.locked img {
   filter: var(--editorDarkMode-primary-filter, none);
-}
-
-[dir="rtl"] .sa-lock-image {
-  left: auto;
-  right: calc(var(--sa-toolbox-width) - 15px - 32px);
 }
 
 /* Setting these styles on gui_stage-and-target-wrapper breaks full screen */
 .sa-body-editor [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen"]),
 [class*="gui_target-wrapper_"] {
-  /* must cover the hidden palette when editor-stage-left is enabled */
+  /* must cover the hidden palette when editor-stage-left is enabled and lock icon when columns is also enabled */
   position: relative;
   z-index: 31;
   padding-inline: 0.5rem;

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -1,7 +1,7 @@
 [class*="gui_tabs_"] {
+  /* overridden by other addons */
   --sa-category-width: 60px;
   --sa-flyout-width: 250px;
-  --sa-toolbox-width: calc(var(--sa-category-width) + var(--sa-flyout-width));
 }
 
 .injectionDiv {
@@ -49,14 +49,16 @@
 .sa-flyout-placeHolder {
   display: var(--hideFlyout-placeholderDisplay) !important;
   position: absolute;
-  top: 0;
-  left: calc(var(--sa-category-width) + 1px);
   height: 100%;
   width: calc(var(--sa-flyout-width) + 1px);
+  top: 0;
+}
+
+[dir="ltr"] .sa-flyout-placeHolder {
+  left: calc(var(--sa-category-width) + 1px);
 }
 
 [dir="rtl"] .sa-flyout-placeHolder {
-  left: auto;
   right: calc(var(--sa-category-width) + 1px);
 }
 

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -115,3 +115,7 @@
 [class*="gui_stage-and-target-wrapper_"] {
   padding: 0;
 }
+
+.Popover {
+  z-index: 40;
+}

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -122,5 +122,6 @@
 /* https://github.com/ScratchAddons/ScratchAddons/issues/4896 */
 .Popover {
   /* above stage wrapper and target pane */
+  /* see editor-stage-left */
   z-index: 51;
 }

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -8,7 +8,7 @@
   border-left-color: transparent;
 }
 
-.gui[dir="rtl"] .injectionDiv {
+[dir="rtl"] .injectionDiv {
   border-left-color: var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
   border-right-color: transparent;
 }
@@ -26,7 +26,7 @@
   border-left: 1px solid var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
 }
 
-.gui[dir="rtl"] .injectionDiv::after {
+[dir="rtl"] .injectionDiv::after {
   left: auto;
   right: -1px;
 }
@@ -37,18 +37,18 @@
   transition-property: margin;
 }
 
-.gui[dir="ltr"] .blocklyFlyout.sa-flyoutClose,
-.gui[dir="ltr"] .blocklyFlyoutScrollbar.sa-flyoutClose,
-.gui[dir="ltr"] .sa-lock-image.sa-flyoutClose {
+[dir="ltr"] .blocklyFlyout.sa-flyoutClose,
+[dir="ltr"] .blocklyFlyoutScrollbar.sa-flyoutClose,
+[dir="ltr"] .sa-lock-image.sa-flyoutClose {
   margin-left: calc(0px - var(--sa-flyout-width) - 10px);
 }
 
-.gui[dir="rtl"] .blocklyFlyout.sa-flyoutClose,
-.gui[dir="rtl"] .blocklyFlyoutScrollbar.sa-flyoutClose {
+[dir="rtl"] .blocklyFlyout.sa-flyoutClose,
+[dir="rtl"] .blocklyFlyoutScrollbar.sa-flyoutClose {
   margin-left: calc(var(--sa-flyout-width) + 10px);
 }
 
-.gui[dir="rtl"] .sa-lock-image.sa-flyoutClose {
+[dir="rtl"] .sa-lock-image.sa-flyoutClose {
   margin-right: calc(0px - var(--sa-flyout-width) - 10px);
 }
 

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -7,12 +7,12 @@
 /* The default left-side border does not work properly when a block is being dragged, */
 /* which lets a 1 pixel column of the flyout be visible. */
 /* To fix this we use two elements that are only visible when a block is being dragged. */
-/* The first element is white/black to cover up the contents, the other has the correct border color. */
-/* Two elements are necessary because the border color has transparency. */
+/* The first element is opaque to cover up the contents with the background color. */
+/* The other element is the transparent border color. */
 .sa-flyout-border-1,
 .sa-flyout-border-2 {
   position: absolute;
-  /* above flyout but below add extension button */
+  /* Above flyout but below add extension button */
   z-index: 40;
   top: 0;
   bottom: 8px;
@@ -121,7 +121,7 @@
 
 /* https://github.com/ScratchAddons/ScratchAddons/issues/4896 */
 .Popover {
-  /* above stage wrapper and target pane */
-  /* see editor-stage-left */
+  /* Above stage wrapper and target pane */
+  /* See editor-stage-left */
   z-index: 51;
 }

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -4,31 +4,30 @@
   --sa-flyout-width: 250px;
 }
 
-.injectionDiv {
-  border-left-color: transparent;
-}
-
-[dir="rtl"] .injectionDiv {
-  border-left-color: var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
-  border-right-color: transparent;
-}
-
-.injectionDiv::after {
-  /* left border of the code area:
-     must be above the flyout and below the extension button */
-  content: "";
+/* The default left-side border does not work properly when a block is being dragged, */
+/* which lets a 1 pixel column of the flyout be visible. */
+/* To fix this we use two elements that are only visible when a block is being dragged. */
+/* The first element is white/black to cover up the contents, the other has the correct border color. */
+/* Two elements are necessary because the border color has transparency. */
+.sa-flyout-border-1,
+.sa-flyout-border-2 {
   display: block;
   position: absolute;
   z-index: 40;
   top: 0;
   bottom: 8px;
   left: -1px;
-  border-left: 1px solid var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
 }
-
-[dir="rtl"] .injectionDiv::after {
+[dir="rtl"] .sa-flyout-border-1,
+[dir="rtl"] .sa-flyout-border-2 {
   left: auto;
   right: -1px;
+}
+.sa-flyout-border-1 {
+  border-left: 1px solid var(--editorDarkMode-page, hsla(215, 100%, 95%, 1));
+}
+.sa-flyout-border-2 {
+  border-left: 1px solid var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
 }
 
 .blocklyFlyout,

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -32,14 +32,12 @@
 }
 
 .blocklyFlyout,
-.blocklyFlyoutScrollbar,
-.sa-lock-image {
+.blocklyFlyoutScrollbar {
   transition-property: margin;
 }
 
 [dir="ltr"] .blocklyFlyout.sa-flyoutClose,
-[dir="ltr"] .blocklyFlyoutScrollbar.sa-flyoutClose,
-[dir="ltr"] .sa-lock-image.sa-flyoutClose {
+[dir="ltr"] .blocklyFlyoutScrollbar.sa-flyoutClose {
   margin-left: calc(0px - var(--sa-flyout-width) - 10px);
 }
 
@@ -48,9 +46,6 @@
   margin-left: calc(var(--sa-flyout-width) + 10px);
 }
 
-[dir="rtl"] .sa-lock-image.sa-flyoutClose {
-  margin-right: calc(0px - var(--sa-flyout-width) - 10px);
-}
 
 .sa-flyout-placeHolder {
   display: var(--hideFlyout-placeholderDisplay) !important;
@@ -116,6 +111,7 @@
   padding: 0;
 }
 
+/* https://github.com/ScratchAddons/ScratchAddons/issues/4896 */
 .Popover {
   z-index: 40;
 }

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -11,8 +11,8 @@
 /* Two elements are necessary because the border color has transparency. */
 .sa-flyout-border-1,
 .sa-flyout-border-2 {
-  display: block;
   position: absolute;
+  /* above flyout but below add extension button */
   z-index: 40;
   top: 0;
   bottom: 8px;

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -219,6 +219,7 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     flyOut = await addon.tab.waitForElement(".blocklyFlyout", {
       markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     scrollBar = document.querySelector(".blocklyFlyoutScrollbar");

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -41,10 +41,9 @@ export default async function ({ addon, global, console, msg }) {
   }
 
   function updateLockDisplay() {
+    lockObject.classList.toggle("locked", flyoutLock);
     lockButton.title = flyoutLock ? msg("unlock") : msg("lock");
     lockIcon.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
-    if (flyoutLock) lockObject.classList.add("locked");
-    else lockObject.classList.remove("locked");
   }
 
   function onmouseenter(e, speed = {}) {
@@ -58,7 +57,6 @@ export default async function ({ addon, global, console, msg }) {
       setTransition(speed);
       flyOut.classList.remove("sa-flyoutClose");
       scrollBar.classList.remove("sa-flyoutClose");
-      lockObject.classList.remove("sa-flyoutClose");
       setTimeout(() => {
         Blockly.getMainWorkspace().recordCachedAreas();
         removeTransition();
@@ -77,7 +75,6 @@ export default async function ({ addon, global, console, msg }) {
     setTransition(speed);
     flyOut.classList.add("sa-flyoutClose");
     scrollBar.classList.add("sa-flyoutClose");
-    lockObject.classList.add("sa-flyoutClose");
     setTimeout(() => {
       Blockly.getMainWorkspace().recordCachedAreas();
       removeTransition();

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -229,9 +229,11 @@ export default async function ({ addon, global, console, msg }) {
     // Code editor left border
     const borderElement1 = document.createElement("div");
     borderElement1.className = "sa-flyout-border-1";
+    addon.tab.displayNoneWhileDisabled(borderElement1);
     injectionDiv.appendChild(borderElement1);
     const borderElement2 = document.createElement("div");
     borderElement2.className = "sa-flyout-border-2";
+    addon.tab.displayNoneWhileDisabled(borderElement2);
     injectionDiv.appendChild(borderElement2);
 
     // Placeholder Div

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -224,6 +224,15 @@ export default async function ({ addon, global, console, msg }) {
     });
     scrollBar = document.querySelector(".blocklyFlyoutScrollbar");
     const blocksWrapper = document.querySelector('[class*="gui_blocks-wrapper_"]');
+    const injectionDiv = document.querySelector(".injectionDiv");
+
+    // Code editor left border
+    const borderElement1 = document.createElement("div");
+    borderElement1.className = "sa-flyout-border-1";
+    injectionDiv.appendChild(borderElement1);
+    const borderElement2 = document.createElement("div");
+    borderElement2.className = "sa-flyout-border-2";
+    injectionDiv.appendChild(borderElement2);
 
     // Placeholder Div
     if (placeHolderDiv) placeHolderDiv.remove();

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -219,7 +219,7 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     flyOut = await addon.tab.waitForElement(".blocklyFlyout", {
       markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "scratch-gui/locales/SELECT_LOCALE"],
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "scratch-gui/locales/SELECT_LOCALE", "fontsLoaded/SET_FONTS_LOADED"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     scrollBar = document.querySelector(".blocklyFlyoutScrollbar");


### PR DESCRIPTION
 - The lock button is now inside the flyout SVG instead of being "above" it, simplifying some things
 - Fixes #4896
 - Removed unnecessary .gui from selectors as some Scratch mods don't have an element with that class
 - Added redux events (minor performance optimization)
 - Fix incorrect placeholder element location using RTL language and columns addon
 - Fix left border still being partially transparent so you could still see the flyout through the border while dragging blocks; now it's completely opaque
 - Fix right border of code editor not working in RTL with editor-stage-left
 - Fix dragged sprites getting covered by target pane and columns category list
