### PR TITLE
zebra-striping: compare colors instead of categories

### DIFF
--- a/addons/zebra-striping/userscript.js
+++ b/addons/zebra-striping/userscript.js
@@ -19,7 +19,7 @@ export default async function ({ addon, msg, console }) {
         if (parent) {
           if (block.isShadow()) {
             isStriped = !!stripeState.get(parent);
-          } else if (parent.getCategory() === block.getCategory()) {
+          } else if (parent.getColour() === block.getColour()) {
             isStriped = !stripeState.get(parent);
           }
         }


### PR DESCRIPTION
Resolves #5194

### Changes

Enables zebra striping when two blocks have the same color, even if the category is different. This only works if the two colors are exactly the same.

### Reason for changes

It's possible to choose the same color for two categories.

### Tests

Tested on Edge and Firefox, using Appel as an example project. In the first screenshot, variables and lists have the same color. In the second screenshot, operators and variables have the same color.
![image](https://user-images.githubusercontent.com/51849865/211395341-5302e0bb-7586-4c72-a868-648cad5f5c7a.png)
![image](https://user-images.githubusercontent.com/51849865/211395349-fcd6c518-2726-4300-9536-cd838be01261.png)
