### PR TITLE
pick-colors-from-stage: only process user-initiated clicks

### DIFF
--- a/addons/pick-colors-from-stage/userscript.js
+++ b/addons/pick-colors-from-stage/userscript.js
@@ -6,11 +6,15 @@ export default async function ({ addon, msg, global, console }) {
   // We only want to handle color picker events from the user clicking on the button, not from
   // addons or other scripts pressing it with click().
   let isMostRecentClickUserInitiated = false;
-  document.addEventListener('click', (e) => {
-    isMostRecentClickUserInitiated = e.isTrusted;
-  }, {
-    capture: true
-  });
+  document.addEventListener(
+    "click",
+    (e) => {
+      isMostRecentClickUserInitiated = e.isTrusted;
+    },
+    {
+      capture: true,
+    }
+  );
 
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {

--- a/addons/pick-colors-from-stage/userscript.js
+++ b/addons/pick-colors-from-stage/userscript.js
@@ -3,6 +3,15 @@ export default async function ({ addon, msg, global, console }) {
 
   const setIsPicking = (picking) => document.body.classList.toggle("sa-stage-color-picker-picking", picking);
 
+  // We only want to handle color picker events from the user clicking on the button, not from
+  // addons or other scripts pressing it with click().
+  let isMostRecentClickUserInitiated = false;
+  document.addEventListener('click', (e) => {
+    isMostRecentClickUserInitiated = e.isTrusted;
+  }, {
+    capture: true
+  });
+
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
     const action = e.detail.action;
@@ -12,7 +21,11 @@ export default async function ({ addon, msg, global, console }) {
       return;
     }
 
-    if (!addon.self.disabled && action.type === "scratch-paint/eye-dropper/ACTIVATE_COLOR_PICKER") {
+    if (
+      !addon.self.disabled &&
+      isMostRecentClickUserInitiated &&
+      action.type === "scratch-paint/eye-dropper/ACTIVATE_COLOR_PICKER"
+    ) {
       setIsPicking(true);
 
       // When scratch-paint's color picker is activated, also activate scratch-gui's color picker.

--- a/addons/pick-colors-from-stage/userscript.js
+++ b/addons/pick-colors-from-stage/userscript.js
@@ -57,6 +57,8 @@ export default async function ({ addon, msg, global, console }) {
       });
     }
 
+    // Don't check for addon being disabled here in case we were dynamically disabled while color
+    // picking. This code won't do anything anyways when the previous code doesn't run.
     if (action.type === "scratch-paint/eye-dropper/DEACTIVATE_COLOR_PICKER") {
       setIsPicking(false);
 


### PR DESCRIPTION
Resolves https://discord.com/channels/806602307750985799/1035494962193772604

> When I set the opacity in the sprite editor for some reason when I hover over stage it thinks that I am going to select a colour to use for sprite editing.

Probably also affects the other addons that use the color picker.