### PR TITLE
Rename the setting “Maximum number of lines” in Line breaks in comments

### DIFF
--- a/addons/comments-linebreaks/addon.json
+++ b/addons/comments-linebreaks/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Line breaks in comments",
-  "description": "Makes line breaks (pressing Enter) in comments on the website visible instead of converting them to spaces.",
+  "description": "Allows adding line breaks (by pressing Enter/Return) in comments you're writing.",
   "credits": [
     {
       "name": "TheColaber",
@@ -34,10 +34,10 @@
       "name": "Add scroll bars to tall comments",
       "id": "scrollbars",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     {
-      "name": "Maximum number of lines",
+      "name": "Maximum number of lines visible at once",
       "id": "height",
       "type": "integer",
       "min": 1,

--- a/addons/comments-linebreaks/addon.json
+++ b/addons/comments-linebreaks/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Line breaks in comments",
-  "description": "Allows adding line breaks (by pressing Enter/Return) in comments you're writing.",
+  "description": "Makes line breaks (pressing Enter) in comments on the website visible instead of converting them to spaces.",
   "credits": [
     {
       "name": "TheColaber",
@@ -34,7 +34,7 @@
       "name": "Add scroll bars to tall comments",
       "id": "scrollbars",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     {
       "name": "Maximum number of lines visible at once",


### PR DESCRIPTION
Resolves no open issues.

### Changes

Changed “Maximum number of lines” to “Maximum number of lines visible at once”.

### Reason for changes

- To make the addon easier to understand

### Tests

Didn’t test the changes, but there weren’t any code changes.
