### PR TITLE
Change setting name capitalization (my-ocular)

### DIFF
--- a/addons/my-ocular/addon.json
+++ b/addons/my-ocular/addon.json
@@ -68,11 +68,11 @@
       "potentialValues": [
         {
           "id": "everywhere",
-          "name": "everywhere"
+          "name": "Everywhere"
         },
         {
           "id": "others",
-          "name": "only on others' profiles"
+          "name": "Only on others' profiles"
         }
       ],
       "default": "everywhere"


### PR DESCRIPTION
PR #5089 broke the unwritten rule. Setting names, as well as possible values, use `Sentence case`.