### PR TITLE
Fix bugs related to the `/projects` error page

### DIFF
--- a/addons/copy-message-link/addon.json
+++ b/addons/copy-message-link/addon.json
@@ -15,7 +15,7 @@
     },
     {
       "url": "project.js",
-      "matches": ["https://scratch.mit.edu/projects/*", "https://scratch.mit.edu/studios/*"],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "runAtComplete": false
     }
   ],
@@ -26,7 +26,7 @@
     },
     {
       "url": "project.css",
-      "matches": ["https://scratch.mit.edu/projects/*", "https://scratch.mit.edu/studios/*"]
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -10,7 +10,7 @@
   "userstyles": [
     {
       "url": "hide_outline.css",
-      "matches": ["https://scratch.mit.edu/projects/*", "https://scratch.mit.edu/studios/*"],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "hide-outline": true
@@ -19,7 +19,7 @@
     },
     {
       "url": "outline_color.css",
-      "matches": ["https://scratch.mit.edu/projects/*", "https://scratch.mit.edu/studios/*"],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "hide-outline": false
@@ -28,7 +28,7 @@
     },
     {
       "url": "fill_transparent.css",
-      "matches": ["https://scratch.mit.edu/projects/*", "https://scratch.mit.edu/studios/*"],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "fill-transparent": true

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -60,7 +60,7 @@
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/projects/*"]
+      "matches": ["projects"]
     }
   ],
   "versionAdded": "1.8.0",

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -82,7 +82,7 @@
     {
       "url": "buttonScroll.js",
       "matches": [
-        "https://scratch.mit.edu/projects/*",
+        "projects",
         "https://scratch.mit.edu/studios/*",
         "https://scratch.mit.edu/users/*",
         "https://scratch.mit.edu/messages"

--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -10,7 +10,7 @@
     {
       "url": "userscript.js",
       "matches": [
-        "https://scratch.mit.edu/projects/*",
+        "projects",
         "https://scratch.mit.edu/studios/*",
         "https://scratch.mit.edu/users/*"
       ]

--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -9,11 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": [
-        "projects",
-        "https://scratch.mit.edu/studios/*",
-        "https://scratch.mit.edu/users/*"
-      ]
+      "matches": ["projects", "https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/users/*"]
     }
   ],
   "versionAdded": "1.0.0",

--- a/addons/resizable-comment-input/addon.json
+++ b/addons/resizable-comment-input/addon.json
@@ -15,11 +15,7 @@
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": [
-        "projects",
-        "https://scratch.mit.edu/users/*/",
-        "https://scratch.mit.edu/studios/*"
-      ]
+      "matches": ["projects", "https://scratch.mit.edu/users/*/", "https://scratch.mit.edu/studios/*"]
     }
   ],
   "enabledByDefault": true

--- a/addons/resizable-comment-input/addon.json
+++ b/addons/resizable-comment-input/addon.json
@@ -16,7 +16,7 @@
     {
       "url": "userstyle.css",
       "matches": [
-        "https://scratch.mit.edu/projects/*",
+        "projects",
         "https://scratch.mit.edu/users/*/",
         "https://scratch.mit.edu/studios/*"
       ]

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -343,7 +343,7 @@ const WELL_KNOWN_PATTERNS = {
   editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/,
   forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
   scratchWWWNoProject:
-    /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher)\/?)?$/,
+    /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher|projects)\/?)?$/,
 };
 
 const WELL_KNOWN_MATCHERS = {

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -342,6 +342,8 @@ const WELL_KNOWN_PATTERNS = {
   newPostScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add)\/?$/,
   editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/,
   forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
+  // scratch-www routes, not including project pages
+  // Matches /projects (an error page) but not /projects/<id>
   scratchWWWNoProject:
     /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher|projects)\/?)?$/,
 };


### PR DESCRIPTION
Resolves #5575

### Changes

* Adds `/projects` to the `scratchWWWNoProjects` regex (not `projects` because it isn't a functional project page).
* Changes some addons to use the `"projects"` match instead of `/projects/*` to prevent them from running on this page.

### Reason for changes

To fix a bug with website dark mode and prevent potential bugs in the future.

### Tests

Tested on Edge and Firefox.