### PR TITLE
Apply dark mode to TurboWarp iframe fullscreen background

### DIFF
--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -52,6 +52,13 @@ export default async function ({ addon, console, msg }) {
           const enabledAddons = await addon.self.getEnabledAddons("editor");
           usp.set("addons", enabledAddons.join(","));
         }
+        if ((await addon.self.getEnabledAddons("theme")).includes("dark-www")) {
+          // TurboWarp player fullscreen uses dark mode if dark-www is enabled.
+          // This might be consistent or not with the vanilla Scratch fullscreen,
+          // depending on the moment you're reading this.
+          usp.set("fullscreen-background", "#000000");
+          // Color #000000 is the default TurboWarp embed bg color if system dark mode detected
+        }
         const iframeUrl = `https://turbowarp.org/${projectId}/embed?${usp}${search}`;
         twIframe.src = "";
         scratchStage.parentElement.prepend(twIframeContainer);

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -56,8 +56,8 @@ export default async function ({ addon, console, msg }) {
           // TurboWarp player fullscreen uses dark mode if dark-www is enabled.
           // This might be consistent or not with the vanilla Scratch fullscreen,
           // depending on the moment you're reading this.
-          usp.set("fullscreen-background", "#000000");
-          // Color #000000 is the default TurboWarp embed bg color if system dark mode detected
+          usp.set("fullscreen-background", "#111111");
+          // Color #111111 is the default TurboWarp embed bg color if system dark mode detected
         }
         const iframeUrl = `https://turbowarp.org/${projectId}/embed?${usp}${search}`;
         twIframe.src = "";

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -52,13 +52,12 @@ export default async function ({ addon, console, msg }) {
           const enabledAddons = await addon.self.getEnabledAddons("editor");
           usp.set("addons", enabledAddons.join(","));
         }
-        if ((await addon.self.getEnabledAddons("theme")).includes("dark-www")) {
-          // TurboWarp player fullscreen uses dark mode if dark-www is enabled.
-          // This might be consistent or not with the vanilla Scratch fullscreen,
-          // depending on the moment you're reading this.
-          usp.set("fullscreen-background", "#111111");
-          // Color #111111 is the default TurboWarp embed bg color if system dark mode detected
-        }
+        // Apply the same fullscreen background color, consistently with the vanilla Scratch fullscreen behavior.
+        // It's not expected here to support dynamicDisable/dyanmicEnable of editor-dark-mode to work exactly
+        // like it does with vanilla.
+        const fullscreenBackground =
+          document.documentElement.style.getPropertyValue("--editorDarkMode-fullscreen") || "white";
+        usp.set("fullscreen-background", fullscreenBackground);
         const iframeUrl = `https://turbowarp.org/${projectId}/embed?${usp}${search}`;
         twIframe.src = "";
         scratchStage.parentElement.prepend(twIframeContainer);


### PR DESCRIPTION
Resolves #4430

### Changes

Code is self explanatory.
We might want to discuss whether we should try to be consistent with the vanilla Scratch fullscreen, which remains unchanged even if `dark-www` is enabled.
Note that users that had system-level dark mode enabled already had dark mode here. This only applies for users that don't have that.

### Tests

Tested in Chromium