### PR TITLE
[GitHub meta] Change CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
 /.github/ @Hans5958
+/addons/addons.json @WorldLanguages  # New addons
+/addon-api @WorldLanguages @apple502j
+/background @WorldLanguages @apple502j
+/content-scripts @WorldLanguages @apple502j
+/libraries @WorldLanguages @apple502j
+manifest.json @WorldLanguages @apple502j

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @Hans5958

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-*       @WorldLanguages
-/addons/ @WorldLanguages
-/.github/ @Hans5958
-/addons-l10n/ @apple502j
-/_locales/ @apple502j
-/addon-api/ @WorldLanguages


### PR DESCRIPTION
Since we allow any org member to merge PRs after 2 approvals, the current CODEOWNERS file makes little sense.

@Hans5958 Do you want to keep your entry, what do you think?

Does any org member want CODEOWNER of a specific folder/addon? It's a good moment to add it
Personally, I'd like to self-request review when appropiate, instead of getting it automatically in every single PR.