### PR TITLE
Fix a lot of issues in rename-broadcast

### DIFF
--- a/addons-l10n/en/rename-broadcasts.json
+++ b/addons-l10n/en/rename-broadcasts.json
@@ -1,5 +1,5 @@
 {
-  "rename-broadcasts/RENAME_BROADCAST": "Rename message",
-  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" messages to:",
-  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Message"
+  "rename-broadcasts/RENAME_BROADCAST": "Rename broadcast",
+  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" broadcasts to:",
+  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Broadcast"
 }

--- a/addons-l10n/en/rename-broadcasts.json
+++ b/addons-l10n/en/rename-broadcasts.json
@@ -1,5 +1,5 @@
 {
-  "rename-broadcasts/RENAME_BROADCAST": "Rename broadcast",
-  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" broadcasts to:",
-  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Broadcast"
+  "rename-broadcasts/RENAME_BROADCAST": "Rename message",
+  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" messages to:",
+  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Message"
 }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -7,7 +7,7 @@ export default async function ({ addon, global, console, msg }) {
     "DELETE_VARIABLE_ID",
     "NEW_BROADCAST_MESSAGE_ID",
     // From rename-broadcasts addon
-    "RENAME_BROADCAST_MESSAGE_ID"
+    "RENAME_BROADCAST_MESSAGE_ID",
   ];
 
   const ADDON_ITEMS = [

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -2,7 +2,14 @@ export default async function ({ addon, global, console, msg }) {
   const Blockly = await addon.tab.traps.getBlockly();
   const vm = addon.tab.traps.vm;
 
-  const SCRATCH_ITEMS_TO_HIDE = ["RENAME_VARIABLE_ID", "DELETE_VARIABLE_ID", "NEW_BROADCAST_MESSAGE_ID"];
+  const SCRATCH_ITEMS_TO_HIDE = [
+    "RENAME_VARIABLE_ID",
+    "DELETE_VARIABLE_ID",
+    "NEW_BROADCAST_MESSAGE_ID",
+    // From rename-broadcasts addon
+    "RENAME_BROADCAST_MESSAGE_ID"
+  ];
+
   const ADDON_ITEMS = [
     "createGlobalVariable",
     "createLocalVariable",

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -5,6 +5,9 @@
     {
       "name": "TheColaber",
       "link": "https://scratch.mit.edu/users/TheColaber"
+    },
+    {
+      "name": "GarboMuffin"
     }
   ],
   "tags": ["editor", "featured"],

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -112,17 +112,22 @@ export default async function ({ addon, msg, console }) {
     );
   };
 
-  if (addon.self.enabledLate) {
+  const updateExistingMenuGenerators = () => {
     const workspace = Blockly.getMainWorkspace();
-    const blocks = workspace.getAllBlocks();
-    for (const block of blocks) {
-      for (const input of block.inputList) {
-        for (const field of input.fieldRow) {
-          if (field instanceof Blockly.FieldVariable) {
-            field.menuGenerator_ = Blockly.FieldVariable.dropdownCreate;
+    const flyout = workspace && workspace.getFlyout();
+    if (workspace && flyout) {
+      const allBlocks = [...workspace.getAllBlocks(), ...flyout.getWorkspace().getAllBlocks()];
+      for (const block of allBlocks) {
+        for (const input of block.inputList) {
+          for (const field of input.fieldRow) {
+            if (field instanceof Blockly.FieldVariable) {
+              field.menuGenerator_ = Blockly.FieldVariable.dropdownCreate;
+            }
           }
         }
       }
     }
-  }
+  };
+
+  updateExistingMenuGenerators();
 }

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -99,7 +99,7 @@ export default async function ({ addon, msg, console }) {
     for (const block of workspace.getAllBlocks()) {
       for (const input of block.inputList) {
         for (const field of input.fieldRow) {
-          if (field.name === "BROADCAST_OPTION") {
+          if (field.name === "BROADCAST_OPTION" && field.getValue() === oldId) {
             field.setValue(newId);
           }
         }

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -10,9 +10,9 @@ export default async function ({ addon, msg }) {
     if (
       !addon.self.disabled &&
       this.defaultType_ === Blockly.BROADCAST_MESSAGE_VARIABLE_TYPE &&
+      // Disable when workspace has no actual broadcast to rename
       this.sourceBlock_.workspace.getVariableTypes().includes("broadcast_msg")
     ) {
-      // Disabled when workspace has no actual broadcast to rename
       options.push([msg("RENAME_BROADCAST"), RENAME_BROADCAST_MESSAGE_ID]);
     }
     return options;
@@ -43,7 +43,7 @@ export default async function ({ addon, msg }) {
         promptText,
         promptDefaultText,
         function (newName) {
-          var validatedText = validate(newName, workspace);
+          const validatedText = validate(newName, workspace);
           if (validatedText) {
             workspace.renameVariableById(variable.getId(), validatedText);
             if (opt_callback) {

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -74,13 +74,12 @@ export default async function ({ addon, msg, console }) {
   };
 
   const renameBroadcast = (workspace, id, oldName, newName) => {
-    // Rename it in the editor
+    // Rename in editor. Undo/redo will work automatically.
     workspace.renameVariableById(id, newName);
 
-    // Rename it in the VM
+    // Rename in VM. Need to manually implement undo/redo.
     renameBroadcastInVM(id, newName);
 
-    // Undo/redo will automatically update the editor, but VM still needs to be updated
     addUndoRedoHook((isRedo) => {
       if (isRedo) {
         renameBroadcastInVM(id, newName);
@@ -108,7 +107,8 @@ export default async function ({ addon, msg, console }) {
     Blockly.Events.setGroup(false);
 
     // Merge in VM to update sprites that aren't open. Need to implement manual undo/redo.
-    // To figure out how to undo this operation, we track which blocks we must touch.
+    // To figure out how to undo this operation, we first figure out which blocks we're
+    // going to touch and keep hold of that list.
     const vmBlocksToUpdate = [];
     const blockContainers = new Set(vm.runtime.targets.map((i) => i.blocks));
     for (const blockContainer of blockContainers) {

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -60,7 +60,7 @@ export default async function ({ addon, msg, console }) {
 
     // Update all references to the broadcast. Broadcasts won't work if these
     // don't match.
-    const blockContainers = new Set(vm.runtime.targets.map(i => i.blocks));
+    const blockContainers = new Set(vm.runtime.targets.map((i) => i.blocks));
     for (const blockContainer of blockContainers) {
       for (const block of Object.values(blockContainer._blocks)) {
         const broadcastOption = block.fields && block.fields.BROADCAST_OPTION;
@@ -99,7 +99,7 @@ export default async function ({ addon, msg, console }) {
     for (const block of workspace.getAllBlocks()) {
       for (const input of block.inputList) {
         for (const field of input.fieldRow) {
-          if (field.name === 'BROADCAST_OPTION') {
+          if (field.name === "BROADCAST_OPTION") {
             field.setValue(newId);
           }
         }
@@ -110,7 +110,7 @@ export default async function ({ addon, msg, console }) {
     // Merge in VM to update sprites that aren't open. Need to implement manual undo/redo.
     // To figure out how to undo this operation, we track which blocks we must touch.
     const vmBlocksToUpdate = [];
-    const blockContainers = new Set(vm.runtime.targets.map(i => i.blocks));
+    const blockContainers = new Set(vm.runtime.targets.map((i) => i.blocks));
     for (const blockContainer of blockContainers) {
       for (const block of Object.values(blockContainer._blocks)) {
         const broadcastOption = block.fields && block.fields.BROADCAST_OPTION;

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -35,7 +35,9 @@ export default async function ({ addon, msg, console }) {
 
   const addUndoRedoHook = (callback) => {
     const eventQueue = Blockly.Events.FIRE_QUEUE_;
-    const undoItem = eventQueue[eventQueue.length - 1];
+    // After a rename is emitted, some unrelated garbage events also get emitted
+    // So we should trap the first event
+    const undoItem = eventQueue[0];
     const originalRun = undoItem.run;
     undoItem.run = function (isRedo) {
       originalRun.call(this, isRedo);

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -1,7 +1,8 @@
 export default async function ({ addon, msg }) {
   const Blockly = await addon.tab.traps.getBlockly();
 
-  Blockly.RENAME_BROADCAST_MESSAGE_ID = "RENAME_BROADCAST_MESSAGE_ID";
+  // editor-searchable-dropdowns relies on this value
+  const RENAME_BROADCAST_MESSAGE_ID = "RENAME_BROADCAST_MESSAGE_ID";
 
   const _dropdownCreate = Blockly.FieldVariable.dropdownCreate;
   Blockly.FieldVariable.dropdownCreate = function () {
@@ -12,7 +13,7 @@ export default async function ({ addon, msg }) {
       this.sourceBlock_.workspace.getVariableTypes().includes("broadcast_msg")
     ) {
       // Disabled when workspace has no actual broadcast to rename
-      options.push([msg("RENAME_BROADCAST"), Blockly.RENAME_BROADCAST_MESSAGE_ID]);
+      options.push([msg("RENAME_BROADCAST"), RENAME_BROADCAST_MESSAGE_ID]);
     }
     return options;
   };
@@ -21,7 +22,7 @@ export default async function ({ addon, msg }) {
   Blockly.FieldVariable.prototype.onItemSelected = function (menu, menuItem) {
     const workspace = this.sourceBlock_.workspace;
     if (this.sourceBlock_ && workspace) {
-      if (menuItem.getValue() === Blockly.RENAME_BROADCAST_MESSAGE_ID) {
+      if (menuItem.getValue() === RENAME_BROADCAST_MESSAGE_ID) {
         Blockly.Variables.renameVariable(workspace, this.variable_);
         return;
       }

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -19,14 +19,14 @@ export default async function ({ addon, msg }) {
 
   const _onItemSelected = Blockly.FieldVariable.prototype.onItemSelected;
   Blockly.FieldVariable.prototype.onItemSelected = function (menu, menuItem) {
-    var workspace = this.sourceBlock_.workspace;
+    const workspace = this.sourceBlock_.workspace;
     if (this.sourceBlock_ && workspace) {
       if (menuItem.getValue() === Blockly.RENAME_BROADCAST_MESSAGE_ID) {
         Blockly.Variables.renameVariable(workspace, this.variable_);
         return;
       }
     }
-    _onItemSelected.call(this, menu, menuItem);
+    return _onItemSelected.call(this, menu, menuItem);
   };
 
   const _renameVariable = Blockly.Variables.renameVariable;
@@ -60,7 +60,7 @@ export default async function ({ addon, msg }) {
       );
       return;
     }
-    _renameVariable.call(this, workspace, variable, opt_callback);
+    return _renameVariable.call(this, workspace, variable, opt_callback);
   };
 
   if (addon.self.enabledLate) {

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -94,6 +94,7 @@ export default async function ({ addon, msg, console }) {
     const newId = newVmVariable.id;
 
     // Merge in editor. Undo/redo will work automatically for this.
+    // Use group so that everything here is undone/redone at the same time.
     Blockly.Events.setGroup(true);
     for (const block of workspace.getAllBlocks()) {
       for (const input of block.inputList) {
@@ -104,9 +105,12 @@ export default async function ({ addon, msg, console }) {
         }
       }
     }
+    // Remove the broadcast from the editor so it doesn't appear in dropdowns.
+    // Undo/redo will work automatically for this.
+    workspace.deleteVariableById(oldId);
     Blockly.Events.setGroup(false);
 
-    // Merge in VM to update sprites that aren't open. Need to implement manual undo/redo.
+    // Merge in VM to update sprites that aren't open. Need to manually implement undo/redo.
     // To figure out how to undo this operation, we first figure out which blocks we're
     // going to touch and keep hold of that list.
     const vmBlocksToUpdate = [];


### PR DESCRIPTION
 - The addon actually works now
 - Undo/redo works
 - When a broadcast with the new name already exists, the old broadcast is "merged" into the new one instead of silently doing nothing
 - ~~I changed some strings to use the same words that Scratch itself uses. If it's too late for string updates then just revert 8424f49696072bcaadbcf4bf55d5d8a059f41a76 before merging.~~ ~~Still think this change is correct but it seems to be too late for string updates~~ moved to https://github.com/ScratchAddons/ScratchAddons/pull/5231
 - editor-searchable-dropdowns now treats the rename message option the same as it does the rename variable option (hide during search)

I've been able to open up Appel and rename broadcasts while the project is running without issues, and those new names are saved when the project is saved and loaded again

This is a draft because it needs more actual testing.
