### PR TITLE
Add support for scratchblocks to full-signature

### DIFF
--- a/addons/full-signature/blocks.css
+++ b/addons/full-signature/blocks.css
@@ -1,3 +1,4 @@
-.scratchblocks, .blocks3 {
+.scratchblocks,
+.blocks3 {
   overflow: auto;
 }

--- a/addons/full-signature/blocks.css
+++ b/addons/full-signature/blocks.css
@@ -2,6 +2,6 @@
   overflow: auto;
 }
 
-.sblocks3 {
+.blocks3 {
   overflow: auto;
 }

--- a/addons/full-signature/blocks.css
+++ b/addons/full-signature/blocks.css
@@ -1,3 +1,7 @@
 .scratchblocks {
   overflow: auto;
 }
+
+.sblocks3 {
+  overflow: auto;
+}

--- a/addons/full-signature/blocks.css
+++ b/addons/full-signature/blocks.css
@@ -1,7 +1,3 @@
-.scratchblocks {
-  overflow: auto;
-}
-
-.blocks3 {
+.scratchblocks, .blocks3 {
   overflow: auto;
 }


### PR DESCRIPTION
Resolves #3684
Continues #4217 (I forgot about that PR...)

### Changes

Full areas addon now adds scrollbar to `scratch blocks 3` (from `scratchblocks` addon).