### PR TITLE
Auto snip images

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -130,7 +130,7 @@
   "pick-colors-from-stage",
   "rename-broadcasts",
   "auto-snip-images",
-  
+
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",
   "// because the first in the list gets their CSS injected first,",

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -129,7 +129,8 @@
   "vol-slider",
   "pick-colors-from-stage",
   "rename-broadcasts",
-
+  "auto-snip-images",
+  
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",
   "// because the first in the list gets their CSS injected first,",

--- a/addons/auto-snip-images/addon.json
+++ b/addons/auto-snip-images/addon.json
@@ -10,9 +10,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": [
-        "https://scratch.mit.edu/discuss/topic/*"
-      ]
+      "matches": ["https://scratch.mit.edu/discuss/topic/*"]
     }
   ],
   "versionAdded": "1.29.0",
@@ -26,8 +24,5 @@
       "default": false
     }
   ],
-  "tags": [
-    "forums",
-    "community"
-  ]
+  "tags": ["forums", "community"]
 }

--- a/addons/auto-snip-images/addon.json
+++ b/addons/auto-snip-images/addon.json
@@ -1,0 +1,33 @@
+{
+  "name": "Auto snip images in forums",
+  "description": "Auto snip images in forums",
+  "credits": [
+    {
+      "name": "Chiroyce",
+      "link": "https://github.com/Chiroyce1"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": [
+        "https://scratch.mit.edu/discuss/topic/*"
+      ]
+    }
+  ],
+  "versionAdded": "1.29.0",
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "settings": [
+    {
+      "name": "Snip all images (even ones outside a quote)",
+      "id": "allPosts",
+      "type": "boolean",
+      "default": false
+    }
+  ],
+  "tags": [
+    "forums",
+    "community"
+  ]
+}

--- a/addons/auto-snip-images/userscript.js
+++ b/addons/auto-snip-images/userscript.js
@@ -1,8 +1,7 @@
 export default async function ({ addon }) {
   const query = addon.settings.get("allPosts") == true ? ".post_body_html > img, blockquote > img" : "blockquote > img";
 
-  document.querySelectorAll(query).forEach(image => {
-
+  document.querySelectorAll(query).forEach((image) => {
     let details = document.createElement("details");
     let summary = document.createElement("summary");
     let newImage = document.createElement("img");
@@ -17,5 +16,5 @@ export default async function ({ addon }) {
     summary.style.fontStyle = "italic";
     details.style.cursor = "pointer";
     details.style.userSelect = "none";
-  })
+  });
 }

--- a/addons/auto-snip-images/userscript.js
+++ b/addons/auto-snip-images/userscript.js
@@ -1,0 +1,21 @@
+export default async function ({ addon }) {
+  const query = addon.settings.get("allPosts") == true ? ".post_body_html > img, blockquote > img" : "blockquote > img";
+
+  document.querySelectorAll(query).forEach(image => {
+
+    let details = document.createElement("details");
+    let summary = document.createElement("summary");
+    let newImage = document.createElement("img");
+
+    newImage.src = image.src;
+    details.appendChild(summary);
+    details.appendChild(newImage);
+    summary.innerText = "Expand image";
+    image.parentElement.insertBefore(details, image);
+    image.remove();
+
+    summary.style.fontStyle = "italic";
+    details.style.cursor = "pointer";
+    details.style.userSelect = "none";
+  })
+}


### PR DESCRIPTION
Resolves #5095 

### Changes

Creates a new addon called `auto-snip-images` to resolve issue, but this still doesn't implement the part where it also works for non SA users (when someone quotes a post that contains images, convert them to links)

### Tests

Tested on a separate Firefox profile, works 👌

### Considerations before merging
- The images flash for a split second, in between the page load and the addon run, so if there was a way to prevent that, it would be nice.
- Improve addon name/description (since I'm bad at that)
