### PR TITLE
Fix opacity slider bugs

### DIFF
--- a/addons/opacity-slider/style.css
+++ b/addons/opacity-slider/style.css
@@ -1,5 +1,5 @@
 .sa-opacity-slider {
-  overflow: hidden;
+  /* overflow: hidden; */
   background-image: linear-gradient(45deg, #eaf0f8 25%, transparent 25%, transparent 75%, #eaf0f8 75%),
     linear-gradient(45deg, #eaf0f8 25%, transparent 25%, transparent 75%, #eaf0f8 75%);
   background-size: 20px 20px;
@@ -13,4 +13,5 @@
   left: 0;
   width: 100%;
   height: 100%;
+  border-radius: 11px;
 }

--- a/addons/opacity-slider/userscript.js
+++ b/addons/opacity-slider/userscript.js
@@ -186,7 +186,7 @@ export default async function ({ addon, console, msg }) {
     };
     addon.tab.redux.addEventListener("statechanged", prevEventHandler);
 
-    if (addon.tab.redux.state.scratchPaint.format !== "VECTOR") continue;
+    if (addon.tab.redux.state.scratchPaint.format.startsWith("BITMAP")) continue;
 
     containerWrapper.appendChild(rowHeader);
     containerWrapper.appendChild(saOpacitySlider);

--- a/addons/opacity-slider/userscript.js
+++ b/addons/opacity-slider/userscript.js
@@ -192,6 +192,9 @@ export default async function ({ addon, console, msg }) {
     rowHeader.appendChild(labelReadout);
     saOpacitySlider.appendChild(saOpacitySliderBg);
     saOpacitySlider.appendChild(saOpacityHandle);
-    element.parentElement.querySelector("div:nth-child(4)").after(containerWrapper);
+    const brightnessSlider = Array.from(element.parentElement.children).filter(
+      (e) => !e.querySelector("div[class*=color-picker_gradient-picker-row]")
+    )[2];
+    brightnessSlider.after(containerWrapper);
   }
 }

--- a/addons/opacity-slider/userscript.js
+++ b/addons/opacity-slider/userscript.js
@@ -186,6 +186,8 @@ export default async function ({ addon, console, msg }) {
     };
     addon.tab.redux.addEventListener("statechanged", prevEventHandler);
 
+    if (addon.tab.redux.state.scratchPaint.format !== "VECTOR") continue;
+
     containerWrapper.appendChild(rowHeader);
     containerWrapper.appendChild(saOpacitySlider);
     rowHeader.appendChild(saLabelName);


### PR DESCRIPTION
Resolves #5205

- Fixes shadow for the opacity slider drag point only shows within the slider itself
- Fixes bug: https://user-images.githubusercontent.com/17484114/195955656-5ee628ae-2e96-45ad-992b-aa93447499ab.png
- Disable opacity slider completely in bitmap (requested by apple502j)