### PR TITLE
Rename the "more links" addon

### DIFF
--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "More links",
-  "description": "Adds links for URLs pointing outside scratch.mit.edu.",
+  "name": "Clickable external links",
+  "description": "Makes URLs pointing outside scratch.mit.edu clickable.",
   "credits": [
     {
       "name": "Hans5958"

--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Clickable external links",
+  "name": "More links",
   "description": "Makes URLs pointing outside scratch.mit.edu clickable.",
   "credits": [
     {


### PR DESCRIPTION
Resolves #4882

### Changes

Changed the name of the "More links" addon to "Clickable external links" and edited the description.

### Reason for changes

The new name makes more sense.

### Tests

Changes should work fine.
