### PR TITLE
Change spelling: "cancelling" to "canceling"

### DIFF
--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -37,7 +37,7 @@
       "default": true
     },
     {
-      "name": "Confirm cancelling comments",
+      "name": "Confirm canceling comments",
       "id": "cancelcomment",
       "type": "boolean",
       "default": true

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -50,7 +50,7 @@ export default async function ({ addon, console, msg }) {
         addon.settings.get("cancelcomment") &&
         e.target.closest("div[data-control='cancel'] > a, .compose-cancel")
       ) {
-        // Do not ask to confirm cancelling empty comments
+        // Do not ask to confirm canceling empty comments
         if (e.target.closest("form").querySelector("textarea").value === "") return;
         title = msg("cancelcomment-title");
         cancelMessage = msg("cancelcomment");


### PR DESCRIPTION
Does not resolve any open issues.

### Changes

Changed "cancelling" to "canceling" in the `confirm-actions` addon.

### Reason for changes

"Canceling" is usually favored by Americans, whereas "cancelling" is usually used in other dialects. Source: https://www.grammarly.com/blog/canceled-vs-cancelled

Nobody will notice this, but I think this change is still worth it.

### Tests

Didn't test, but the changes should work just fine. It's just language.
