### PR TITLE
hide-project-stats: "new" tag for `studios` setting

### DIFF
--- a/addons/hide-project-stats/addon.json
+++ b/addons/hide-project-stats/addon.json
@@ -181,7 +181,7 @@
   "latestUpdate": {
     "version": "1.29.0",
     "temporaryNotice": "The padding between statistics has been fixed, there is now an option to show statistics on your own projects, and the My Stuff page is now supported.",
-    "newSettings": ["comments", "showOwnStats", "myStuff"]
+    "newSettings": ["comments", "showOwnStats", "myStuff", "studios"]
   },
   "enabledByDefault": false
 }


### PR DESCRIPTION
Marks the "Hide broken (always 0) studio count" setting on `hide-project-stats` as a new setting for v1.29.0.