### PR TITLE
Rename the Extra key support addon, plus its settings and description

### DIFF
--- a/addons/editor-extra-keys/addon.json
+++ b/addons/editor-extra-keys/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Extra key support",
-  "description": "Adds more keys to the \"key () pressed?\" and \"when () key pressed\" block dropdowns, such as enter, dot, comma, and more.",
+  "name": "Extra key options",
+  "description": "Adds more keys to the \"key () pressed?\" and \"when () key pressed\" block dropdowns, such as enter, dot, comma, and more. These keys will work even for users who do not have this addon.",
   "tags": ["editor", "codeEditor", "beta"],
   "credits": [
     {
@@ -22,13 +22,13 @@
   ],
   "settings": [
     {
-      "name": "Enable experimental keys",
+      "name": "Show experimental keys",
       "id": "experimentalKeys",
       "type": "boolean",
       "default": false
     },
     {
-      "name": "Enable Shift keys",
+      "name": "Show Shift keys",
       "id": "shiftKeys",
       "type": "boolean",
       "default": false


### PR DESCRIPTION
Resolves #4862

### Changes

Renamed `editor-extra-keys`, plus edited its description and setting names.

### Reason for changes

_Extra key "support"_ seems a little misleading - this addon actually just adds more keys to the drop-menus of key-pressed blocks, but after you add them to a project, they work fine for all users, even those who do not have Scratch Addons installed.

### Tests

Should work fine.
