### PR TITLE
find-bar: fix block scrolling regression

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -210,7 +210,7 @@ export default async function ({ addon, msg, console }) {
         }
       }
 
-      this.utils.offsetX = this.dropdownOut.getBoundingClientRect().right + 26;
+      this.utils.offsetX = this.dropdownOut.getBoundingClientRect().width + 32;
       this.utils.offsetY = 32;
     }
 


### PR DESCRIPTION
Fixes a regression from https://github.com/ScratchAddons/ScratchAddons/pull/5638 where navigating to a block using the find bar would incorrectly navigate so the block was either in the top right corner of the workspace or offscreen.