### PR TITLE
Fix middle click popup description

### DIFF
--- a/addons/middle-click-popup/addon.json
+++ b/addons/middle-click-popup/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Insert blocks by name",
-  "description": "Middle click on the code area, use Ctrl+Space or Shift+Space to bring up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code area. Hold Shift while dragging to avoid closing the box when adding multiple blocks at once.",
+  "description": "Middle click on the code area, use Ctrl+Space or Shift+Click to bring up a floating input box where you can type the name of a block (or parts of it) and drag the block into the code area. Hold Shift while dragging to avoid closing the box when adding multiple blocks at once.",
   "credits": [
     {
       "name": "griffpatch"


### PR DESCRIPTION
This has been wrong for a while, but it should have been Shift+Click, not Shift+Space.