### PR TITLE
scratch messaging: Ctrl + Enter to post message

### DIFF
--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -68,7 +68,12 @@
           </div>
         </bdo>
         <div class="reply-box-comment" v-show="replying">
-          <textarea class="reply-textarea" maxlength="500" v-model="replyBoxValue"></textarea>
+          <textarea
+            class="reply-textarea"
+            maxlength="500"
+            v-model="replyBoxValue"
+            @keyup.enter="postComment($event.shiftKey)"
+          ></textarea>
           <div class="reply-box-buttons">
             <button @click="postComment()" class="large-button post-button" :disabled="postingComment">
               {{ postingComment ? messages.postingMsg : messages.postMsg }}

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -72,7 +72,7 @@
             class="reply-textarea"
             maxlength="500"
             v-model="replyBoxValue"
-            @keyup.enter="postComment($event.ctrlKey || $event.metaKey)"
+            @keyup.enter="($event.ctrlKey || $event.metaKey) && postComment()"
           ></textarea>
           <div class="reply-box-buttons">
             <button @click="postComment()" class="large-button post-button" :disabled="postingComment">

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -72,7 +72,7 @@
             class="reply-textarea"
             maxlength="500"
             v-model="replyBoxValue"
-            @keyup.enter="postComment($event.shiftKey)"
+            @keyup.enter="postComment($event.ctrlKey || $event.metaKey)"
           ></textarea>
           <div class="reply-box-buttons">
             <button @click="postComment()" class="large-button post-button" :disabled="postingComment">

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -70,8 +70,7 @@ export default async ({ addon, msg, safeMsg }) => {
       };
     },
     methods: {
-      postComment(shouldPost = true) {
-        if (!shouldPost) return;
+      postComment() {
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js
           const regex = /scratch[ ]?add[ ]?ons/;

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -70,7 +70,7 @@ export default async ({ addon, msg, safeMsg }) => {
       };
     },
     methods: {
-      postComment(shouldPost) {
+      postComment(shouldPost = true) {
         if (!shouldPost) return;
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -70,7 +70,8 @@ export default async ({ addon, msg, safeMsg }) => {
       };
     },
     methods: {
-      postComment() {
+      postComment(shouldPost) {
+        if (!shouldPost) return;
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js
           const regex = /scratch[ ]?add[ ]?ons/;


### PR DESCRIPTION
Suggested by micahlt on discord
https://discord.com/channels/806602307750985799/1024110625070272613

> At the moment, you can use Ctrl+Enter to submit comments on users, studios, and projects without clicking the Post button.  I'd love to see the same feature in SA's Scratch Messaging addon that appears in the extension popup.
