### PR TITLE
Dynamic enable/disable for `one-click-studio-invites`

### DIFF
--- a/addons/one-click-studio-invites/addon.json
+++ b/addons/one-click-studio-invites/addon.json
@@ -20,5 +20,7 @@
     }
   ],
   "tags": ["community", "studios"],
-  "versionAdded": "1.27.0"
+  "versionAdded": "1.27.0",
+  "dynamicEnable": true,
+  "dynamicDisable": true
 }

--- a/addons/one-click-studio-invites/userscript.js
+++ b/addons/one-click-studio-invites/userscript.js
@@ -42,7 +42,7 @@ export default async function (
     }
 
     addon.tab.displayNoneWhileDisabled(button, { display: "block" });
-    
+
     button.addEventListener("click", async () => {
       if (userProfile.invited) {
         button.classList.add("loading");

--- a/addons/one-click-studio-invites/userscript.js
+++ b/addons/one-click-studio-invites/userscript.js
@@ -41,6 +41,8 @@ export default async function (
       button.disabled = true;
     }
 
+    addon.tab.displayNoneWhileDisabled(button, { display: "block" });
+    
     button.addEventListener("click", async () => {
       if (userProfile.invited) {
         button.classList.add("loading");

--- a/addons/one-click-studio-invites/userstyle.css
+++ b/addons/one-click-studio-invites/userstyle.css
@@ -1,6 +1,5 @@
 .sa-curator-invite-button {
   text-align: center;
-  display: block;
 }
 .sa-curator-invite-button.loading {
   cursor: wait !important;


### PR DESCRIPTION
A step towards #1673

### Changes

Made the "Accept Invite" button show when you enable the addon and hide when you disable it, all without a refresh.

### Reason for changes

We're trying to add dynamic enable/disable support to all addons at some point.

### Tests

Tested on Edge with SA v1.30.0-pre.
