### PR TITLE
Change preset loading confirmation message to say that settings will be overwritten

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -66,7 +66,7 @@
     "message": "For website"
   },
   "confirmPreset": {
-    "message": "Load this preset and overwrite current settings?"
+    "message": "Load this preset and overwrite this addon's current settings?"
   },
   "confirmReset": {
     "message": "Are you sure you want to reset this addon to default settings?"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -66,7 +66,7 @@
     "message": "For website"
   },
   "confirmPreset": {
-    "message": "Are you sure you want to load this preset?"
+    "message": "Load this preset and overwrite current settings?"
   },
   "confirmReset": {
     "message": "Are you sure you want to reset this addon to default settings?"


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves no open issues.

### Changes

Are you sure you want to load this preset? → Load this preset and overwrite current settings?

### Reason for changes

Someone may not realize that loading a preset is going to permanently overwrite their custom settings.

### Tests

Shouldn't need a test.