### PR TITLE
`user-id`: Option to show only on hover

### DIFF
--- a/addons/user-id/addon.json
+++ b/addons/user-id/addon.json
@@ -5,6 +5,10 @@
     {
       "name": "yes-i-am-lanky",
       "link": "https://scratch.mit.edu/users/yes-i-am-lanky/"
+    },
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
     }
   ],
   "userscripts": [
@@ -17,11 +21,32 @@
     {
       "url": "userstyle.css",
       "matches": ["profiles"]
+    },
+    {
+      "url": "hover.css",
+      "matches": ["profiles"],
+      "if": {
+        "settings": { "onlyonhover": true }
+      }
+    }
+  ],
+  "settings": [
+    {
+      "id": "onlyonhover",
+      "name": "Only show when hovering over username",
+      "default": false,
+      "type": "boolean"
     }
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "injectAsStyleElt": true,
+  "updateUserstylesOnSettingsChange": true,
   "tags": ["community", "profiles"],
   "versionAdded": "1.19.0",
+  "latestUpdate": {
+    "version": "1.31.0",
+    "newSettings": ["onlyonhover"]
+  },
   "enabledByDefault": false
 }

--- a/addons/user-id/addon.json
+++ b/addons/user-id/addon.json
@@ -40,7 +40,6 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "injectAsStyleElt": true,
   "updateUserstylesOnSettingsChange": true,
   "tags": ["community", "profiles"],
   "versionAdded": "1.19.0",

--- a/addons/user-id/addon.json
+++ b/addons/user-id/addon.json
@@ -44,7 +44,7 @@
   "tags": ["community", "profiles"],
   "versionAdded": "1.19.0",
   "latestUpdate": {
-    "version": "1.31.0",
+    "version": "1.32.0",
     "newSettings": ["onlyonhover"]
   },
   "enabledByDefault": false

--- a/addons/user-id/addon.json
+++ b/addons/user-id/addon.json
@@ -26,13 +26,13 @@
       "url": "hover.css",
       "matches": ["profiles"],
       "if": {
-        "settings": { "onlyonhover": true }
+        "settings": { "only-on-hover": true }
       }
     }
   ],
   "settings": [
     {
-      "id": "onlyonhover",
+      "id": "only-on-hover",
       "name": "Only show when hovering over username",
       "default": false,
       "type": "boolean"
@@ -45,7 +45,7 @@
   "versionAdded": "1.19.0",
   "latestUpdate": {
     "version": "1.32.0",
-    "newSettings": ["onlyonhover"]
+    "newSettings": ["only-on-hover"]
   },
   "enabledByDefault": false
 }

--- a/addons/user-id/hover.css
+++ b/addons/user-id/hover.css
@@ -1,0 +1,7 @@
+.header-text > h2:hover:nth-child(1) > :nth-child(1) {
+    opacity: 1;
+}
+
+.sa-user-id {
+    opacity: 0;
+}

--- a/addons/user-id/hover.css
+++ b/addons/user-id/hover.css
@@ -1,7 +1,3 @@
-.header-text > h2:hover:nth-child(1) > :nth-child(1) {
-  opacity: 1;
-}
-
-.sa-user-id {
-  opacity: 0;
+.header-text > h2:not(:hover) > .sa-user-id {
+  display: none !important;
 }

--- a/addons/user-id/hover.css
+++ b/addons/user-id/hover.css
@@ -1,7 +1,7 @@
 .header-text > h2:hover:nth-child(1) > :nth-child(1) {
-    opacity: 1;
+  opacity: 1;
 }
 
 .sa-user-id {
-    opacity: 0;
+  opacity: 0;
 }


### PR DESCRIPTION
Resolves #5329

### Changes

Added an option to the `user-id` addon that makes the user ID only appear when you're hovering over the username.

### Reason for changes

Having the user ID next to the username is useful whenever you want to use it, but what if you don't always like it to show up?

### Tests

Tested on Edge 108 with SA v1.30.0-pre and it works.
