### PR TITLE
Fix redux devtools conflict

### DIFF
--- a/content-scripts/load-redux.js
+++ b/content-scripts/load-redux.js
@@ -39,7 +39,8 @@ fix this warning."
     }
   }
 
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = function (...args) {
+  let newerCompose;
+  function compose(...args) {
     const scratchAddonsRedux = window.__scratchAddonsRedux;
     const reduxTarget = (scratchAddonsRedux.target = new EventTarget());
     scratchAddonsRedux.state = {};
@@ -62,8 +63,17 @@ fix this warning."
       };
     }
     args.splice(1, 0, ReDucks.applyMiddleware(middleware));
-    return ReDucks.compose.apply(this, args);
-  };
+    return newerCompose
+      ? newerCompose.apply(this, args)
+      : ReDucks.compose.apply(this, args);
+  }
+
+  Object.defineProperty(window, "__REDUX_DEVTOOLS_EXTENSION_COMPOSE__", {
+    get: () => compose,
+    set: (v) => {
+      newerCompose = v;
+    },
+  });
 }
 
 if (!(document.documentElement instanceof SVGElement)) {

--- a/content-scripts/load-redux.js
+++ b/content-scripts/load-redux.js
@@ -63,9 +63,7 @@ fix this warning."
       };
     }
     args.splice(1, 0, ReDucks.applyMiddleware(middleware));
-    return newerCompose
-      ? newerCompose.apply(this, args)
-      : ReDucks.compose.apply(this, args);
+    return newerCompose ? newerCompose.apply(this, args) : ReDucks.compose.apply(this, args);
   }
 
   Object.defineProperty(window, "__REDUX_DEVTOOLS_EXTENSION_COMPOSE__", {

--- a/content-scripts/load-redux.js
+++ b/content-scripts/load-redux.js
@@ -1,12 +1,5 @@
 function injectRedux() {
   window.__scratchAddonsRedux = {};
-  if (typeof window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ !== "undefined") {
-    return console.warn(
-      "Redux feature is disabled due to conflict. \
-Some addons will not work. Uninstall other browser extensions to \
-fix this warning."
-    );
-  }
 
   // ReDucks: Redux ducktyped
   // Not actual Redux, but should be compatible
@@ -39,7 +32,7 @@ fix this warning."
     }
   }
 
-  let newerCompose;
+  let newerCompose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
   function compose(...args) {
     const scratchAddonsRedux = window.__scratchAddonsRedux;
     const reduxTarget = (scratchAddonsRedux.target = new EventTarget());


### PR DESCRIPTION
### Changes

Shuffled the `inject-redux` script around a little so that it does not break when redux devtools is enabled. If the `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` variable is already set, it replaces the function and instead of using it's own ducktyped compose function uses the old `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` and only edits middleware. If `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` is set *after* sa updates it, same thing happens with the new value.

### Reason for changes

It's annoying not being able to use Redux DevTools to develop addons.

### Tests

No conflicts on my end, but i need some other people to test too.
