### PR TITLE
Clarify some strings

### DIFF
--- a/addons/better-quoter/addon.json
+++ b/addons/better-quoter/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Better forum quoter",
-  "description": "Select text in a forum post and click quote in the bottom right corner to only quote the select text.",
+  "description": "Select text in a forum post and click quote in the bottom right corner to only quote the selected text.",
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/default-costume-editor-color/addon.json
+++ b/addons/default-costume-editor-color/addon.json
@@ -34,7 +34,7 @@
       "default": 4
     },
     {
-      "name": "Recall previous color instead of resetting after switching tools",
+      "name": "Use previous color instead of resetting after switching tools",
       "id": "persistence",
       "type": "boolean",
       "default": true

--- a/addons/default-costume-editor-color/addon.json
+++ b/addons/default-costume-editor-color/addon.json
@@ -34,7 +34,7 @@
       "default": 4
     },
     {
-      "name": "Use previous color instead of default when switching tools",
+      "name": "Recall previous color instead of resetting after switching tools",
       "id": "persistence",
       "type": "boolean",
       "default": true

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Colored context menus",
-  "description": "Makes block right click context menus colorful.",
+  "description": "Makes the background of block right click menus colorful.",
   "credits": [
     {
       "name": "GarboMuffin"

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Colored context menus",
-  "description": "Makes the background of block right click context menus colorful.",
+  "description": "Makes block right click context menus colorful.",
   "credits": [
     {
       "name": "GarboMuffin"

--- a/addons/editor-colored-context-menus/addon.json
+++ b/addons/editor-colored-context-menus/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Colored context menus",
-  "description": "Makes the background of block right click menus colorful.",
+  "description": "Makes the background of block right click context menus colorful.",
   "credits": [
     {
       "name": "GarboMuffin"

--- a/addons/move-to-top-bottom/addon.json
+++ b/addons/move-to-top-bottom/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Move costume to top or bottom",
-  "description": "Adds buttons to the right click context menu for costumes and sounds to move them to the top or the bottom of the list.",
+  "description": "Adds options to the right click context menu for costumes and sounds to move them to the top or the bottom of the list.",
   "info": [
     {
       "text": "This addon was previously part of the \"developer tools\" addon but has moved here.",

--- a/addons/move-to-top-bottom/addon.json
+++ b/addons/move-to-top-bottom/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Move costume to top or bottom",
-  "description": "Adds a right click context menu item to move a costume or a sound to the top or the bottom of the list.",
+  "description": "Adds buttons to the right click context menu for costumes and sounds to move them to the top or the bottom of the list.",
   "info": [
     {
       "text": "This addon was previously part of the \"developer tools\" addon but has moved here.",


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5074

### Changes

Changes the setting name "Use previous color instead of default when switching tools" → "Recall previous color instead of resetting after switching tools", plus a few other edits ranging from corrections to clarifications.

### Reason for changes

To make it clearer what that option does.

### Tests

No, but it should work - it's just text.
