### PR TITLE
Use local language RelativeTimeFormat in scratch-messaging

### DIFF
--- a/background/handle-l10n.js
+++ b/background/handle-l10n.js
@@ -6,7 +6,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     return sendResponse(
       Object.fromEntries(
         Object.keys(scratchAddons.l10n.messages)
-          .filter((value) => value.startsWith(`${request.l10nAddonId}/`))
+          .filter((value) => value.startsWith(`${request.l10nAddonId}/`) || value.startsWith(`_`))
           .map((value) => [value, scratchAddons.l10n.messages[value]])
       )
     );

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -200,7 +200,7 @@ export default async ({ addon, msg, safeMsg }) => {
         return vue.username;
       },
       commentTimeAgo() {
-        const timeFormatter = new Intl.RelativeTimeFormat("en", {
+        const timeFormatter = new Intl.RelativeTimeFormat(msg.locale, {
           localeMatcher: "best fit",
           numeric: "auto",
           style: "short",


### PR DESCRIPTION
Resolves bug reported by a translator.

> why are there no translations for these strings?

![image](https://user-images.githubusercontent.com/17484114/197422122-c0bccd73-0913-4491-9e16-2dad5c2b207f.png)


TODOs:

- [x] Fix `scratchAddons.l10n.locale` always returning `"en"` in popup context
- [x] Consider how the new "show addon names and descriptions in English" setting (#5202) should behave here, and in popups in general (edit: see comment https://github.com/ScratchAddons/ScratchAddons/pull/5202#issuecomment-1382453521)