### PR TITLE
hide-delete-button: Fix sounds option

### DIFF
--- a/addons/hide-delete-button/sounds.css
+++ b/addons/hide-delete-button/sounds.css
@@ -1,3 +1,3 @@
-[data-tabs] > :nth-child(5) div[class*="delete-button_delete-button_"] {
+[data-tabs] > :nth-child(4) div[class*="delete-button_delete-button_"] {
   display: none;
 }


### PR DESCRIPTION
hide-delete-button's option to hide the delete button in the sounds list was not working previously.

Tested in Firefox and Chromium on Linux
