### PR TITLE
Make `60fps` disabled by default and `pause` enabled by default

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -36,7 +36,7 @@
       "default": 60
     }
   ],
-  "tags": ["editor", "projectPlayer", "recommended"],
+  "tags": ["editor", "projectPlayer", "featured"],
   "versionAdded": "1.1.0",
-  "enabledByDefault": true
+  "enabledByDefault": false
 }

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -25,5 +25,5 @@
     }
   ],
   "tags": ["editor", "projectPlayer", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }


### PR DESCRIPTION
Resolves #5404

### Changes

- The 60FPS project player mode addon is now disabled by default and was bumped down from the Recommended section to the Featured section.
- The Pause button addon is now enabled by default.

### Reason for changes

Described in #5404

### Tests

Not tested, but I think it will work fine.
