### PR TITLE
Fix unreadable text in jQueryUI modals in dark mode

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -664,3 +664,10 @@ input.link.black {
   background-image: url("%addon-self-dir%/assets/meow.png");
   background-size: 20px 15px;
 }
+
+/* If the color scheme of an iframe element is different from that
+   of the document inside, it gets an opaque backgound. The .iframeshim
+   is meant to be entirely transparent. */
+.iframeshim {
+  color-scheme: light;
+}


### PR DESCRIPTION
Resolves #5298

### Changes

Sets `color-scheme` on iframes to light. The explanation is in a code comment.

### Reason for changes

To make text in certain modals readable.

### Tests

The profile report modal is now readable:
![Screenshot of the modal](https://user-images.githubusercontent.com/51849865/199191164-9a818b9e-9e6a-417e-adcb-fe120e4dd78e.png)