### PR TITLE
Suggestion form changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/--feature.yml
+++ b/.github/ISSUE_TEMPLATE/--feature.yml
@@ -15,8 +15,8 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Why this would be helpful/solve a problem
-      description: A clear and concise description of how this change could help with a problem or how it could improve something.
+      label: Why this would be helpful
+      description: How would this help with a problem or make something better?
       placeholder: Sometimes I want to...
     validations:
       required: true
@@ -24,9 +24,9 @@ body:
   - type: textarea
     id: howitworks
     attributes:
-      label: What this change does
-      description: A clear and concise description of what this enhancement/change does.
-      placeholder: There will be a new option...
+      label: My suggestion
+      description: Describe the changes you're suggesting and how they work.
+      placeholder: Add an option to...
     validations:
       required: true
 
@@ -34,11 +34,11 @@ body:
     id: alternatives
     attributes:
       label: Possible alternatives
-      description: A clear and concise description of any alternative solutions or features you've thought about or heard of.
+      description: Any alternative solutions or features you've thought about?
       placeholder: We could also ... instead.
 
   - type: textarea
     id: notes
     attributes:
-      label: Demonstration(s) and additional context
+      label: Additional context
       description: Add any other information like screenshots, videos, or context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/--new-addon.yml
+++ b/.github/ISSUE_TEMPLATE/--new-addon.yml
@@ -10,6 +10,7 @@ body:
         - Avoid creating duplicates! Read the FAQ page and search through issues and discussions before creating one.
         - Try to make a simple but descriptive title, and include the detailed information below.
         - Make sure to use the latest version of Scratch Addons.
+        - If your new addon is similar to another existing addon, consider mentioning merging them in the Possible alternatives field or suggesting a [new feature](https://github.com/ScratchAddons/ScratchAddons/issues/new?assignees=&labels=status%3A+needs+triage%2Ctype%3A+enhancement&template=--feature.yml) for it.
         - For help, check our [FAQ page](https://scratchaddons.com/faq), open a [discussion](https://github.com/ScratchAddons/ScratchAddons/discussions) or ask on our [Discord server](https://discord.gg/R5NBqwMjNc).
 
   - type: textarea
@@ -34,8 +35,8 @@ body:
     id: alternatives
     attributes:
       label: Possible alternatives
-      description: Any alternative solutions or features you've thought about?
-      placeholder: We could also ... instead.
+      description: Could this addon's features also be merged with or added to another one instead? Any alternative solutions or features you've thought about?
+      placeholder: We could also add these features to the ... addon instead.
 
   - type: textarea
     id: notes

--- a/.github/ISSUE_TEMPLATE/--new-addon.yml
+++ b/.github/ISSUE_TEMPLATE/--new-addon.yml
@@ -15,8 +15,8 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Why this would be helpful/solve a problem
-      description: A clear and concise description of how this addon could help with a problem or how it could improve something.
+      label: Why this would be helpful
+      description: How would this help with a problem or make something better?
       placeholder: Sometimes I want to...
     validations:
       required: true
@@ -24,8 +24,8 @@ body:
   - type: textarea
     id: howitworks
     attributes:
-      label: What this addon does
-      description: A clear and concise description of how the features this addon provides work and what they do.
+      label: How this addon works
+      description: Describe your addon and how it works.
       placeholder: This addon adds a button to...
     validations:
       required: true
@@ -34,11 +34,11 @@ body:
     id: alternatives
     attributes:
       label: Possible alternatives
-      description: A clear and concise description of any alternative solutions or features you've thought about or heard of.
+      description: Any alternative solutions or features you've thought about?
       placeholder: We could also ... instead.
 
   - type: textarea
     id: notes
     attributes:
-      label: Demonstration(s) and additional context
-      description: Add any other information like screenshots, videos, or context about the new addon here.
+      label: Additional context
+      description: Add any other information like screenshots, videos, or context about your new addon here.


### PR DESCRIPTION
Resolves #5436

### Changes

Various wording changes/revisions in the suggestion-type issue forms:
- Some headings (like "What this change does") changed
- Some form descriptions changed
- New step in `Read before creating` section on New Addon form: _"If your new addon is similar to another existing addon, consider mentioning merging them in the Possible alternatives field or suggesting a [new feature](https://github.com/ScratchAddons/ScratchAddons/issues/new?assignees=&labels=status%3A+needs+triage%2Ctype%3A+enhancement&template=--feature.yml) for it."_
### Reason for changes

To allow for more flexibility in suggestions and to make writing suggestions easier.

### Tests

Took a look at the changes on [my fork](https://github.com/DNin01/ScratchAddons/tree/5d9855ba8c42b38fa2b9f5c14955e3e8a55b1704/.github/ISSUE_TEMPLATE).
