### PR TITLE
Fix TurboWarp player white background

### DIFF
--- a/addons/turbowarp-player/style.css
+++ b/addons/turbowarp-player/style.css
@@ -48,4 +48,8 @@
   margin-top: -3px;
 
   border: none;
+
+  /* Transparency only works if the iframe has the same color-scheme
+     as the document inside */
+  color-scheme: light;
 }


### PR DESCRIPTION
Resolves #5445

### Changes

Adds `color-scheme: light` to the TurboWarp iframe.

### Reason for changes

To fix the white background in dark mode.

### Tests

Tested on Edge and Firefox.