### PR TITLE
Fix blue icon next to closed stickies

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -459,7 +459,7 @@ input.link.black:active,
   color: var(--darkWww-link-scratchr2);
 }
 .inew,
-.isticky {
+.isticky:not(.iclosed) {
   filter: var(--darkWww-link-scratchr2IconFilter);
 }
 

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -327,7 +327,7 @@ body > #pagewrapper {
   font-weight: normal;
 }
 .inew,
-.isticky {
+.isticky:not(.iclosed) {
   filter: var(--darkWww-link-iconFilter, var(--scratchr2-defaultLinkIconFilter));
 }
 .djangobb > .postmsg {


### PR DESCRIPTION
### Changes

Fixes a bug in `dark-www` and `scratchr2` that changed the color of the gray pin icons next to closed sticky topics to blue.

### Tests

1.30.1:
![screenshot](https://user-images.githubusercontent.com/51849865/216771780-0c2a490a-6e18-4a18-b272-d3e05ea72629.png)

With this change:
![screenshot](https://user-images.githubusercontent.com/51849865/216771773-93049e39-eb07-4e52-a8c1-3ddd865a9cca.png)