### PR TITLE
Add info note to disable-paste-offset

### DIFF
--- a/addons/disable-paste-offset/addon.json
+++ b/addons/disable-paste-offset/addon.json
@@ -1,6 +1,12 @@
 {
   "name": "Do not shift pasted items",
   "description": "Paste copied items at their original position instead of shifted slightly in the costume editor.",
+  "info": [
+    {
+      "text": "This behavior can also be achieved without needing this addon, by Alt+Clicking the item.",
+      "id": "vanilla"
+    }
+  ],
   "credits": [
     {
       "name": "GarboMuffin"

--- a/addons/disable-paste-offset/addon.json
+++ b/addons/disable-paste-offset/addon.json
@@ -3,7 +3,7 @@
   "description": "Paste copied items at their original position instead of shifted slightly in the costume editor.",
   "info": [
     {
-      "text": "This behavior can also be achieved without needing this addon, by Alt+Clicking the item.",
+      "text": "This behavior can also be achieved without this addon by Alt+Clicking the item.",
       "id": "vanilla"
     }
   ],


### PR DESCRIPTION
From feedback:

> just figured out there's a SA feature allowing to duplicate an object at the same place on costume editor but we could already do this by holding option/alt and click on the item

### Changes

Add an info note to the addon to make users aware of this. The phrasing can be changed and probably should.