### PR TITLE
Update Clone Scratch Addons link and more

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ If you're making a new addon, our [FAQ page](https://scratchaddons.com/docs/deve
 1. **If you have something in mind, want to report a bug, or anything else, it's best if you create or find an issue first (see above). That way, we can discuss it before you start a pull request.**
 2. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) this repository if you haven't already.
 3. If you already have a fork, make sure to [sync its `master` branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) to ensure your fork of Scratch Addons is up to date with ours.
-4. [Clone Scratch Addons](https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository) so you can make and test your changes.
+4. [Clone Scratch Addons](https://github.com/ScratchAddons/ScratchAddons#from-source) and load it into your browser so you can make and test your changes.
 5. [Create a new branch](https://github.com/firstcontributions/first-contributions/blob/main/README.md#create-a-branch) from the `master` branch.
-6. [Create, commit, and push](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-and-pushing-changes) the changes you want to make. Make sure you're committing to your new branch.
+6. [Create, commit, and push](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-and-pushing-changes) your changes. Make sure you're committing to your new branch.
 7. Go to the website and enable workflows in Actions on your fork so we can automatically clean up your code if necessary.
 8. Finally, [create a pull request](https://github.com/ScratchAddons/ScratchAddons/compare) on the origin repository (ScratchAddons/ScratchAddons). We will review your changes and talk about any further improvements if necessary.
 
-If you don't want to use Git, [this page](https://docs.github.com/en/get-started/quickstart/set-up-git#using-git) mentions other ways to make changes, too.
+(The linked information shows you how to use [Git](https://git-scm.com/) to commit your changes, but you can also use the website, [GitHub Desktop](https://desktop.github.com/), [Visual Studio Code](https://code.visualstudio.com/), or any other software that lets you make your changes.)


### PR DESCRIPTION
Resolves no open issues.

### Changes

- Clone Scratch Addons now heads to instructions on how to download AND add the extension to your browser.
- Rephrased the part at the bottom that tells you other ways to commit changes.

### Reason for changes

I felt that those details were a little vague for new contributors.