### PR TITLE
Show how to clone a fork

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,10 +19,10 @@ If you're making a new addon, our [FAQ page](https://scratchaddons.com/docs/deve
 1. **If you have something in mind, want to report a bug, or anything else, it's best if you create or find an issue first (see above). That way, we can discuss it before you start a pull request.**
 2. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) this repository if you haven't already.
 3. If you already have a fork, make sure to [sync its `master` branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) to ensure your fork of Scratch Addons is up to date with ours.
-4. [Clone Scratch Addons](https://github.com/ScratchAddons/ScratchAddons#from-source) and load it into your browser so you can make and test your changes.
+4. [Clone your fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository) and [load it into your browser](https://github.com/ScratchAddons/ScratchAddons#from-source) so you can make and test your changes.
 5. [Create a new branch](https://github.com/firstcontributions/first-contributions/blob/main/README.md#create-a-branch) from the `master` branch.
 6. [Create, commit, and push](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-and-pushing-changes) your changes. Make sure you're committing to your new branch.
 7. Go to the website and enable workflows in Actions on your fork so we can automatically clean up your code if necessary.
 8. Finally, [create a pull request](https://github.com/ScratchAddons/ScratchAddons/compare) on the origin repository (ScratchAddons/ScratchAddons). We will review your changes and talk about any further improvements if necessary.
 
-(The linked information shows you how to use [Git](https://git-scm.com/) to commit your changes, but you can also use the website, [GitHub Desktop](https://desktop.github.com/), [Visual Studio Code](https://code.visualstudio.com/), or any other software that lets you make your changes.)
+(These instructions are for using [Git](https://git-scm.com/) to commit your changes, but you can also use the website, [GitHub Desktop](https://desktop.github.com/), [Visual Studio Code](https://code.visualstudio.com/), or any other software that lets you make your changes.)


### PR DESCRIPTION
### Changes

Step 4 on **Creating pull requests** in the contributing guidelines now links to instructions on GitHub Docs that show you how to clone a fork and part of the README that shows you how to add it to your browser.

### Reason for changes

Users should know how to clone their fork, otherwise they may clone the origin repository instead.
