### PR TITLE
Link changelog link directly to version

### DIFF
--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -56,7 +56,7 @@ const vue = new Vue({
       const uiLanguage = chrome.i18n.getUILanguage();
       const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
       const utm = `utm_source=extension&utm_medium=popup&utm_campaign=v${chrome.runtime.getManifest().version}`;
-      return `https://scratchaddons.com/${localeSlash}changelog/?${utm}`;
+      return `https://scratchaddons.com/${localeSlash}changelog/?${utm}#v${chrome.runtime.getManifest().version}`;
     },
     version() {
       const prerelease = chrome.runtime.getManifest().version_name.includes("-prerelease");


### PR DESCRIPTION
### Changes

Do adjustments to the changelog link so it goes directly to the version, instead stuck on the top.

### Reason for changes

So the link would stick to the current extension version that is used, even if it is not latest.

### Tests

Negligble to be tested, but I haven't done it.
