### PR TITLE
Fix incorrect add extension button corner when using editor-stage-left and columns

### DIFF
--- a/addons/columns/style.css
+++ b/addons/columns/style.css
@@ -49,7 +49,8 @@
   height: calc(1.75rem - 2px);
   background-color: transparent;
   border-color: var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
-  border-radius: 0.25rem;
+  /* !important to override editor-stage-left styles */
+  border-radius: 0.25rem !important;
 }
 
 [class*="gui_extension-button-container_"]:hover {

--- a/addons/columns/style.css
+++ b/addons/columns/style.css
@@ -49,8 +49,11 @@
   height: calc(1.75rem - 2px);
   background-color: transparent;
   border-color: var(--editorDarkMode-border, rgba(0, 0, 0, 0.15));
-  /* !important to override editor-stage-left styles */
-  border-radius: 0.25rem !important;
+}
+
+/* [dir] is for specificity to override editor-stage-left */
+[dir] [class*="gui_extension-button-container_"] {
+  border-radius: 0.25rem;
 }
 
 [class*="gui_extension-button-container_"]:hover {


### PR DESCRIPTION
When both editor-stage-left and columns were enabled, the add extension button's bottom left corner (or bottom right in RTL) would be more rounded than the other corners.

Before

![image](https://user-images.githubusercontent.com/33787854/181176137-9fc34488-7eea-48e9-ab14-56a24c634553.png)

After

![image](https://user-images.githubusercontent.com/33787854/181176028-2384dcf6-aee4-4ec2-9fe4-ffe681be450e.png)
