### PR TITLE
Dont let `find-bar` and `jump-to-def` run when devtools extension installed

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -459,6 +459,7 @@ export default async function ({ addon, msg, console }) {
         list: "data_lists",
         LIST: "data_lists",
         costume: "looks",
+        sound: "sounds",
       };
       if (proc.cls === "flag") {
         item.className = "flag";

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -3,6 +3,13 @@ import BlockInstance from "./blockly/BlockInstance.js";
 import Utils from "./blockly/Utils.js";
 
 export default async function ({ addon, msg, console }) {
+  if (!addon.self._isDevtoolsExtension && window.initGUI) {
+    console.log("Extension running, stopping addon");
+    window._devtoolsAddonEnabled = true;
+    window.dispatchEvent(new CustomEvent("scratchAddonsDevtoolsAddonStopped"));
+    return;
+  }
+
   const Blockly = await addon.tab.traps.getBlockly();
 
   class FindBar {

--- a/addons/jump-to-def/userscript.js
+++ b/addons/jump-to-def/userscript.js
@@ -1,5 +1,12 @@
 import Utils from "../find-bar/blockly/Utils.js";
 export default async function ({ addon, msg, global, console }) {
+  if (!addon.self._isDevtoolsExtension && window.initGUI) {
+    console.log("Extension running, stopping addon");
+    window._devtoolsAddonEnabled = true;
+    window.dispatchEvent(new CustomEvent("scratchAddonsDevtoolsAddonStopped"));
+    return;
+  }
+
   const utils = new Utils(addon);
 
   const Blockly = await addon.tab.traps.getBlockly();


### PR DESCRIPTION
This uses the code from the devtools files. This also fixes a bug where the items in the sounds tab were not appropriately styled.