### PR TITLE
fullscreen: resize stage canvas

### DIFF
--- a/addons/fullscreen/userscript.js
+++ b/addons/fullscreen/userscript.js
@@ -40,15 +40,19 @@ export default async function ({ addon, console }) {
     }
   }
 
-  // Properly scale variable monitors on stage resize.
+  // Properly resize the canvas and scale variable monitors on stage resize.
   let monitorScaler, resizeObserver, stage;
   async function initScaler() {
     monitorScaler = await addon.tab.waitForElement("[class*=monitor-list_monitor-list-scaler]");
     stage = await addon.tab.waitForElement('[class*="stage-wrapper_full-screen"] [class*="stage_stage"]');
     resizeObserver = new ResizeObserver(() => {
+      const stageSize = stage.getBoundingClientRect();
+      // Width and height attributes of the canvas need to match the actual size.
+      const renderer = addon.tab.traps.vm.runtime.renderer;
+      if (renderer) renderer.resize(stageSize.width, stageSize.height);
       // Scratch uses the `transform` CSS property on a stage overlay element
       // to control the scaling of variable monitors.
-      const scale = stage.getBoundingClientRect().width / 480;
+      const scale = stageSize.width / 480;
       monitorScaler.style.transform = `scale(${scale}, ${scale})`;
     });
     resizeObserver.observe(stage);


### PR DESCRIPTION
Resolves #3815

### Changes

Calls `renderer.resize()` when the window size changes.

### Reason for changes

To fix a bug.

### Tests

Tested on Edge and Firefox.