### PR TITLE
Update `sprite-properties` speed setting names

### DIFF
--- a/addons/sprite-properties/addon.json
+++ b/addons/sprite-properties/addon.json
@@ -52,17 +52,17 @@
       "default": false
     },
     {
-      "name": "Animation duration",
+      "name": "Animation speed",
       "id": "transitionDuration",
       "type": "select",
       "potentialValues": [
         {
           "id": "none",
-          "name": "None"
+          "name": "Instant"
         },
         {
           "id": "short",
-          "name": "Short"
+          "name": "Quick"
         },
         {
           "id": "default",
@@ -70,7 +70,7 @@
         },
         {
           "id": "long",
-          "name": "Long"
+          "name": "Slow"
         }
       ],
       "default": "default"


### PR DESCRIPTION
### Changes

Changes the names of the speed settings from None/Short/Default/Long to Instant/Quick/Default/Slow.

### Reason for changes

Since I’ve changed the names of the different speed settings on two other addons, I wanted to apply that change to this addon, too.

### Tests

Should be fine.
