### PR TITLE
Update `live-featured-project`

### DIFF
--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -12,6 +12,19 @@
       "name": "Hans5958",
       "note": "remake",
       "id": "remake"
+    },
+    {
+      "name": "ErrorGamer2000",
+      "link": "https://github.com/ErrorGamer2000",
+      "note": "update",
+      "id": "update"
+    }
+  ],
+  "info": [
+    {
+      "id": "privacy",
+      "type": "warning",
+      "text": "Enabling the \"Use Scratch username\" when using the TurboWarp player will give TurboWarp access to your Scratch username."
     }
   ],
   "userscripts": [
@@ -35,21 +48,17 @@
     },
     {
       "id": "alternativePlayer",
-      "name": "Alternative player",
+      "name": "Project player",
       "type": "select",
       "default": "none",
       "potentialValues": [
         {
           "id": "none",
-          "name": "None"
+          "name": "Scratch"
         },
         {
           "id": "turbowarp",
           "name": "TurboWarp"
-        },
-        {
-          "id": "forkphorus",
-          "name": "forkphorus"
         }
       ]
     },
@@ -63,17 +72,17 @@
       }
     },
     {
-      "id": "forceAlternative",
-      "name": "Force using alternative player",
+      "id": "enableTWAddons",
+      "name": "Enable TurboWarp addons",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "if": {
-        "settings": { "alternativePlayer": ["turbowarp", "forkphorus"] }
+        "settings": { "alternativePlayer": ["turbowarp"] }
       }
     },
     {
-      "id": "enableTWAddons",
-      "name": "Enable TurboWarp addons",
+      "id": "shareUsername",
+      "name": "Use Scratch username",
       "type": "boolean",
       "default": true,
       "if": {

--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -64,11 +64,11 @@
     },
     {
       "id": "autoPlay",
-      "name": "Auto-play projects (for alternative players)",
+      "name": "Auto-play projects",
       "type": "boolean",
       "default": false,
       "if": {
-        "settings": { "alternativePlayer": ["turbowarp", "forkphorus"] }
+        "settings": { "alternativePlayer": ["turbowarp"] }
       }
     },
     {

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -1,10 +1,12 @@
 export default async function ({ addon, msg }) {
   const showMenu = addon.settings.get("showMenu");
-  const forceAlternative = addon.settings.get("forceAlternative");
-  const alternativePlayer = addon.settings.get("alternativePlayer");
+  const player = addon.settings.get("alternativePlayer");
   const autoPlay = addon.settings.get("autoPlay");
   const enableTWAddons = addon.settings.get("enableTWAddons");
+  const shareUsername = addon.settings.get("shareUsername");
+
   const enabledAddons = await addon.self.getEnabledAddons("editor");
+  const username = await addon.auth.fetchUsername();
 
   const stageElement = document.querySelector(".stage");
   const projectId = window.Scratch.INIT_DATA.PROFILE.featuredProject.id;
@@ -75,32 +77,20 @@ export default async function ({ addon, msg }) {
     const usp = new URLSearchParams();
     if (autoPlay) usp.set("autoplay", "");
     if (enableTWAddons) usp.set("addons", enabledAddons.join(","));
+    if (shareUsername) usp.set("username", username);
     iframeElement.setAttribute("src", `https://turbowarp.org/${projectId}/embed?${usp}`);
     wrapperElement.dataset.player = "turbowarp";
     if (!showMenu) iframeElement.setAttribute("height", "260");
   };
 
-  const loadForkphorus = () => {
-    wrapperElement.dataset.player = "forkphorus";
-    iframeElement.setAttribute(
-      "src",
-      `https://forkphorus.github.io/embed.html?id=${projectId}&auto-start=${autoPlay}&ui=${showMenu}`
-    );
-  };
-
   // Start loading the players
 
-  if (forceAlternative && alternativePlayer !== "none") {
-    if (alternativePlayer === "turbowarp") loadTurboWarp();
-    else if (alternativePlayer === "forkphorus") loadForkphorus();
-  } else {
-    loadScratch();
-    iframeElement.addEventListener("load", () => {
-      if (iframeElement.contentDocument.querySelector(".not-available-outer") !== null) {
-        if (alternativePlayer === "turbowarp") loadTurboWarp();
-        else if (alternativePlayer === "forkphorus") loadForkphorus();
-        else stageElement.removeChild(wrapperElement);
-      }
-    });
-  }
+  if (player === "turbowarp") loadTurboWarp();
+  else loadScratch();
+  iframeElement.addEventListener("load", () => {
+    if (iframeElement.contentDocument.querySelector(".not-available-outer") !== null) {
+      // Project is unshared and cannot be accessed
+      stageElement.removeChild(wrapperElement);
+    }
+  });
 }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -74,7 +74,9 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
         addonsEnabled["middle-click-popup"] = false;
       }
     }
-
+    if (addonsEnabled["live-featured-project"]?.alternativePlayer === "forkphorus") {
+      addonsEnabled["live-featured-project"].alternativePlayer = "turbowarp";
+    }
     for (const { manifest, addonId } of scratchAddons.manifests) {
       // TODO: we should be using Object.create(null) instead of {}
       const settings = addonSettings[addonId] || {};


### PR DESCRIPTION
### Changes

- Shared project changes
  - No longer tries to fall back to alternative player if the project is unshared.
  - No longer has `forkphorus` as an option in favor of TurboWarp
- Added a "Use Scratch username" option when using TurboWarp player.

### Reason for changes

The "Use Scratch username" option was prompted by this feedback:

> only one problem that I know of: username blocks do not work on the featured projects. plz, fix this.

### Tests

Username is correctly set in TurboWarp player.
Migration code changes forkphorus to TurboWarp.
