### PR TITLE
Add dark comment migration

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -5,6 +5,7 @@ import minifySettings from "../libraries/common/minify-settings.js";
  the versions separately. Current versions:
 
  - editor-dark-mode 2 (bumped in v1.23 twice)
+ - editor-theme3 4 (last bumped in v1.29)
  */
 
 const updatePresetIfMatching = (settings, version, oldPreset = null, preset = null) => {
@@ -23,7 +24,12 @@ const updatePresetIfMatching = (settings, version, oldPreset = null, preset = nu
     if (preset === null) return;
     const map = {};
     for (const key of Object.keys(oldPreset)) {
-      if (settings[key] !== oldPreset[key]) return;
+      if (settings[key] !== oldPreset[key]) return console.log(settings, oldPreset, key);
+      map[key] = preset.values[key];
+    }
+
+    // For newly added keys
+    for (const key of Object.keys(preset.values).filter((k) => !Object.prototype.hasOwnProperty.call(oldPreset, k))) {
       map[key] = preset.values[key];
     }
     Object.assign(settings, map);
@@ -138,6 +144,58 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
         }
 
         if (addonId === "editor-dark-mode") updatePresetIfMatching(settings, 2);
+
+        if (addonId === "editor-theme3") {
+          madeAnyChanges = madeChangesToAddon = true;
+          updatePresetIfMatching(
+            settings,
+            1,
+            {
+              "motion-color": "#4a6cd4",
+              "looks-color": "#8a55d7",
+              "sounds-color": "#bb42c3",
+              "events-color": "#c88330",
+              "control-color": "#e1a91a",
+              "sensing-color": "#2ca5e2",
+              "operators-color": "#5cb712",
+              "data-color": "#ee7d16",
+              "data-lists-color": "#cc5b22",
+              "custom-color": "#632d99",
+              "Pen-color": "#0e9a6c",
+              "sa-color": "#29beb8",
+              "input-color": "#ffffff",
+              text: "white",
+            },
+            manifest.presets.find((p) => p.id === "original")
+          );
+          updatePresetIfMatching(
+            settings,
+            2,
+            {
+              "motion-color": "#004099",
+              "looks-color": "#220066",
+              "sounds-color": "#752475",
+              "events-color": "#997300",
+              "control-color": "#664100",
+              "sensing-color": "#1f5f7a",
+              "operators-color": "#235c23",
+              "data-color": "#b35900",
+              "data-lists-color": "#993300",
+              "custom-color": "#99004d",
+              "Pen-color": "#064734",
+              "sa-color": "#166966",
+              "input-color": "#202020",
+              text: "white",
+            },
+            manifest.presets.find((p) => p.id === "dark")
+          );
+
+          if (addonSettings["editor-dark-mode"]?.darkComments === false) {
+            // Transition v1.28 to v1.29
+            // Override the preset color if dark comments are not enabled
+            addonSettings["comment-color"] = "#FEF49C";
+          }
+        }
       }
 
       if (addonsEnabled[addonId] === undefined) addonsEnabled[addonId] = !!manifest.enabledByDefault;

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -110,7 +110,9 @@ let fuse;
       } else {
         addonsEnabled[addonId] = addonValue.enabled;
       }
-      addonSettings[addonId] = Object.assign({}, addonSettings[addonId], addonValue.settings);
+      addonSettings[addonId] = Object.assign({}, addonSettings[addonId]);
+      delete addonSettings[addonId]._version;
+      Object.assign(addonSettings[addonId], addonValue.settings);
     }
     if (handleConfirmClicked) confirmElem.removeEventListener("click", handleConfirmClicked, { once: true });
     let resolvePromise = null;


### PR DESCRIPTION
Adds migration code for #3862.

### Changes
- Add migration code for 3862. If dark comment is turned off, the vanilla color is always used. If dark comment is turned on, the default for the preset is used, if applicable. Use the attached JSONs for testing: [testcases.zip](https://github.com/ScratchAddons/ScratchAddons/files/9675771/testcases.zip)
- Fix bug with importing old, non-versioned settings files when the current version uses versioned settings - such as loading the testcase in this branch in current version. They previously skipped the preset transition code. (This does not affect things currently, because the only broken code, v1.23 editor-dark-mode transition code, was removed in 1.28.)

### Reason for changes
The now-merged pull request moved a setting between addons, which requires transition code.

### Tests
Tested on Firefox 105. Use the attached testcase to test easily.