### PR TITLE
progress-bar: improve rounded design

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -38,12 +38,6 @@
 [class*="inline-message_success_"] {
   color: var(--editorDarkMode-menuBar-dimText);
 }
-.u-progress-bar-outer {
-  border-color: var(--editorDarkMode-menuBar-text);
-}
-.u-progress-bar-inner {
-  background-color: var(--editorDarkMode-menuBar-text);
-}
 [class*="spinner_spinner_"][class*="spinner_info_"] {
   border-color: var(--editorDarkMode-menuBar-transparentText);
 }

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -4,6 +4,10 @@
   "credits": [
     {
       "name": "GarboMuffin"
+    },
+    {
+      "name": "jbthepig",
+      "link": "https://scratch.mit.edu/users/jbthepig/"
     }
   ],
   "userscripts": [

--- a/addons/progress-bar/userscript.js
+++ b/addons/progress-bar/userscript.js
@@ -3,6 +3,9 @@ export default async function ({ addon, console, msg }) {
 
   const barOuter = document.createElement("div");
   barOuter.className = "u-progress-bar-outer";
+  const barBackground = document.createElement("div");
+  barBackground.className = "u-progress-bar-background";
+  barOuter.appendChild(barBackground);
   const barInner = document.createElement("div");
   barInner.className = "u-progress-bar-inner";
   barOuter.appendChild(barInner);

--- a/addons/progress-bar/userstyle.css
+++ b/addons/progress-bar/userstyle.css
@@ -1,14 +1,21 @@
 .u-progress-bar-outer {
   width: 100%;
   height: calc(1px * var(--progressBar-height));
-  box-sizing: border-box;
-  border: 1px solid white;
+  position: relative;
+}
+.u-progress-bar-background {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: currentColor;
+  opacity: 0.25;
   border-radius: calc(1px * var(--progressBar-height));
 }
 .u-progress-bar-inner {
+  position: absolute;
   width: 0;
   height: 100%;
-  background-color: white;
+  background-color: currentColor;
   border-radius: calc(1px * var(--progressBar-height));
 }
 
@@ -25,6 +32,14 @@
   transition: width 0.2s;
   border-radius: 0px;
 }
+.u-progress-bar-top .u-progress-bar-background,
+.u-progress-bar-top .u-progress-bar-inner {
+  background-color: var(--darkWww-navbar-text, white);
+}
+.sa-body-editor .u-progress-bar-top .u-progress-bar-background,
+.sa-body-editor .u-progress-bar-top .u-progress-bar-inner {
+  background-color: var(--editorDarkMode-menuBar-text, white);
+}
 
 .u-progress-bar-caption {
   margin: 5px 0;
@@ -35,12 +50,13 @@
   margin: auto;
   width: 250px;
 }
-[class^="inline-message_inline-message"].u-progress-bar-integrated {
+[class^="inline-message_inline-message"] .u-progress-bar-integrated,
+[class^="alert_alert"] .u-progress-bar-integrated {
   min-width: 100px;
   margin-top: 2px;
 }
-.remix-button .u-progress-bar-integrated,
-[class^="alert_alert"] .u-progress-bar-integrated {
-  border-color: black;
-  background-color: black;
+.remix-button .u-progress-bar-integrated {
+  /* Align left edge with remix icon */
+  margin-left: 3px;
+  width: calc(100% - 3px);
 }


### PR DESCRIPTION
### Changes

* Removes the border from the progress bar and adds a transparent background instead
* Uses the `currentColor` keyword to make specific styles for the alert progress bar unnecessary
* Improves the placement of save and remix progress bars

### Reason for changes

https://github.com/ScratchAddons/ScratchAddons/pull/5583#issuecomment-1376901183

### Tests

Tested on Edge and Firefox.