### PR TITLE
Fix comment replies on deleted profiles cause messaging to fail

### DIFF
--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -197,7 +197,7 @@ export async function fetchMigratedComments(
     const getReplies = async (offset) => {
       const repliesRes = await fetch(getRepliesUrl(parentId, offset));
       if (!repliesRes.ok) {
-        if (repliesRes.status === 404 || repliesRes === 403) return;
+        if (repliesRes.status === 404 || repliesRes.status === 403) return;
         throw HTTPError.fromResponse(`Ignoring comment ${resourceType}/${commentId}`, repliesRes);
       }
       const repliesJson = await repliesRes.json();

--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -162,7 +162,7 @@ export async function fetchMigratedComments(
     const res = await fetch(getCommentUrl(commentId));
 
     if (!res.ok) {
-      if (res.status === 404) continue;
+      if (res.status === 404 || res.status === 403) continue;
       throw HTTPError.fromResponse(`Error when fetching comment ${resourceType}/${commentId}`, res);
     }
     const json = await res.json();
@@ -197,7 +197,7 @@ export async function fetchMigratedComments(
     const getReplies = async (offset) => {
       const repliesRes = await fetch(getRepliesUrl(parentId, offset));
       if (!repliesRes.ok) {
-        if (repliesRes.status === 404) return;
+        if (repliesRes.status === 404 || repliesRes === 403) return;
         throw HTTPError.fromResponse(`Ignoring comment ${resourceType}/${commentId}`, repliesRes);
       }
       const repliesJson = await repliesRes.json();


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5318

### Changes

This changes `popups/scratch-messaging/api.js` to be prepared for 403 errors when fetching comments or replies, as well as 404 errors.

### Reason for changes

The Scratch Messaging popup would error whenever it tried fetching comments/replies from banned profiles. It's only ready for 404 errors when fetching, not 403.

### Tests

I did test:
Browser: Chrome 106
Scratch Addons version: v1.29 (tested on multiple other beta versions though)
Operating system: MacOS
