### PR TITLE
Fix more vol-slider bugs

### DIFF
--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -21,7 +21,7 @@ export default async function ({ addon, global, console }) {
     }
   };
   addon.self.addEventListener("disabled", () => {
-    setVol(1);
+    setVol(getDefVol());
     icon.style.display = "none";
   });
 

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -6,6 +6,7 @@ export default async function ({ addon, global, console }) {
   icon.src = "/static/assets/e21225ab4b675bc61eed30cfb510c288.svg";
   icon.loading = "lazy";
   icon.style.display = "none";
+  icon.style.userSelect = "none";
   icon.className = "sa-mute-icon";
   const toggleMute = (e) => {
     if (!addon.self.disabled && (e.ctrlKey || e.metaKey)) {

--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -53,7 +53,7 @@ export default async function ({ addon, global, console }) {
     setVol(this.value);
   });
 
-  let i = 0;
+  let loaded;
   while (true) {
     await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
       markAsSeen: true,
@@ -63,11 +63,11 @@ export default async function ({ addon, global, console }) {
     addon.tab.appendToSharedSpace({ space: "afterStopButton", element: container, order: 0 });
     container.appendChild(icon);
     container.appendChild(slider);
-    if (i < 1) {
+    if (!loaded) {
       setup(vm);
       setDefVol(addon.settings.get("defVol") / 100);
       setVol(getDefVol());
+      loaded = true;
     }
-    i++;
   }
 }

--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -52,7 +52,8 @@ export default async function ({ addon, global, console }) {
   slider.addEventListener("input", function (e) {
     setVol(this.value);
   });
-
+  
+  let i = 0;
   while (true) {
     await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
       markAsSeen: true,
@@ -62,8 +63,11 @@ export default async function ({ addon, global, console }) {
     addon.tab.appendToSharedSpace({ space: "afterStopButton", element: container, order: 0 });
     container.appendChild(icon);
     container.appendChild(slider);
-    setup(vm);
-    setDefVol(addon.settings.get("defVol") / 100);
-    setVol(getDefVol());
+    if (i < 1) {
+      setup(vm);
+      setDefVol(addon.settings.get("defVol") / 100);
+      setVol(getDefVol());
+    }
+    i++;
   }
 }

--- a/addons/vol-slider/userstyle.css
+++ b/addons/vol-slider/userstyle.css
@@ -15,6 +15,7 @@
 
 .sa-volume input[type="range"] {
   -webkit-appearance: none;
+  appearance: none;
   width: 50px;
   height: 6px;
   border-radius: 3px;
@@ -24,6 +25,7 @@
 
 .sa-volume input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
+  appearance: none;
   width: 12px;
   height: 12px;
   border-radius: 50%;

--- a/addons/vol-slider/userstyle.css
+++ b/addons/vol-slider/userstyle.css
@@ -11,6 +11,7 @@
 .sa-volume > * {
   vertical-align: middle;
   margin-top: 6px;
+  user-select: none;
 }
 
 .sa-volume input[type="range"] {


### PR DESCRIPTION
Resolves #5282

### Changes

Fixes a bug in the volume slider addon that causes the project volume to reset when entering or leaving the editor. Also fixes a VSCode warning and uses the default volume when dynamically disabling `mute-project` instead of 1.

### Reason for changes

The volume shouldn't reset when opening or leaving the editor.

### Tests

Tested on Chromium 106.