### PR TITLE
scratch-messaging: break long words in topic and studio titles

### DIFF
--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -78,6 +78,7 @@ button {
 }
 .thread-list {
   padding-bottom: 20px;
+  overflow-wrap: break-word;
 }
 .thread-list:first-child,
 .username-list {


### PR DESCRIPTION
Resolves #5360

### Changes

Adds `overflow-wrap: break-word` to forum and studio titles in the Messaging popup.

### Reason for changes

To prevent long titles from overflowing.

### Tests

Tested by changing the title using the inspector.