### PR TITLE
Wait for previous suspend/resume to complete when pausing

### DIFF
--- a/addons/debugger/module.js
+++ b/addons/debugger/module.js
@@ -86,12 +86,14 @@ const stepUnsteppedThreads = (lastSteppedThread) => {
 };
 
 export const setPaused = (_paused) => {
-  if (paused !== _paused) {
+  const didChange = paused !== _paused;
+  if (didChange) {
     paused = _paused;
     eventTarget.dispatchEvent(new CustomEvent("change"));
   }
 
-  if (_paused) {
+  // Don't check didChange as new threads could've started that we need to pause.
+  if (paused) {
     audioContextStateChange = audioContextStateChange.then(() => {
       return vm.runtime.audioEngine.audioContext.suspend();
     });
@@ -105,7 +107,10 @@ export const setPaused = (_paused) => {
       setSteppingThread(activeThread);
       eventTarget.dispatchEvent(new CustomEvent("step"));
     }
-  } else {
+  }
+
+  // Only run unpausing logic when pause state changed to avoid unnecessary work
+  if (!paused && didChange) {
     audioContextStateChange = audioContextStateChange.then(() => {
       return vm.runtime.audioEngine.audioContext.resume();
     });


### PR DESCRIPTION
In some browsers (Chrome), calling resume() and suspend() simultaneously or very closely together results in the resume() call winning in the end, so wait for the previous resume/suspend call to finish before starting a new one.

Closes https://github.com/ScratchAddons/ScratchAddons/issues/5361

Tested by running this in the JS console:

```js
var btn = document.querySelector('.pause-btn')
for (let i = 0; i < 33; i++) btn.click()
```