### PR TITLE
rename-broadcasts: Update some strings

### DIFF
--- a/addons-l10n/en/rename-broadcasts.json
+++ b/addons-l10n/en/rename-broadcasts.json
@@ -1,5 +1,5 @@
 {
-  "rename-broadcasts/RENAME_BROADCAST": "Rename broadcast",
-  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" broadcasts to:",
-  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Broadcast"
+  "rename-broadcasts/RENAME_BROADCAST": "Rename message",
+  "rename-broadcasts/RENAME_BROADCAST_TITLE": "Rename all \"{name}\" messages to:",
+  "rename-broadcasts/RENAME_BROADCAST_MODAL_TITLE": "Rename Message"
 }

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Rename broadcasts",
-  "description": "Adds an option to rename broadcasts in the broadcast blocks' dropdowns.",
+  "description": "Adds an option to rename broadcast messages in the broadcast blocks' dropdowns.",
   "credits": [
     {
       "name": "TheColaber",


### PR DESCRIPTION
Extracted from https://github.com/ScratchAddons/ScratchAddons/pull/5215

Scratch uses strings like "New Message" or "New message name:", so the addon should too

Maybe the addon's name should also be changed. I have no particularly strong feelings on that.

Took this out to a separate one because I don't know what the plan is for merging these this close to release