### PR TITLE
Fix hide-flyout and sprite-folders conflicts

### DIFF
--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -98,22 +98,17 @@
   filter: var(--editorDarkMode-primary-filter, none);
 }
 
-/* Setting these styles on gui_stage-and-target-wrapper breaks full screen */
-.sa-body-editor [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen"]),
-[class*="gui_target-wrapper_"] {
+.sa-hide-flyout-not-fullscreen .sa-body-editor [class*="gui_stage-and-target-wrapper"] {
   position: relative;
+  /* We need to be above these to hide the flyout while dragging blocks: */
+  /* .blocklyFlyout (z-index: 20) */
+  /* .blocklyFlyoutScrollbar (z-index: 30) */
+  /* and above these so that dragged sprites aren't obscured: */
+  /* .blocklyToolboxDiv (z-index: 40) */
+  /* .gui_extension-button-container_b4rCs (z-index: 42) */
+  z-index: 43;
   padding-inline: 0.5rem;
   background-color: var(--editorDarkMode-page, hsl(215, 100%, 95%));
-}
-/* Both must be above hidden flyout when dragging block with editor-stage-left enabled */
-/* Both must be above category list when columns is enabled so dragged sprites appear aren't obscured */
-/* Stage wrapper must be above target pane so dragged sprites aren't obscured */
-/* However, It cannot be above the sprite context menu. */
-.sa-body-editor [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen"]) {
-  z-index: 49;
-}
-[class*="gui_target-wrapper_"] {
-  z-index: 49;
 }
 
 [class*="gui_stage-and-target-wrapper_"] {

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -108,8 +108,9 @@
 /* Both must be above hidden flyout when dragging block with editor-stage-left enabled */
 /* Both must be above category list when columns is enabled so dragged sprites appear aren't obscured */
 /* Stage wrapper must be above target pane so dragged sprites aren't obscured */
+/* However, It cannot be above the sprite context menu. */
 .sa-body-editor [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen"]) {
-  z-index: 50;
+  z-index: 49;
 }
 [class*="gui_target-wrapper_"] {
   z-index: 49;

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -81,6 +81,12 @@ export default async function ({ addon, console, msg }) {
     }, speed * 1000);
   }
 
+  const updateIsFullScreen = () => {
+    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
+    document.documentElement.classList.toggle("sa-hide-flyout-not-fullscreen", !isFullScreen);
+  };
+  updateIsFullScreen();
+
   let didOneTimeSetup = false;
   function doOneTimeSetup() {
     if (didOneTimeSetup) {
@@ -105,6 +111,9 @@ export default async function ({ addon, console, msg }) {
           }
           break;
         }
+        case "scratch-gui/mode/SET_FULL_SCREEN":
+          updateIsFullScreen();
+          break;
       }
     });
 


### PR DESCRIPTION
### Changes

Slightly tweaked the `z-index` change on the stage wrapper to prevent sprite context menus from being cut off with the folders addon enabled.
