### PR TITLE
New addon: Rename broadcasts

### DIFF
--- a/addons-l10n/en/rename-broadcasts.json
+++ b/addons-l10n/en/rename-broadcasts.json
@@ -1,0 +1,5 @@
+{
+  "rename-broadcasts/RENAME_BROADCAST": "Rename broadcast",
+  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" broadcasts to:",
+  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Broadcast"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -126,6 +126,7 @@
   "find-bar",
   "jump-to-def",
   "pick-colors-from-stage",
+  "rename-broadcasts",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -14,5 +14,7 @@
       "matches": ["projects"]
     }
   ],
-  "versionAdded": "1.29.0"
+  "versionAdded": "1.29.0",
+  "dynamicEnable": true,
+  "dynamicDisable": true
 }

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -7,7 +7,7 @@
       "link": "https://scratch.mit.edu/users/TheColaber"
     }
   ],
-  "tags": ["editor"],
+  "tags": ["editor", "featured"],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Rename broadcasts",
-  "description": "Adds an option to rename broadcasts in the broadcast blocks' dropdown.",
+  "description": "Adds an option to rename broadcasts in the broadcast blocks' dropdowns.",
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -13,5 +13,6 @@
       "url": "userscript.js",
       "matches": ["projects"]
     }
-  ]
+  ],
+  "versionAdded": "1.29.0"
 }

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -1,0 +1,17 @@
+{
+  "name": "Rename broadcasts",
+  "description": "Adds an option to rename broadcasts in the broadcast blocks' dropdown.",
+  "credits": [
+    {
+      "name": "TheColaber",
+      "link": "https://scratch.mit.edu/users/TheColaber"
+    }
+  ],
+  "tags": ["editor"],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ]
+}

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -1,0 +1,62 @@
+export default async function ({ addon, msg, global, console }) {
+  const Blockly = await addon.tab.traps.getBlockly();
+
+  Blockly.RENAME_BROADCAST_MESSAGE_ID = "RENAME_BROADCAST_MESSAGE_ID";
+
+  const _dropdownCreate = Blockly.FieldVariable.dropdownCreate;
+  Blockly.FieldVariable.dropdownCreate = function () {
+    const options = _dropdownCreate.call(this);
+    console.log(options);
+    if (this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+      options.push([msg("RENAME_BROADCAST"), Blockly.RENAME_BROADCAST_MESSAGE_ID]);
+    }
+    return options;
+  };
+
+  const _onItemSelected = Blockly.FieldVariable.prototype.onItemSelected;
+  Blockly.FieldVariable.prototype.onItemSelected = function (menu, menuItem) {
+    var workspace = this.sourceBlock_.workspace;
+    if (this.sourceBlock_ && workspace) {
+      if (menuItem.getValue() === Blockly.RENAME_BROADCAST_MESSAGE_ID) {
+        Blockly.Variables.renameVariable(workspace, this.variable_);
+        return;
+      }
+    }
+    _onItemSelected.call(this, menu, menuItem);
+  };
+
+  const _renameVariable = Blockly.Variables.renameVariable;
+  Blockly.Variables.renameVariable = function (workspace, variable, opt_callback) {
+    console.log(variable);
+    const varType = variable.type;
+    if (varType === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+      const modalTitle = msg("RENAME_BROADCAST_MODAL_TITLE");
+      const validate = Blockly.Variables.nameValidator_.bind(null, varType);
+      const promptText = msg("RENAME_BROADCAST_TITLE", { name: variable.name });
+      const promptDefaultText = variable.name;
+
+      Blockly.prompt(
+        promptText,
+        promptDefaultText,
+        function (newName) {
+          var validatedText = validate(newName, workspace);
+          if (validatedText) {
+            workspace.renameVariableById(variable.getId(), validatedText);
+            if (opt_callback) {
+              opt_callback(newName);
+            }
+          } else {
+            // User canceled prompt without a value.
+            if (opt_callback) {
+              opt_callback(null);
+            }
+          }
+        },
+        modalTitle,
+        varType
+      );
+      return;
+    }
+    _renameVariable.call(this, workspace, variable, opt_callback);
+  };
+}

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, msg, global, console }) {
+export default async function ({ addon, msg }) {
   const Blockly = await addon.tab.traps.getBlockly();
 
   Blockly.RENAME_BROADCAST_MESSAGE_ID = "RENAME_BROADCAST_MESSAGE_ID";
@@ -6,7 +6,7 @@ export default async function ({ addon, msg, global, console }) {
   const _dropdownCreate = Blockly.FieldVariable.dropdownCreate;
   Blockly.FieldVariable.dropdownCreate = function () {
     const options = _dropdownCreate.call(this);
-    if (!addon.self.disabled && this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+    if (!addon.self.disabled && this.defaultType_ === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
       options.push([msg("RENAME_BROADCAST"), Blockly.RENAME_BROADCAST_MESSAGE_ID]);
     }
     return options;

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -6,7 +6,12 @@ export default async function ({ addon, msg }) {
   const _dropdownCreate = Blockly.FieldVariable.dropdownCreate;
   Blockly.FieldVariable.dropdownCreate = function () {
     const options = _dropdownCreate.call(this);
-    if (!addon.self.disabled && this.defaultType_ === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+    if (
+      !addon.self.disabled &&
+      this.defaultType_ === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE &&
+      this.sourceBlock_.workspace.getVariableTypes().includes("broadcast_msg")
+    ) {
+      // Disabled when workspace has no actual broadcast to rename
       options.push([msg("RENAME_BROADCAST"), Blockly.RENAME_BROADCAST_MESSAGE_ID]);
     }
     return options;

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -6,8 +6,7 @@ export default async function ({ addon, msg, global, console }) {
   const _dropdownCreate = Blockly.FieldVariable.dropdownCreate;
   Blockly.FieldVariable.dropdownCreate = function () {
     const options = _dropdownCreate.call(this);
-    console.log(options);
-    if (this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
+    if (!addon.self.disabled && this.defaultType_ == Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
       options.push([msg("RENAME_BROADCAST"), Blockly.RENAME_BROADCAST_MESSAGE_ID]);
     }
     return options;
@@ -27,7 +26,6 @@ export default async function ({ addon, msg, global, console }) {
 
   const _renameVariable = Blockly.Variables.renameVariable;
   Blockly.Variables.renameVariable = function (workspace, variable, opt_callback) {
-    console.log(variable);
     const varType = variable.type;
     if (varType === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE) {
       const modalTitle = msg("RENAME_BROADCAST_MODAL_TITLE");
@@ -59,4 +57,18 @@ export default async function ({ addon, msg, global, console }) {
     }
     _renameVariable.call(this, workspace, variable, opt_callback);
   };
+
+  if (addon.self.enabledLate) {
+    const workspace = Blockly.getMainWorkspace();
+    const blocks = workspace.getAllBlocks();
+    for (const block of blocks) {
+      for (const input of block.inputList) {
+        for (const field of input.fieldRow) {
+          if (field instanceof Blockly.FieldVariable) {
+            field.menuGenerator_ = Blockly.FieldVariable.dropdownCreate;
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Requested in the discord server https://discord.com/channels/806602307750985799/1024221040961929266

![image](https://user-images.githubusercontent.com/72760579/194785065-af0f6820-f8a2-441c-83d1-d8183d30c6e7.png)

Currently, you can rename by clicking on the dropdown and choosing "Rename broadcast" which will open a model. This addon is consistent with scratch's method to rename variables. I did not create the option to rename the broadcast by right-clicking on the block to stay consistent.