### PR TITLE
Add v1.30 update notification

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -242,14 +242,14 @@
   "extensionHasUpdated": {
     "message": "Scratch Addons has updated to v$1"
   },
-  "extensionUpdateInfo1_v1_29": {
-    "message": "New addon: \"opacity slider\", which adds an opacity slider to the costume editor color picker. Go to $1 to enable it."
+  "extensionUpdateInfo1_v1_30": {
+    "message": "New addon: \"costume editor snapping\", which lets you snap objects in the costume editor to bounding boxes and vector nodes. Go to $1 to enable it."
   },
   "scratchAddonsSettings": {
     "message": "Scratch Addons settings"
   },
-  "extensionUpdateInfo2_v1_29": {
-    "message": "Other new addons added this update are \"project volume slider\", \"rename broadcasts\", and \"select stage colors in the costume editor\"."
+  "extensionUpdateInfo2_v1_30": {
+    "message": "Other new addons added this update are \"collapsing sprite properties\", \"insert blocks by name\", and \"always show number pad\"."
   },
   "notAffiliated": {
     "message": "Scratch Addons is not affiliated with Scratch."

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -649,7 +649,7 @@ const showBanner = () => {
   });
   const notifInnerText1 = Object.assign(document.createElement("span"), {
     style: NOTIF_TEXT_STYLE,
-    innerHTML: escapeHTML(chrome.i18n.getMessage("extensionUpdateInfo1_v1_29", DOLLARS)).replace(
+    innerHTML: escapeHTML(chrome.i18n.getMessage("extensionUpdateInfo1_v1_30", DOLLARS)).replace(
       /\$(\d+)/g,
       (_, i) =>
         [
@@ -668,7 +668,7 @@ const showBanner = () => {
   });
   const notifInnerText2 = Object.assign(document.createElement("span"), {
     style: NOTIF_TEXT_STYLE,
-    textContent: chrome.i18n.getMessage("extensionUpdateInfo2_v1_29"),
+    textContent: chrome.i18n.getMessage("extensionUpdateInfo2_v1_30"),
   });
   const notifFooter = Object.assign(document.createElement("span"), {
     style: NOTIF_TEXT_STYLE,


### PR DESCRIPTION
> New addon: "costume editor snapping", which lets you snap objects in the costume editor to bounding boxes and vector nodes. Go to [Scratch Addons settings](https://scratch.mit.edu/scratch-addons-extension/settings?source=updatenotif) to enable it.

> Other new addons added this update are "collapsing sprite properties", "insert blocks by name", and "always show number pad".

YouTube video thumbnail and link are still pending.

![image](https://user-images.githubusercontent.com/17484114/209587945-f6f55363-f23e-4e10-be0f-5060efa65907.png)