### PR TITLE
Change colors of extension icons based on background and block color

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -726,6 +726,10 @@
       "url": "paper.js",
       "matches": ["projects"],
       "runAtComplete": false
+    },
+    {
+      "url": "extension_icons.js",
+      "matches": ["projects"]
     }
   ],
   "userstyles": [

--- a/addons/editor-dark-mode/extension_icons.js
+++ b/addons/editor-dark-mode/extension_icons.js
@@ -1,6 +1,6 @@
 import { textColor } from "../../libraries/common/cs/text-color.esm.js";
 
-const dataUriRegex = new RegExp('^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$');
+const dataUriRegex = new RegExp("^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$");
 
 export default async function ({ addon, console }) {
   const Blockly = await addon.tab.traps.getBlockly();
@@ -16,12 +16,12 @@ export default async function ({ addon, console }) {
       const oldSvg = atob(match[1]);
       const newColor = textColor(addon.settings.get("categoryMenu"), null, "#ffffff");
       if (newColor) {
-        const newSvg = oldSvg.replace(/#575e75|#4d4d4d/ig, newColor);
+        const newSvg = oldSvg.replace(/#575e75|#4d4d4d/gi, newColor);
         this.iconURI_ = `data:image/svg+xml;base64,${btoa(newSvg)}`;
       }
     }
     oldCategoryCreateDom.call(this);
-  }
+  };
 
   const reloadToolbox = () => {
     const workspace = Blockly.getMainWorkspace();

--- a/addons/editor-dark-mode/extension_icons.js
+++ b/addons/editor-dark-mode/extension_icons.js
@@ -1,0 +1,38 @@
+import { textColor } from "../../libraries/common/cs/text-color.esm.js";
+
+const dataUriRegex = new RegExp('^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$');
+
+export default async function ({ addon, console }) {
+  const Blockly = await addon.tab.traps.getBlockly();
+
+  const oldCategoryCreateDom = Blockly.Toolbox.Category.prototype.createDom;
+  Blockly.Toolbox.Category.prototype.createDom = function () {
+    if (addon.self.disabled) return oldCategoryCreateDom.call(this);
+    if (!this.iconURI_ || !["music", "videoSensing", "text2speech"].includes(this.id_))
+      return oldCategoryCreateDom.call(this);
+
+    const match = dataUriRegex.exec(this.iconURI_);
+    if (match) {
+      const oldSvg = atob(match[1]);
+      const newColor = textColor(addon.settings.get("categoryMenu"), null, "#ffffff");
+      if (newColor) {
+        const newSvg = oldSvg.replace(/#575e75|#4d4d4d/ig, newColor);
+        this.iconURI_ = `data:image/svg+xml;base64,${btoa(newSvg)}`;
+      }
+    }
+    oldCategoryCreateDom.call(this);
+  }
+
+  const reloadToolbox = () => {
+    const workspace = Blockly.getMainWorkspace();
+    const flyout = workspace.getFlyout();
+    const toolbox = workspace.getToolbox();
+    const flyoutWorkspace = flyout.getWorkspace();
+    Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);
+    toolbox.populate_(workspace.options.languageTree);
+  };
+  reloadToolbox();
+  addon.settings.addEventListener("change", reloadToolbox);
+  addon.self.addEventListener("disabled", reloadToolbox);
+  addon.self.addEventListener("reenabled", reloadToolbox);
+}

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -1,6 +1,6 @@
 import { removeAlpha, multiply, alphaBlend, recolorFilter } from "../../libraries/common/cs/text-color.esm.js";
 
-const dataUriRegex = new RegExp('^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$');
+const dataUriRegex = new RegExp("^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$");
 const extensionsCategory = {
   id: null,
   settingId: "Pen-color",
@@ -145,8 +145,7 @@ export default async function ({ addon, console }) {
     // Category bubbles
     if (this.iconURI_) {
       if (addon.self.disabled) return oldCategoryCreateDom.call(this);
-      if (!["sa-blocks", "videoSensing", "text2speech"].includes(this.id_))
-        return oldCategoryCreateDom.call(this);
+      if (!["sa-blocks", "videoSensing", "text2speech"].includes(this.id_)) return oldCategoryCreateDom.call(this);
 
       const match = dataUriRegex.exec(this.iconURI_);
       if (match) {
@@ -154,7 +153,7 @@ export default async function ({ addon, console }) {
         const category = this.id_ === "sa-blocks" ? saCategory : extensionsCategory;
         const newColor = isColoredTextMode ? tertiaryColor(category) : primaryColor(category);
         if (newColor) {
-          const newSvg = oldSvg.replace(/#29beb8|#0ebd8c/ig, newColor);
+          const newSvg = oldSvg.replace(/#29beb8|#0ebd8c/gi, newColor);
           this.iconURI_ = `data:image/svg+xml;base64,${btoa(newSvg)}`;
         }
       }

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -1,5 +1,6 @@
 import { removeAlpha, multiply, alphaBlend, recolorFilter } from "../../libraries/common/cs/text-color.esm.js";
 
+const dataUriRegex = new RegExp('^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$');
 const extensionsCategory = {
   id: null,
   settingId: "Pen-color",
@@ -142,6 +143,22 @@ export default async function ({ addon, console }) {
   const oldCategoryCreateDom = Blockly.Toolbox.Category.prototype.createDom;
   Blockly.Toolbox.Category.prototype.createDom = function () {
     // Category bubbles
+    if (this.iconURI_) {
+      if (addon.self.disabled) return oldCategoryCreateDom.call(this);
+      if (!["sa-blocks", "videoSensing", "text2speech"].includes(this.id_))
+        return oldCategoryCreateDom.call(this);
+
+      const match = dataUriRegex.exec(this.iconURI_);
+      if (match) {
+        const oldSvg = atob(match[1]);
+        const category = this.id_ === "sa-blocks" ? saCategory : extensionsCategory;
+        const newColor = isColoredTextMode ? tertiaryColor(category) : primaryColor(category);
+        if (newColor) {
+          const newSvg = oldSvg.replace(/#29beb8|#0ebd8c/ig, newColor);
+          this.iconURI_ = `data:image/svg+xml;base64,${btoa(newSvg)}`;
+        }
+      }
+    }
     oldCategoryCreateDom.call(this);
     if (this.iconURI_) return;
     const category = categories.find((item) => item.id === this.id_);


### PR DESCRIPTION
### Changes

Updates editor dark mode and customizable block colors addons to change the colors of extension icons in the category menu. The affected icons are debugger, music, video sensing, and text to speech.