### PR TITLE
Remove link to Scratch profile from disable-auto-save credits

### DIFF
--- a/addons/disable-auto-save/addon.json
+++ b/addons/disable-auto-save/addon.json
@@ -10,8 +10,7 @@
   ],
   "credits": [
     {
-      "name": "RustingRobot",
-      "link": "https://scratch.mit.edu/users/RustingRobot/"
+      "name": "RustingRobot"
     }
   ],
   "dynamicEnable": true,


### PR DESCRIPTION
Change was requested via email to me.