### PR TITLE
editor-dark-mode: fix invisible caret in paint editor

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -563,6 +563,19 @@
       }
     },
     {
+      "name": "input-colorScheme",
+      "value": {
+        "type": "textColor",
+        "black": "light",
+        "white": "dark",
+        "source": {
+          "type": "settingValue",
+          "settingId": "input"
+        },
+        "threshold": 128
+      }
+    },
+    {
       "name": "input-transparent90",
       "value": {
         "type": "multiply",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -244,6 +244,7 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .u-dropdown-searchbar:focus {
   background-color: var(--editorDarkMode-input);
   color: var(--editorDarkMode-input-text);
+  color-scheme: var(--editorDarkMode-input-colorScheme);
 }
 .u-dropdown-searchbar,
 .project-title-input_title-field_en5Gd {
@@ -623,10 +624,6 @@ img[src="/static/assets/26255153f92ea41df149a58d3c3fe2cf.svg"] /* record modal s
       transparent 75%,
       var(--editorDarkMode-accent-paintEditorBackground) 75%
     );
-}
-.sa-color-picker > .sa-color-picker-color {
-  /* Use the dark version of the browser's default button appearance. */
-  color-scheme: dark;
 }
 .Popover .resize-sensor {
   /* The <object> gets a white background if color-scheme is dark. */

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -590,7 +590,8 @@ img[src="/static/assets/26255153f92ea41df149a58d3c3fe2cf.svg"] /* record modal s
 }
 
 /* Miscellaneous styles */
-[class*="stage-wrapper_"] {
+[class*="stage-wrapper_"],
+.paint-editor_canvas-container_x2D0a {
   color: #575e75;
 }
 .sprite-selector_sprite-selector_2KgCX {

--- a/addons/editor-dark-mode/paper.css
+++ b/addons/editor-dark-mode/paper.css
@@ -1,3 +1,7 @@
+.paint-editor_canvas-container_x2D0a {
+  color: var(--editorDarkMode-accent-text);
+}
+
 .paper-canvas_paper-canvas_1y588 {
   background-color: var(--editorDarkMode-accent-paintEditorBackground);
 }


### PR DESCRIPTION
Resolves #5502

### Changes

Fixes #5502 by setting the text color to `#575e75` unless the dark paint editor setting is enabled.
Also changes something unrelated that I forgot to do in #5077.

### Tests

Tested on Edge and Firefox.