### PR TITLE
items-per-row: avoid changing layout with default settings

### DIFF
--- a/addons/items-per-row/classes.js
+++ b/addons/items-per-row/classes.js
@@ -9,12 +9,19 @@ function setClasses(setting, value, thresholds) {
     if (value <= threshold) document.body.classList.add(className);
     else document.body.classList.remove(className);
   }
+  if (thresholds.exact) {
+    for (let threshold of thresholds.exact) {
+      const className = `items-per-row-${setting}-${threshold}`;
+      if (value === threshold) document.body.classList.add(className);
+      else document.body.classList.remove(className);
+    }
+  }
 }
 
 export default async function ({ addon, console }) {
   await addon.tab.waitForElement("body");
   const updateClasses = () => {
-    setClasses("search", addon.settings.get("search"), { min: [5], max: [2] });
+    setClasses("search", addon.settings.get("search"), { min: [5], max: [2], exact: [4] });
     setClasses("studio-projects", addon.settings.get("studioProjects"), { min: [4, 5], max: [] });
     setClasses("studio-curators", addon.settings.get("studioCurators"), { min: [4, 5], max: [2] });
     setClasses("projects", addon.settings.get("projects"), { min: [6, 7], max: [4, 3] });

--- a/addons/items-per-row/search.css
+++ b/addons/items-per-row/search.css
@@ -26,6 +26,13 @@
   height: auto;
 }
 
+.items-per-row-search-4 .grid .thumbnail.project {
+  height: 204px;
+}
+.items-per-row-search-4 .grid .thumbnail.gallery {
+  height: 160px;
+}
+
 .grid .thumbnail .thumbnail-image,
 .grid .thumbnail .thumbnail-info {
   width: calc(100% - 16px);

--- a/addons/items-per-row/studio.css
+++ b/addons/items-per-row/studio.css
@@ -18,12 +18,6 @@
   padding-right: 0;
 }
 
-.studio-project-tile .studio-project-image,
-.studio-project-tile .studio-project-avatar,
-.studio-member-tile .studio-member-image {
-  vertical-align: middle;
-}
-
 .items-per-row-studio-curators-min5 .studio-member-tile .studio-member-image {
   width: 24px;
   height: 24px;
@@ -33,10 +27,6 @@
   height: 60px;
 }
 
-.studio-project-tile .studio-project-bottom {
-  padding-top: 8px;
-  padding-bottom: 8px;
-}
 .items-per-row-studio-projects-min4 .studio-project-tile .studio-project-bottom {
   padding-left: 8px;
   padding-right: 0;


### PR DESCRIPTION
Resolves #3293

### Changes

Modifies the CSS of the `items-per-row` addon to avoid changing the height of rows on Explore, search, and studio pages.

### Reason for changes

If the selected number of items is the same as Scratch's default, the addon shouldn't make any changes.

### Tests

Tested on Edge and Firefox.