### PR TITLE
gamepad: Remove hints cache

### DIFF
--- a/addons/gamepad/gamepadlib.js
+++ b/addons/gamepad/gamepadlib.js
@@ -153,6 +153,7 @@ class GamepadData {
   }
 
   resetMappings() {
+    this.hints = this.gamepadLib.getHints();
     this.buttonMappings = this.getDefaultButtonMappings().map(transformAndCopyMapping);
     this.axesMappings = this.getDefaultAxisMappings().map(transformAndCopyMapping);
   }
@@ -164,10 +165,10 @@ class GamepadData {
 
   getDefaultButtonMappings() {
     let buttons;
-    if (this.gamepadLib.hints.importedSettings) {
-      buttons = this.gamepadLib.hints.importedSettings.buttons;
+    if (this.hints.importedSettings) {
+      buttons = this.hints.importedSettings.buttons;
     } else {
-      const usedKeys = this.gamepadLib.hints.usedKeys;
+      const usedKeys = this.hints.usedKeys;
       const alreadyUsedKeys = new Set();
       const { usesArrows, usesWASD } = getMovementConfiguration(usedKeys);
       if (usesWASD) {
@@ -359,14 +360,14 @@ class GamepadData {
 
   getDefaultAxisMappings() {
     let axes = [];
-    if (this.gamepadLib.hints.importedSettings) {
-      axes = this.gamepadLib.hints.importedSettings.axes;
+    if (this.hints.importedSettings) {
+      axes = this.hints.importedSettings.axes;
     } else {
       // Only return default axis mappings when there are 4 axes, like an xbox controller
       // If there isn't exactly 4, we can't really predict what the axes mean
       // Some controllers map the dpad to *both* buttons and axes at the same time, which would cause conflicts.
       if (this.gamepad.axes.length === 4) {
-        const usedKeys = this.gamepadLib.hints.usedKeys;
+        const usedKeys = this.hints.usedKeys;
         const { usesArrows, usesWASD } = getMovementConfiguration(usedKeys);
         if (usesWASD) {
           axes.push(defaultAxesMappings.wasd[0]);
@@ -421,8 +422,6 @@ class GamepadLib extends EventTarget {
 
     this.connectCallbacks = [];
 
-    this.hints = defaultHints();
-
     this.keysPressedThisFrame = new Set();
     this.oldKeysPressed = new Set();
 
@@ -451,19 +450,16 @@ class GamepadLib extends EventTarget {
     });
   }
 
-  ensureHintsGenerated() {
-    if (this.hints.generated) {
-      return;
-    }
-    if (this.getHintsLazily) {
-      Object.assign(this.hints, this.getHintsLazily());
-    }
-    this.hints.generated = true;
+  getHints() {
+    return Object.assign(defaultHints(), this.getUserHints());
+  }
+
+  getUserHints() {
+    // to be overridden by users
+    return {};
   }
 
   resetControls() {
-    this.hints = defaultHints();
-    this.ensureHintsGenerated();
     for (const gamepad of this.gamepads.values()) {
       gamepad.resetMappings();
     }
@@ -476,7 +472,6 @@ class GamepadLib extends EventTarget {
   }
 
   handleConnect(e) {
-    this.ensureHintsGenerated();
     for (const callback of this.connectCallbacks) {
       callback();
     }

--- a/addons/gamepad/userscript.js
+++ b/addons/gamepad/userscript.js
@@ -86,7 +86,7 @@ export default async function ({ addon, console, msg }) {
   GamepadLib.setConsole(console);
   const gamepad = new GamepadLib();
 
-  gamepad.getHintsLazily = () => {
+  gamepad.getUserHints = () => {
     const parsedOptions = parseOptionsComment();
     if (parsedOptions) {
       return {


### PR DESCRIPTION
This fixes an issue from my Scratch comments:

>  Problem with Turbowarp. I'm using the desktop client, so I don't know if that's the issue. Basically, when I try to change the gamepad controls using the gamepad support addon, it resets the controls when I unplug the controller, even after saving the project. Am I doing something wrong? 

1. Plug in a controller
2. Customize settings
3. Save them to the project
4. Unplug controller
5. Plug controller in again
6. It should have the settings that were customized, not the default ones

Controllers are not plugged and unplugged often enough to justify have a fragile cache here