### PR TITLE
middle-click-popup: Fix editor-theme3 compatibility and placeholder text

### DIFF
--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -52,7 +52,7 @@ export default async function ({ addon, msg, console }) {
       this.dropdownOut.addEventListener("mousedown", (...e) => this.onClick(...e));
 
       document.addEventListener("keydown", (e) => {
-        if (addon.tab.editorMode !== 'editor') {
+        if (addon.tab.editorMode !== "editor") {
           return;
         }
 
@@ -337,9 +337,9 @@ export default async function ({ addon, msg, console }) {
           // same as procedures. Without making bigger changes to the custom block color system
           // hardcoding these is the best solution for now.
           sensing_of: "sensing",
-          event_whenbackdropswitchesto: "events"
+          event_whenbackdropswitchesto: "events",
         };
-        let ending = option.block.getCategory() || blockTypes[option.block.type] || 'null';
+        let ending = option.block.getCategory() || blockTypes[option.block.type] || "null";
         if (option.block.isScratchExtension) {
           ending = "pen";
         } else if (addon.tab.getCustomBlock(option.block.procCode_)) {

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -35,6 +35,7 @@ export default async function ({ addon, msg, console }) {
       this.dropdownOut.className = "sa-float-bar-dropdown-out";
 
       this.floatInput = this.dropdownOut.appendChild(document.createElement("input"));
+      this.floatInput.placeholder = msg("start-typing");
       this.floatInput.className = "sa-float-bar-input";
       this.floatInput.className = addon.tab.scratchClass("input_input-form", {
         others: "sa-float-bar-input",

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -328,9 +328,14 @@ export default async function ({ addon, msg, console }) {
         li.innerText = desc;
         li.data = { text: desc, lower: " " + desc.toLowerCase(), option: option };
 
-        // Many of the sensing_of blocks in the flyout have a category of `null` for some reason,
-        // the same as procedures.
-        let ending = option.block.type === "sensing_of" ? "sensing" : option.block.getCategory();
+        const blockTypes = {
+          // Some of these blocks in the flyout have a category of `null` for some reason, the
+          // same as procedures. Without making bigger changes to the custom block color system
+          // hardcoding these is the best solution for now.
+          sensing_of: "sensing",
+          event_whenbackdropswitchesto: "events"
+        };
+        let ending = option.block.getCategory() || blockTypes[option.block.type] || 'null';
         if (option.block.isScratchExtension) {
           ending = "pen";
         } else if (addon.tab.getCustomBlock(option.block.procCode_)) {

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -328,7 +328,9 @@ export default async function ({ addon, msg, console }) {
         li.innerText = desc;
         li.data = { text: desc, lower: " " + desc.toLowerCase(), option: option };
 
-        let ending = option.block.getCategory();
+        // Many of the sensing_of blocks in the flyout have a category of `null` for some reason,
+        // the same as procedures.
+        let ending = option.block.type === "sensing_of" ? "sensing" : option.block.getCategory();
         if (option.block.isScratchExtension) {
           ending = "pen";
         } else if (addon.tab.getCustomBlock(option.block.procCode_)) {

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -334,7 +334,7 @@ export default async function ({ addon, msg, console }) {
           ending = "addon-custom-block";
         }
 
-        li.className = "sa-block-color-" + ending + " sa-" + bType;
+        li.className = "sa-block-color sa-block-color-" + ending + " sa-" + bType;
         if (count > this.DROPDOWN_BLOCK_LIST_MAX_ROWS) {
           // Limit maximum number of rows to prevent lag when no filter is applied
           li.style.display = "none";

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -52,6 +52,10 @@ export default async function ({ addon, msg, console }) {
       this.dropdownOut.addEventListener("mousedown", (...e) => this.onClick(...e));
 
       document.addEventListener("keydown", (e) => {
+        if (addon.tab.editorMode !== 'editor') {
+          return;
+        }
+
         let ctrlKey = e.ctrlKey || e.metaKey;
 
         if (e.key === " " && ctrlKey) {

--- a/addons/middle-click-popup/userstyle.css
+++ b/addons/middle-click-popup/userstyle.css
@@ -71,22 +71,19 @@
 }
 
 .sa-float-bar-dropdown > li {
-  background-color: var(--sa-block-background-primary);
-}
-.sa-float-bar-dropdown > li:hover,
-.sa-float-bar-dropdown > li.sel {
-  background-color: var(--sa-block-field-background);
-}
-
-.sa-float-bar-dropdown > li {
   height: 19px;
   padding: 3px 8px;
   margin: 2px 0.3em;
   box-sizing: border-box;
   position: relative;
-  color: white;
+  background-color: var(--sa-block-colored-background);
+  color: var(--sa-block-text);
   font-weight: bold;
   width: min-content;
+}
+.sa-float-bar-dropdown > li:hover,
+.sa-float-bar-dropdown > li.sel {
+  background-color: var(--sa-block-colored-background-secondary);
 }
 
 .sa-float-bar-dropdown > li.sa-hat {


### PR DESCRIPTION
 - Fix the middle click popup issue described in https://github.com/TurboWarp/scratch-gui/issues/680. The find bar issue described there is an unrelated downstream bug.
 - Fix placeholder text of the input. The string already exists; it just wasn't used
 - Fix color of blocks like "backdrop # of stage" and "when backdrop switches to"
 - Disable ctrl+space outside of the editor

<table>
<tr>
<th>git master</th>
<th>this PR</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/33787854/210157000-7de60309-c43d-446a-8d5c-732848b8e367.png"></td>
<td><img src="https://user-images.githubusercontent.com/33787854/210156989-adeb2777-1492-4d37-8372-79d808fda2e6.png"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/33787854/210158177-e237f39d-3a8d-4a61-a39b-378bd5fa2bef.png"></td>
<td><img src="https://user-images.githubusercontent.com/33787854/210158173-3a877bd9-b8f5-49b8-9dd5-fdc68ecebac1.png"></td>
</tr>
</table>
