### PR TITLE
find-bar: scroll dropdown when using arrow keys to navigate

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -449,6 +449,7 @@ export default async function ({ addon, msg, console }) {
         nxt = dir === -1 ? nxt.previousSibling : nxt.nextSibling;
       }
       if (nxt) {
+        nxt.scrollIntoView({ block: "nearest" });
         this.onItemClick(nxt);
       }
     }


### PR DESCRIPTION
Resolves #4899

### Changes

Calls `scrollIntoView()` when the selection in the find bar dropdown is changed using arrow keys.

### Reason for changes

To make navigating long dropdowns using the keyboard easier.

### Tests

Tested on Edge and Firefox.