### PR TITLE
Show error message if an addon.json is invalid

### DIFF
--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -42,7 +42,13 @@ const localizeSettings = (addonId, setting, tableId) => {
   const useDefault = scratchAddons.l10n.locale.startsWith("en");
   for (const addonId of addonIds) {
     if (addonId.startsWith("//")) continue;
-    const manifest = await (await fetch(`/addons/${addonId}/addon.json`)).json();
+    let manifest;
+    try {
+      manifest = await (await fetch(`/addons/${addonId}/addon.json`)).json();
+    } catch (ex) {
+      console.error(`Failed to load addon manifest for ${addonId}, skipping to next addon:`, ex);
+      continue;
+    }
     let potentiallyNeedsMissingDynamicWarning =
       manifest.updateUserstylesOnSettingsChange && !(manifest.dynamicEnable && manifest.dynamicDisable);
     if (!useDefault) {

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -47,6 +47,9 @@ const localizeSettings = (addonId, setting, tableId) => {
       manifest = await (await fetch(`/addons/${addonId}/addon.json`)).json();
     } catch (ex) {
       console.error(`Failed to load addon manifest for ${addonId}, skipping to next addon:`, ex);
+      chrome.tabs.create({
+        url: `data:text/plain,Scratch Addons crashed: invalid addon.json for addon with id ${addonId}. Click the "Errors" button on the extension tile for more details.`,
+      });
       continue;
     }
     let potentiallyNeedsMissingDynamicWarning =

--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -46,11 +46,11 @@ const localizeSettings = (addonId, setting, tableId) => {
     try {
       manifest = await (await fetch(`/addons/${addonId}/addon.json`)).json();
     } catch (ex) {
-      console.error(`Failed to load addon manifest for ${addonId}, skipping to next addon:`, ex);
+      console.error(`Failed to load addon manifest for ${addonId}, crashing:`, ex);
       chrome.tabs.create({
         url: `data:text/plain,Scratch Addons crashed: invalid addon.json for addon with id ${addonId}. Click the "Errors" button on the extension tile for more details.`,
       });
-      continue;
+      throw ex;
     }
     let potentiallyNeedsMissingDynamicWarning =
       manifest.updateUserstylesOnSettingsChange && !(manifest.dynamicEnable && manifest.dynamicDisable);


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #4947

### Changes
Stops crashing the manifest loader if an addon manifest is invalid, and error in background page
<!-- Please describe the changes you've made. -->

### Tests
Firefox
<!-- If applicable. Have you tested this pull request? If so, how? -->
