### PR TITLE
variable-manager: Prevent creating conflicting variable names

### DIFF
--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -164,8 +164,17 @@ export default async function ({ addon, console, msg }) {
           }
         }
 
+        let nameAlreadyUsed = false;
+        if (this.target.isStage) {
+          // Global variables must not conflict with any global variables or local variables in any sprite.
+          const existingNames = vm.runtime.getAllVarNamesOfType(this.scratchVariable.type);
+          nameAlreadyUsed = existingNames.includes(newName)
+        } else {
+          // Local variables must not conflict with any global variables or local variables in this sprite.
+          nameAlreadyUsed = !!workspace.getVariable(newName, this.scratchVariable.type)
+        }
+
         const isEmpty = !newName.trim();
-        const nameAlreadyUsed = !!workspace.getVariable(newName, this.scratchVariable.type);
         if (isEmpty || nameAlreadyUsed) {
           label.value = this.scratchVariable.name;
         } else {

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -168,10 +168,10 @@ export default async function ({ addon, console, msg }) {
         if (this.target.isStage) {
           // Global variables must not conflict with any global variables or local variables in any sprite.
           const existingNames = vm.runtime.getAllVarNamesOfType(this.scratchVariable.type);
-          nameAlreadyUsed = existingNames.includes(newName)
+          nameAlreadyUsed = existingNames.includes(newName);
         } else {
           // Local variables must not conflict with any global variables or local variables in this sprite.
-          nameAlreadyUsed = !!workspace.getVariable(newName, this.scratchVariable.type)
+          nameAlreadyUsed = !!workspace.getVariable(newName, this.scratchVariable.type);
         }
 
         const isEmpty = !newName.trim();


### PR DESCRIPTION
This prevents variable-manager from getting the project into a broken state:

1. Create a variable "For this sprite only" in sprite A (eg. "local")
2. In another sprite, create a global variable (eg. "global")
3. Using variable-manager, rename "global" to "local"
4. Go back to the original sprite. Using variable-manager you will see both a local and global variable with the same name, and in the editor you will only see one of these and blocks that interact with these variables may not work as expected.

Tested in Firefox on Linux
