### PR TITLE
fix old tokens being used for turbowarp button

### DIFF
--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -29,12 +29,14 @@ export default async function ({ addon, console, msg }) {
   button.onclick = async () => {
     const projectId = window.location.pathname.split("/")[2];
     let search = "";
+    let fetchHeaders = {}
+    if (await addon.auth.fetchXToken()) {
+      fetchHeaders['x-token'] = await addon.auth.fetchXToken()
+    }
     let projectToken = (
       await (
         await fetch(`https://api.scratch.mit.edu/projects/${projectId}&nocache=${Date.now()}`, {
-          headers: {
-            "x-token": await addon.auth.fetchXToken(),
-          },
+          headers: fetchHeaders
         })
       ).json()
     ).project_token;

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -27,12 +27,22 @@ export default async function ({ addon, console, msg }) {
   }
 
   button.onclick = async () => {
+    const projectId = window.location.pathname.split("/")[2];
     let search = "";
+    let projectToken = (
+      await (
+        await fetch(`https://api.scratch.mit.edu/projects/${projectId}`, {
+          headers: {
+            "x-token": addon.auth._lastXToken,
+          },
+        })
+      ).json()
+    ).project_token;
     if (
       addon.tab.redux.state?.preview?.projectInfo?.public === false &&
       addon.tab.redux.state.preview.projectInfo.project_token
     ) {
-      search = `#?token=${addon.tab.redux.state.preview.projectInfo.project_token}`;
+      search = `#?token=${projectToken}`;
     }
     if (action === "player") {
       playerToggled = !playerToggled;
@@ -41,7 +51,6 @@ export default async function ({ addon, console, msg }) {
         const usp = new URLSearchParams();
         usp.set("settings-button", "1");
         if (username) usp.set("username", username);
-        const projectId = window.location.pathname.split("/")[2];
         if (addon.settings.get("addons")) {
           const enabledAddons = await addon.self.getEnabledAddons("editor");
           usp.set("addons", enabledAddons.join(","));

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -31,7 +31,7 @@ export default async function ({ addon, console, msg }) {
     let search = "";
     let projectToken = (
       await (
-        await fetch(`https://api.scratch.mit.edu/projects/${projectId}`, {
+        await fetch(`https://api.scratch.mit.edu/projects/${projectId}&nocache=${Date.now()}`, {
           headers: {
             "x-token": addon.auth._lastXToken,
           },

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -29,21 +29,16 @@ export default async function ({ addon, console, msg }) {
   button.onclick = async () => {
     const projectId = window.location.pathname.split("/")[2];
     let search = "";
-    let fetchHeaders = {}
-    if (await addon.auth.fetchXToken()) {
-      fetchHeaders['x-token'] = await addon.auth.fetchXToken()
-    }
-    let projectToken = (
-      await (
-        await fetch(`https://api.scratch.mit.edu/projects/${projectId}?nocache=${Date.now()}`, {
-          headers: fetchHeaders
-        })
-      ).json()
-    ).project_token;
-    if (
-      addon.tab.redux.state?.preview?.projectInfo?.public === false &&
-      addon.tab.redux.state.preview.projectInfo.project_token
-    ) {
+    if (addon.tab.redux.state?.preview?.projectInfo?.public === false) {
+      let projectToken = (
+        await (
+          await fetch(`https://api.scratch.mit.edu/projects/${projectId}?nocache=${Date.now()}`, {
+            headers: {
+              "x-token": await addon.auth.fetchXToken(),
+            },
+          })
+        ).json()
+      ).project_token;
       search = `#?token=${projectToken}`;
     }
     if (action === "player") {

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -33,7 +33,7 @@ export default async function ({ addon, console, msg }) {
       await (
         await fetch(`https://api.scratch.mit.edu/projects/${projectId}&nocache=${Date.now()}`, {
           headers: {
-            "x-token": addon.auth._lastXToken,
+            "x-token": await addon.auth.fetchXToken(),
           },
         })
       ).json()


### PR DESCRIPTION
### Changes

With the Turbowarp button addon, the current method of getting the project token does not update, even though the token itself does. This can cause the Turbowarp button to crash when the token hasn't been fetched after a little while. This makes it fetch the token each time the Turbowarp button is pressed (which, in most scenarios, would only be once).
![image](https://user-images.githubusercontent.com/86856959/204063429-1e4f0543-de2f-42ba-935d-2377d973f56c.png)

### Reason for changes

Because we don't want to crash the addon...

### Tests

I tested between the production version from the Chrome Web Store (v1.29) and the version with my changes.