### PR TITLE
Prevent visited links from turning blue on messages page

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -221,6 +221,7 @@ body:not(.sa-body-editor) .button.white,
 .tabs li.active:hover,
 .grid .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .unsupported-browser .faq-link-text,
+a.social-messages-profile-link,
 a.social-messages-profile-link:link,
 .studio-selector-button-text-unselected,
 .studio-project-tile .studio-project-username,
@@ -613,9 +614,9 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button:checked {
 }
 
 /* Link color */
-a,
+a:not(a.social-messages-profile-link),
 a:link,
-a:visited,
+a:visited:not(a.social-messages-profile-link),
 body:not(.sa-body-editor) .button.white,
 .news li h4,
 .intro-banner .intro-button,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -221,7 +221,7 @@ body:not(.sa-body-editor) .button.white,
 .tabs li.active:hover,
 .grid .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .unsupported-browser .faq-link-text,
-a.social-messages-profile-link,
+a.social-messages-profile-link:visited,
 a.social-messages-profile-link:link,
 .studio-selector-button-text-unselected,
 .studio-project-tile .studio-project-username,
@@ -614,9 +614,9 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button:checked {
 }
 
 /* Link color */
-a:not(a.social-messages-profile-link),
+a,
 a:link,
-a:visited:not(a.social-messages-profile-link),
+a:visited,
 body:not(.sa-body-editor) .button.white,
 .news li h4,
 .intro-banner .intro-button,


### PR DESCRIPTION
Resolves #5709

### Changes

Links that are visited no longer turn blue on the messages page when dark-www is enabled.

### Reason for changes

What's happening currently is inconsistent with the behavior of vanilla Scratch.

### Tests

Tested on a chromium browser.