### PR TITLE
Remove unlocalized instance of "Scratch Addons"

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -11,7 +11,6 @@ const PERMISSIONS_IGNORED_IN_FIREFOX = ["declarativeNetRequestWithHostAccess"];
 export default (env, manifest) => {
   // Deep-clone
   manifest = JSON.parse(JSON.stringify(manifest));
-  manifest.browser_action["default_icon"] = "images/icon.png";
   manifest.icons["1024"] = "images/icon.png";
   manifest.icons["32"] = "images/icon-32.png";
   manifest.icons["16"] = "images/icon-16.png";

--- a/manifest.json
+++ b/manifest.json
@@ -8,11 +8,7 @@
   "background": {
     "page": "background/background.html"
   },
-  "browser_action": {
-    "default_icon": "images/icon-blue.png",
-    "default_popup": "webpages/popup/index.html",
-    "default_title": "Scratch Addons"
-  },
+  "browser_action": { "default_popup": "webpages/popup/index.html" },
   "icons": {
     "16": "images/icon-blue-16.png",
     "32": "images/icon-blue-32.png",


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5273 

### Changes

<!-- Please describe the changes you've made. -->

Removed properties from manifest.json that are equal to their defaults.

### Reason for changes

<!-- Why should these changes be made? -->

Redundancy and this wasn't localized

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested locally, this does still display properly with the proper tooltip.