### PR TITLE
Exclude emails from `isNotScratchWWW` match

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -349,12 +349,12 @@ const WELL_KNOWN_PATTERNS = {
 const WELL_KNOWN_MATCHERS = {
   isNotScratchWWW: (match) => {
     const { projects, projectEmbeds, scratchWWWNoProject } = WELL_KNOWN_PATTERNS;
-    // Server errors are neither r2 nor www
+    // Server errors and emails are neither r2 nor www
     return !(
       projects.test(match) ||
       projectEmbeds.test(match) ||
       scratchWWWNoProject.test(match) ||
-      /^\/(?:50[03]\/?$|cdn\/)/.test(match)
+      /^\/(?:50[03]\/?$|cdn\/|emails\/)/.test(match)
     );
   },
 };


### PR DESCRIPTION
Resolves #4513

### Changes

Excludes paths starting with `/emails/` from the `isNotScratchWWW` match pattern.

### Reason for changes

There's no reason for addons to affect emails. Website dark mode currently makes them unreadable.

### Tests

Tested on Edge and Firefox. The following link can be used for testing: https://scratch.mit.edu/emails/welcome/LakeMackay/1/