### PR TITLE
block-duplicate: respect block-cherry-picking's invert setting 

### DIFF
--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -2,7 +2,9 @@ let enableCherryPicking = false;
 let invertCherryPicking = false;
 export function setCherryPicking(newEnabled, newInverted) {
   enableCherryPicking = newEnabled;
-  invertCherryPicking = newInverted;
+  // If cherry picking is disabled, also disable invert. Duplicating blocks can still cause
+  // this setting to be used.
+  invertCherryPicking = newEnabled && newInverted;
 }
 
 let enableDuplication = false;

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -51,9 +51,8 @@ export async function load(addon) {
       this.targetBlock_.type !== "procedures_definition";
 
     const isCherryPickingInverted = invertCherryPicking && !isRightClickDuplicate && block.getParent();
-    const isCherryPicking = isDuplicating
-      ? ctrlOrMetaPressed
-      : enableCherryPicking && ctrlOrMetaPressed === !isCherryPickingInverted && !block.isShadow();
+    const canCherryPick = enableCherryPicking || isDuplicating;
+    const isCherryPicking = canCherryPick && ctrlOrMetaPressed === !isCherryPickingInverted && !block.isShadow();
 
     if (isDuplicating || isCherryPicking) {
       if (!ScratchBlocks.Events.getGroup()) {


### PR DESCRIPTION
Resolves https://discord.com/channels/806602307750985799/1034089671984169030

Previously, if you had block-cherry-picking enabled in invert mode, normal block drags would only drag one block but alt+dragging would duplicate the entire stack. Now alt+dragging will just duplicate the one block unless ctrl is being held. This is what users would expect to happen.
