### PR TITLE
Fix vol-slider bugs

### DIFF
--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -14,13 +14,16 @@ export default async function ({ addon, global, console }) {
   const container = document.createElement("div");
   container.className = "sa-volume";
 
+  if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
+    document.body.classList.add("sa-vol-slider-small");
+  }
   document.addEventListener(
     "click",
     (e) => {
       if (e.target.closest("[class*='stage-header_stage-button-first']")) {
-        container.style.display = "none";
+        document.body.classList.add("sa-vol-slider-small");
       } else if (e.target.closest("[class*='stage-header_stage-button-last']")) {
-        container.style.display = "inline-block";
+        document.body.classList.remove("sa-vol-slider-small");
       }
     },
     { capture: true }

--- a/addons/vol-slider/userstyle.css
+++ b/addons/vol-slider/userstyle.css
@@ -4,6 +4,10 @@
   padding-right: 0.25rem;
 }
 
+.sa-vol-slider-small .sa-volume {
+  display: none !important;
+}
+
 .sa-volume > * {
   vertical-align: middle;
   margin-top: 6px;

--- a/addons/vol-slider/userstyle.css
+++ b/addons/vol-slider/userstyle.css
@@ -1,3 +1,9 @@
+.sa-volume {
+  /* Same lateral padding as .clone-container-container */
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
 .sa-volume > * {
   vertical-align: middle;
   margin-top: 6px;


### PR DESCRIPTION
Resolves #5200

- Adds some visual margin (internally padding) between the volslider container and any elements next to it. These elements may be the green flag if `editor-buttons-reverse-order` is enabled. It may also be the containers from `mouse-pos` or `clones`.
- Small stage detection fixes. 1. Fix dynamically enabling this addon when small stage enabled 2. Fix enabling small stage mode, going to the project page, then back