### PR TITLE
Allow opacity slider to be moved by clicking

### DIFF
--- a/addons/opacity-slider/userscript.js
+++ b/addons/opacity-slider/userscript.js
@@ -90,7 +90,6 @@ export default async function ({ addon, console, msg }) {
   };
 
   const handleClickBackground = (event) => {
-    if (event.target !== saOpacitySlider) return;
     handleClickOffset = HANDLE_WIDTH / 2;
     changeOpacity(scaleMouseToSliderPosition(event));
   };
@@ -163,6 +162,7 @@ export default async function ({ addon, console, msg }) {
       className: `sa-opacity-handle ${addon.tab.scratchClass("slider_handle")}`,
     });
     saOpacityHandle.addEventListener("mousedown", handleMouseDown);
+    saOpacityHandle.addEventListener("click", (event) => event.stopPropagation());
     const lastSlider = document.querySelector('[class*="slider_last"]');
     lastSlider.className = addon.tab.scratchClass("slider_container");
     setHandlePos(defaultAlpha);


### PR DESCRIPTION
Resolves #5312

### Changes

Fixes a bug in the opacity slider code that made it impossible to move the slider by clicking.

### Reason for changes

To make the addon easier to use.

### Tests

Tested on Edge and Firefox.