### PR TITLE
Correct block palette opacity in preview

### DIFF
--- a/webpages/settings/components/previews/editor-dark-mode.html
+++ b/webpages/settings/components/previews/editor-dark-mode.html
@@ -30,7 +30,7 @@
       '--categoryMenu': settings.categoryMenu,
       '--categoryMenu-text': colors.categoryMenuText,
       '--categoryMenu-selection': colors.categoryMenuSelection,
-      '--palette': colors.palette,
+      '--palette': settings.palette,
       '--selector': settings.selector,
       '--selector-text': colors.selectorText,
       '--selector2': settings.selector2,

--- a/webpages/settings/components/previews/editor-dark-mode.js
+++ b/webpages/settings/components/previews/editor-dark-mode.js
@@ -75,7 +75,6 @@ export default async function ({ template }) {
           ),
           primaryTransparent: multiply(this.settings.primary, { a: 0.35 }),
           inputTransparent: multiply(this.settings.input, { a: 0.25 }),
-          palette: multiply(this.settings.palette, { a: 0.8 }),
         };
       },
     },


### PR DESCRIPTION
### Changes

Updates the setting preview to match what actually appears in the editor after #4916.