### PR TITLE
Fix broken reshape tool with paint-snap

### DIFF
--- a/addons/paint-snap/updateSelectTool.js
+++ b/addons/paint-snap/updateSelectTool.js
@@ -110,7 +110,7 @@ export const updateSelectTool = (paper, tool) => {
       return p1.getDistance(p2);
     };
 
-    const selectionAnchor = getLayer("isGuideLayer").children.find((c) => c.data.isSelectionBound).selectionAnchor;
+    const selectionAnchor = getLayer("isGuideLayer").children.find((c) => c.data.isSelectionBound)?.selectionAnchor ?? {};
 
     const resetAnchorColor = () => {
       selectionAnchor.strokeColor = new paper.Color(0.30196078431372547, 0.592156862745098, 1);

--- a/addons/paint-snap/updateSelectTool.js
+++ b/addons/paint-snap/updateSelectTool.js
@@ -110,7 +110,8 @@ export const updateSelectTool = (paper, tool) => {
       return p1.getDistance(p2);
     };
 
-    const selectionAnchor = getLayer("isGuideLayer").children.find((c) => c.data.isSelectionBound)?.selectionAnchor ?? {};
+    const selectionAnchor =
+      getLayer("isGuideLayer").children.find((c) => c.data.isSelectionBound)?.selectionAnchor ?? {};
 
     const resetAnchorColor = () => {
       selectionAnchor.strokeColor = new paper.Color(0.30196078431372547, 0.592156862745098, 1);


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5577 

### Changes

Fixed the reshape tool not working correctly.

### Tests

None yet, but theoretically this should work based off of the error. @mxmou Can you test please?
