### PR TITLE
Fix "presets" label in the Addons popup

### DIFF
--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -251,11 +251,16 @@ body.iframe .addon-setting.boolean-setting .setting-label {
 }
 body.iframe .presets-column > .setting-label {
   margin-inline-start: 0;
+  margin-top: 10px;
   margin-bottom: 0;
+  width: 100%;
 }
 body.iframe .presets-column > .addon-setting {
   margin: 5px 0;
   margin-inline-end: 10px;
+}
+body.iframe .presets-column > .addon-setting:last-child {
+  margin-inline-end: 0;
 }
 
 body.iframe .addons-container {


### PR DESCRIPTION
Resolves #5549

### Changes

Moves the "presets" label in the popup above the list of presets.

### Reason for changes

It was previously next to the first preset, with no spacing around it, which didn't look very good.

### Tests

![image](https://user-images.githubusercontent.com/51849865/211516177-ae57db8b-6433-44d0-8c75-69df536219a5.png)
![image](https://user-images.githubusercontent.com/51849865/211516182-07fafdb9-7fa7-480b-9c2c-ed8be62f2195.png)