### PR TITLE
Fix reference to `--danger-orange`

### DIFF
--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -36,7 +36,7 @@ button {
   box-shadow: var(--content-shadow);
 }
 .message-type-admin {
-  border-color: var(--danger-orange);
+  border-color: var(--orange);
 }
 
 .message-type-title {


### PR DESCRIPTION
### Changes

Fixes a reference to a CSS variable that doesn't exist.

### Reason for changes

To fix a bug.

### Tests

![image](https://user-images.githubusercontent.com/51849865/206520031-013f6fd1-abc7-4d79-a85c-197468aba3c2.png)