### PR TITLE
Transparent navbar

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1973,8 +1973,8 @@
     {
       "name": "Navigation bar background",
       "id": "navbar",
-      "type": "color",
       "allowTransparency": true,
+      "type": "color",
       "default": "#4d97ff"
     },
     {

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1974,6 +1974,7 @@
       "name": "Navigation bar background",
       "id": "navbar",
       "type": "color",
+      "allowTransparency": true,
       "default": "#4d97ff"
     },
     {

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1973,8 +1973,8 @@
     {
       "name": "Navigation bar background",
       "id": "navbar",
-      "allowTransparency": true,
       "type": "color",
+      "allowTransparency": true,
       "default": "#4d97ff"
     },
     {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

<!-- Resolves # -->

### Changes

<!-- Please describe the changes you've made. -->
Added a slider to the color picker for the navbar in the `dark-www` addon which allows the user to change the transparency.

### Reason for changes

<!-- Why should these changes be made? -->
The feature was already in the Scratch 2.0 -> 3.0 addon. The transparency slider disappeared when the settings were moved to the dark-www addon. This had the consequence that people who changed the transparency in the old version could not change or disable it anymore. Another reason is that a transparent navbar looks good to some users.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested by changing the transparency and using it for a while, and I've never noticed any issues.
