### PR TITLE
New repo action: send comment on stale issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -8,7 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'ScratchAddons'
     steps:
-      - uses: actions/stale@v6
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+      - name: Execute Action
+        uses: actions/stale@v6
         with:
           stale-issue-message: 'Ping! There has been no activity for 7 days.'
           stale-pr-message: 'Ping! There has been no activity for 7 days.'
@@ -18,6 +25,4 @@ jobs:
           stale-issue-label: ''
           stale-pr-label: ''
           operations-per-run: 5
-    permissions:
-      issues: write
-      pull-requests: write
+          repo-token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,8 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-message: 'Ping! There has been no activity for 7 days.'
+          stale-issue-message: 'Ping! There has been no activity for 7 days.'
+          stale-pr-message: 'Ping! There has been no activity for 7 days.'
           only-label: 'status: awaiting answer/followup'
           days-before-stale: 7
           days-before-close: -1

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,7 +14,8 @@ jobs:
           only-label: 'status: awaiting answer/followup'
           days-before-stale: 7
           days-before-close: -1
-          stale-label: ''
+          stale-issue-label: ''
+          stale-pr-label: ''
           operations-per-run: 5
     permissions:
       issues: write

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,3 +20,4 @@ jobs:
           operations-per-run: 5
     permissions:
       issues: write
+      pull-requests: write

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,12 +10,11 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-issue-message: 'Ping! There has been no activity for 7 days.'
+          stale-message: 'Ping! There has been no activity for 7 days.'
           only-label: 'status: awaiting answer/followup'
-          days-before-issue-stale: 7
+          days-before-stale: 7
           days-before-close: -1
-          stale-issue-label: ''
+          stale-label: ''
           operations-per-run: 5
-          days-before-pr-stale: -1
     permissions:
       issues: write

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    name: Stale
     runs-on: ubuntu-latest
     if: github.repository_owner == 'ScratchAddons'
     steps:

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -25,5 +25,5 @@ jobs:
           days-before-close: -1
           stale-issue-label: ''
           stale-pr-label: ''
-          operations-per-run: 5
+          operations-per-run: 30
           repo-token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,21 @@
+name: Send comment on stale issues
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'ScratchAddons'
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: 'Ping! There has been no activity for 7 days.'
+          only-label: 'status: awaiting answer/followup'
+          days-before-issue-stale: 7
+          days-before-close: -1
+          stale-issue-label: ''
+          operations-per-run: 5
+          days-before-pr-stale: -1
+    permissions:
+      issues: write


### PR DESCRIPTION
Messages from me on Discord:
> Is there a way to get a reminder if a specific GitHub issue hasn't had discussion for a specific period of time?
I sometimes expect someone to reply so I can remember about the issue, but if no one does, the issue falls into oblivion

This new GitHub action will not close any issues/PRs automatically.
It will not affect any issues/PRs, unless they have the `status: awaiting answer/followup` label. Only in issues/PRs that have that label, the bot will send a message after 7 days of inactivity.

**Example imaginary situation where I would use this:**
1. I comment on the issue/PR
![image](https://user-images.githubusercontent.com/17484114/204672157-e70b9bd9-29ee-4092-92ca-18e5ce802ed6.png)
2. I add the `status: awaiting answer/followup` label to the issue/PR.
3. In case mxmou (example) doesn't reply for 7 days, the bot will post a new comment. At that point, I can ping mxmou again, or merge the PR.
If mxmou replies in time, I simply remove the label.

The goal here is to make it harder for us to forget about issues/PRs in situations where we were expecting a reply or follow-up from someone.