### PR TITLE
Improve scratchstats addon

### DIFF
--- a/addons-l10n/en/scratchstats.json
+++ b/addons-l10n/en/scratchstats.json
@@ -1,7 +1,6 @@
 {
   "scratchstats/title": "Statistics",
   "scratchstats/view-more": "View on ScratchStats.com",
-  "scratchstats/loading": "Loading...",
   "scratchstats/followers": "followers",
   "scratchstats/most-followed-global": "most followed on Scratch",
   "scratchstats/most-followed-location": "most followed by location",
@@ -9,5 +8,6 @@
   "scratchstats/most-favorites": "most favorites",
   "scratchstats/most-views": "most views",
   "scratchstats/err": "Statistics could not be loaded.",
+  "scratchstats/err-chart": "Chart could not be loaded.",
   "scratchstats/followers-title": "Followers over time"
 }

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1810,6 +1810,11 @@
     {
       "url": "experimental_forums_preview.js",
       "matches": ["editingScreens"]
+    },
+    {
+      "url": "scratchstats.js",
+      "matches": ["profiles"],
+      "runAtComplete": false
     }
   ],
   "userstyles": [

--- a/addons/dark-www/scratchstats.js
+++ b/addons/dark-www/scratchstats.js
@@ -1,0 +1,24 @@
+import { textColor } from "../../libraries/common/cs/text-color.esm.js";
+
+export default async function ({ addon, console }) {
+  // Style the chart added by the scratchstats addon
+  const canvas = await addon.tab.waitForElement("#sa-scratchstats-chart", { markAsSeen: true });
+  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
+  const updateChart = window._saUpdateScratchstatsChart = () => {
+    const chart = Chart.getChart(canvas);
+    if (!chart) return;
+    const color = addon.self.disabled ? "#575e75" : textColor(addon.settings.get("box"));
+    const lineColor = addon.self.disabled ? "rgba(0, 0, 0, 0.1)" : addon.settings.get("border");
+    const options = chart.options;
+    options.scales.x.ticks.color = options.scales.y.ticks.color = color;
+    options.scales.x.grid.tickColor = options.scales.y.grid.tickColor = color;
+    options.scales.x.grid.borderColor = options.scales.y.grid.borderColor = color;
+    options.scales.x.grid.color = options.scales.y.grid.color = lineColor;
+    options.plugins.title.color = color;
+    chart.update();
+  }
+  updateChart();
+  addon.settings.addEventListener("change", updateChart);
+  addon.self.addEventListener("disabled", updateChart);
+  addon.self.addEventListener("reenabled", updateChart);
+}

--- a/addons/dark-www/scratchstats.js
+++ b/addons/dark-www/scratchstats.js
@@ -4,7 +4,7 @@ export default async function ({ addon, console }) {
   // Style the chart added by the scratchstats addon
   const canvas = await addon.tab.waitForElement("#sa-scratchstats-chart", { markAsSeen: true });
   await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
-  const updateChart = window._saUpdateScratchstatsChart = () => {
+  const updateChart = (window._saUpdateScratchstatsChart = () => {
     const chart = Chart.getChart(canvas);
     if (!chart) return;
     const color = addon.self.disabled ? "#575e75" : textColor(addon.settings.get("box"));
@@ -16,7 +16,7 @@ export default async function ({ addon, console }) {
     options.scales.x.grid.color = options.scales.y.grid.color = lineColor;
     options.plugins.title.color = color;
     chart.update();
-  }
+  });
   updateChart();
   addon.settings.addEventListener("change", updateChart);
   addon.self.addEventListener("disabled", updateChart);

--- a/addons/dark-www/scratchstats.js
+++ b/addons/dark-www/scratchstats.js
@@ -4,7 +4,7 @@ export default async function ({ addon, console }) {
   // Style the chart added by the scratchstats addon
   const canvas = await addon.tab.waitForElement("#sa-scratchstats-chart", { markAsSeen: true });
   await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
-  const updateChart = (window._saUpdateScratchstatsChart = () => {
+  const updateChart = () => {
     const chart = Chart.getChart(canvas);
     if (!chart) return;
     const color = addon.self.disabled ? "#575e75" : textColor(addon.settings.get("box"));
@@ -16,7 +16,7 @@ export default async function ({ addon, console }) {
     options.scales.x.grid.color = options.scales.y.grid.color = lineColor;
     options.plugins.title.color = color;
     chart.update();
-  });
+  };
   updateChart();
   addon.settings.addEventListener("change", updateChart);
   addon.self.addEventListener("disabled", updateChart);

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -1,3 +1,5 @@
+@import url("%addon-self-dir%/../../libraries/common/css/spinner.css");
+
 body > #pagewrapper {
   min-height: 0;
 }

--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -1,3 +1,5 @@
+@import url("%addon-self-dir%/../../libraries/common/cs/spinner.css");
+
 #content {
   padding-top: 204px;
 }

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -704,24 +704,3 @@ select:focus {
   background: var(--darkWww-box, white);
   color: var(--darkWww-link, #4d97ff);
 }
-
-/* Spinner animation code */
-/* From https://github.com/LLK/scratch-www/blob/develop/src/components/spinner/spinner.scss */
-@keyframes spin-intro {
-  0% {
-    transform: scale(0);
-    opacity: 0;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-@keyframes spin {
-  0% {
-    transform: rotate(0);
-  }
-  100% {
-    transform: rotate(359deg);
-  }
-}

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -1,3 +1,5 @@
+@import url("%addon-self-dir%/../../libraries/common/cs/spinner.css");
+
 #comments #comments-loading,
 #comments .posting {
   background-image: none;

--- a/addons/scratchstats/addon.json
+++ b/addons/scratchstats/addon.json
@@ -12,7 +12,8 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/users/*/"]
+      "matches": ["https://scratch.mit.edu/users/*/"],
+      "runAtComplete": false
     }
   ],
   "userstyles": [

--- a/addons/scratchstats/style.css
+++ b/addons/scratchstats/style.css
@@ -1,3 +1,5 @@
+@import url("../../libraries/common/cs/spinner.css");
+
 .sa-stats > .box-head a {
   float: right;
 }
@@ -9,12 +11,19 @@
 .sa-stats > .box-content {
   padding: 20px;
 }
+
+.sa-stats-section {
+  position: relative;
+}
 .sa-stats-row {
   display: flex;
   justify-content: center;
 }
-.sa-stats-row {
-  margin-bottom: 16px;
+.sa-stats-section.sa-stats-placeholder > .sa-stats-row {
+  opacity: 0.25;
+}
+.sa-stats-row + .sa-stats-row {
+  margin-top: 16px;
 }
 .sa-stats-row > * {
   padding: 0 40px;
@@ -25,4 +34,25 @@
   font-size: 32px;
   font-weight: bold;
   line-height: normal;
+}
+
+.sa-chart-section {
+  margin-top: 16px;
+  position: relative;
+  height: 400px; /* used by Chart.js to set chart size */
+}
+.sa-chart-section.sa-stats-placeholder > canvas {
+  opacity: 0.25;
+}
+
+.sa-stats-placeholder {
+  pointer-events: none;
+  user-select: none;
+}
+.sa-stats .sa-spinner,
+.sa-stats-error {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -45,7 +45,7 @@ export default async function ({ addon, msg, console }) {
 
     const followRow = document.createElement("div");
     element.appendChild(followRow);
-    followRow.className = "sa-stats-row"
+    followRow.className = "sa-stats-row";
     followRow.appendChild(createSimpleItem(data, (data) => data?.statistics?.followers, msg("followers")));
     followRow.appendChild(
       createSimpleRankItem(data, (data) => data?.statistics?.ranks?.followers, msg("most-followed-global"))
@@ -82,14 +82,20 @@ export default async function ({ addon, msg, console }) {
       )
     );
 
-    if (loading) element.appendChild(Object.assign(document.createElement("div"), {
-      className: "sa-spinner",
-    }));
+    if (loading)
+      element.appendChild(
+        Object.assign(document.createElement("div"), {
+          className: "sa-spinner",
+        })
+      );
 
-    if (error) element.appendChild(Object.assign(document.createElement("div"), {
-      className: "sa-stats-error",
-      innerText: msg("err"),
-    }));
+    if (error)
+      element.appendChild(
+        Object.assign(document.createElement("div"), {
+          className: "sa-stats-error",
+          innerText: msg("err"),
+        })
+      );
   };
 
   const username = location.pathname.split("/")[2];
@@ -134,7 +140,7 @@ export default async function ({ addon, msg, console }) {
   stats.appendChild(chartSection);
   const chartLoadingSpinner = Object.assign(document.createElement("div"), {
     className: "sa-spinner",
-  })
+  });
   chartSection.appendChild(chartLoadingSpinner);
 
   fetch(`https://scratchdb.lefty.one/v3/user/info/${username}`)
@@ -159,75 +165,74 @@ export default async function ({ addon, msg, console }) {
       const stepAvg = historyData.reduce((acc, cur) => acc + cur.value / historyData.length, 0);
       const stepLog = Math.log10(stepAvg);
       const stepSize = Math.pow(10, Math.max(Math.round(stepLog) - 1, 1));
-      new Chart(
-        canvas,
-        {
-          type: "scatter",
-          data: {
-            datasets: [
-              {
-                data: historyData.map((item) => {
-                  return { x: Date.parse(item.date), y: item.value };
-                }),
-                fill: false,
-                showLine: true,
-                borderColor: "#4d97ff",
-                lineTension: 0,
-              },
-            ],
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            scales: {
-              x: {
-                ticks: {
-                  callback: (x) => new Date(x).toDateString(),
-                  color: textColor,
-                },
-                grid: {
-                  borderColor: textColor,
-                  tickColor: textColor,
-                  color: lineColor,
-                },
-              },
-              y: {
-                ticks: {
-                  stepSize,
-                  color: textColor,
-                },
-                grid: {
-                  borderColor: textColor,
-                  tickColor: textColor,
-                  color: lineColor,
-                },
-              },
+      new Chart(canvas, {
+        type: "scatter",
+        data: {
+          datasets: [
+            {
+              data: historyData.map((item) => {
+                return { x: Date.parse(item.date), y: item.value };
+              }),
+              fill: false,
+              showLine: true,
+              borderColor: "#4d97ff",
+              lineTension: 0,
             },
-            plugins: {
-              title: {
-                display: true,
-                text: msg("followers-title"),
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              ticks: {
+                callback: (x) => new Date(x).toDateString(),
                 color: textColor,
               },
-              tooltip: {
-                callbacks: {
-                  label: (context) => `${new Date(Number(context.raw.x)).toDateString()}: ${context.parsed.y}`,
-                },
+              grid: {
+                borderColor: textColor,
+                tickColor: textColor,
+                color: lineColor,
               },
-              legend: {
-                display: false,
+            },
+            y: {
+              ticks: {
+                stepSize,
+                color: textColor,
+              },
+              grid: {
+                borderColor: textColor,
+                tickColor: textColor,
+                color: lineColor,
               },
             },
           },
-        }
-      );
+          plugins: {
+            title: {
+              display: true,
+              text: msg("followers-title"),
+              color: textColor,
+            },
+            tooltip: {
+              callbacks: {
+                label: (context) => `${new Date(Number(context.raw.x)).toDateString()}: ${context.parsed.y}`,
+              },
+            },
+            legend: {
+              display: false,
+            },
+          },
+        },
+      });
     })
     .catch(() => {
       chartLoadingSpinner.remove();
       chartSection.classList.add("sa-stats-placeholder");
-      chartSection.appendChild(Object.assign(document.createElement("div"), {
-        className: "sa-stats-error",
-        innerText: msg("err-chart"),
-      }));
+      chartSection.appendChild(
+        Object.assign(document.createElement("div"), {
+          className: "sa-stats-error",
+          innerText: msg("err-chart"),
+        })
+      );
     });
 }

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -1,4 +1,5 @@
 function createItem(number, label) {
+  // Creates a large number with a label below
   const item = document.createElement("div");
   const numberDiv = document.createElement("div");
   item.appendChild(numberDiv);
@@ -10,18 +11,101 @@ function createItem(number, label) {
   return item;
 }
 
+function createSimpleItem(data, getter, label) {
+  // Used when only one number has to be displayed
+  const result = getter(data);
+  const number = result !== undefined ? result.toLocaleString() : "?";
+  return createItem(number, label);
+}
+
+function createSimpleRankItem(data, getter, label) {
+  // Used when the number is a rank: adds a number sign as a prefix
+  const result = getter(data);
+  const number = result !== undefined ? `#${result.toLocaleString()}` : "?";
+  return createItem(number, label);
+}
+
+function createDoubleRankItem(data, globalGetter, countryGetter, label) {
+  // Used to display a global rank next to a country rank
+  const globalResult = globalGetter(data);
+  const globalRank = globalResult !== undefined ? `#${globalResult.toLocaleString()}` : "?";
+  const countryResult = countryGetter(data);
+  const countryRank = countryResult !== undefined ? `#${countryResult.toLocaleString()}` : "?";
+  const number = `${globalRank} (${countryRank})`;
+  return createItem(number, label);
+}
+
 export default async function ({ addon, msg, console }) {
+  const createStatsSection = (element, { data, loading, error } = {}) => {
+    // "element" is the element whose content to replace
+    // "data" is the data from ScratchDB, or null to display a placeholder
+
+    element.className = `sa-stats-section ${loading || error ? "sa-stats-placeholder" : ""}`;
+    while (element.firstChild) element.firstChild.remove();
+
+    const followRow = document.createElement("div");
+    element.appendChild(followRow);
+    followRow.className = "sa-stats-row"
+    followRow.appendChild(createSimpleItem(data, (data) => data?.statistics?.followers, msg("followers")));
+    followRow.appendChild(
+      createSimpleRankItem(data, (data) => data?.statistics?.ranks?.followers, msg("most-followed-global"))
+    );
+    followRow.appendChild(
+      createSimpleRankItem(data, (data) => data?.statistics?.ranks?.country?.followers, msg("most-followed-location"))
+    );
+
+    const ranksRow = document.createElement("div");
+    element.appendChild(ranksRow);
+    ranksRow.className = "sa-stats-row";
+    ranksRow.appendChild(
+      createDoubleRankItem(
+        data,
+        (data) => data?.statistics?.ranks?.loves,
+        (data) => data?.statistics?.ranks?.country?.loves,
+        msg("most-loves")
+      )
+    );
+    ranksRow.appendChild(
+      createDoubleRankItem(
+        data,
+        (data) => data?.statistics?.ranks?.favorites,
+        (data) => data?.statistics?.ranks?.country?.favorites,
+        msg("most-favorites")
+      )
+    );
+    ranksRow.appendChild(
+      createDoubleRankItem(
+        data,
+        (data) => data?.statistics?.ranks?.views,
+        (data) => data?.statistics?.ranks?.country?.views,
+        msg("most-views")
+      )
+    );
+
+    if (loading) element.appendChild(Object.assign(document.createElement("div"), {
+      className: "sa-spinner",
+    }));
+
+    if (error) element.appendChild(Object.assign(document.createElement("div"), {
+      className: "sa-stats-error",
+      innerText: msg("err"),
+    }));
+  };
+
   const username = location.pathname.split("/")[2];
   if (!username) return;
-  const content = document.querySelector("#content");
-  const commentBox = document.querySelector(
+
+  // waitForElement is necessary because the userscript doesn't have runAtComplete
+  const content = await addon.tab.waitForElement("#content");
+  // #content exists, its children might not
+  const commentBox = await addon.tab.waitForElement(
     "#content > .box:not(#profile-data):not(.slider-carousel-container):not(#page-404)"
   );
-  if (!commentBox) return;
   const statsBox = document.createElement("div");
   content.insertBefore(statsBox, commentBox);
   addon.tab.displayNoneWhileDisabled(statsBox, { display: "block" });
   statsBox.className = "box sa-stats slider-carousel-container";
+
   const statsHeader = document.createElement("div");
   statsBox.appendChild(statsHeader);
   statsHeader.className = "box-head";
@@ -35,67 +119,49 @@ export default async function ({ addon, msg, console }) {
   const statsMoreIcon = document.createElement("img");
   statsMoreLink.insertBefore(statsMoreIcon, statsMoreLink.firstChild);
   statsMoreIcon.src = addon.self.dir + "/scratchstats.png";
+
   const stats = document.createElement("div");
   statsBox.appendChild(stats);
   stats.className = "box-content";
-  stats.innerText = msg("loading");
+
+  const statsSection = document.createElement("div");
+  stats.appendChild(statsSection);
+  createStatsSection(statsSection, { loading: true });
+
+  const chartSection = Object.assign(document.createElement("div"), {
+    className: "sa-chart-section",
+  });
+  stats.appendChild(chartSection);
+  const chartLoadingSpinner = Object.assign(document.createElement("div"), {
+    className: "sa-spinner",
+  })
+  chartSection.appendChild(chartLoadingSpinner);
 
   fetch(`https://scratchdb.lefty.one/v3/user/info/${username}`)
     .then(async function (response) {
-      stats.removeChild(stats.firstChild); // remove loading message
-      const followRow = document.createElement("div");
-      stats.appendChild(followRow);
-      followRow.className = "sa-stats-row";
-      const ranksRow = document.createElement("div");
-      stats.appendChild(ranksRow);
-      ranksRow.className = "sa-stats-row";
       const data = await response.json();
-      followRow.appendChild(createItem(data.statistics.followers.toLocaleString(), msg("followers")));
-      followRow.appendChild(
-        createItem(`#${data.statistics.ranks.followers.toLocaleString()}`, msg("most-followed-global"))
-      );
-      followRow.appendChild(
-        createItem(`#${data.statistics.ranks.country.followers.toLocaleString()}`, msg("most-followed-location"))
-      );
-      ranksRow.appendChild(
-        createItem(
-          `#${data.statistics.ranks.loves.toLocaleString()} (#${data.statistics.ranks.country.loves.toLocaleString()})`,
-          msg("most-loves")
-        )
-      );
-      ranksRow.appendChild(
-        createItem(
-          `#${data.statistics.ranks.favorites.toLocaleString()} (#${data.statistics.ranks.country.favorites.toLocaleString()})`,
-          msg("most-favorites")
-        )
-      );
-      ranksRow.appendChild(
-        createItem(
-          `#${data.statistics.ranks.views.toLocaleString()} (#${data.statistics.ranks.country.views.toLocaleString()})`,
-          msg("most-views")
-        )
-      );
+      createStatsSection(statsSection, { data });
     })
-    .catch(() => (stats.innerText = msg("err"))); // innerText to remove loading message
-    fetch(`https://scratchdb.lefty.one/v3/user/graph/${username}/followers?range=364&segment=6`)
-      .then(async function (response) {
-        const historyData = await response.json();
-        if (historyData.length === 0) return;
-        await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
-        const canvasContainer = document.createElement("div");
-        stats.appendChild(canvasContainer);
-        canvasContainer.style.position = "relative";
-        canvasContainer.style.height = "400px";
-        const canvas = document.createElement("canvas");
-        canvasContainer.appendChild(canvas);
-        canvas.id = "sa-scratchstats-chart";
+    .catch(() => createStatsSection(statsSection, { error: true }));
 
-        const textColor = "#575e75";
-        const lineColor = "rgba(0, 0, 0, 0.1)";
-        const stepAvg = historyData.reduce((acc, cur) => acc + cur.value / historyData.length, 0);
-        const stepLog = Math.log10(stepAvg);
-        const stepSize = Math.pow(10, Math.max(Math.round(stepLog) - 1, 1));
-        new Chart(canvas, {
+  fetch(`https://scratchdb.lefty.one/v3/user/graph/${username}/followers?range=364&segment=6`)
+    .then(async (response) => {
+      const historyData = await response.json();
+      if (historyData.length === 0) throw new Error("scratchstats: No history data");
+      chartLoadingSpinner.remove();
+      await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
+      const canvas = document.createElement("canvas");
+      chartSection.appendChild(canvas);
+      canvas.id = "sa-scratchstats-chart";
+
+      const textColor = "#575e75";
+      const lineColor = "rgba(0, 0, 0, 0.1)";
+      const stepAvg = historyData.reduce((acc, cur) => acc + cur.value / historyData.length, 0);
+      const stepLog = Math.log10(stepAvg);
+      const stepSize = Math.pow(10, Math.max(Math.round(stepLog) - 1, 1));
+      new Chart(
+        canvas,
+        {
           type: "scatter",
           data: {
             datasets: [
@@ -153,7 +219,15 @@ export default async function ({ addon, msg, console }) {
               },
             },
           },
-        });
-      })
-      .catch(() => stats.appendChild(document.createTextNode(msg("err")))); // appended so basic stats are still there, it's just the chart that's gone
+        }
+      );
+    })
+    .catch(() => {
+      chartLoadingSpinner.remove();
+      chartSection.classList.add("sa-stats-placeholder");
+      chartSection.appendChild(Object.assign(document.createElement("div"), {
+        className: "sa-stats-error",
+        innerText: msg("err-chart"),
+      }));
+    });
 }

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -88,6 +88,10 @@ export default async function ({ addon, msg, console }) {
         canvasContainer.style.height = "400px";
         const canvas = document.createElement("canvas");
         canvasContainer.appendChild(canvas);
+        canvas.id = "sa-scratchstats-chart";
+
+        const textColor = "#575e75";
+        const lineColor = "rgba(0, 0, 0, 0.1)";
         const stepAvg = historyData.reduce((acc, cur) => acc + cur.value / historyData.length, 0);
         const stepLog = Math.log10(stepAvg);
         const stepSize = Math.pow(10, Math.max(Math.round(stepLog) - 1, 1));
@@ -113,11 +117,23 @@ export default async function ({ addon, msg, console }) {
               x: {
                 ticks: {
                   callback: (x) => new Date(x).toDateString(),
+                  color: textColor,
+                },
+                grid: {
+                  borderColor: textColor,
+                  tickColor: textColor,
+                  color: lineColor,
                 },
               },
               y: {
                 ticks: {
                   stepSize,
+                  color: textColor,
+                },
+                grid: {
+                  borderColor: textColor,
+                  tickColor: textColor,
+                  color: lineColor,
                 },
               },
             },
@@ -125,6 +141,7 @@ export default async function ({ addon, msg, console }) {
               title: {
                 display: true,
                 text: msg("followers-title"),
+                color: textColor,
               },
               tooltip: {
                 callbacks: {

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -75,68 +75,68 @@ export default async function ({ addon, msg, console }) {
           msg("most-views")
         )
       );
-      fetch(`https://scratchdb.lefty.one/v3/user/graph/${username}/followers?range=364&segment=6`)
-        .then(async function (response) {
-          const historyData = await response.json();
-          if (historyData.length === 0) return;
-          await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
-          const canvasContainer = document.createElement("div");
-          stats.appendChild(canvasContainer);
-          canvasContainer.style.position = "relative";
-          canvasContainer.style.height = "400px";
-          const canvas = document.createElement("canvas");
-          canvasContainer.appendChild(canvas);
-          const stepAvg = historyData.reduce((acc, cur) => acc + cur.value / historyData.length, 0);
-          const stepLog = Math.log10(stepAvg);
-          const stepSize = Math.pow(10, Math.max(Math.round(stepLog) - 1, 1));
-          new Chart(canvas, {
-            type: "scatter",
-            data: {
-              datasets: [
-                {
-                  data: historyData.map((item) => {
-                    return { x: Date.parse(item.date), y: item.value };
-                  }),
-                  fill: false,
-                  showLine: true,
-                  borderColor: "#4d97ff",
-                  lineTension: 0,
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              scales: {
-                x: {
-                  ticks: {
-                    callback: (x) => new Date(x).toDateString(),
-                  },
-                },
-                y: {
-                  ticks: {
-                    stepSize,
-                  },
-                },
-              },
-              plugins: {
-                title: {
-                  display: true,
-                  text: msg("followers-title"),
-                },
-                tooltip: {
-                  callbacks: {
-                    label: (context) => `${new Date(Number(context.raw.x)).toDateString()}: ${context.parsed.y}`,
-                  },
-                },
-                legend: {
-                  display: false,
-                },
-              },
-            },
-          });
-        })
-        .catch(() => stats.appendChild(document.createTextNode(msg("err")))); // appended so basic stats are still there, it's just the chart that's gone
     })
     .catch(() => (stats.innerText = msg("err"))); // innerText to remove loading message
+    fetch(`https://scratchdb.lefty.one/v3/user/graph/${username}/followers?range=364&segment=6`)
+      .then(async function (response) {
+        const historyData = await response.json();
+        if (historyData.length === 0) return;
+        await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
+        const canvasContainer = document.createElement("div");
+        stats.appendChild(canvasContainer);
+        canvasContainer.style.position = "relative";
+        canvasContainer.style.height = "400px";
+        const canvas = document.createElement("canvas");
+        canvasContainer.appendChild(canvas);
+        const stepAvg = historyData.reduce((acc, cur) => acc + cur.value / historyData.length, 0);
+        const stepLog = Math.log10(stepAvg);
+        const stepSize = Math.pow(10, Math.max(Math.round(stepLog) - 1, 1));
+        new Chart(canvas, {
+          type: "scatter",
+          data: {
+            datasets: [
+              {
+                data: historyData.map((item) => {
+                  return { x: Date.parse(item.date), y: item.value };
+                }),
+                fill: false,
+                showLine: true,
+                borderColor: "#4d97ff",
+                lineTension: 0,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                ticks: {
+                  callback: (x) => new Date(x).toDateString(),
+                },
+              },
+              y: {
+                ticks: {
+                  stepSize,
+                },
+              },
+            },
+            plugins: {
+              title: {
+                display: true,
+                text: msg("followers-title"),
+              },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${new Date(Number(context.raw.x)).toDateString()}: ${context.parsed.y}`,
+                },
+              },
+              legend: {
+                display: false,
+              },
+            },
+          },
+        });
+      })
+      .catch(() => stats.appendChild(document.createTextNode(msg("err")))); // appended so basic stats are still there, it's just the chart that's gone
 }

--- a/libraries/common/cs/spinner.css
+++ b/libraries/common/cs/spinner.css
@@ -1,0 +1,36 @@
+/* Spinner animation code */
+/* From https://github.com/LLK/scratch-www/blob/develop/src/components/spinner/spinner.scss */
+
+@keyframes spin-intro {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+}
+
+.sa-spinner {
+  display: block;
+  width: 22.8px;
+  height: 22.8px;
+  background-image: url(https://scratch.mit.edu/svgs/modal/spinner-blue.svg);
+  background-size: 100%;
+  filter: var(--darkWww-link-iconFilter, none);
+  animation-name: spin-intro, spin;
+  animation-duration: 0.25s, 1s;
+  animation-timing-function: cubic-bezier(0.3, -3, 0.6, 3), cubic-bezier(0.4, 0.1, 0.4, 1);
+  animation-delay: 0s, 0.25s;
+  animation-iteration-count: 1, infinite;
+}


### PR DESCRIPTION
Resolves #4968
Resolves #5022

### Changes

* Fixes the layout shift by disabling `runAtComplete` and showing the div containing the chart before the chart loads.
* Shows a loading spinner instead of the "Loading..." text.
* Loads the chart even if the user info is not available.
* Shows question marks if only some user info is available.
* Makes the chart look better in dark mode.

![image](https://user-images.githubusercontent.com/51849865/186377841-9b7e699e-ffbe-48c9-864c-3f9f6bdf0ed7.png)