### PR TITLE
Auto-merge hotfixes and translation updates into `beta` branch

### DIFF
--- a/.github/workflows/beta-cherrypick.yml
+++ b/.github/workflows/beta-cherrypick.yml
@@ -1,0 +1,22 @@
+name: Cherry-pick hotfixes & translations to `beta` branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  beta-cherrypick:
+    name: Cherry-pick hotfixes & translations to `beta` branch
+    if: github.event.pull_request.merged == true && (github.event.label.name == 'type: bug' || github.event.pull_request.user.login == 'scratchaddons-bot')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+    - uses: actions/checkout@v3
+    
+    - name: Merge into `beta` branch
+      uses: devmasx/merge-branch@1.4.0
+      with:
+        type: now
+        from_branch: ${{ github.ref }}
+        target_branch: beta
+        github_token: ${{ github.token }}

--- a/.github/workflows/beta-cherrypick.yml
+++ b/.github/workflows/beta-cherrypick.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   beta-cherrypick:
     name: Cherry-pick hotfixes & translations to `beta` branch
-    if: github.event.pull_request.merged == true && (github.event.label.name == 'type: bug' || github.event.pull_request.user.login == 'scratchaddons-bot')
+    if: "${{ github.event.pull_request.merged == true && (github.event.label.name == 'type: beta patch' || github.event.pull_request.user.login == 'scratchaddons-bot') }}"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/beta-cherrypick.yml
+++ b/.github/workflows/beta-cherrypick.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-    - uses: actions/checkout@v3
+      uses: actions/checkout@v3
     
     - name: Merge into `beta` branch
       uses: devmasx/merge-branch@1.4.0


### PR DESCRIPTION
Partially implements #5490.

### Changes

<!-- Please describe the changes you've made. -->
Adds a GitHub workflow that is triggered whenever a PR is merged that was labeled with `type: beta patch` or created by @scratchaddons-bot. This workflow merges that PR into the `beta` branch in addition to the branch it was just merged into.

### Reason for changes

<!-- Why should these changes be made? -->
Under the proposed system in the issue linked above, it would be convenient to have any hotfixes and translation updates automatically merged into the `beta` branch.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Not tested yet.