### PR TITLE
Move the icon for closing sprite properties

### DIFF
--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -81,8 +81,7 @@ export default async function ({ addon, global, console, msg }) {
   }
 
   async function injectCloseButton() {
-    let container = propertiesPanel.querySelector("[class*='sprite-info_row_']:nth-child(2)");
-    injectButton(container, PROPS_CLOSE_BTN_CLASS, "/collapse.svg", msg("close-properties-panel-tooltip"));
+    injectButton(propertiesPanel, PROPS_CLOSE_BTN_CLASS, "/collapse.svg", msg("close-properties-panel-tooltip"));
   }
 
   async function injectButton(container, className, iconPath, tooltip) {

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -17,12 +17,22 @@
 }
 
 .sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
-  height: 6.3125rem;
+  /* The height needs to be known for the animation to work.
+     6.5rem + 5px is the exact height of sprite info when
+     this addon is enabled:
+       0.75rem (top padding)
+     + 2rem + 2px (.icon-wrappers in the first row)
+     + 0.5rem (margin between rows)
+     + 2rem + 2px (.icon-wrappers in the second row)
+     + 1.25rem (close button)
+     + 1px (bottom border) */
+  height: calc(6.5rem + 5px);
   padding: 0.75rem;
+  padding-bottom: 0;
 }
 
 .sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
-  height: calc(100% - 6.3125rem);
+  height: calc(100% - 6.5rem - 5px);
 }
 
 .sa-sprite-properties-btn {
@@ -50,6 +60,10 @@
 }
 
 .sa-sprite-properties-close-btn {
+  width: 100%;
+  height: 1.25rem;
+  padding: 0;
+  padding-top: 0.5rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -59,4 +73,9 @@
 
 .sa-sprite-properties-close-btn img {
   filter: var(--editorDarkMode-accent-filter);
+  transition: opacity 0.25s ease-out;
+}
+
+.sa-sprite-properties-close-btn:hover img {
+  opacity: 0.75;
 }


### PR DESCRIPTION
See https://github.com/ScratchAddons/ScratchAddons/pull/5158#issuecomment-1345303499

### Changes

The "collapsing sprite properties" addon adds an arrow to close the properties panel when it's expanded. It looks like this:
![image](https://user-images.githubusercontent.com/51849865/208973672-77faf3d1-8a34-434b-99a2-961902807ec9.png)

This PR changes it to look like this instead:
![image](https://user-images.githubusercontent.com/51849865/208973792-6f837a8d-7d1c-4b6a-afb4-7af0d791838c.png)

A large area around it is clickable.

### Reason for changes

To make it more visible.

### Tests

Tested on Edge and Firefox.