### PR TITLE
hi-res-thumbnails: fix bugs

### DIFF
--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -21,7 +21,8 @@ export default async function ({ addon, console }) {
     }
   });
   main: while (true) {
-    const image = await addon.tab.waitForElement("img", {
+    // Images in forum posts are ignored.
+    const image = await addon.tab.waitForElement("img:not(.postmsg *)", {
       markAsSeen: true,
     });
 

--- a/addons/hi-res-thumbnails/userscript.js
+++ b/addons/hi-res-thumbnails/userscript.js
@@ -3,19 +3,21 @@ export default async function ({ addon, console }) {
   const UPLOADS_REGEX = /^https?:\/\/uploads\.scratch\.mit\.edu\//;
   const thumbnails = [];
   addon.self.addEventListener("disabled", () => {
-    for (const { image, lazySrc } of thumbnails) {
-      if (lazySrc) {
-        image.dataset.original = lazySrc;
+    for (const { image, src, lazy } of thumbnails) {
+      if (lazy) {
+        image.dataset.original = src;
       }
-      image.src = lazySrc;
+      if (image.src) {
+        image.src = src;
+      }
     }
   });
   addon.self.addEventListener("reenabled", () => {
-    for (const { image, src, lazySrc, newSrc } of thumbnails) {
-      if (lazySrc) {
+    for (const { image, src, lazy, newSrc } of thumbnails) {
+      if (lazy) {
         image.dataset.original = newSrc;
       }
-      if (src) {
+      if (image.src) {
         image.src = newSrc;
       }
     }
@@ -68,7 +70,7 @@ export default async function ({ addon, console }) {
       newSrc = cdn2[1].replace("cdn2", "uploads") + width + "x" + height + cdn2[4];
     }
 
-    reloadImageSafe(image, newSrc);
+    reloadImageSafe(image, src, newSrc, { lazy });
   }
 
   function resizeToScreenRes(width, height, image) {
@@ -136,14 +138,14 @@ export default async function ({ addon, console }) {
 
     return [width, height];
   }
-  function reloadImageSafe(image, newSrc) {
+  function reloadImageSafe(image, src, newSrc, { lazy = false } = {}) {
     thumbnails.push({
       image,
-      src: image.src,
-      lazySrc: image.dataset.original,
+      src,
+      lazy,
       newSrc,
     });
-    if (image.classList.contains("lazy")) {
+    if (lazy) {
       image.dataset.original = newSrc;
     }
     if (image.src) {


### PR DESCRIPTION
Resolves #3987

### Changes

* Ignores images in forum posts and signatures.
* Fixes dynamic disable (it currently breaks all images that don't have lazy loading).

### Reason for changes

The addon can't handle forum images correctly because they don't have width/height attributes or CSS properties. If it runs before the image loads, it tries to resize it to 0x0. If the image loads first, the addon will make it larger instead of increasing the resolution.

### Tests

Tested on Edge and Firefox.