### PR TITLE
sprite-properties: Fix some bugs

### DIFF
--- a/addons/drag-drop/dragged-over.css
+++ b/addons/drag-drop/dragged-over.css
@@ -1,11 +1,13 @@
 /* Based on the `stage-selector_raised` class */
-[class*="stage-selector_header_"],
-[class*="sprite-selector_sprite-selector"],
-[class*="monitor_list-body"] {
+div[class*="stage-selector_header_"],
+div[class*="sprite-selector_sprite-selector"],
+div[class*="sprite-info_sprite-info"],
+div[class*="monitor_list-body"] {
   transition: background-color 0.25s ease;
 }
 .sa-dragged-over,
-.sa-dragged-over [class*="stage-selector_header_"],
-.sa-dragged-over [class*="monitor_list-body"] {
+.sa-dragged-over div[class*="stage-selector_header_"],
+.sa-dragged-over div[class*="sprite-info_sprite-info"],
+.sa-dragged-over div[class*="monitor_list-body"] {
   background-color: hsla(215, 100%, 77%, 1);
 }

--- a/addons/drag-drop/dragged-over.css
+++ b/addons/drag-drop/dragged-over.css
@@ -1,13 +1,11 @@
 /* Based on the `stage-selector_raised` class */
 [class*="stage-selector_header_"],
 [class*="sprite-selector_sprite-selector"],
-[class*="sprite-info_sprite-info"],
 [class*="monitor_list-body"] {
   transition: background-color 0.25s ease;
 }
 .sa-dragged-over,
 .sa-dragged-over [class*="stage-selector_header_"],
-.sa-dragged-over [class*="sprite-info_sprite-info"],
 .sa-dragged-over [class*="monitor_list-body"] {
   background-color: hsla(215, 100%, 77%, 1);
 }

--- a/addons/drag-drop/dragged-over.css
+++ b/addons/drag-drop/dragged-over.css
@@ -1,13 +1,13 @@
 /* Based on the `stage-selector_raised` class */
-div[class*="stage-selector_header_"],
-div[class*="sprite-selector_sprite-selector"],
-div[class*="sprite-info_sprite-info"],
-div[class*="monitor_list-body"] {
+[class*="stage-selector_header_"],
+[class*="sprite-selector_sprite-selector"],
+[class*="sprite-info_sprite-info"],
+[class*="monitor_list-body"] {
   transition: background-color 0.25s ease;
 }
 .sa-dragged-over,
-.sa-dragged-over div[class*="stage-selector_header_"],
-.sa-dragged-over div[class*="sprite-info_sprite-info"],
-.sa-dragged-over div[class*="monitor_list-body"] {
+.sa-dragged-over [class*="stage-selector_header_"],
+.sa-dragged-over [class*="sprite-info_sprite-info"],
+.sa-dragged-over [class*="monitor_list-body"] {
   background-color: hsla(215, 100%, 77%, 1);
 }

--- a/addons/sprite-properties/addon.json
+++ b/addons/sprite-properties/addon.json
@@ -40,16 +40,21 @@
   ],
   "settings": [
     {
-      "name": "Collapse panel by default",
-      "id": "hideByDefault",
-      "type": "boolean",
-      "default": true
-    },
-    {
       "name": "Automatically collapse when mouse leaves sprite panel",
       "id": "autoCollapse",
       "type": "boolean",
       "default": false
+    },
+    {
+      "name": "Collapse panel by default",
+      "id": "hideByDefault",
+      "type": "boolean",
+      "default": true,
+      "if": {
+        "settings": {
+          "autoCollapse": false
+        }
+      }
     },
     {
       "name": "Animation speed",

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -50,8 +50,6 @@ export default async function ({ addon, console, msg }) {
   addon.settings.addEventListener("change", autoHidePanel);
 
   function applySettings() {
-    autoHidePanel();
-
     const visibleByDefault = !addon.settings.get("autoCollapse") && !addon.settings.get("hideByDefault");
     setPropertiesPanelVisible(visibleByDefault);
   }

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -80,11 +80,11 @@ export default async function ({ addon, global, console, msg }) {
     }
   }
 
-  async function injectCloseButton() {
+  function injectCloseButton() {
     injectButton(propertiesPanel, PROPS_CLOSE_BTN_CLASS, "/collapse.svg", msg("close-properties-panel-tooltip"));
   }
 
-  async function injectButton(container, className, iconPath, tooltip) {
+  function injectButton(container, className, iconPath, tooltip) {
     if (container.querySelector("." + className)) return;
     let btnIcon = document.createElement("img");
     btnIcon.setAttribute("src", addon.self.dir + iconPath);

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -7,6 +7,8 @@ export default async function ({ addon, console, msg }) {
   /** @type {HTMLElement} */
   let propertiesPanel;
 
+  // A mutation observer is the only reliable way to detect when a different sprite has
+  // been selected or when the folder that contains the focused sprite has been opened.
   const observer = new MutationObserver(() => {
     injectInfoButton();
   });

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -15,7 +15,10 @@ export default async function ({ addon, global, console, msg }) {
       let spriteIndex = e.detail.action.targets.findIndex((el) => el.id === spriteId);
       // The focused sprite might not be in the target list if, for example, we are editing a clone.
       if (spriteIndex !== -1) {
-        injectInfoButton(spriteIndex);
+        // Wait for React to finish updating DOM before injecting the button.
+        queueMicrotask(() => {
+          injectInfoButton(spriteIndex);
+        });
       }
     }
   });

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -134,6 +134,7 @@ export default async function ({ addon, global, console, msg }) {
         "fontsLoaded/SET_FONTS_LOADED",
         "scratch-gui/locales/SELECT_LOCALE",
       ],
+      reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     spriteContainer = propertiesPanel.parentElement; // also contains sprite grid
     updateWideLocaleMode();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -68,7 +68,7 @@ export default async function ({ addon, global, console, msg }) {
 
   function injectInfoButton(spriteIndex) {
     let selectedSprite;
-    if (typeof spriteIndex === 'number') {
+    if (typeof spriteIndex === "number") {
       selectedSprite = document.querySelector(
         `[class*='sprite-selector_sprite-wrapper_']:nth-child(${spriteIndex}) [class*="sprite-selector_sprite_"]`
       );
@@ -109,7 +109,7 @@ export default async function ({ addon, global, console, msg }) {
     // Easiest way to detect this without hardcoding a language list is with this selector that only
     // exists when the sprite info panel is using the larger layout with text above the input.
     const isWideLocale = !!propertiesPanel.querySelector("[class^=label_input-group-column_]");
-    document.body.classList.toggle('sa-sprite-properties-wide-locale', isWideLocale);
+    document.body.classList.toggle("sa-sprite-properties-wide-locale", isWideLocale);
   }
 
   document.addEventListener(
@@ -129,11 +129,7 @@ export default async function ({ addon, global, console, msg }) {
   while (true) {
     propertiesPanel = await addon.tab.waitForElement('[class^="sprite-info_sprite-info_"]', {
       markAsSeen: true,
-      reduxEvents: [
-        "scratch-gui/mode/SET_PLAYER",
-        "fontsLoaded/SET_FONTS_LOADED",
-        "scratch-gui/locales/SELECT_LOCALE",
-      ],
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     spriteContainer = propertiesPanel.parentElement; // also contains sprite grid

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -56,6 +56,13 @@ export default async function ({ addon, global, console, msg }) {
   async function init() {
     propertiesPanel = await addon.tab.waitForElement('[class^="sprite-info_sprite-info_"]');
     spriteContainer = propertiesPanel.parentElement; // also contains sprite grid
+
+    // Certain languages, such as Japanese, use a different layout for the sprite info panel
+    // Easiest way to detect this without hardcoding a language list is with this selector that only
+    // exists when the sprite info panel is using the larger layout with text above the input.
+    const isWideLocale = !!propertiesPanel.querySelector("[class^=label_input-group-column_]");
+    document.body.classList.toggle('sa-sprite-properties-wide-locale', isWideLocale);
+
     setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
     injectInfoButton();
     injectCloseButton();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -27,19 +27,6 @@ export default async function ({ addon, global, console, msg }) {
     }
   });
 
-  // Close properties panel when mouse leaves the entire sprite panel
-  document.body.addEventListener(
-    "mouseleave",
-    (e) => {
-      if (e.target.matches('[class*="sprite-selector_sprite-selector_2KgCX"]')) {
-        autoHidePanel();
-      }
-    },
-    {
-      capture: true,
-    }
-  );
-
   function setPropertiesPanelVisible(visible) {
     document.body.classList.toggle(SHOW_PROPS_CLASS, visible);
     document.body.classList.toggle(HIDE_PROPS_CLASS, !visible);
@@ -55,18 +42,30 @@ export default async function ({ addon, global, console, msg }) {
       setPropertiesPanelVisible(false);
     }
   }
+  // Close properties panel when mouse leaves the entire sprite panel
+  document.body.addEventListener(
+    "mouseleave",
+    (e) => {
+      if (e.target.matches('[class*="sprite-selector_sprite-selector_2KgCX"]')) {
+        autoHidePanel();
+      }
+    },
+    {
+      capture: true,
+    }
+  );  
+  addon.settings.addEventListener("change", autoHidePanel);
 
   function applySettings() {
     autoHidePanel();
     setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
   }
-  addon.settings.addEventListener("change", applySettings);
+  addon.self.addEventListener("reenabled", applySettings);
   applySettings();
 
   addon.self.addEventListener("disabled", () => {
     setPropertiesPanelVisible(true);
   });
-  addon.self.addEventListener("reenabled", applySettings);
 
   function injectInfoButton(spriteIndex) {
     let selectedSprite;

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -94,6 +94,7 @@ export default async function ({ addon, global, console, msg }) {
     if (container.querySelector("." + className)) return;
     let btnIcon = document.createElement("img");
     btnIcon.setAttribute("src", addon.self.dir + iconPath);
+    btnIcon.draggable = false;
     let btn = document.createElement("button");
     btn.classList.add(className);
     btn.setAttribute("title", tooltip);

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -51,7 +51,7 @@ export default async function ({ addon, global, console, msg }) {
     {
       capture: true,
     }
-  );  
+  );
   addon.settings.addEventListener("change", autoHidePanel);
 
   function applySettings() {

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -51,7 +51,9 @@ export default async function ({ addon, console, msg }) {
 
   function applySettings() {
     autoHidePanel();
-    setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
+
+    const visibleByDefault = !addon.settings.get("autoCollapse") && !addon.settings.get("hideByDefault");
+    setPropertiesPanelVisible(visibleByDefault);
   }
   addon.self.addEventListener("reenabled", applySettings);
   applySettings();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -21,6 +21,12 @@ export default async function ({ addon, global, console, msg }) {
         injectInfoButton(spriteIndex);
       }
     }
+
+    if (e.detail.action.type === "scratch-gui/locales/SELECT_LOCALE") {
+      queueMicrotask(() => {
+        init();
+      });
+    }
   });
 
   // Open the properties panel when double clicking in the sprite grid

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -7,15 +7,8 @@ export default async function ({ addon, global, console, msg }) {
   /** @type {HTMLElement} */
   let propertiesPanel;
 
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (e.detail.action.type === "scratch-gui/targets/UPDATE_TARGET_LIST") {
-      // This event happens when targets are rearranged, move, switch costumes, etc.
-      // Wait for React to finish updating DOM before injecting the button.
-      queueMicrotask(() => {
-        injectInfoButton();
-      });
-    }
+  const observer = new MutationObserver(() => {
+    injectInfoButton();
   });
 
   // Toggle the properties panel when double clicking in the sprite grid
@@ -134,6 +127,11 @@ export default async function ({ addon, global, console, msg }) {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
+    });
+    observer.observe(propertiesPanel.parentNode, {
+      childList: true,
+      attributes: true,
+      subtree: true,
     });
     updateWideLocaleMode();
     injectInfoButton();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -20,7 +20,7 @@ export default async function ({ addon, global, console, msg }) {
     }
   });
 
-  // Open the properties panel when double clicking in the sprite grid
+  // Toggle the properties panel when double clicking in the sprite grid
   document.addEventListener("click", (e) => {
     if (e.detail === 2 && e.target.closest('[class^="sprite-selector_scroll-wrapper_"]')) {
       togglePropertiesPanel();
@@ -40,7 +40,11 @@ export default async function ({ addon, global, console, msg }) {
     }
   );
 
-  addon.settings.addEventListener("change", () => autoHidePanel());
+  // When auto hide setting is enabled, immediately hide the panel.
+  addon.settings.addEventListener("change", () => {
+    autoHidePanel();
+  });
+
   addon.self.addEventListener("disabled", () => {
     setPropertiesPanelVisible(true);
     removeCloseButton();
@@ -101,9 +105,13 @@ export default async function ({ addon, global, console, msg }) {
   }
 
   function updateWideLocaleMode() {
-    // Certain languages, such as Japanese, use a different layout for the sprite info panel
-    // Easiest way to detect this without hardcoding a language list is with this selector that only
-    // exists when the sprite info panel is using the larger layout with text above the input.
+    // Certain "wide" languages such as Japanese use a different layout for the sprite info panel
+    // Easiest way to detect this is with this selector that only exists when the sprite info panel
+    // is using the layout with text above the input.
+    // Note that when the stage is in small mode, "wide" languages use the same info panel as other
+    // languages.
+    // List of languages is here:
+    // https://github.com/LLK/scratch-gui/blob/e15b2dfa3a2e58e80fae8d1586c7f56aa0cc0ede/src/lib/locale-utils.js#L6-L18
     const isWideLocale = !!propertiesPanel.querySelector("[class^=label_input-group-column_]");
     document.body.classList.toggle("sa-sprite-properties-wide-locale", isWideLocale);
   }
@@ -111,7 +119,6 @@ export default async function ({ addon, global, console, msg }) {
   document.addEventListener(
     "click",
     (e) => {
-      // In small stage mode, wide locales use the same properties panel as other languages.
       if (
         e.target.closest("[class*='stage-header_stage-button-first']") ||
         e.target.closest("[class*='stage-header_stage-button-last']")

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, global, console, msg }) {
+export default async function ({ addon, console, msg }) {
   const SHOW_PROPS_CLASS = "sa-show-sprite-properties";
   const HIDE_PROPS_CLASS = "sa-hide-sprite-properties";
   const PROPS_INFO_BTN_CLASS = "sa-sprite-properties-info-btn";

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -1,7 +1,7 @@
 export default async function ({ addon, global, console, msg }) {
   const SHOW_PROPS_CLASS = "sa-show-sprite-properties";
   const HIDE_PROPS_CLASS = "sa-hide-sprite-properties";
-  const PROPS_BTN_CLASS = "sa-sprite-properties-btn";
+  const PROPS_INFO_BTN_CLASS = "sa-sprite-properties-info-btn";
   const PROPS_CLOSE_BTN_CLASS = "sa-sprite-properties-close-btn";
 
   /** @type {HTMLElement} */
@@ -76,7 +76,7 @@ export default async function ({ addon, global, console, msg }) {
       selectedSprite = document.querySelector('[class*="sprite-selector-item_is-selected"]');
     }
     if (selectedSprite) {
-      injectButton(selectedSprite, PROPS_BTN_CLASS, "/info.svg", msg("open-properties-panel-tooltip"));
+      injectButton(selectedSprite, PROPS_INFO_BTN_CLASS, "/info.svg", msg("open-properties-panel-tooltip"));
     }
   }
 

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -65,8 +65,8 @@ export default async function ({ addon, global, console, msg }) {
 
   addon.self.addEventListener("disabled", () => {
     setPropertiesPanelVisible(true);
-    removeCloseButton();
   });
+  addon.self.addEventListener("reenabled", applySettings);
 
   function injectInfoButton(spriteIndex) {
     let selectedSprite;
@@ -99,11 +99,6 @@ export default async function ({ addon, global, console, msg }) {
     btn.appendChild(btnIcon);
     container.appendChild(btn);
     addon.tab.displayNoneWhileDisabled(btn, { display: "flex" });
-  }
-
-  function removeCloseButton() {
-    let closeBtn = document.querySelector("." + PROPS_CLOSE_BTN_CLASS);
-    if (closeBtn) closeBtn.remove();
   }
 
   function updateWideLocaleMode() {

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -109,6 +109,28 @@ export default async function ({ addon, global, console, msg }) {
     if (closeBtn) closeBtn.remove();
   }
 
+  function updateWideLocaleMode() {
+    // Certain languages, such as Japanese, use a different layout for the sprite info panel
+    // Easiest way to detect this without hardcoding a language list is with this selector that only
+    // exists when the sprite info panel is using the larger layout with text above the input.
+    const isWideLocale = !!propertiesPanel.querySelector("[class^=label_input-group-column_]");
+    document.body.classList.toggle('sa-sprite-properties-wide-locale', isWideLocale);
+  }
+
+  document.addEventListener(
+    "click",
+    (e) => {
+      // In small stage mode, wide locales use the same properties panel as other languages.
+      if (
+        e.target.closest("[class*='stage-header_stage-button-first']") ||
+        e.target.closest("[class*='stage-header_stage-button-last']")
+      ) {
+        setTimeout(updateWideLocaleMode);
+      }
+    },
+    { capture: true }
+  );
+
   while (true) {
     propertiesPanel = await addon.tab.waitForElement('[class^="sprite-info_sprite-info_"]', {
       markAsSeen: true,
@@ -119,13 +141,7 @@ export default async function ({ addon, global, console, msg }) {
       ],
     });
     spriteContainer = propertiesPanel.parentElement; // also contains sprite grid
-
-    // Certain languages, such as Japanese, use a different layout for the sprite info panel
-    // Easiest way to detect this without hardcoding a language list is with this selector that only
-    // exists when the sprite info panel is using the larger layout with text above the input.
-    const isWideLocale = !!propertiesPanel.querySelector("[class^=label_input-group-column_]");
-    document.body.classList.toggle('sa-sprite-properties-wide-locale', isWideLocale);
-
+    updateWideLocaleMode();
     setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
     injectInfoButton();
     injectCloseButton();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -6,8 +6,6 @@ export default async function ({ addon, global, console, msg }) {
 
   /** @type {HTMLElement} */
   let propertiesPanel;
-  /** @type {HTMLElement} */
-  let spriteContainer; // also contains sprite grid
 
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
@@ -49,14 +47,12 @@ export default async function ({ addon, global, console, msg }) {
   });
 
   function setPropertiesPanelVisible(visible) {
-    if (spriteContainer) {
-      spriteContainer.classList.toggle(SHOW_PROPS_CLASS, visible);
-      spriteContainer.classList.toggle(HIDE_PROPS_CLASS, !visible);
-    }
+    document.body.classList.toggle(SHOW_PROPS_CLASS, visible);
+    document.body.classList.toggle(HIDE_PROPS_CLASS, !visible);
   }
 
   function togglePropertiesPanel() {
-    const isCurrentlyOpen = spriteContainer.classList.contains(SHOW_PROPS_CLASS);
+    const isCurrentlyOpen = document.body.classList.contains(SHOW_PROPS_CLASS);
     setPropertiesPanelVisible(!isCurrentlyOpen);
   }
 
@@ -132,7 +128,6 @@ export default async function ({ addon, global, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
-    spriteContainer = propertiesPanel.parentElement; // also contains sprite grid
     updateWideLocaleMode();
     setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
     injectInfoButton();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -130,11 +130,15 @@ export default async function ({ addon, console, msg }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
-    observer.observe(propertiesPanel.parentNode, {
+
+    const spriteSelector = propertiesPanel.parentNode;
+    const scrollWrapper = spriteSelector.querySelector('[class*="sprite-selector_scroll-wrapper_"]');
+    const itemsWrapper = scrollWrapper.firstChild;
+    observer.observe(itemsWrapper, {
       childList: true,
-      attributes: true,
       subtree: true,
     });
+
     updateWideLocaleMode();
     injectInfoButton();
     injectCloseButton();

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -40,16 +40,6 @@ export default async function ({ addon, global, console, msg }) {
     }
   );
 
-  // When auto hide setting is enabled, immediately hide the panel.
-  addon.settings.addEventListener("change", () => {
-    autoHidePanel();
-  });
-
-  addon.self.addEventListener("disabled", () => {
-    setPropertiesPanelVisible(true);
-    removeCloseButton();
-  });
-
   function setPropertiesPanelVisible(visible) {
     document.body.classList.toggle(SHOW_PROPS_CLASS, visible);
     document.body.classList.toggle(HIDE_PROPS_CLASS, !visible);
@@ -65,6 +55,18 @@ export default async function ({ addon, global, console, msg }) {
       setPropertiesPanelVisible(false);
     }
   }
+
+  function applySettings() {
+    autoHidePanel();
+    setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
+  }
+  addon.settings.addEventListener("change", applySettings);
+  applySettings();
+
+  addon.self.addEventListener("disabled", () => {
+    setPropertiesPanelVisible(true);
+    removeCloseButton();
+  });
 
   function injectInfoButton(spriteIndex) {
     let selectedSprite;
@@ -136,7 +138,6 @@ export default async function ({ addon, global, console, msg }) {
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     updateWideLocaleMode();
-    setPropertiesPanelVisible(!addon.settings.get("hideByDefault"));
     injectInfoButton();
     injectCloseButton();
   }

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -11,19 +11,13 @@ export default async function ({ addon, global, console, msg }) {
 
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
-    const action = e.detail.action;
-
-    // When target list changes, move icon to the focused sprite.
-    if (action.type === "scratch-gui/targets/UPDATE_TARGET_LIST") {
-      const spriteId = action.editingTarget;
-      if (spriteId) {
-        const spriteIndex = action.targets.findIndex((el) => el.id === spriteId);
-        // The focused sprite might not be in the target list if, for example, we are editing a clone.
-        if (spriteIndex !== -1) {
-          queueMicrotask(() => {
-            injectInfoButton(spriteIndex);
-          });
-        }
+    if (e.detail.action.type === "scratch-gui/targets/UPDATE_TARGET_LIST") {
+      let spriteId = e.detail.action.editingTarget;
+      if (!spriteId) return;
+      let spriteIndex = e.detail.action.targets.findIndex((el) => el.id === spriteId);
+      // The focused sprite might not be in the target list if, for example, we are editing a clone.
+      if (spriteIndex !== -1) {
+        injectInfoButton(spriteIndex);
       }
     }
   });

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -30,9 +30,23 @@
   padding: 0.75rem;
   padding-bottom: 0;
 }
+.sa-sprite-properties-wide-locale .sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
+  /* In wide languages, add in addition to the previous:
+     + 2 * 0.625rem * 1.2 (extra row's text now uses vertical space)
+     + 2 * 0.25rem (each row has extra padding) */
+  height: calc(6.5rem + 5px + 2rem);
+}
+[class^="label_input-group-column_"] {
+  /* Default line-height: normal is inconsistent across browsers, but above style needs constant line-height. */
+  line-height: 1.2;
+}
 
+/* see heights in above selectors */
 .sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
   height: calc(100% - 6.5rem - 5px);
+}
+.sa-sprite-properties-wide-locale .sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
+  height: calc(100% - 6.5rem - 5px - 2rem);
 }
 
 .sa-sprite-properties-btn {

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -49,7 +49,7 @@
   height: calc(100% - 6.5rem - 5px - 2rem);
 }
 
-.sa-sprite-properties-btn {
+.sa-sprite-properties-info-btn {
   display: none !important;
   position: absolute;
   justify-content: center;
@@ -63,11 +63,11 @@
   background-color: var(--editorDarkMode-primary, hsla(215, 100%, 65%, 1));
 }
 
-.sa-hide-sprite-properties [class*="sprite-selector-item_is-selected"] .sa-sprite-properties-btn {
+.sa-hide-sprite-properties [class*="sprite-selector-item_is-selected"] .sa-sprite-properties-info-btn {
   display: flex !important;
 }
 
-.sa-sprite-properties-btn img {
+.sa-sprite-properties-info-btn img {
   width: calc(1rem - 6px);
   height: calc(1rem - 6px);
   filter: var(--editorDarkMode-primary-filter);

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -87,6 +87,7 @@
   align-items: center;
   border: none;
   background-color: transparent;
+  user-select: none;
 }
 
 .sa-sprite-properties-close-btn img {
@@ -96,4 +97,9 @@
 
 .sa-sprite-properties-close-btn:hover img {
   opacity: 0.75;
+}
+
+/* Prevent double clicking from highlighting the "Choose a sprite" button */
+[class*="action-menu_main-button_"] {
+  user-select: none;
 }

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -32,7 +32,7 @@
 }
 .sa-sprite-properties-wide-locale .sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
   /* In wide languages, add in addition to the previous:
-     + 2 * 0.625rem * 1.2 (extra row's text now uses vertical space)
+     + 2 * 0.625rem * 1.2 (each row's text label now uses vertical space)
      + 2 * 0.25rem (each row has extra padding) */
   height: calc(6.5rem + 5px + 2rem);
 }

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -50,7 +50,8 @@
 }
 
 .sa-sprite-properties-info-btn {
-  display: flex;
+  /* !important to override displayNoneWhileDisabled's inline styles */
+  display: flex !important;
   position: absolute;
   justify-content: center;
   align-items: center;
@@ -65,6 +66,9 @@
 [dir="rtl"] .sa-sprite-properties-info-btn {
   left: auto;
   right: -2px;
+}
+.sa-show-sprite-properties .sa-sprite-properties-info-btn {
+  display: none !important;
 }
 
 .sa-sprite-properties-info-btn img {

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -62,6 +62,10 @@
   border-radius: 100%;
   background-color: var(--editorDarkMode-primary, hsla(215, 100%, 65%, 1));
 }
+[dir="rtl"] .sa-sprite-properties-info-btn {
+  left: auto;
+  right: -2px;
+}
 
 .sa-hide-sprite-properties [class*="sprite-selector-item_is-selected"] .sa-sprite-properties-info-btn {
   display: flex !important;

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -30,7 +30,7 @@
   padding: 0.75rem;
   padding-bottom: 0;
 }
-.sa-sprite-properties-wide-locale .sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
+.sa-sprite-properties-wide-locale.sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
   /* In wide languages, add in addition to the previous:
      + 2 * 0.625rem * 1.2 (each row's text label now uses vertical space)
      + 2 * 0.25rem (each row has extra padding) */
@@ -45,7 +45,7 @@
 .sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
   height: calc(100% - 6.5rem - 5px);
 }
-.sa-sprite-properties-wide-locale .sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
+.sa-sprite-properties-wide-locale.sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
   height: calc(100% - 6.5rem - 5px - 2rem);
 }
 

--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -50,7 +50,7 @@
 }
 
 .sa-sprite-properties-info-btn {
-  display: none !important;
+  display: flex;
   position: absolute;
   justify-content: center;
   align-items: center;
@@ -65,10 +65,6 @@
 [dir="rtl"] .sa-sprite-properties-info-btn {
   left: auto;
   right: -2px;
-}
-
-.sa-hide-sprite-properties [class*="sprite-selector-item_is-selected"] .sa-sprite-properties-info-btn {
-  display: flex !important;
 }
 
 .sa-sprite-properties-info-btn img {


### PR DESCRIPTION
 - Fixes https://github.com/ScratchAddons/ScratchAddons/issues/5561
 - Fixes https://github.com/ScratchAddons/ScratchAddons/issues/5572 / https://discord.com/channels/751206349614088204/758464349768515604/1061135466251943946 - properties panel now works in ["wide" languages](https://github.com/LLK/scratch-gui/blob/e15b2dfa3a2e58e80fae8d1586c7f56aa0cc0ede/src/lib/locale-utils.js#L6-L18) such as Japanese and Italian
 - Fixes collapse icon being draggable
 - Fixes RTL support
 - Fixes properties panel after entering editor momentarily being hidden when auto-collapse is disabled
 - Whether the panel is collapsed or not is now preserved through leaving the editor and going back in rather than resetting to the default from settings
 - Fixes info button disappearing after renaming sprite
 - Fixes performance issue caused by running document.querySelector every time targets update (oftentimes every frame)
 - Fixes compatibility with folders addon - if the current target was in a closed folder and the folder was opened, the info button would not be added

drag-drop related changes and fix to #5557 moved to https://github.com/ScratchAddons/ScratchAddons/pull/5570
