### PR TITLE
Remove beta tag from default-costume-editor-color

### DIFF
--- a/addons/default-costume-editor-color/addon.json
+++ b/addons/default-costume-editor-color/addon.json
@@ -41,7 +41,7 @@
     }
   ],
   "versionAdded": "1.26.0",
-  "tags": ["editor", "costumeEditor", "featured", "beta"],
+  "tags": ["editor", "costumeEditor", "featured"],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "enabledByDefault": false


### PR DESCRIPTION
This addon was marked as beta by garbomuffin when released, see commit https://github.com/ScratchAddons/ScratchAddons/pull/4267/commits/aaeee39d3655d042369418c55bee043f4cbcfc4e

No relevant bugs were reported, so we should remove the beta tag