### PR TITLE
`hide-flyout` animation speed changes

### DIFF
--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -86,17 +86,17 @@
       "default": "cathover"
     },
     {
-      "name": "Animation duration",
+      "name": "Animation speed",
       "id": "speed",
       "type": "select",
       "potentialValues": [
         {
           "id": "none",
-          "name": "None"
+          "name": "Instant"
         },
         {
           "id": "short",
-          "name": "Short"
+          "name": "Quick"
         },
         {
           "id": "default",
@@ -104,7 +104,7 @@
         },
         {
           "id": "long",
-          "name": "Long"
+          "name": "Slow"
         }
       ],
       "default": "default"

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -17,9 +17,9 @@ export default async function ({ addon, global, console, msg }) {
   function getSpeedValue() {
     let data = {
       none: "0",
-      short: "0.19",
-      default: "0.31",
-      long: "0.46",
+      short: "0.2",
+      default: "0.3",
+      long: "0.5",
     };
     return data[addon.settings.get("speed")];
   }

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -92,7 +92,7 @@ export default async function ({ addon, global, console, msg }) {
     addon.tab.redux.addEventListener("statechanged", (e) => {
       switch (e.detail.action.type) {
         // Event casted when you switch between tabs
-        case "scratch-gui/navigation/ACTIVATE_TAB":
+        case "scratch-gui/navigation/ACTIVATE_TAB": {
           // always 0, 1, 2
           const toggleSetting = getToggleSetting();
           if (

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -17,9 +17,9 @@ export default async function ({ addon, global, console, msg }) {
   function getSpeedValue() {
     let data = {
       none: "0",
-      short: "0.25",
-      default: "0.5",
-      long: "1",
+      short: "0.19",
+      default: "0.31",
+      long: "0.46",
     };
     return data[addon.settings.get("speed")];
   }
@@ -92,7 +92,7 @@ export default async function ({ addon, global, console, msg }) {
     addon.tab.redux.addEventListener("statechanged", (e) => {
       switch (e.detail.action.type) {
         // Event casted when you switch between tabs
-        case "scratch-gui/navigation/ACTIVATE_TAB": {
+        case "scratch-gui/navigation/ACTIVATE_TAB":
           // always 0, 1, 2
           const toggleSetting = getToggleSetting();
           if (
@@ -104,7 +104,6 @@ export default async function ({ addon, global, console, msg }) {
             toggle = false;
           }
           break;
-        }
       }
     });
 

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -104,6 +104,7 @@ export default async function ({ addon, global, console, msg }) {
             toggle = false;
           }
           break;
+        }
       }
     });
 


### PR DESCRIPTION
Resolves no open issues.

### Changes

- I changed the setting title from "Animation duration" to "Animation speed".
- I changed the option names from _None/Short/Default/Long_ to _Instant/Quick/Default/Slow_.
- I made each setting faster.

### Reason for changes

1. The Long setting was honestly _too_ slow.
2. Even on the Short setting, it still felt a little slower than I'd like.

### Tests

Changes tested in Edge 106. No problems found.