### PR TITLE
`editor-devtools`: import `compatibility.css` from `editor-theme3`

### DIFF
--- a/addons/editor-devtools/userscript.css
+++ b/addons/editor-devtools/userscript.css
@@ -1,3 +1,5 @@
+@import url("../editor-theme3/compatibility.css");
+
 .s3devLabel {
   display: flex;
   width: 100%;


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5228

### Changes

<!-- Please describe the changes you've made. -->
Imports `compatibility.css` from `editor-theme3` to allow blocks in the Shift+Click popup to have colored backgrounds regardless of whether or not other addons using this stylesheet are enabled.

### Reason for changes

<!-- Why should these changes be made? -->
Regression caused by https://github.com/ScratchAddons/ScratchAddons/pull/4817

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested to work in browsers with Chromium 106.