### PR TITLE
`progress-bar`: Round the progress bar and set default height to 8px

### DIFF
--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -32,7 +32,7 @@
       "type": "integer",
       "min": 3,
       "max": 25,
-      "default": 10
+      "default": 8
     }
   ],
   "dynamicEnable": true,

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -32,7 +32,7 @@
       "type": "integer",
       "min": 3,
       "max": 25,
-      "default": 5
+      "default": 10
     }
   ],
   "dynamicEnable": true,

--- a/addons/progress-bar/userstyle.css
+++ b/addons/progress-bar/userstyle.css
@@ -3,11 +3,13 @@
   height: calc(1px * var(--progressBar-height));
   box-sizing: border-box;
   border: 1px solid white;
+  border-radius: calc(1px * var(--progressBar-height));
 }
 .u-progress-bar-inner {
   width: 0;
   height: 100%;
   background-color: white;
+  border-radius: calc(1px * var(--progressBar-height));
 }
 
 .u-progress-bar-top {

--- a/addons/progress-bar/userstyle.css
+++ b/addons/progress-bar/userstyle.css
@@ -23,6 +23,7 @@
 }
 .u-progress-bar-top .u-progress-bar-inner {
   transition: width 0.2s;
+  border-radius: 0px;
 }
 
 .u-progress-bar-caption {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves no open issues.

### Changes
The progress bar in the `progress-bar` addon is now rounded. It previously had disgusting square edges that stuck out, so this helps it look better.

I also set the default `Progress bar height (px)` value to ~~10~~ 8 (previously 5), since 5 is very small and hides away.

### Reason for changes
The square edges were aesthetically unpleasing, and the small size made it appear as if the addon was trying to hide as opposed to being useful, so I improved it.

### Tests
Working on Chrome 109 (beta, 32-bit) on a Chromebook. I would appreciate it if someone could test this on Firefox.