### PR TITLE
sprite-properties: fix compatibility with search-sprites

### DIFF
--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -132,8 +132,7 @@ export default async function ({ addon, console, msg }) {
     });
 
     const spriteSelector = propertiesPanel.parentNode;
-    const scrollWrapper = spriteSelector.querySelector('[class*="sprite-selector_scroll-wrapper_"]');
-    const itemsWrapper = scrollWrapper.firstChild;
+    const itemsWrapper = spriteSelector.querySelector('[class*="sprite-selector_items-wrapper_"]');
     observer.observe(itemsWrapper, {
       childList: true,
       subtree: true,


### PR DESCRIPTION
Fixes https://github.com/ScratchAddons/ScratchAddons/issues/5658

I believe I broke this in https://github.com/ScratchAddons/ScratchAddons/pull/5563
