### PR TITLE
forum-id: auto-add post number small & in brackets

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -197,7 +197,11 @@ function setup() {
     const username = post.find(".username").text();
     const idText =
       !forumIdAddon?.self?.disabled && forumIdAddon?.settings?.get?.("auto_add")
-        ? `[small](${getIDLink(id.substring(1), post["0"].querySelector(".box-head > .conr").textContent, false)})[/small]`
+        ? `[small](${getIDLink(
+            id.substring(1),
+            post["0"].querySelector(".box-head > .conr").textContent,
+            false
+          )})[/small]`
         : "";
     getPostText(id, post[0], window.getSelection()).then((text) => {
       paste(`[quote=${username}]${idText}\n${text}\n[/quote]\n`);

--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -197,7 +197,7 @@ function setup() {
     const username = post.find(".username").text();
     const idText =
       !forumIdAddon?.self?.disabled && forumIdAddon?.settings?.get?.("auto_add")
-        ? getIDLink(id.substring(1), post["0"].querySelector(".box-head > .conr").textContent, false)
+        ? `[small](${getIDLink(id.substring(1), post["0"].querySelector(".box-head > .conr").textContent, false)})[/small]`
         : "";
     getPostText(id, post[0], window.getSelection()).then((text) => {
       paste(`[quote=${username}]${idText}\n${text}\n[/quote]\n`);


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5766 

### Changes
<!-- Please describe the changes you've made. -->
Fixes a regression caused by #5240 that made the link added by `forum-id` with the 'auto add post link to quotes' setting enabled large and without brackets.

### Reason for changes
<!-- Why should these changes be made? -->
Keeps the behaviour consistent with the current release.

### Tests
<!-- If applicable. Have you tested this pull request? If so, how? -->
Tested on chromium 107 - the standalone 'quote post number' button works as it always has and auto-adding the link doea format it as before #5240.
