### PR TITLE
Fix block-cherry-picking and block-duplicate race

### DIFF
--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -1,12 +1,12 @@
-import * as sharedModule from '../block-duplicate/module.js';
+import * as sharedModule from "../block-duplicate/module.js";
 
 export default async function ({ addon, global, console }) {
   const update = () => {
     sharedModule.setCherryPicking(!addon.self.disabled, addon.settings.get("invertDrag"));
   };
-  addon.self.addEventListener('disabled', update);
-  addon.self.addEventListener('reenabled', update);
-  addon.settings.addEventListener('change', update);
+  addon.self.addEventListener("disabled", update);
+  addon.self.addEventListener("reenabled", update);
+  addon.settings.addEventListener("change", update);
   update();
   sharedModule.load(addon);
 }

--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -1,40 +1,12 @@
+import * as sharedModule from '../block-duplicate/module.js';
+
 export default async function ({ addon, global, console }) {
-  const ScratchBlocks = await addon.tab.traps.getBlockly();
-
-  let ctrlKeyPressed = false;
-  document.addEventListener(
-    "mousedown",
-    function (e) {
-      ctrlKeyPressed = e.ctrlKey || e.metaKey;
-    },
-    {
-      capture: true,
-    }
-  );
-
-  // https://github.com/LLK/scratch-blocks/blob/912b8cc728bea8fd91af85078c64fcdbfe21c87a/core/gesture.js#L454
-  const originalStartDraggingBlock = ScratchBlocks.Gesture.prototype.startDraggingBlock_;
-  ScratchBlocks.Gesture.prototype.startDraggingBlock_ = function (...args) {
-    if (!addon.self.disabled) {
-      // Scratch uses fake mouse events to implement right click > duplicate
-      // This has no connection to the block-duplicate addon.
-      const isDuplicate = !(this.mostRecentEvent_ instanceof MouseEvent);
-      const block = this.targetBlock_;
-      const invert = addon.settings.get("invertDrag") && !isDuplicate && block.getParent();
-      const isShadow = block.isShadow();
-      if (ctrlKeyPressed === !invert && !isShadow) {
-        if (!ScratchBlocks.Events.getGroup()) {
-          ScratchBlocks.Events.setGroup(true);
-        }
-        if (isDuplicate) {
-          const nextBlock = block.getNextBlock();
-          if (nextBlock) {
-            nextBlock.dispose();
-          }
-        }
-        block.unplug(true);
-      }
-    }
-    return originalStartDraggingBlock.call(this, ...args);
+  const update = () => {
+    sharedModule.setCherryPicking(!addon.self.disabled, addon.settings.get("invertDrag"));
   };
+  addon.self.addEventListener('disabled', update);
+  addon.self.addEventListener('reenabled', update);
+  addon.settings.addEventListener('change', update);
+  update();
+  sharedModule.load(addon);
 }

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -66,10 +66,9 @@ export async function load(addon) {
     }
 
     if (isDuplicating) {
-      this.startWorkspace_.setResizesEnabled(false);
-
       // Based on https://github.com/LLK/scratch-blocks/blob/feda366947432b9d82a4f212f43ff6d4ab6f252f/core/scratch_blocks_utils.js#L171
       // Setting this.shouldDuplicateOnDrag_ = true does NOT work because it doesn't call changeObscuredShadowIds
+      this.startWorkspace_.setResizesEnabled(false);
       ScratchBlocks.Events.disable();
       let newBlock;
       try {

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -37,12 +37,10 @@ export async function load(addon) {
   // https://github.com/LLK/scratch-blocks/blob/912b8cc728bea8fd91af85078c64fcdbfe21c87a/core/gesture.js#L454
   const originalStartDraggingBlock = ScratchBlocks.Gesture.prototype.startDraggingBlock_;
   ScratchBlocks.Gesture.prototype.startDraggingBlock_ = function (...args) {
-    /** @type {MouseEvent} */
-    const event = this.mostRecentEvent_;
     let block = this.targetBlock_;
 
     // Scratch uses fake mouse events to implement right click > duplicate
-    const isRightClickDuplicate = !(event instanceof MouseEvent);
+    const isRightClickDuplicate = !(this.mostRecentEvent_ instanceof MouseEvent);
 
     const isDuplicating = (
       enableDuplication &&

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -56,7 +56,7 @@ export async function load(addon) {
       enableCherryPicking &&
       ctrlOrMetaPressed === !isCherryPickingInverted &&
       !block.isShadow()
-    );
+    ) || (isDuplicating && ctrlOrMetaPressed);
 
     if (isDuplicating) {
       this.startWorkspace_.setResizesEnabled(false);

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -58,6 +58,13 @@ export async function load(addon) {
       !block.isShadow()
     ) || (isDuplicating && ctrlOrMetaPressed);
 
+    if (isDuplicating || isCherryPicking) {
+      if (!ScratchBlocks.Events.getGroup()) {
+        // Scratch will disable grouping on its own later.
+        ScratchBlocks.Events.setGroup(true);
+      }
+    }
+
     if (isDuplicating) {
       this.startWorkspace_.setResizesEnabled(false);
 
@@ -86,10 +93,6 @@ export async function load(addon) {
     }
 
     if (isCherryPicking) {
-      if (!ScratchBlocks.Events.getGroup()) {
-        // Scratch will disable grouping on its own later.
-        ScratchBlocks.Events.setGroup(true);
-      }
       if (isRightClickDuplicate || isDuplicating) {
         const nextBlock = block.getNextBlock();
         if (nextBlock) {

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -1,0 +1,106 @@
+let enableCherryPicking = false;
+let invertCherryPicking = false;
+export function setCherryPicking(newEnabled, newInverted) {
+  enableCherryPicking = newEnabled;
+  invertCherryPicking = newInverted;
+}
+
+let enableDuplication = false;
+export function setDuplication(newEnabled) {
+  enableDuplication = newEnabled;
+}
+
+// mostRecentEvent_ is sometimes a fake event, so we can't rely on reading its properties.
+let ctrlOrMetaPressed = false;
+let altPressed = false;
+document.addEventListener(
+  "mousedown",
+  function (e) {
+    ctrlOrMetaPressed = e.ctrlKey || e.metaKey;
+    altPressed = e.altKey;
+  },
+  {
+    capture: true,
+  }
+);
+
+let loaded = false;
+
+export async function load(addon) {
+  if (loaded) {
+    return;
+  }
+  loaded = true;
+
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+
+  // https://github.com/LLK/scratch-blocks/blob/912b8cc728bea8fd91af85078c64fcdbfe21c87a/core/gesture.js#L454
+  const originalStartDraggingBlock = ScratchBlocks.Gesture.prototype.startDraggingBlock_;
+  ScratchBlocks.Gesture.prototype.startDraggingBlock_ = function (...args) {
+    /** @type {MouseEvent} */
+    const event = this.mostRecentEvent_;
+    let block = this.targetBlock_;
+
+    // Scratch uses fake mouse events to implement right click > duplicate
+    const isRightClickDuplicate = !(event instanceof MouseEvent);
+
+    const isDuplicating = (
+      enableDuplication &&
+      altPressed &&
+      !isRightClickDuplicate &&
+      !this.flyout_ &&
+      !this.shouldDuplicateOnDrag_ &&
+      this.targetBlock_.type !== "procedures_definition"
+    );
+
+    const isCherryPickingInverted = invertCherryPicking && !isRightClickDuplicate && block.getParent();
+    const isCherryPicking = (
+      enableCherryPicking &&
+      ctrlOrMetaPressed === !isCherryPickingInverted &&
+      !block.isShadow()
+    );
+
+    if (isDuplicating) {
+      this.startWorkspace_.setResizesEnabled(false);
+
+      // Based on https://github.com/LLK/scratch-blocks/blob/feda366947432b9d82a4f212f43ff6d4ab6f252f/core/scratch_blocks_utils.js#L171
+      // Setting this.shouldDuplicateOnDrag_ = true does NOT work because it doesn't call changeObscuredShadowIds
+      ScratchBlocks.Events.disable();
+      let newBlock;
+      try {
+        const xmlBlock = ScratchBlocks.Xml.blockToDom(block);
+        newBlock = ScratchBlocks.Xml.domToBlock(xmlBlock, this.startWorkspace_);
+        ScratchBlocks.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
+        const xy = block.getRelativeToSurfaceXY();
+        newBlock.moveBy(xy.x, xy.y);
+      } catch (e) {
+        console.error(e);
+      }
+      ScratchBlocks.Events.enable();
+
+      if (newBlock) {
+        block = newBlock;
+        this.targetBlock_ = newBlock;
+        if (ScratchBlocks.Events.isEnabled()) {
+          ScratchBlocks.Events.fire(new ScratchBlocks.Events.BlockCreate(newBlock));
+        }
+      }
+    }
+
+    if (isCherryPicking) {
+      if (!ScratchBlocks.Events.getGroup()) {
+        // Scratch will disable grouping on its own later.
+        ScratchBlocks.Events.setGroup(true);
+      }
+      if (isRightClickDuplicate || isDuplicating) {
+        const nextBlock = block.getNextBlock();
+        if (nextBlock) {
+          nextBlock.dispose();
+        }
+      }
+      block.unplug(true);
+    }
+
+    return originalStartDraggingBlock.call(this, ...args);
+  };
+}

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -52,11 +52,11 @@ export async function load(addon) {
     );
 
     const isCherryPickingInverted = invertCherryPicking && !isRightClickDuplicate && block.getParent();
-    const isCherryPicking = (
+    const isCherryPicking = isDuplicating ? ctrlOrMetaPressed : (
       enableCherryPicking &&
       ctrlOrMetaPressed === !isCherryPickingInverted &&
       !block.isShadow()
-    ) || (isDuplicating && ctrlOrMetaPressed);
+    );
 
     if (isDuplicating || isCherryPicking) {
       if (!ScratchBlocks.Events.getGroup()) {

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -42,21 +42,18 @@ export async function load(addon) {
     // Scratch uses fake mouse events to implement right click > duplicate
     const isRightClickDuplicate = !(this.mostRecentEvent_ instanceof MouseEvent);
 
-    const isDuplicating = (
+    const isDuplicating =
       enableDuplication &&
       altPressed &&
       !isRightClickDuplicate &&
       !this.flyout_ &&
       !this.shouldDuplicateOnDrag_ &&
-      this.targetBlock_.type !== "procedures_definition"
-    );
+      this.targetBlock_.type !== "procedures_definition";
 
     const isCherryPickingInverted = invertCherryPicking && !isRightClickDuplicate && block.getParent();
-    const isCherryPicking = isDuplicating ? ctrlOrMetaPressed : (
-      enableCherryPicking &&
-      ctrlOrMetaPressed === !isCherryPickingInverted &&
-      !block.isShadow()
-    );
+    const isCherryPicking = isDuplicating
+      ? ctrlOrMetaPressed
+      : enableCherryPicking && ctrlOrMetaPressed === !isCherryPickingInverted && !block.isShadow();
 
     if (isDuplicating || isCherryPicking) {
       if (!ScratchBlocks.Events.getGroup()) {

--- a/addons/block-duplicate/userscript.js
+++ b/addons/block-duplicate/userscript.js
@@ -1,47 +1,11 @@
+import * as sharedModule from './module.js';
+
 export default async function ({ addon, global, console }) {
-  const ScratchBlocks = await addon.tab.traps.getBlockly();
-  const originalStartDraggingBlock = ScratchBlocks.Gesture.prototype.startDraggingBlock_;
-  // https://github.com/LLK/scratch-blocks/blob/e86f115457006d1cde83baa23eaaf1ee16d315f5/core/gesture.js#L454
-  ScratchBlocks.Gesture.prototype.startDraggingBlock_ = function (...args) {
-    if (
-      !this.flyout_ &&
-      !this.shouldDuplicateOnDrag_ &&
-      this.targetBlock_.type !== "procedures_definition" &&
-      this.mostRecentEvent_.altKey &&
-      !addon.self.disabled
-    ) {
-      // Scratch will reset these when the drag ends
-      if (!ScratchBlocks.Events.getGroup()) {
-        ScratchBlocks.Events.setGroup(true);
-      }
-      this.startWorkspace_.setResizesEnabled(false);
-      // Based on https://github.com/LLK/scratch-blocks/blob/feda366947432b9d82a4f212f43ff6d4ab6f252f/core/scratch_blocks_utils.js#L171
-      // Setting this.shouldDuplicateOnDrag_ = true does NOT work because it doesn't call changeObscuredShadowIds
-      ScratchBlocks.Events.disable();
-      let newBlock;
-      try {
-        const xmlBlock = ScratchBlocks.Xml.blockToDom(this.targetBlock_);
-        newBlock = ScratchBlocks.Xml.domToBlock(xmlBlock, this.startWorkspace_);
-        ScratchBlocks.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
-        const xy = this.targetBlock_.getRelativeToSurfaceXY();
-        newBlock.moveBy(xy.x, xy.y);
-        if (this.mostRecentEvent_.ctrlKey || this.mostRecentEvent_.metaKey) {
-          const nextBlock = newBlock.getNextBlock();
-          if (nextBlock) {
-            nextBlock.dispose();
-          }
-        }
-      } catch (e) {
-        console.error(e);
-      }
-      ScratchBlocks.Events.enable();
-      if (newBlock) {
-        this.targetBlock_ = newBlock;
-        if (ScratchBlocks.Events.isEnabled()) {
-          ScratchBlocks.Events.fire(new ScratchBlocks.Events.BlockCreate(newBlock));
-        }
-      }
-    }
-    return originalStartDraggingBlock.call(this, ...args);
+  const update = () => {
+    sharedModule.setDuplication(!addon.self.disabled);
   };
+  addon.self.addEventListener('disabled', update);
+  addon.self.addEventListener('reenabled', update);
+  update();
+  sharedModule.load(addon);
 }

--- a/addons/block-duplicate/userscript.js
+++ b/addons/block-duplicate/userscript.js
@@ -1,11 +1,11 @@
-import * as sharedModule from './module.js';
+import * as sharedModule from "./module.js";
 
 export default async function ({ addon, global, console }) {
   const update = () => {
     sharedModule.setDuplication(!addon.self.disabled);
   };
-  addon.self.addEventListener('disabled', update);
-  addon.self.addEventListener('reenabled', update);
+  addon.self.addEventListener("disabled", update);
+  addon.self.addEventListener("reenabled", update);
   update();
   sharedModule.load(addon);
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/806602307750985799/1015981428472811520/1016169173514211421

> Has anyone noticed the Ctrl + Alt drag to duplicate a single block is bugged? It is currently leaving the original block detached from the script after duplicating
> https://cdn.discordapp.com/attachments/1015981428472811520/1015982258844356679/2022-09-04_14-50-06.mp4

The addons trapped the same method and would break if they ran in the wrong order (regression from https://github.com/ScratchAddons/ScratchAddons/pull/4682). They now use a shared module to ensure consistent order.