### PR TITLE
`clones`: Setting to show on project page

### DIFF
--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -32,7 +32,7 @@
   "settings": [
     {
       "id": "projectpage",
-      "name": "Also show on project page",
+      "name": "Show on project page",
       "default": false,
       "type": "boolean"
     },

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -8,6 +8,10 @@
     {
       "name": "OregSam",
       "link": "https://github.com/OregSamSas"
+    },
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
     }
   ],
   "dynamicEnable": true,
@@ -40,9 +44,8 @@
     }
   ],
   "latestUpdate": {
-    "version": "1.28.0",
-    "newSettings": ["showicononly"],
-    "isMajor": false
+    "version": "1.30.0",
+    "temporaryNotice": "You can now choose whether the clone counter shows up only in the editor or also on the project page."
   },
   "tags": ["editor", "projectPlayer", "recommended"],
   "enabledByDefault": false

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -44,7 +44,7 @@
     }
   ],
   "latestUpdate": {
-    "version": "1.30.0",
+    "version": "1.31.0",
     "newSettings": ["projectpage"]
   },
   "tags": ["editor", "projectPlayer", "recommended"],

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -45,7 +45,7 @@
   ],
   "latestUpdate": {
     "version": "1.30.0",
-    "newSettings": "projectpage"
+    "newSettings": ["projectpage"]
   },
   "tags": ["editor", "projectPlayer", "recommended"],
   "enabledByDefault": false

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -45,7 +45,7 @@
   ],
   "latestUpdate": {
     "version": "1.30.0",
-    "temporaryNotice": "You can now choose whether the clone counter shows up only in the editor or also on the project page."
+    "newSettings": "projectpage"
   },
   "tags": ["editor", "projectPlayer", "recommended"],
   "enabledByDefault": false

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -31,9 +31,9 @@
   ],
   "settings": [
     {
-      "id": "editoronly",
-      "name": "Only show in editor",
-      "default": true,
+      "id": "projectpage",
+      "name": "Also show on project page",
+      "default": false,
       "type": "boolean"
     },
     {

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -27,6 +27,12 @@
   ],
   "settings": [
     {
+      "id": "editoronly",
+      "name": "Only show in editor",
+      "default": true,
+      "type": "boolean"
+    },
+    {
       "id": "showicononly",
       "name": "Show icon only",
       "default": false,

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -51,7 +51,8 @@ export default async function ({ addon, console, msg }) {
       count.dataset.str = cache[v] || msg("clones", { cloneCount: v });
     }
 
-    if (v === 0) countContainerContainer.style.display = "none";
+    if (v === 0 || (addon.tab.editorMode !== "editor" && !showOnProjectPage))
+      countContainerContainer.style.display = "none";
     else addon.tab.displayNoneWhileDisabled(countContainerContainer, { display: "flex" });
   }
 
@@ -78,8 +79,7 @@ export default async function ({ addon, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
 
-    if (addon.tab.editorMode === "editor" || showOnProjectPage) {
-      addon.tab.appendToSharedSpace({ space: "afterStopButton", element: countContainerContainer, order: 2 });
-    }
+    addon.tab.appendToSharedSpace({ space: "afterStopButton", element: countContainerContainer, order: 2 });
+    doCloneChecks(true);
   }
 }

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
 
-  let alsoShowOnProjectPage = addon.settings.get("projectpage");
+  let showOnProjectPage = addon.settings.get("projectpage");
   let showIconOnly = addon.settings.get("showicononly");
 
   if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
@@ -57,7 +57,7 @@ export default async function ({ addon, console, msg }) {
 
   addon.settings.addEventListener("change", () => {
     showIconOnly = addon.settings.get("showicononly");
-    alsoShowOnProjectPage = addon.settings.get("projectpage");
+    showOnProjectPage = addon.settings.get("projectpage");
     doCloneChecks(true);
   });
 
@@ -78,7 +78,7 @@ export default async function ({ addon, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
 
-    if (addon.tab.editorMode === "editor" || alsoShowOnProjectPage) {
+    if (addon.tab.editorMode === "editor" || showOnProjectPage) {
       addon.tab.appendToSharedSpace({ space: "afterStopButton", element: countContainerContainer, order: 2 });
     }
   }

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -1,6 +1,7 @@
 export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
 
+  let showOnlyInEditor = addon.settings.get("editoronly");
   let showIconOnly = addon.settings.get("showicononly");
 
   if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
@@ -56,6 +57,7 @@ export default async function ({ addon, console, msg }) {
 
   addon.settings.addEventListener("change", () => {
     showIconOnly = addon.settings.get("showicononly");
+    showOnlyInEditor = addon.settings.get("editoronly");
     doCloneChecks(true);
   });
 
@@ -76,7 +78,7 @@ export default async function ({ addon, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
 
-    if (addon.tab.editorMode === "editor") {
+    if (addon.tab.editorMode === "editor" || showOnlyInEditor === false) {
       addon.tab.appendToSharedSpace({ space: "afterStopButton", element: countContainerContainer, order: 2 });
     }
   }

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
 
-  let showOnlyInEditor = addon.settings.get("editoronly");
+  let alsoShowOnProjectPage = addon.settings.get("editoronly");
   let showIconOnly = addon.settings.get("showicononly");
 
   if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
@@ -57,7 +57,7 @@ export default async function ({ addon, console, msg }) {
 
   addon.settings.addEventListener("change", () => {
     showIconOnly = addon.settings.get("showicononly");
-    showOnlyInEditor = addon.settings.get("editoronly");
+    alsoShowOnProjectPage = addon.settings.get("projectpage");
     doCloneChecks(true);
   });
 
@@ -78,7 +78,7 @@ export default async function ({ addon, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
 
-    if (addon.tab.editorMode === "editor" || !showOnlyInEditor) {
+    if (addon.tab.editorMode === "editor" || alsoShowOnProjectPage) {
       addon.tab.appendToSharedSpace({ space: "afterStopButton", element: countContainerContainer, order: 2 });
     }
   }

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
 
-  let alsoShowOnProjectPage = addon.settings.get("editoronly");
+  let alsoShowOnProjectPage = addon.settings.get("projectpage");
   let showIconOnly = addon.settings.get("showicononly");
 
   if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -78,7 +78,7 @@ export default async function ({ addon, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
 
-    if (addon.tab.editorMode === "editor" || showOnlyInEditor === false) {
+    if (addon.tab.editorMode === "editor" || !showOnlyInEditor) {
       addon.tab.appendToSharedSpace({ space: "afterStopButton", element: countContainerContainer, order: 2 });
     }
   }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Inspired by https://github.com/ScratchAddons/ScratchAddons/issues/5486#issuecomment-1364735331

### Changes

Added an option to change whether the clone counter also shows on the project page. The previous behavior was only in the editor. Now, this can be changed.

### Reason for changes

Viewers and creators might want to see it outside the editor in some cases.

### Tests

Tested (including the latest changes) on Edge with SA v1.30.0-pre.