### PR TITLE
New addon: Disable warning not save (2)

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -125,6 +125,7 @@
   "zebra-striping",
   "find-bar",
   "jump-to-def",
+  "disable-warning-not-save",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/disable-warning-not-save/addon.json
+++ b/addons/disable-warning-not-save/addon.json
@@ -1,0 +1,25 @@
+{
+  "name": "Disable warning not save",
+  "description": "Disables warning when exiting or refreshing an unsaved project.",
+  "tags": ["editor", "danger"],
+  "versionAdded": "1.19.0",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "credits": [
+    {
+      "name": "valmontechno",
+      "link": "https://scratch.mit.edu/users/valmontechno/"
+    }
+  ],
+  "info": [
+    {
+      "type": "warning",
+      "text": "You will no longer be notified if you accidentally quit an unsaved project. Be sure to save your changes frequently to avoid losing them.",
+      "id": "warning"
+    }
+  ]
+}

--- a/addons/disable-warning-not-save/userscript.js
+++ b/addons/disable-warning-not-save/userscript.js
@@ -1,0 +1,5 @@
+export default async function ({ addon, global, console }) {
+  setTimeout(function () {
+    document.body.onbeforeunload = function () {};
+  }, 500);
+}


### PR DESCRIPTION
I formatted the code with Prettier compared to my last pull request.

Disables warning when exiting or refreshing an unsaved project.