### PR TITLE
Get textContent instead of innerHTML (forum-search)

### DIFF
--- a/addons/forum-search/userscript.js
+++ b/addons/forum-search/userscript.js
@@ -260,7 +260,7 @@ export default async function ({ addon, global, console, msg }) {
         break;
       }
       case 4: {
-        let category = document.getElementsByClassName("box-head")[1].getElementsByTagName("span")[0].innerHTML;
+        let category = document.getElementsByClassName("box-head")[1].getElementsByTagName("span")[0].textContent;
         locationQuery = ` +category:"${category}"`;
         searchPlaceholder = msg("search-cat", { cat: category });
         break;


### PR DESCRIPTION
Resolves bug from feedback:
> There's a new forum now ( https://scratch.mit.edu/discuss/60/ ) called "Project Save & Level Codes", which has an ampersand in it.
When the forum search addon is enabled and you visit this page, then the placeholder text says "Project Save \&amp; Level Codes" instead of the expected "Project Save & Level Codes".