### PR TITLE
Remove beta tag from opacity-slider

### DIFF
--- a/addons/opacity-slider/addon.json
+++ b/addons/opacity-slider/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Opacity slider",
   "description": "Adds an opacity slider to the costume editor color picker.",
-  "tags": ["editor", "costumeEditor", "beta", "featured"],
+  "tags": ["editor", "costumeEditor", "featured"],
   "info": [
     {
       "type": "info",


### PR DESCRIPTION
No serious bugs reported regarding opacity slider, so we can remove the beta tag