### PR TITLE
dark-www: support updated Explore page tabs

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -777,6 +777,17 @@
       }
     },
     {
+      "name": "gray-darkText",
+      "value": {
+        "type": "textColor",
+        "black": "#3b3b3b",
+        "source": {
+          "type": "settingValue",
+          "settingId": "gray"
+        }
+      }
+    },
+    {
       "name": "gray-boxHighlight",
       "value": {
         "type": "textColor",

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -317,9 +317,12 @@ body:not(.sa-body-editor) .outer .sort-mode .select select:focus {
 }
 .outer .categories li {
   background-color: var(--darkWww-gray-tab);
+  border-color: var(--darkWww-gray-darkText);
+  color: var(--darkWww-gray-text);
 }
 .outer .categories li:hover {
   background-color: var(--darkWww-gray-tabHover);
+  color: var(--darkWww-gray-darkText);
 }
 .toggle-switch .slider {
   background-color: var(--darkWww-gray-darker);


### PR DESCRIPTION
### Changes

Makes website dark mode compatible with the recent change to the design of tabs on the Explore page.

### Reason for changes

To make text on the tabs readable.

### Tests

Tested locally (this change isn't on scratch.mit.edu yet).

Without the addon:
![image](https://user-images.githubusercontent.com/51849865/219116706-4c77136e-b583-4f65-8e12-07ed45bf51ad.png)

Before this change:
![image](https://user-images.githubusercontent.com/51849865/219116740-b0b79c99-3214-42d9-adb0-1d3e8e88f102.png)

After this change:
![image](https://user-images.githubusercontent.com/51849865/219116772-24c184d3-a041-4fc2-90b9-dc8b2207534d.png)