### PR TITLE
Change `custom-zoom` animation speeds

### DIFF
--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -62,17 +62,17 @@
       "default": false
     },
     {
-      "name": "Autohide Animation duration",
+      "name": "Autohide Animation Speed",
       "id": "speed",
       "type": "select",
       "potentialValues": [
         {
           "id": "none",
-          "name": "None"
+          "name": "Instant"
         },
         {
           "id": "short",
-          "name": "Short"
+          "name": "Quick"
         },
         {
           "id": "default",
@@ -80,7 +80,7 @@
         },
         {
           "id": "long",
-          "name": "Long"
+          "name": "Slow"
         }
       ],
       "default": "default",

--- a/addons/custom-zoom/userscript.js
+++ b/addons/custom-zoom/userscript.js
@@ -5,9 +5,9 @@ export default async function ({ addon, global, console }) {
   let previousIsHovered = false;
   const speeds = {
     none: "0s",
-    short: "0.25s",
-    default: "0.5s",
-    long: "1s",
+    short: "0.2s",
+    default: "0.3s",
+    long: "0.5s",
   };
 
   const customZoomAreaElement = document.createElement("div");


### PR DESCRIPTION
Resolves no open issues. Related to #5260.

### Changes

Applies the same animation speed changes I made to `hide-flyout` last month (PR linked above) to `custom-zoom`'s autohide zoom controls feature.

### Reason for changes

1. I don't think anyone was going to use the Long setting.
2. Even on the Short setting, it still felt just a _little_ slower than I'd like.

### Tests

Tested on Edge 107. Everything seems fine.