### PR TITLE
Fix long status regression

### DIFF
--- a/addons/my-ocular/discuss.js
+++ b/addons/my-ocular/discuss.js
@@ -19,7 +19,7 @@ export default async function ({ addon, global, console, msg }) {
     status.title = msg("status-hover");
     status.innerText = userStatus;
     status.style.fontStyle = "italic";
-    addon.tab.displayNoneWhileDisabled(status, { display: "inline-block" });
+    addon.tab.displayNoneWhileDisabled(status);
 
     // Create my-ocular dot
     let dot = document.createElement("span");


### PR DESCRIPTION
Resolves #5286

### Changes

Removes `display: inline-block` from ocular statuses in the forums.

### Reason for changes

To fix a bug.

### Tests

Tested [this post](https://scratch.mit.edu/discuss/post/6682478/). Nothing changed on Firefox - this was a Chrome-only bug. On Chrome, the bug is fixed - the status doesn't cover the post.