### PR TITLE
Apply Scratch block-affecting addons to all forum pages

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -152,14 +152,14 @@
     },
     {
       "url": "forums/base.css",
-      "matches": ["editingScreens"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": { "forums": true }
       }
     },
     {
       "url": "forums/black_text.css",
-      "matches": ["editingScreens"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "forums": true,
@@ -169,7 +169,7 @@
     },
     {
       "url": "forums/color_on_white.css",
-      "matches": ["editingScreens"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "forums": true,
@@ -179,7 +179,7 @@
     },
     {
       "url": "forums/color_on_black.css",
-      "matches": ["editingScreens"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "forums": true,

--- a/addons/scratchblocks/addon.json
+++ b/addons/scratchblocks/addon.json
@@ -18,7 +18,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["editingScreens"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "runAtComplete": false
     }
   ],

--- a/addons/scratchblocks/userscript.js
+++ b/addons/scratchblocks/userscript.js
@@ -27,7 +27,7 @@ async function getLocales(addon) {
     59: "fa",
   };
 
-  if (location.pathname.split("/")[2] === "settings") {
+  if (["settings", "search"].includes(location.pathname.split("/")[2])) {
     return ["en"];
   }
 


### PR DESCRIPTION
Resolves #5290

### Changes

Makes the `editor-theme3` and `scratchblocks` addons take effect on all forum pages, not just topic pages.

### Reason for changes

Scratch blocks can appear on the forums in places other than forum topics, such as [post listing pages](https://scratch.mit.edu/discuss/search/?page=1&action=show_user&show_as=posts) and search results from the `forum-search` addon.

The only downside is unnecessary userstyle injection (on pages where there are never any Scratch blocks), which might impact performance, but it probably won't be noticeable.

### Tests

Tested on Edge 107. There was an issue but mxmou fixed it for me. Other than that, I didn’t find any problems.