### PR TITLE
New addon: number-pad

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -130,6 +130,7 @@
   "pick-colors-from-stage",
   "rename-broadcasts",
   "middle-click-popup",
+  "number-pad",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/number-pad/addon.json
+++ b/addons/number-pad/addon.json
@@ -1,0 +1,19 @@
+{
+  "name": "Always show number pad",
+  "description": "Show Scratch's number pad input when editing number fields on all devices instead of only touchscreen devices.",
+  "credits": [
+    {
+      "name": "GarboMuffin"
+    }
+  ],
+  "tags": ["editor", "codeEditor"],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.28.0"
+}

--- a/addons/number-pad/addon.json
+++ b/addons/number-pad/addon.json
@@ -15,5 +15,5 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "versionAdded": "1.28.0"
+  "versionAdded": "1.31.0"
 }

--- a/addons/number-pad/addon.json
+++ b/addons/number-pad/addon.json
@@ -6,6 +6,12 @@
       "name": "GarboMuffin"
     }
   ],
+  "info": [
+    {
+      "text": "A number pad will show when editing number inputs from certain blocks, such as \"set x to\".",
+      "id": "explanation"
+    }
+  ],
   "tags": ["editor", "codeEditor"],
   "userscripts": [
     {

--- a/addons/number-pad/addon.json
+++ b/addons/number-pad/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Always show number pad",
-  "description": "Show Scratch's number pad input when editing number fields on all devices instead of only touchscreen devices.",
+  "description": "Show Scratch's number pad input when editing number fields on all devices, instead of only touchscreen devices.",
   "credits": [
     {
       "name": "GarboMuffin"
@@ -15,5 +15,5 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "versionAdded": "1.31.0"
+  "versionAdded": "1.30.0"
 }

--- a/addons/number-pad/userscript.js
+++ b/addons/number-pad/userscript.js
@@ -1,0 +1,12 @@
+export default async function ({ addon, msg, console }) {
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+
+  // https://github.com/LLK/scratch-blocks/blob/develop/core/field_number.js#L165
+  const originalMouseDown = ScratchBlocks.FieldNumber.prototype.showEditor_;
+  ScratchBlocks.FieldNumber.prototype.showEditor_ = function (...args) {
+    if (!addon.self.disabled) {
+      this.useTouchInteraction_ = true;
+    }
+    return originalMouseDown.apply(this, args);
+  };
+}


### PR DESCRIPTION
https://github.com/ScratchAddons/ScratchAddons/discussions/5396

Apparently on touchscreen devices, Scratch shows this menu on number inputs:

![image](https://user-images.githubusercontent.com/33787854/205468454-a2aa2984-a099-43e8-a707-80943983f125.png)

This addon makes it always appear on  all devices.
