### PR TITLE
Rename "Mute" to "Do not disturb"

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -36,10 +36,10 @@
     "message": "Until I turn it back on"
   },
   "muteFor": {
-    "message": "Mute"
+    "message": "Do not disturb"
   },
   "unmute": {
-    "message": "Unmute"
+    "message": "Turn off Do not disturb"
   },
   "recommended": {
     "message": "Recommended"

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -7,7 +7,7 @@
   "info": [
     {
       "type": "info",
-      "text": "You can use Do Not Disturb (right-click extension icon \u2192 Do not disturb) to hide the message count.",
+      "text": "You can use Do Not Disturb (right click extension icon \u2192 Do not disturb) to temporarily hide the message count.",
       "id": "dndtohide"
     }
   ],

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -4,6 +4,13 @@
   "tags": ["popup", "recommended"],
   "enabledByDefault": true,
   "versionAdded": "1.0.0",
+  "info": [
+    {
+      "type": "notice",
+      "text": "Turning on Do Not Disturb (right-click extension icon \u2192 Do not disturb) will hide the message count.",
+      "id": "dndtohide"
+    }
+  ],
   "settings": [
     {
       "name": "Badge color",

--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -6,8 +6,8 @@
   "versionAdded": "1.0.0",
   "info": [
     {
-      "type": "notice",
-      "text": "Turning on Do Not Disturb (right-click extension icon \u2192 Do not disturb) will hide the message count.",
+      "type": "info",
+      "text": "You can use Do Not Disturb (right-click extension icon \u2192 Do not disturb) to hide the message count.",
       "id": "dndtohide"
     }
   ],

--- a/addons/scratch-notifier/addon.json
+++ b/addons/scratch-notifier/addon.json
@@ -15,6 +15,13 @@
     }
   ],
   "permissions": ["notifications"],
+  "info": [
+    {
+      "type": "info",
+      "text": "You can use Do Not Disturb (right-click extension icon \u2192 Do not disturb) to temporarily disable notifications from Scratch Addons.",
+      "id": "dndtosilence"
+    }
+  ],
   "settings": [
     {
       "name": "Mark all messages as read after clicking notification",

--- a/addons/scratch-notifier/addon.json
+++ b/addons/scratch-notifier/addon.json
@@ -18,7 +18,7 @@
   "info": [
     {
       "type": "info",
-      "text": "You can use Do Not Disturb (right-click extension icon \u2192 Do not disturb) to temporarily disable notifications from Scratch Addons.",
+      "text": "You can use Do Not Disturb (right click extension icon \u2192 Do not disturb) to temporarily disable notifications.",
       "id": "dndtosilence"
     }
   ],


### PR DESCRIPTION
Resolves #4955

### Changes

When right clicking the Scratch Addons extension icon, there was a Mute option, which silenced and hid notifications from the Scratch Notifier addon and hid the messages badge. I renamed this setting to "Do not disturb" and added a note to notification-related addons to tell the user that enabling this feature will hide the message count.

### Reason for changes

It described the feature better.

### Tests

Changes tested.
