### PR TITLE
fullscreen: fix incorrect position of answer input

### DIFF
--- a/addons/fullscreen/removeBorder.css
+++ b/addons/fullscreen/removeBorder.css
@@ -3,3 +3,8 @@
   border: 0 !important;
   border-radius: 0 !important;
 }
+
+[class*="stage_stage-overlays_"][class*="stage_full-screen_"] {
+  top: 0;
+  left: 0;
+}


### PR DESCRIPTION
### Changes

Fixes a bug in the enhanced full screen addon that caused the answer input to be positioned incorrectly (slightly too low and not centered).

### Tests

Before:
![image](https://user-images.githubusercontent.com/51849865/209833415-9eb030d4-b8f4-43fc-9f7d-8c32c0863a71.png)

After:
![image](https://user-images.githubusercontent.com/51849865/209833422-588a55eb-a353-44bd-a95e-fc1fd041c80f.png)