### PR TITLE
editor-dark-mode: white insertion marker

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -675,6 +675,17 @@
       }
     },
     {
+      "name": "workspace-insertionMarker",
+      "value": {
+        "type": "textColor",
+        "black": "#000000",
+        "source": {
+          "type": "settingValue",
+          "settingId": "workspace"
+        }
+      }
+    },
+    {
       "name": "categoryMenu-text",
       "value": {
         "type": "textColor",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -304,6 +304,9 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .blocklyMainWorkspaceScrollbar .blocklyScrollbarHandle {
   fill: var(--editorDarkMode-workspace-scrollbar);
 }
+.blocklyInsertionMarker > .blocklyPath {
+  fill: var(--editorDarkMode-workspace-insertionMarker);
+}
 
 /* Block category menu background */
 .blocklyToolboxDiv,


### PR DESCRIPTION
### Changes

Makes the block insertion marker white in dark mode.

### Reason for changes

To make it more visible.

### Tests

![image](https://user-images.githubusercontent.com/51849865/216693668-8be9e079-e838-47de-a8cd-3b43c694ea3c.png)