### PR TITLE
editor-dark-mode: fix color of project title and remix button

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -26,11 +26,13 @@
 }
 .menu-bar_menu-bar-item_oLDa-,
 .input_input-form_l9eYg.project-title-input_title-field_en5Gd,
+.author-info_author-info_2Pliw,
 .inline-message_info_E7dNO,
 .modal_header-item_2zQTd {
   color: var(--editorDarkMode-menuBar-text);
 }
-.share-button_share-button_Nxxf0 {
+.share-button_share-button_Nxxf0,
+.menu-bar_remix-button_2LQQc {
   color: white;
 }
 .inline-message_success_1jfE0 {


### PR DESCRIPTION
Resolves #4685

### Changes

Sets the text color of the project title and remix button in the editor correctly.

### Reason for changes

To make sure that text is readable.

### Tests

![image](https://user-images.githubusercontent.com/51849865/209940954-f2ac75d3-2531-47ab-adb2-17564da4a009.png)