### PR TITLE
Add support for explore page to infinite-scroll

### DIFF
--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -96,7 +96,8 @@
         "projects",
         "https://scratch.mit.edu/studios/*",
         "https://scratch.mit.edu/users/*",
-        "https://scratch.mit.edu/messages"
+        "https://scratch.mit.edu/messages",
+        "https://scratch.mit.edu/explore/*"
       ]
     },
     {

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -7,6 +7,11 @@
     },
     {
       "name": "Hans5958"
+    },
+    {
+      "name": "Jazza",
+      "note": "Explore page",
+      "id": "explore"
     }
   ],
   "settings": [
@@ -65,6 +70,12 @@
       "default": true
     },
     {
+      "name": "Explore",
+      "id": "exploreScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
       "name": "Fix Footer",
       "id": "showFooter",
       "type": "boolean",
@@ -117,5 +128,9 @@
   ],
   "tags": ["community", "featured"],
   "versionAdded": "1.2.0",
+   "latestUpdate": {
+     "version": "1.31.0",
+     "newSettings": ["exploreScroll"]
+  },
   "enabledByDefault": false
 }

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -135,4 +135,4 @@
   },
   "enabledByDefault": false
 }
-//fake commit to see if it will prettify
+ 

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -127,9 +127,9 @@
   ],
   "tags": ["community", "featured"],
   "versionAdded": "1.2.0",
-   "latestUpdate": {
-     "version": "1.31.0",
-     "newSettings": ["exploreScroll"]
+  "latestUpdate": {
+    "version": "1.31.0",
+    "newSettings": ["exploreScroll"]
   },
   "enabledByDefault": false
-} 
+}

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -9,9 +9,7 @@
       "name": "Hans5958"
     },
     {
-      "name": "Jazza",
-      "note": "Explore page",
-      "id": "explore"
+      "name": "Jazza"
     }
   ],
   "settings": [

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -134,5 +134,4 @@
      "newSettings": ["exploreScroll"]
   },
   "enabledByDefault": false
-}
- 
+} 

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -34,12 +34,6 @@
       "default": true
     },
     {
-      "name": "Studio Comments",
-      "id": "studioScroll",
-      "type": "boolean",
-      "default": true
-    },
-    {
       "name": "Studio Projects",
       "id": "studioProjectScroll",
       "type": "boolean",
@@ -48,6 +42,12 @@
     {
       "name": "Add to Studio Menu",
       "id": "studioBrowseProjectScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Studio Comments",
+      "id": "studioScroll",
       "type": "boolean",
       "default": true
     },

--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -135,3 +135,4 @@
   },
   "enabledByDefault": false
 }
+//fake commit to see if it will prettify

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -2,6 +2,7 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
   let func;
   let prevScrollDetector;
   const yProviderValue = yProvider;
+  let prevHeight = 0;
   while (true) {
     const el = await addon.tab.waitForElement(selector, {
       markAsSeen: true,
@@ -17,11 +18,11 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
     prevScrollDetector = scrollDetecter;
     func = () => {
       const threshold = yProvider ? yProvider.scrollTop + yProvider.clientHeight : window.scrollY + window.innerHeight;
+      let height = el.closest(heightControl).offsetHeight;
       if (typeof pathname === "string" && (window.location.pathname.split("/")[3] || "") !== pathname) return;
-      if (threshold >= el.closest(heightControl).offsetHeight - 500) {
-        if (el) {
-          el.click();
-        }
+      if (threshold >= height - 500 && height > prevHeight) {
+          prevHeight = height;
+          el.click(); 
       }
     };
     scrollDetecter.addEventListener("scroll", func, { passive: true });

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -69,7 +69,7 @@ export default async function ({ addon, console }) {
     commentLoader(addon, "#view", "div > .studio-members:last-child .studio-grid-load-more > button", "curators"); // Only scrolling curators for now
   if (isStudio && addon.settings.get("studioActivityScroll"))
     commentLoader(addon, "#view", ".studio-activity .studio-grid-load-more > button", "activity");
-  if (window.location.pathname.split("/")[1] === "explore" && addon.settings.get("exploreScroll")) //temporary comment so Jazza don't get lost
+  if (window.location.pathname.split("/")[1] === "explore" && addon.settings.get("exploreScroll"))
     commentLoader(addon, "#projectBox", "#projectBox button");
 
   // Enable scrolling for studio-followers

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -68,6 +68,8 @@ export default async function ({ addon, console }) {
     commentLoader(addon, "#view", "div > .studio-members:last-child .studio-grid-load-more > button", "curators"); // Only scrolling curators for now
   if (isStudio && addon.settings.get("studioActivityScroll"))
     commentLoader(addon, "#view", ".studio-activity .studio-grid-load-more > button", "activity");
+  if (window.location.pathname.split("/")[1] === "explore" && addon.settings.get("exploreScroll")) //temporary comment so Jazza don't get lost
+    commentLoader(addon, "#projectBox", "#projectBox button");
 
   // Enable scrolling for studio-followers
   // Disabled, see #3238

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -21,8 +21,8 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
       let height = el.closest(heightControl).offsetHeight;
       if (typeof pathname === "string" && (window.location.pathname.split("/")[3] || "") !== pathname) return;
       if (threshold >= height - 500 && height > prevHeight) {
-          prevHeight = height;
-          el.click(); 
+        prevHeight = height;
+        el.click();
       }
     };
     scrollDetecter.addEventListener("scroll", func, { passive: true });


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #2520

### Changes
In addition to the new setting for the explore page, I reorganized the studio settings to be in the same order as the tabs on scratch, and fixed the addon spamming the messages API for no reason. 
(This is my first time making a pr or anything to do with GitHub so please say if I do anything wrong)

<!-- Please describe the changes you've made. -->

### Reason for changes
The suggestion to add infinite scrolling to the explore page got 31 upvotes on the SA discord
(Also redguy said it would be easy)

<!-- Why should these changes be made? -->

### Tests
Tested every setting again after changes, on chromium 109.0.5414.87. The network log shows no API spamming.

<!-- If applicable. Have you tested this pull request? If so, how? -->
