### PR TITLE
clones: correct count when dynamically enabled

### DIFF
--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -70,6 +70,16 @@ export default async function ({ addon, console, msg }) {
     return ret;
   };
 
+  if (addon.self.enabledLate) {
+    // Clone count might be inaccurate if the user deleted sprites
+    // before enabling the addon
+    let count = 0;
+    for (let target of vm.runtime.targets) {
+      if (!target.isOriginal) ++count;
+    }
+    vm.runtime._cloneCounter = count;
+  }
+
   while (true) {
     await addon.tab.waitForElement('[class*="controls_controls-container"]', {
       markAsSeen: true,


### PR DESCRIPTION
Resolves #4635

### Changes

Calculates the correct clone count when `clones` is dynamically enabled.

### Reason for changes

To prevent the counter from showing a negative number.

### Tests

Tested on Edge and Firefox.