### PR TITLE
Add `latestUpdate` to `progress-bar`

### DIFF
--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -12,7 +12,7 @@
   ],
   "latestUpdate": {
     "version": "1.31.0",
-    "temporaryNotice": "The progress bar has had a redisign since Scratch Addons 1.30.1."
+    "temporaryNotice": "The progress bar has had a redesign since v1.30.1."
   },
   "userscripts": [
     {

--- a/addons/progress-bar/addon.json
+++ b/addons/progress-bar/addon.json
@@ -10,6 +10,10 @@
       "link": "https://scratch.mit.edu/users/jbthepig/"
     }
   ],
+  "latestUpdate": {
+    "version": "1.31.0",
+    "temporaryNotice": "The progress bar has had a redisign since Scratch Addons 1.30.1."
+  },
   "userscripts": [
     {
       "url": "userscript.js",


### PR DESCRIPTION
### Changes

Adds the update tag to the progress bar addon with a temporary notice about the changes from 1.30.1.

### Reason for changes

A lot of users might have missed it since there was no update tag on the settings page.

### Tests

Tested on Chromium 110.