### PR TITLE
Don't reload already-loaded scripts

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -61,8 +61,12 @@ export default class Tab extends Listenable {
         } else if (obj.error === null) {
           // Script has been appended to document.head, but not loaded yet.
           obj.script.addEventListener("load", (e) => {
-            obj.loaded = true;
-            resolve(e);
+            // Script loaded successfully - resolve the promise, but don't edit the global object (since it's already been edited by the original listener).
+            resolve();
+          });
+          obj.script.addEventListener("error", ({ error }) => {
+            // Script failed to load - reject the promise, but don't edit the global object (since it's already been edited by the original listener).
+            reject(`Failed to load script from ${url} - ${error}`);
           });
         } else {
           // Script has been appended to document.head, and failed to load.

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -10,6 +10,7 @@ scratchAddons.eventTargets = {
   self: [],
 };
 scratchAddons.session = {};
+scratchAddons.loadedScripts = {};
 const consoleOutput = (logAuthor = "[page]") => {
   const style = {
     // Remember to change these as well on cs.js


### PR DESCRIPTION
## Changes
Stop duplicate scripts from running, e.g color-picker and 2d-color-picker use tinycolor, and if you use both at the same time it loads the same script two times