### PR TITLE
Make logo larger, stretch group divider to align with box

### DIFF
--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -19,6 +19,7 @@ body {
 #header {
   display: flex;
   height: 60px;
+  padding: 0 1rem;
 }
 #title-text,
 #settings {
@@ -29,15 +30,14 @@ body {
   flex-grow: 1;
   display: flex;
   align-items: center;
-  padding: 0 20px;
 }
 #logo {
   height: 30px;
-  margin-inline-end: 20px;
+  margin-inline-end: 0.75rem;
+  transform: scale(1.75);
   vertical-align: middle;
 }
 #settings {
-  padding: 0 20px;
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/webpages/settings/components/addon-group-header.html
+++ b/webpages/settings/components/addon-group-header.html
@@ -15,7 +15,6 @@
     align-items: center;
     cursor: pointer;
     margin: 0px 11px;
-    padding: 0px 10px;
   }
 
   .addon-group > img {
@@ -37,7 +36,6 @@
     border-top: 1px solid var(--content-separator);
     width: 100px;
     margin-inline-start: 20px;
-    margin-inline-end: 5px;
     flex: 1;
   }
 </style>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -122,7 +122,7 @@
       <div id="title">
         <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
         <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" />
-        <h1 v-cloak>{{ msg("settings") }}</h1>  
+        <h1 v-cloak>{{ msg("settings") }}</h1>
       </div>
       <img v-cloak @click="setTheme(!theme)" class="theme-switch" :src="themePath" />
     </div>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -119,9 +119,11 @@
   </head>
   <body v-cloak :class="{light: theme}">
     <div class="navbar">
-      <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
-      <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" />
-      <h1 v-cloak>{{ msg("settings") }}</h1>
+      <div id="title">
+        <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
+        <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" />
+        <h1 v-cloak>{{ msg("settings") }}</h1>  
+      </div>
       <img v-cloak @click="setTheme(!theme)" class="theme-switch" :src="themePath" />
     </div>
     <div class="main">

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -22,7 +22,7 @@ body {
   color: var(--white-text);
   display: flex;
   align-items: center;
-  padding: 0 14px;
+  padding: 0 1rem;
   box-shadow: var(--large-shadow);
   user-select: none;
   position: relative;
@@ -42,7 +42,13 @@ h1 {
 .logo {
   height: 30px;
   width: 30px;
-  margin-inline-end: 9px;
+  transform: scale(1.75);
+  margin-inline-end: .75rem;
+}
+#title {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
 }
 
 .main {
@@ -137,13 +143,7 @@ h1 {
 
 .theme-switch {
   height: 25px;
-  right: 25px;
-  position: fixed;
   cursor: pointer;
-}
-[dir="rtl"] .theme-switch {
-  right: auto;
-  left: 25px;
 }
 
 .hidden-button {
@@ -197,12 +197,6 @@ body.iframe .navbar {
 body.iframe .main {
   /* No calc -60px because there's no navbar */
   height: 100%;
-}
-body.iframe .addon-group {
-  padding-inline: 6px;
-}
-body.iframe .addon-group > img {
-  margin-inline-end: 5px;
 }
 body.iframe .addon-topbar {
   height: 44px;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -43,7 +43,7 @@ h1 {
   height: 30px;
   width: 30px;
   transform: scale(1.75);
-  margin-inline-end: .75rem;
+  margin-inline-end: 0.75rem;
 }
 #title {
   flex-grow: 1;

--- a/webpages/styles/components/smallmode.css
+++ b/webpages/styles/components/smallmode.css
@@ -15,6 +15,5 @@
   cursor: pointer;
   width: 24px;
   height: 24px;
-  margin-inline-start: 13px;
   margin-inline-end: 5px;
 }


### PR DESCRIPTION
Primarily, this PR does two things:
1. Make the logo larger to make it more prominent. The size is now as large as the website.
2. Stretch the addon group divider to align with the box and other items, not the inside contents. This is an old issue and I wanted to push this again.

The PR also does some small styling changes on other parts. (prefer flex, prefer rem, etc).

![Screen Shot 2022-09-13 at 13 43 38](https://user-images.githubusercontent.com/11584103/189829187-238cb674-e2dd-4b7f-bba1-339ddc09a597.png)
![Screen Shot 2022-09-13 at 12 52 11](https://user-images.githubusercontent.com/11584103/189829183-9a7a2d00-ebc5-40f7-8ae3-721537e3c097.png)
