### PR TITLE
find-bar: Fix some errors searching for broadcasts

### DIFF
--- a/addons-l10n/en/find-bar.json
+++ b/addons-l10n/en/find-bar.json
@@ -1,4 +1,5 @@
 {
   "find-bar/find": "Find",
-  "find-bar/find-placeholder": "Find (Ctrl+F)"
+  "find-bar/find-placeholder": "Find (Ctrl+F)",
+  "find-bar/complex-broadcast": "(complex)"
 }

--- a/addons-l10n/en/find-bar.json
+++ b/addons-l10n/en/find-bar.json
@@ -1,5 +1,5 @@
 {
   "find-bar/find": "Find",
   "find-bar/find-placeholder": "Find (Ctrl+F)",
-  "find-bar/complex-broadcast": "(complex)"
+  "find-bar/complex-broadcast": "(expression)"
 }

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -361,13 +361,13 @@ export default async function ({ addon, msg, console }) {
 
     getCallsToEvents() {
       const uses = [];
-      const found = {};
+      const alreadyFound = new Set();
 
       for (const block of this.workspace.getAllBlocks()) {
         if (block.type === "event_broadcast" || block.type === "event_broadcastandwait") {
           const eventName = block.getChildren()[0].inputList[0].fieldRow[0].getText();
-          if (!found[eventName]) {
-            found[eventName] = block;
+          if (!alreadyFound.has(eventName)) {
+            alreadyFound.add(eventName);
             uses.push({ eventName: eventName, block: block });
           }
         }

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -363,17 +363,12 @@ export default async function ({ addon, msg, console }) {
       const uses = []; // Definition First, then calls to it
       const found = {};
 
-      let topBlocks = this.workspace.getTopBlocks();
-      for (const topBlock of topBlocks) {
-        /** @type {!Array<!Blockly.Block>} */
-        let kids = topBlock.getDescendants();
-        for (const block of kids) {
-          if (block.type === "event_broadcast" || block.type === "event_broadcastandwait") {
-            const eventName = block.getChildren()[0].inputList[0].fieldRow[0].getText();
-            if (!found[eventName]) {
-              found[eventName] = block;
-              uses.push({ eventName: eventName, block: block });
-            }
+      for (const block of this.workspace.getAllBlocks()) {
+        if (block.type === "event_broadcast" || block.type === "event_broadcastandwait") {
+          const eventName = block.getChildren()[0].inputList[0].fieldRow[0].getText();
+          if (!found[eventName]) {
+            found[eventName] = block;
+            uses.push({ eventName: eventName, block: block });
           }
         }
       }

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -373,11 +373,11 @@ export default async function ({ addon, msg, console }) {
           continue;
         }
 
-        let eventName = '';
+        let eventName = "";
         if (broadcastInput.type === "event_broadcast_menu") {
           eventName = broadcastInput.inputList[0].fieldRow[0].getText();
         } else {
-          eventName = msg('complex-broadcast');
+          eventName = msg("complex-broadcast");
         }
         if (!alreadyFound.has(eventName)) {
           alreadyFound.add(eventName);

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -369,12 +369,16 @@ export default async function ({ addon, msg, console }) {
         }
 
         const broadcastInput = block.getChildren()[0];
-        // If this is a block like "broadcast (1 + 1)", don't index it.
-        if (!broadcastInput || broadcastInput.type !== "event_broadcast_menu") {
+        if (!broadcastInput) {
           continue;
         }
 
-        const eventName = broadcastInput.inputList[0].fieldRow[0].getText();
+        let eventName = '';
+        if (broadcastInput.type === "event_broadcast_menu") {
+          eventName = broadcastInput.inputList[0].fieldRow[0].getText();
+        } else {
+          eventName = msg('complex-broadcast');
+        }
         if (!alreadyFound.has(eventName)) {
           alreadyFound.add(eventName);
           uses.push({ eventName: eventName, block: block });
@@ -619,13 +623,16 @@ export default async function ({ addon, msg, console }) {
           } else if (block.opcode === "event_broadcast" || block.opcode === "event_broadcastandwait") {
             const broadcastInputBlockId = block.inputs.BROADCAST_INPUT.block;
             const broadcastInputBlock = blocks._blocks[broadcastInputBlockId];
-            // Don't try to index blocks like "broadcast (1 + 1)"
-            if (
-              broadcastInputBlock &&
-              broadcastInputBlock.opcode === "event_broadcast_menu" &&
-              broadcastInputBlock.fields.BROADCAST_OPTION.value === name
-            ) {
-              uses.push(new BlockInstance(target, block));
+            if (broadcastInputBlock) {
+              let eventName;
+              if (broadcastInputBlock.opcode === "event_broadcast_menu") {
+                eventName = broadcastInputBlock.fields.BROADCAST_OPTION.value;
+              } else {
+                eventName = msg("complex-broadcast");
+              }
+              if (eventName === name) {
+                uses.push(new BlockInstance(target, block));
+              }
             }
           }
         }

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -360,7 +360,7 @@ export default async function ({ addon, msg, console }) {
     }
 
     getCallsToEvents() {
-      const uses = []; // Definition First, then calls to it
+      const uses = [];
       const found = {};
 
       for (const block of this.workspace.getAllBlocks()) {


### PR DESCRIPTION
These no longer cause issues:

![image](https://user-images.githubusercontent.com/33787854/208818959-d44da2c1-eda6-4200-a946-134523d7d1d5.png)

 - Broadcasts with complex inputs will be treated as if they are named ~~"(complex)"~~ "(expression)" instead of throwing errors. The reasoning for this behavior is: generating a meaningful text description for complex blocks is not trivial, very few projects use this anyways, but skipping them entirely seems like a bad idea
 - Broadcasts named after Object.prototype builtins will work reliably now.
 - Closes https://github.com/TurboWarp/scratch-gui/issues/669
