### PR TITLE
middle-click-popup: fix rename-broadcasts compatibility

### DIFF
--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -426,7 +426,9 @@ export default async function ({ addon, msg, console }) {
             code === "createLocalVariable" ||
             code === "createGlobalList" ||
             code === "createLocalList" ||
-            code === "createBroadcast"
+            code === "createBroadcast" ||
+            // rename-broadcasts compatibility
+            code === "RENAME_BROADCAST_MESSAGE_ID"
           ) {
             continue; // Skip these
           }


### PR DESCRIPTION
Fixes this bug from feedback https://discord.com/channels/751206349614088204/758464349768515604/1058040403468750898

> if u search b r b when adding a block with middle click it will suggest you broadcast ( rename broadcast ) which isn't supposed to happen as its a custom option to rename a broadcast and not a broadcast you have used and if u click on it, it creates the broadcast "rename broadcast"
> very minor bug but its a bug sooo :P
