### PR TITLE
New addon "Move to Top Layer"

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -99,6 +99,7 @@
   "block-cherry-picking",
   "hide-new-variables",
   "move-to-top-bottom",
+  "move-to-top-layer",
   "search-my-stuff",
   "fullscreen",
   "echo-effect",

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -1,0 +1,31 @@
+{
+  "name":"Move Sprite to Top Layer",
+  "description":"This addon allows you to move a selected sprite to the top layer",
+  "info": [
+    {
+      "type": "notice",
+      "text": "Press \"Shift\" while clicking a sprite in the sprite list to both select and move it to the top layer.",
+      "id": "shortcuts"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Norbiros",
+      "link": "https://scratch.mit.edu/users/Norbir/"
+    },
+    {
+      "name": "s_federici",
+      "link": "https://scratch.mit.edu/users/s_federici/"
+    }
+  ],
+  "userscripts":[
+    {
+      "url":"userscript.js",
+      "matches":["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "tags": ["editor", "codeEditor", "beta"],
+  "versionAdded": "1.30.1"
+}

--- a/addons/move-to-top-layer/userscript.js
+++ b/addons/move-to-top-layer/userscript.js
@@ -1,0 +1,27 @@
+// Welcome to Move to Top Layer code!
+// Code was written by Norbiros
+//
+// If you find any bugs, or you want to change anything
+// create an issue on the Scratch Addon github repository (or create a PR)!
+
+export default async function ({ addon, global, console, msg }) {  
+  const vm = addon.tab.traps.vm;
+
+  // look for sprite list
+  let spriteList = document.getElementsByClassName("sprite-selector_items-wrapper_4bcOj box_box_2jjDp");
+  // add event triggered by mouse click on sprite list
+  spriteList[0].addEventListener("click",
+    // when the sprite list is clicked
+    function(e) {
+      // if shift is pressed
+      if (e.shiftKey) {
+        // get the sprite thumbnail closest to the click
+        let parentDiv = event.target.closest(".sprite-selector_sprite-wrapper_1C5Mq")
+        // get the name of the sprite
+        let name = parentDiv.querySelector('.sprite-selector-item_sprite-name_1PXjh').innerText;
+        // move the sprite with that name to front
+        vm.runtime.getSpriteTargetByName(name).goToFront();
+      }
+    },
+    false);
+}


### PR DESCRIPTION
New addon "Move to Top Layer" to move a sprite to the top layer when shift-clicking its thumbnail in the sprite list. I extracted the code for this addon from a larger addon created by Norbiros that wasn't fully accepted by ScratchAddons.

Resolves #4231

### Changes

Created new addon "move-to-top-layer"

### Reason for changes

When a sprite is covered by other sprites on the Stage so that it is not visible, to make it visible you have to go to the palette and run a "go to front layer" block. By enabling this extension it can be quickly brought to the front layer by simply shift-clicking its thumbnail in the sprite list

### Tests

I tested this extension locally as an unpacked extension.
