### PR TITLE
Speed up open full screen settings popup glide-in

### DIFF
--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -96,7 +96,7 @@ export default async function ({ template }) {
           if (result === false) {
             if (isIframe) {
               this.$root.addonToEnable = this.addon;
-              document.querySelector(".popup").style.animation = "dropDown 1.6s 1";
+              document.querySelector(".popup").style.animation = "dropDown 0.5s 1";
               this.$root.showPopupModal = true;
             } else
               chrome.permissions.request(

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -96,7 +96,7 @@ export default async function ({ template }) {
           if (result === false) {
             if (isIframe) {
               this.$root.addonToEnable = this.addon;
-              document.querySelector(".popup").style.animation = "dropDown 0.5s 1";
+              document.querySelector(".popup").style.animation = "dropDown 0.35s 1";
               this.$root.showPopupModal = true;
             } else
               chrome.permissions.request(

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -358,7 +358,7 @@ let fuse;
         setTimeout(() => window.parent.close(), 100);
       },
       hidePopup() {
-        document.querySelector(".popup").style.animation = "closePopup 1.6s 1";
+        document.querySelector(".popup").style.animation = "closePopup 1s 1";
         document.querySelector(".popup").addEventListener(
           "animationend",
           () => {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -358,7 +358,7 @@ let fuse;
         setTimeout(() => window.parent.close(), 100);
       },
       hidePopup() {
-        document.querySelector(".popup").style.animation = "closePopup 1s 1";
+        document.querySelector(".popup").style.animation = "closePopup 0.6s 1";
         document.querySelector(".popup").addEventListener(
           "animationend",
           () => {


### PR DESCRIPTION
### Subject

The notification that pops up when you try to enable the Scratch Notifier addon from the extension popup. It needs you to open the full screen settings page because I guess the extension popup cannot request permissions.
![Popup reading, "to enable the 'Scratch Notifier' addon, go to the full screen settings page."](https://user-images.githubusercontent.com/106490990/210462020-7415307a-d524-4d97-8ad3-c53d91d87f71.png)


### Changes

Made the drop-down duration of this popup 0.35s and the dismiss duration 0.6s. Basically, I just sped up the animation. It may seem like a lot, but it was pretty slow to begin with.

### Reason for changes

With the previous, slower animation speed, it would take a second for it to come onscreen. This change makes it snappier and more responsive, which can help make it easier to notice.

### Tests

Tested on Microsoft Edge.
