### PR TITLE
Fix image uploader Material icon

### DIFF
--- a/addons/material-forum-editor-buttons/icons.css
+++ b/addons/material-forum-editor-buttons/icons.css
@@ -68,7 +68,8 @@
   background-image: url(done.svg) !important;
 }
 #ibbBtn,
-#uploadButton {
+#uploadButton,
+.sa-image-upload-button {
   background-image: url(uploader.svg) !important;
 }
 


### PR DESCRIPTION
Resolves #5337

### Changes

Adds the new class name for the image uploader button to the `material-forum-editor-buttons` userstyle. I didn't remove the old one because some people might still be using Jeffalo's extension.

Is the `#ibbBtn` selector still needed? It was apparently added for compatibility with an ImgBB userscript made by easrng. Event if that userscript still exists, it probably doesn't work because the Wikimedia open redirect bug was fixed.

### Reason for changes

To fix a bug.

### Tests

Before:
![image](https://user-images.githubusercontent.com/51849865/203322496-52e1c9cf-202e-4a19-a3fd-002838bb5642.png)
![image](https://user-images.githubusercontent.com/51849865/203322539-63ac965f-6690-48ee-9176-5c919dc00399.png)

After:
![image](https://user-images.githubusercontent.com/51849865/203322566-68b8dafe-af01-47d4-a401-582f2c6c022e.png)
![image](https://user-images.githubusercontent.com/51849865/203322574-6d12f9dd-3372-4638-9069-3b6749e0d4be.png)