### PR TITLE
turbowarp-player: enable settings button

### DIFF
--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -39,6 +39,7 @@ export default async function ({ addon, console, msg }) {
       if (playerToggled) {
         const username = await addon.auth.fetchUsername();
         const usp = new URLSearchParams();
+        usp.set("settings-button", "1");
         if (username) usp.set("username", username);
         const projectId = window.location.pathname.split("/")[2];
         if (addon.settings.get("addons")) {


### PR DESCRIPTION
Always enable the settings button when using turbowarp-player in replace mode. Lets people enable things like high quality pen if they want to. For people who don't want to use those features, they can simply not click on the button.

This directly or indirectly addresses:

 - https://github.com/ScratchAddons/ScratchAddons/discussions/5213
 - https://github.com/ScratchAddons/ScratchAddons/issues/4005
 - #1439 

but does not necessarily resolve them

There are other PRs that touch this addon but they are stalled. This is a small one-line change to implement a feature that people want.