### PR TITLE
Fix last-edit-tooltip race condition

### DIFF
--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -2,7 +2,7 @@ export default async function ({ addon, global, console, msg }) {
   let { redux } = addon.tab;
 
   await redux.waitForState((state) => state.preview.status.project === "FETCHED", {
-    actions: ["SET_INFO"],
+    actions: ["SET_PROJECT_INFO"],
   });
 
   let data = redux.state.preview.projectInfo;


### PR DESCRIPTION
The last-edit-tooltip addon currently waits for a Redux action named `"SET_INFO"`, which doesn't exist. This means that it only works if the info has already been loaded when it runs.