### PR TITLE
Reword sentences in `initialise-sprite-position`

### DIFF
--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Customizable new sprite position",
-  "description": "Change where newly created sprites are placed.",
+  "description": "Change where newly created sprites are placed on the stage.",
   "credits": [
     {
       "name": "pufferfish101007",

--- a/addons/initialise-sprite-position/addon.json
+++ b/addons/initialise-sprite-position/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Customizable new sprite position",
-  "description": "Change the default x/y position of new sprites.",
+  "description": "Change where newly created sprites are placed.",
   "credits": [
     {
       "name": "pufferfish101007",
@@ -34,27 +34,27 @@
     },
     {
       "id": "library",
-      "name": "Randomize the position of library sprites",
+      "name": "Place sprites from library at random position",
       "type": "boolean",
       "default": false
     },
     {
       "id": "duplicate",
-      "name": "Behavior when duplicating sprites",
+      "name": "Position for duplicated sprites",
       "type": "select",
       "default": "randomize",
       "potentialValues": [
         {
           "id": "custom",
-          "name": "Send to specified x/y values"
+          "name": "Specified x/y position"
         },
         {
           "id": "keep",
-          "name": "Keep the same as the original sprite"
+          "name": "Same as original sprite"
         },
         {
           "id": "randomize",
-          "name": "Randomize"
+          "name": "Random"
         }
       ]
     }


### PR DESCRIPTION
### Changes

Reworded the description and some settings in the `initialise-sprite-position` addon.

### Reason for changes

To make it easier to understand it.

### Tests

Should work fine.
