### PR TITLE
Fix user dropdown text overflowing

### DIFF
--- a/addons/discuss-button/compact-nav.css
+++ b/addons/discuss-button/compact-nav.css
@@ -9,8 +9,9 @@
   display: block;
   font-size: 0.75rem;
   font-weight: normal;
-  line-height: 0px;
-  padding-bottom: 15px;
+  line-height: normal;
+  padding-bottom: 8px;
+  white-space: normal;
 }
 
 .sa-compact-profile-icon {

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -540,6 +540,7 @@ select:focus {
 #topnav ul.account-nav ul.user-nav li a {
   color: var(--darkWww-navbar-text, white);
   font-size: 13px;
+  white-space: normal;
 }
 #topnav ul.account-nav ul.user-nav li:hover {
   background: var(--darkWww-navbar-border, rgba(0, 0, 0, 0.1));


### PR DESCRIPTION
### Changes

Adds `white-space: normal;` to the `#topnav ul.account-nav ul.user-nav li a` style rule in `addons/scratchr2/scratchr2.css`

### Reason for changes

To resolve #5715

After:
![Text word-wrapping in the user dropdown](https://user-images.githubusercontent.com/106490990/218185399-3f87d406-e145-4053-93af-9c4151e8daf7.png)


### Tests

Tested on Edge 111.
