### PR TITLE
variable-manager: Require a click to display variables that are way too big

### DIFF
--- a/addons-l10n/en/variable-manager.json
+++ b/addons-l10n/en/variable-manager.json
@@ -2,5 +2,6 @@
   "variable-manager/for-this-sprite": "Variables for this sprite",
   "variable-manager/for-all-sprites": "Variables for all sprites",
   "variable-manager/variables": "Variables",
-  "variable-manager/search": "Search"
+  "variable-manager/search": "Search",
+  "variable-manager/too-big": "Too big to display."
 }

--- a/addons-l10n/en/variable-manager.json
+++ b/addons-l10n/en/variable-manager.json
@@ -3,5 +3,5 @@
   "variable-manager/for-all-sprites": "Variables for all sprites",
   "variable-manager/variables": "Variables",
   "variable-manager/search": "Search",
-  "variable-manager/too-big": "Too big to display."
+  "variable-manager/too-big": "Click to display very large value."
 }

--- a/addons/variable-manager/style.css
+++ b/addons/variable-manager/style.css
@@ -1,17 +1,17 @@
 /* Change z-indexes to allow more than 3 tabs */
-.gui_tab_27Unf.gui_is-selected_sHAiu {
+[class*="gui_tab_"][class*="gui_is-selected_"] {
   z-index: 10 !important;
 }
-.gui_tab_27Unf:nth-of-type(1) {
+[class*="gui_tab_"]:nth-of-type(1) {
   z-index: 9;
 }
-.gui_tab_27Unf:nth-of-type(2) {
+[class*="gui_tab_"]:nth-of-type(2) {
   z-index: 8;
 }
-.gui_tab_27Unf:nth-of-type(3) {
+[class*="gui_tab_"]:nth-of-type(3) {
   z-index: 7;
 }
-.gui_tab_27Unf:nth-of-type(4) {
+[class*="gui_tab_"]:nth-of-type(4) {
   z-index: 6;
 }
 

--- a/addons/variable-manager/style.css
+++ b/addons/variable-manager/style.css
@@ -86,6 +86,11 @@
   resize: none;
 }
 
+.sa-var-manager input:disabled, .sa-var-manager textarea:disabled {
+  font-style: italic;
+  opacity: 0.8;
+}
+
 .sa-var-manager table {
   border-radius: 5px;
   border-collapse: collapse;

--- a/addons/variable-manager/style.css
+++ b/addons/variable-manager/style.css
@@ -86,9 +86,28 @@
   resize: none;
 }
 
-.sa-var-manager input:disabled, .sa-var-manager textarea:disabled {
+.sa-var-manager-too-big {
+  display: none;
+  cursor: pointer;
+  font: inherit;
   font-style: italic;
+  color: inherit;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 8px;
   opacity: 0.8;
+  width: 100%;
+  text-align: left;
+}
+.sa-var-manager-too-big:hover {
+  text-decoration: underline;
+}
+[data-too-big="true"] .sa-var-manager-too-big {
+  display: block;
+}
+[data-too-big="true"] .sa-var-manager-input {
+  display: none;
 }
 
 .sa-var-manager table {

--- a/addons/variable-manager/style.css
+++ b/addons/variable-manager/style.css
@@ -106,7 +106,7 @@
 [data-too-big="true"] .sa-var-manager-too-big {
   display: block;
 }
-[data-too-big="true"] .sa-var-manager-input {
+[data-too-big="true"] .sa-var-manager-value-input {
   display: none;
 }
 

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -93,13 +93,16 @@ export default async function ({ addon, console, msg }) {
       if (!this.visible && !force) return;
 
       let newValue;
+      let maxSafeLength;
       if (this.scratchVariable.type === "list") {
         newValue = this.scratchVariable.value.join("\n");
+        maxSafeLength = 5000000;
       } else {
         newValue = this.scratchVariable.value;
+        maxSafeLength = 1000000;
       }
 
-      if (!this.ignoreTooBig && newValue.length > 1000000) {
+      if (!this.ignoreTooBig && newValue.length > maxSafeLength) {
         this.input.value = "";
         this.row.dataset.tooBig = true;
         return;

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -91,12 +91,19 @@ export default async function ({ addon, console, msg }) {
     updateValue(force) {
       if (!this.visible && !force) return;
       let newValue;
+      let tooBig;
       if (this.scratchVariable.type === "list") {
         newValue = this.scratchVariable.value.join("\n");
+        tooBig = newValue.length > 200000 * 100;
       } else {
         newValue = this.scratchVariable.value;
+        tooBig = newValue.length > 2000000;
       }
-      if (newValue !== this.input.value) {
+      if (tooBig) {
+        this.input.disabled = true;
+        this.input.value = msg("too-big");
+      } else if (newValue !== this.input.value) {
+        this.input.disabled = false;
         this.input.value = newValue;
       }
     }

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -236,7 +236,7 @@ export default async function ({ addon, console, msg }) {
       } else {
         input = document.createElement("input");
       }
-      input.className = "sa-var-manager-input";
+      input.className = "sa-var-manager-value-input";
       input.id = id;
       this.input = input;
 
@@ -270,8 +270,8 @@ export default async function ({ addon, console, msg }) {
         manager.classList.remove("freeze");
       });
 
-      valueCell.appendChild(tooBigElement);
       valueCell.appendChild(input);
+      valueCell.appendChild(tooBigElement);
       row.appendChild(labelCell);
       row.appendChild(valueCell);
 


### PR DESCRIPTION
When variables exceed around 1,000,000 characters in length, they cause excessive performance issues and sometimes cause the whole tab to crash. (there was an issue in TW/scratch-gui about this, but I can't find it anymore)

Instead of that, this PR shows a warning:

![image](https://user-images.githubusercontent.com/33787854/211172721-ea27cfa9-fada-4171-bd6d-6385953d825b.png)

The thresholds are set high enough that most people will never see this message.

An earlier version of this PR with similar thresholds has been in TurboWarp for a very long time with the message "Too big to safely display. If this limit is too low, use the feedback button at the top of the screen." No one has submitted feedback about this.
