### PR TITLE
Remove unused devtools setting

### DIFF
--- a/addons/editor-devtools/addon.json
+++ b/addons/editor-devtools/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Developer tools",
-  "description": "Adds new menu options to the editor: copy/paste blocks, better clean up, go to custom block definition, and more! Use Ctrl+Space (Shift+Space on macOS) to bring up the \"add block by name\" popup.",
+  "description": "Adds new menu options to the editor: copy/paste blocks, better clean up, and more! Use Ctrl+Space (Shift+Space on macOS) to bring up the \"add block by name\" popup.",
   "credits": [
     {
       "name": "griffpatch"
@@ -16,12 +16,6 @@
     {
       "name": "Paste blocks at mouse cursor",
       "id": "enablePasteBlocksAtMouse",
-      "type": "boolean",
-      "default": true
-    },
-    {
-      "name": "Middle mouse click variables, custom blocks or events to navigate",
-      "id": "enableMiddleClickFinder",
       "type": "boolean",
       "default": true
     }
@@ -40,6 +34,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["editor", "codeEditor", "costumeEditor", "recommended"],
+  "tags": ["editor", "codeEditor", "recommended"],
   "enabledByDefault": true
 }


### PR DESCRIPTION
See #4817

Removes the now unused `enableMiddleClickFinder` `ditor-devtools` setting. Also removes the `costumeEditor` tag since there (probably) aren't any costume editor devtools features left.