### PR TITLE
Add `node_modules` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ ehthumbs_vista.db
 
 # Folder config file
 [Dd]esktop.ini
+
+# Development files
+node_modules/


### PR DESCRIPTION
### Changes

Added `node_modules/` to `.gitignore`.

### Reason for changes

I've been working on a development feature that uses node, and am unable to switch between branches because this is not present. If my bundling pr gets merged, this will need to be present anyways. It's only a single line.