### PR TITLE
Custom brand image addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -1,4 +1,5 @@
 [
+  "custom-brand-image",
   "editor-searchable-dropdowns",
   "editor-devtools",
   "forum-search",

--- a/addons/custom-brand-image/addon.json
+++ b/addons/custom-brand-image/addon.json
@@ -1,0 +1,33 @@
+{
+  "name": "Custom brand image",
+  "description": "Allows you to change the Scratch brand image to any image from any URL.",
+  "credits": [
+    {
+      "name": "TJ20201",
+      "link": "https://github.com/TJ20201"
+    }
+  ],
+  "versionAdded": "1.30.0",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/*"]
+    }
+  ],
+  "settings": [
+    {
+      "id": "imageurl",
+      "name": "Custom image url",
+      "default": "",
+      "type": "string"
+    },
+    {
+      "id": "showbrand",
+      "name": "Show brand image (TOGGLING REQUIRES PAGE REFRESH)",
+      "default": true,
+      "type": "boolean"
+    }
+  ],
+  "tags": ["community", "theme"],
+  "enabledByDefault": false
+}

--- a/addons/custom-brand-image/userscript.js
+++ b/addons/custom-brand-image/userscript.js
@@ -1,0 +1,15 @@
+export default async function ({ addon, global, console }) {
+  function update() {
+    var logos = document.querySelectorAll("#navigation .logo a")
+    for (let i = 0; i < logos.length; i++) {
+      if (addon.settings.get("showbrand") == true) {
+        logos[i].style.backgroundImage = `url(${addon.settings.get("imageurl")})`
+      } else {
+      	logos[i].remove()
+      }
+    }
+  }
+  document.body.addEventListener("load", update);
+  addon.settings.addEventListener("change", update);
+  update()
+}


### PR DESCRIPTION
### Changes
Adds the ability to change the image for the brand icon (the Scratch logo in the top left) or hide it completely. This is a CSS addon, however the CSS is managed through JS due to the `url()` parameter not accepting variables.
### Reason for changes
I only made this addon out of boredom, so I do not expect it to be accepted as it isn't highly-requested or fix any issue with Scratch or other Scratch addons.
### Tests
This addon was tested on Chrome 108 on a x64 Windows 10 Home device.
### Example
This is an example of me using this addon to change the Scratch logo to "Get it from Microsoft". (Red background is due to customisation through a different addon)
![image](https://user-images.githubusercontent.com/86313252/209479720-54e84c3a-6c42-4586-95e1-fa1ee0ad04ca.png)
