### PR TITLE
editor-theme3: Enable toolbox refresh after reloading flyout

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -303,6 +303,7 @@ export default async function ({ addon, console }) {
     const flyoutWorkspace = flyout.getWorkspace();
     Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);
     toolbox.populate_(workspace.options.languageTree);
+    workspace.toolboxRefreshEnabled_ = true;
   };
 
   updateColors();


### PR DESCRIPTION
Fixes this bug: https://discord.com/channels/751206349614088204/755131743136383107/1060029229900775465

1. Disable editor-theme3
2. Open the editor in a new tab
3. Dynamically enable editor-theme3
4. Create a variable. The variable will not appear in the toolbox until you force the editor to reload (switching sprites, editor tabs, etc.)

This can also probably happen on normal page loads with the addon enabled if you get unlucky with when the addon loads.

The fix used here is based on similar code that already exists in custom-block-shape.

Historical context that led to the code being the way it is: https://github.com/ScratchAddons/ScratchAddons/pull/3805/commits/2f80e2c396554e9597f2be8da84d95ba5e65c73f https://github.com/ScratchAddons/ScratchAddons/pull/3805/commits/426a8d7e8fe111975b10268b4b8dc86546e3a71f https://github.com/ScratchAddons/ScratchAddons/pull/3805/commits/e035777e7bd2f10470e2fd53bd5979f154934f88

Tested in Chromium and Firefox on Linux