### PR TITLE
Fix editor-devtools not styling properly in darkmode

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -150,7 +150,8 @@ img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
 .slider_handle_3f0xk,
 .sound-editor_button_1_6Li,
 .library-item_library-item_1DcMO,
-.find-dropdown-out.visible,
+.s3devDDOut.vis, /* devtools style */
+.find-dropdown-out.visible, /* find-bar style */
 .prompt_body_18Z-I,
 .custom-procedures_body_SQBv6,
 .slider-prompt_body_2ZkXL,
@@ -184,11 +185,11 @@ img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
 .selector_new-buttons_2qHDd::before {
   background: linear-gradient(var(--editorDarkMode-accent-opacity0), var(--editorDarkMode-accent));
 }
-.find-dropdown > li.boolean::before {
+.s3devDD > li.boolean::before /* devtools style */ {
   border-top: 9px solid var(--editorDarkMode-accent);
   border-bottom: 10px solid var(--editorDarkMode-accent);
 }
-.find-dropdown > li.boolean::after {
+.s3devDD > li.boolean::after  /* devtools style */ {
   border-top: 9px solid var(--editorDarkMode-accent);
   border-bottom: 10px solid var(--editorDarkMode-accent);
 }


### PR DESCRIPTION
I know this isn't the place to put this, but at some point, we should not have dark mode be styling elements created by other addons like this. Instead, we would have a scratch class that you would add to elements that just set their background to #fff or similar and the darkmode addon would change that class' background. The code would be cleaner and shorter in the long run. This would work for addons such as devtools (middle click menu), find-bar, hide-flyout, gamepad (which currently does not have darkmode support in the editor, but I think that was on purpose?), onion skinning, and a lot more but I won't list them all.