### PR TITLE
New addon-blink animation

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -182,7 +182,7 @@
       (This is working as intended per spec.)
       Use CSS class to force animation.
     */
-    animation: addonBlink 2s 1;
+    animation: addonBlink 1s 2 ease-in-out;
   }
 
   .addon-buttons {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -79,17 +79,12 @@ h1 {
 }
 
 @keyframes addonBlink {
-  10% {
+  0% {
     border: 1px solid var(--content-border);
-  }
-  25% {
-    border: 1px solid var(--orange);
   }
   50% {
-    border: 1px solid var(--content-border);
-  }
-  75% {
     border: 1px solid var(--orange);
+    filter: drop-shadow(0px 0px 7px var(--orange));
   }
   100% {
     border: 1px solid var(--content-border);

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -84,7 +84,7 @@ h1 {
   }
   50% {
     border: 1px solid var(--orange);
-    filter: drop-shadow(0px 0px 7px var(--orange));
+    filter: drop-shadow(0px 0px 4px var(--orange));
   }
   100% {
     border: 1px solid var(--content-border);


### PR DESCRIPTION
### Changes

- The `addon-blink` animation now has a drop-shadow to make the addon glow orange
- The animation's timing has been modified 

### Reason for changes

I feel like the animation is more noticeable with these changes.

### Steps to reproduce

To see the animation for yourself:
1. Search for "Scratch Notifier" in the popup.
2. Disable the addon if it's already enabled, then enable the addon, then on the following prompt, choose "Open full screen settings".
3. Observe the animation. Refresh the page or use developer tools to replay it.

### Tests

Tested on Edge 109.
