### PR TITLE
Fix addons running on iframes without src (Firefox)

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,5 +1,6 @@
 try {
   if (window.parent.location.origin !== "https://scratch.mit.edu") throw "Scratch Addons: not first party iframe";
+  if (window.frameElement && window.frameElement.getAttribute("src") === null) throw "Ignored iframe without src attribute";
 } catch {
   throw "Scratch Addons: not first party iframe";
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -1,6 +1,7 @@
 try {
   if (window.parent.location.origin !== "https://scratch.mit.edu") throw "Scratch Addons: not first party iframe";
-  if (window.frameElement && window.frameElement.getAttribute("src") === null) throw "Ignored iframe without src attribute";
+  if (window.frameElement && window.frameElement.getAttribute("src") === null)
+    throw "Ignored iframe without src attribute";
 } catch {
   throw "Scratch Addons: not first party iframe";
 }


### PR DESCRIPTION
Resolves #4380

### Changes

Throws at the top of `cs.js` if being ran on an iframe when `iframe.getAttribute("src") === null`
Other content script files will still run on Firefox, but I don't think that is causing any trouble.

### Tests

Tested on Firefox 106
Checked website dark mode should not apply to the contact us form
Checked addons should still run in iframes (pause+live-featured-project in profile)
