### PR TITLE
Unbreak hide-flyout and hide-stage compatibility

### DIFF
--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -16,10 +16,13 @@
   border-radius: 0;
 }
 
-.sa-stage-hidden [class*="gui_stage-and-target-wrapper_"],
+/* [class*="gui_flex-wrapper_"] is for specificity over hide-flyout */
+.sa-stage-hidden [class*="gui_flex-wrapper_"] [class*="gui_stage-and-target-wrapper_"],
 .sa-stage-hidden [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"]),
 .sa-stage-hidden [class*="gui_target-wrapper_"] {
   padding: 0;
+  /* override hide-flyout */
+  padding-inline: 0;
 }
 
 .sa-stage-hidden

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -21,8 +21,6 @@
 .sa-stage-hidden [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"]),
 .sa-stage-hidden [class*="gui_target-wrapper_"] {
   padding: 0;
-  /* override hide-flyout */
-  padding-inline: 0;
 }
 
 .sa-stage-hidden


### PR DESCRIPTION
I broke this in https://github.com/ScratchAddons/ScratchAddons/pull/5424. The stage would still use some space on the right:

![image](https://user-images.githubusercontent.com/33787854/210315580-4ec0b4ff-65fc-452f-a33d-f4d41d45e511.png)

Tested fix in RTL and LTR in Firefox