### PR TITLE
editor-stage-left: fix flipped stage button icons

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -1,5 +1,8 @@
-[class^="stage-header_stage-button-icon"] {
+[dir="ltr"] [class^="stage-header_stage-size-toggle-group"] [class^="stage-header_stage-button-icon"] {
   transform: scaleX(-1);
+}
+[dir="rtl"] [class^="stage-header_stage-size-toggle-group"] [class^="stage-header_stage-button-icon"] {
+  transform: none;
 }
 [class^="target-pane_target-pane"] {
   flex-direction: row-reverse;


### PR DESCRIPTION
Resolves #2851

### Changes

Fixes a bug in `editor-stage-left` that caused gamepad and debugger icons to be flipped. Large stage, small stage and hide stage icons are still flipped, as expected.

### Tests

LTR:
![image](https://user-images.githubusercontent.com/51849865/209681522-91beb661-2f5f-48af-8329-6d4e565fa37b.png)
RTL:
![image](https://user-images.githubusercontent.com/51849865/209681631-5136f119-9123-4c19-8ea2-760b6445ad9f.png)