### PR TITLE
Fix some onion-skinning and paint-snap visual issues

### DIFF
--- a/addons/onion-skinning/style.css
+++ b/addons/onion-skinning/style.css
@@ -91,6 +91,6 @@
   stroke: #ddd;
 }
 
-.sa-onion-label {
+.sa-onion-settings-label {
   white-space: nowrap;
 }

--- a/addons/onion-skinning/style.css
+++ b/addons/onion-skinning/style.css
@@ -1,7 +1,7 @@
 .sa-onion-button {
   position: relative;
 }
-.sa-onion-button:active {
+.sa-onion-button:focus-within {
   background-color: hsla(215, 100%, 65%, 0.2);
 }
 .sa-onion-button[data-enabled="true"] .sa-onion-image {

--- a/addons/onion-skinning/style.css
+++ b/addons/onion-skinning/style.css
@@ -27,7 +27,7 @@
 
 .sa-onion-settings {
   position: absolute;
-  bottom: 0px;
+  bottom: 100%;
   /* based on the styles for the color dropdown */
   padding: 4px;
   border-radius: 4px;

--- a/addons/paint-snap/userstyle.css
+++ b/addons/paint-snap/userstyle.css
@@ -1,7 +1,7 @@
 .sa-paint-snap-button {
   position: relative;
 }
-.sa-paint-snap-button:active {
+.sa-paint-snap-button:focus-within {
   background-color: hsla(215, 100%, 65%, 0.2);
 }
 .sa-paint-snap-button[data-enabled="true"] .sa-paint-snap-image {

--- a/addons/paint-snap/userstyle.css
+++ b/addons/paint-snap/userstyle.css
@@ -27,7 +27,7 @@
 
 .sa-paint-snap-settings {
   position: absolute;
-  bottom: 0px;
+  bottom: 100%;
   /* based on the styles for the color dropdown */
   padding: 4px;
   border-radius: 4px;


### PR DESCRIPTION
This is a partial follow-up to https://github.com/ScratchAddons/ScratchAddons/pull/5069, primarily regarding changes to onion-skinning

 - Fix onion skinning setting labels wrapping unexpectedly
 - Restore previous input background color change when an onion skinning settings input was focused so the user can easily tell what input they're editing, reverting https://github.com/ErrorGamer2000/ScratchAddons/commit/7afb158dcfd9e2d3f36e75415059b31f61ed4a68. I feel that the browser's native text caret that is invisible half the time is not sufficient for indicating focus. If that commit was intended to fix a different "visual bug", I can't tell what it was.
 - Use a smaller motion when opening the onion skinning settings menu (similar to the animation pre-paint-snap). I feel that the animation was too large and distracting.

The last 2 also apply to the paint-snap addon.

@ErrorGamer2000 