### PR TITLE
Animate scratchr2 modal backdrop correctly

### DIFF
--- a/addon-api/content-script/modal.js
+++ b/addon-api/content-script/modal.js
@@ -124,10 +124,8 @@ export const createScratchWwwModal = (title, { isOpen = false, useSizesClass = t
 
 export const createScratchr2Modal = (title, { isOpen = false } = {}) => {
   const backdrop = Object.assign(document.createElement("div"), {
-    className: "modal-backdrop fade",
+    className: "modal-backdrop fade hide",
   });
-  if (isOpen) backdrop.classList.add("in");
-  else backdrop.classList.add("hide");
   document.body.appendChild(backdrop);
   const modal = Object.assign(document.createElement("div"), {
     className: "modal fade hide",
@@ -157,7 +155,7 @@ export const createScratchr2Modal = (title, { isOpen = false } = {}) => {
     setTimeout(() => {
       backdrop.classList.add("in");
       modal.classList.add("in");
-    }, 300);
+    }, 0);
   };
   const close = () => {
     modal.classList.remove("in");


### PR DESCRIPTION
Resolves #5590

### Changes

* Removes the delay before a modal created using `addon.tab.confirm` or other `addon.tab.*` methods appears on a scratchr2 page
* Makes the modal backdrop fade in instead of appearing instantly

### Reason for changes

To match Scratch's modals such as "change featured project" more closely.

### Tests

Tested on Edge and Firefox.