### PR TITLE
Fix condition for showing reset dropdown

### DIFF
--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -46,10 +46,12 @@ export default async function ({ template }) {
         return (
           !this.tableChild &&
           this.addon.presets &&
-          this.addon.presets.some((preset) =>
-            Object.prototype.hasOwnProperty.call(preset.values, this.setting.id) && this.setting.type === "color"
-              ? preset.values[this.setting.id].toLowerCase() !== this.setting.default.toLowerCase()
-              : preset.values[this.setting.id] !== this.setting.default
+          this.addon.presets.some(
+            (preset) =>
+              Object.prototype.hasOwnProperty.call(preset.values, this.setting.id) &&
+              (this.setting.type === "color"
+                ? preset.values[this.setting.id].toLowerCase() !== this.setting.default.toLowerCase()
+                : preset.values[this.setting.id] !== this.setting.default)
           )
         );
       },


### PR DESCRIPTION
### Changes

Fixes the condition for showing a reset dropdown next to a setting.

### Reason for changes

The dropdown should be hidden if the setting isn't changed by any preset.

### Tests

Tested by copying the `addon.json` change from #5602.