### PR TITLE
Allow adding list items through variable-manager by pressing enter

### DIFF
--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -24,6 +24,10 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.11.0",
+  "latestUpdate": {
+    "version": "1.28.0",
+    "temporaryNotice": "List items can now be inserted without holding shift.",
+  },
   "tags": ["editor", "featured"],
   "enabledByDefault": false
 }

--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -26,7 +26,7 @@
   "versionAdded": "1.11.0",
   "latestUpdate": {
     "version": "1.28.0",
-    "temporaryNotice": "List items can now be inserted without holding shift."
+    "temporaryNotice": "List items can now be inserted without holding the Shift key."
   },
   "tags": ["editor", "featured"],
   "enabledByDefault": false

--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -26,7 +26,7 @@
   "versionAdded": "1.11.0",
   "latestUpdate": {
     "version": "1.28.0",
-    "temporaryNotice": "List items can now be inserted without holding shift.",
+    "temporaryNotice": "List items can now be inserted without holding shift."
   },
   "tags": ["editor", "featured"],
   "enabledByDefault": false

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -153,7 +153,7 @@ export default async function ({ addon, global, console, msg }) {
         label.blur();
       };
       label.addEventListener("keydown", (e) => {
-        if (e.key === "Enter" && !e.shiftKey) e.target.blur();
+        if (e.key === "Enter") e.target.blur();
       });
       label.addEventListener("focusout", onLabelOut);
 
@@ -199,7 +199,7 @@ export default async function ({ addon, global, console, msg }) {
       };
 
       input.addEventListener("keydown", (e) => {
-        if (e.key === "Enter" && !e.shiftKey) e.target.blur();
+        if (e.target.nodeName === "INPUT" && e.key === "Enter") e.target.blur();
       });
       input.addEventListener("focusout", onInputOut);
 


### PR DESCRIPTION
Resolves #3235

### Changes

Replaces the `variable-manager` shift key check with an element type check.

### Reason for changes

The shift key doesn't have to be held while creating list items anymore.

### Tests

Tested on Chromium 103. Pressing enter on a variable input still unfocuses it.