### PR TITLE
Don't color addon block insertion markers

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -130,7 +130,7 @@ const injectWorkspace = (ScratchBlocks) => {
   const oldUpdateColour = BlockSvg.prototype.updateColour;
   BlockSvg.prototype.updateColour = function (...args) {
     // procedures_prototype also have a procedure code but we do not want to color them.
-    if (this.type === "procedures_call") {
+    if (!this.isInsertionMarker() && this.type === "procedures_call") {
       const block = this.procCode_ && getCustomBlock(this.procCode_);
       if (block) {
         this.colour_ = color.color;


### PR DESCRIPTION
Before, the insertion marker for addon blocks was given color:

![image](https://user-images.githubusercontent.com/33787854/211468465-b37147b1-1670-4ed8-98b6-352eab7768ab.png)

Now, it looks the same as every other block:

![image](https://user-images.githubusercontent.com/33787854/211468409-445539e7-7332-4e05-8f31-912627294dae.png)
