### PR TITLE
`cat-blocks`: Change info type from warning to notice

### DIFF
--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -18,7 +18,7 @@
   ],
   "info": [
     {
-      "type": "warning",
+      "type": "notice",
       "text": "The \"Watch mouse cursor\" option may impact performance when the editor is open.",
       "id": "watch"
     }

--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -19,7 +19,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "The \"Watch mouse cursor\" option may impact performance when the editor is open.",
+      "text": "The \"watch mouse cursor\" setting may impact performance when the editor is open.",
       "id": "watch"
     }
   ],


### PR DESCRIPTION
### Changes

Previously, the message on the `cat-blocks` addon that the "Watch mouse cursor" option may affect performance was a red warning. I changed it to a yellow notice.

### Reason for changes

The warning message is pretty bright for a minor warning that only applies if you turn on a setting that I don't think everyone will use.

### Tests

Change tested.
