### PR TITLE
Fix variable manager order conflict with find-bar

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -416,7 +416,8 @@ export default class Tab extends Listenable {
       afterSoundTab: {
         element: () => q("[class^='react-tabs_react-tabs__tab-list']"),
         from: () => [q("[class^='react-tabs_react-tabs__tab-list']").children[2]],
-        until: () => [q("#s3devToolBar")],
+        // Element used in find-bar addon
+        until: () => [q(".sa-find-bar")],
       },
       forumsBeforePostReport: {
         element: () => scope.querySelector(".postfootright > ul"),

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -31,22 +31,22 @@ export default async function ({ addon, msg, console }) {
 
     createDom(root) {
       const findBar = root.appendChild(document.createElement("div"));
-      findBar.className = "find-bar";
+      findBar.className = "sa-find-bar";
       addon.tab.displayNoneWhileDisabled(findBar, { display: "flex" });
 
       this.findLabel = findBar.appendChild(document.createElement("label"));
-      this.findLabel.htmlFor = "find-input";
+      this.findLabel.htmlFor = "sa-find-input";
       this.findLabel.textContent = msg("find");
 
       this.findWrapper = findBar.appendChild(document.createElement("span"));
-      this.findWrapper.className = "find-wrapper";
+      this.findWrapper.className = "sa-find-wrapper";
 
       this.dropdownOut = this.findWrapper.appendChild(document.createElement("label"));
-      this.dropdownOut.className = "find-dropdown-out";
+      this.dropdownOut.className = "sa-find-dropdown-out";
 
       this.findInput = this.dropdownOut.appendChild(document.createElement("input"));
       this.findInput.className = addon.tab.scratchClass("input_input-form", {
-        others: "find-input",
+        others: "sa-find-input",
       });
       this.findInput.type = "search";
       this.findInput.placeholder = msg("find-placeholder");
@@ -398,7 +398,7 @@ export default async function ({ addon, msg, console }) {
 
     createDom() {
       this.el = document.createElement("ul");
-      this.el.className = "find-dropdown";
+      this.el.className = "sa-find-dropdown";
       return this.el;
     }
 
@@ -462,7 +462,7 @@ export default async function ({ addon, msg, console }) {
         sound: "sounds",
       };
       if (proc.cls === "flag") {
-        item.className = "flag";
+        item.className = "sa-find-flag";
       } else {
         const colorId = colorIds[proc.cls];
         item.className = `sa-block-color sa-block-color-${colorId}`;
@@ -674,10 +674,10 @@ export default async function ({ addon, msg, console }) {
 
     createDom() {
       this.el = document.createElement("span");
-      this.el.className = "find-carousel";
+      this.el.className = "sa-find-carousel";
 
       const leftControl = this.el.appendChild(document.createElement("span"));
-      leftControl.className = "find-carousel-control";
+      leftControl.className = "sa-find-carousel-control";
       leftControl.textContent = "◀";
       leftControl.addEventListener("mousedown", (e) => this.navLeft(e));
 
@@ -685,7 +685,7 @@ export default async function ({ addon, msg, console }) {
       this.count.innerText = this.blocks.length > 0 ? this.idx + 1 + " / " + this.blocks.length : "0";
 
       const rightControl = this.el.appendChild(document.createElement("span"));
-      rightControl.className = "find-carousel-control";
+      rightControl.className = "sa-find-carousel-control";
       rightControl.textContent = "▶";
       rightControl.addEventListener("mousedown", (e) => this.navRight(e));
 

--- a/addons/find-bar/userstyle.css
+++ b/addons/find-bar/userstyle.css
@@ -1,6 +1,6 @@
 @import url("../editor-theme3/compatibility.css");
 
-.find-bar {
+.sa-find-bar {
   display: flex;
   align-items: center;
   white-space: nowrap;
@@ -9,7 +9,7 @@
   height: 100%;
 }
 
-.find-bar > label {
+.sa-find-bar > label {
   /* padding instead of margin so clicking on the empty area will select the input */
   padding-left: 1.5em;
   padding-right: 1em;
@@ -21,12 +21,12 @@
   padding-top: 2px;
 }
 
-[dir="rtl"] .find-bar > label {
+[dir="rtl"] .sa-find-bar > label {
   padding-right: 1.5em;
   padding-left: 1em;
 }
 
-.find-wrapper {
+.sa-find-wrapper {
   overflow: visible;
   position: relative;
   height: 2rem;
@@ -34,7 +34,7 @@
   max-width: 16em;
 }
 
-.find-dropdown-out {
+.sa-find-dropdown-out {
   display: block;
   top: -6px;
   z-index: 100;
@@ -47,7 +47,7 @@
   margin-top: 6px;
 }
 
-.find-dropdown-out.visible {
+.sa-find-dropdown-out.visible {
   position: absolute;
   width: 16em;
   box-shadow: 0px 0px 8px 1px rgba(0, 0, 0, 0.3);
@@ -63,7 +63,7 @@
   flex-grow: 0;
 }
 
-.find-input {
+.sa-find-input {
   width: 100%;
   box-sizing: border-box !important;
   /* !important required for extension, because CSS injection method (and hence order) differs from addon */
@@ -75,12 +75,12 @@
   padding-left: 0.4em;
 }
 
-.find-input:focus {
+.sa-find-input:focus {
   /* Change Scratch default styles */
   box-shadow: none;
 }
 
-.find-dropdown {
+.sa-find-dropdown {
   display: none;
   position: relative;
   padding: 0.2em 0;
@@ -95,11 +95,11 @@
   border: none;
 }
 
-.find-dropdown-out.visible > .find-dropdown {
+.sa-find-dropdown-out.visible > .sa-find-dropdown {
   display: block;
 }
 
-.find-dropdown > li {
+.sa-find-dropdown > li {
   display: block;
   padding: 0.5em 0.3em;
   white-space: nowrap;
@@ -109,50 +109,39 @@
   overflow: hidden;
 }
 
-.find-dropdown > li > b {
+.sa-find-dropdown > li > b {
   background-color: #aaffaa;
   color: black;
 }
 
 /* Drop down items */
-.find-dropdown > li:hover,
-.find-dropdown > li.sel {
+.sa-find-dropdown > li:hover,
+.sa-find-dropdown > li.sel {
   color: white;
   cursor: pointer;
 }
 
-.find-dropdown > li::before {
+.sa-find-dropdown > li::before {
   content: "\25CF "; /* ● */
 }
 
-.flag {
+.sa-find-flag {
   color: #4cbf56;
 }
-.flag:hover,
-.flag.sel {
+.sa-find-flag:hover,
+.sa-find-flag.sel {
   background-color: #4cbf56;
 }
 
-.costume,
-.sound {
-  color: rgb(26, 66, 255);
-}
-.costume:hover,
-.costume.sel,
-.sound:hover,
-.sound.sel {
-  background-color: rgb(26, 66, 255);
-}
-
-.find-dropdown .sa-block-color {
+.sa-find-dropdown .sa-block-color {
   color: var(--sa-block-colored-text);
 }
-.find-dropdown .sa-block-color:hover,
-.find-dropdown .sa-block-color.sel {
+.sa-find-dropdown .sa-block-color:hover,
+.sa-find-dropdown .sa-block-color.sel {
   background-color: var(--sa-block-bright-background);
 }
 
-.find-carousel {
+.sa-find-carousel {
   font-weight: normal;
   position: absolute;
   right: 0;
@@ -162,10 +151,10 @@
   padding: 0;
 }
 
-.find-carousel-control {
+.sa-find-carousel-control {
   padding: 0 6px;
 }
 
-.find-carousel-control:hover {
+.sa-find-carousel-control:hover {
   color: #ffff80;
 }


### PR DESCRIPTION
Fixes the element used in the Tab.js API and renames all created elements to have the `sa-` prefix as requested by WL.