### PR TITLE
Update aqua (same as remix button) color

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -437,6 +437,18 @@
       }
     },
     {
+      "name": "box-tabSelected",
+      "value": {
+        "type": "textColor",
+        "black": "#328554",
+        "white": "#13ecaf",
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
+    },
+    {
       "name": "box-buttonDisabled",
       "value": {
         "type": "textColor",

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -267,6 +267,10 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .tabs li:hover {
   border-color: var(--darkWww-box-tabHover);
 }
+.tabs li.active,
+.tabs li.active:hover {
+  border-color: var(--darkWww-box-tabSelected);
+}
 .social-message-icon {
   opacity: var(--darkWww-box-messageIconOpacity);
 }

--- a/addons/horizontal-mystuff-tabs/scratchr2.css
+++ b/addons/horizontal-mystuff-tabs/scratchr2.css
@@ -57,7 +57,7 @@
 .v-tabs li.active:hover {
   background-color: transparent;
   border: none;
-  border-bottom: 3px solid #328554;
+  border-bottom: 3px solid var(--darkWww-box-tabSelected, #328554);
 }
 
 .button[data-control="load-more"] {

--- a/addons/horizontal-mystuff-tabs/scratchr2.css
+++ b/addons/horizontal-mystuff-tabs/scratchr2.css
@@ -57,7 +57,7 @@
 .v-tabs li.active:hover {
   background-color: transparent;
   border: none;
-  border-bottom: 3px solid #0fbd8c;
+  border-bottom: 3px solid #328554;
 }
 
 .button[data-control="load-more"] {

--- a/addons/old-studio-layout/scratchr2.css
+++ b/addons/old-studio-layout/scratchr2.css
@@ -54,7 +54,7 @@
 .studio-tab-nav a.active.nav_link > li,
 .studio-tab-nav a.active.nav_link:hover > li {
   background: transparent;
-  border-color: #0fbd8c;
+  border-color: #328554;
   color: var(--darkWww-box-text, #575e75);
 }
 .studio-tab-nav .active > li img,

--- a/addons/old-studio-layout/scratchr2.css
+++ b/addons/old-studio-layout/scratchr2.css
@@ -54,7 +54,7 @@
 .studio-tab-nav a.active.nav_link > li,
 .studio-tab-nav a.active.nav_link:hover > li {
   background: transparent;
-  border-color: #328554;
+  border-color: var(--darkWww-box-tabSelected, #328554);
   color: var(--darkWww-box-text, #575e75);
 }
 .studio-tab-nav .active > li img,

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -29,7 +29,7 @@ body > #pagewrapper {
   padding-bottom: 8px;
   border: none;
   border-radius: 0;
-  background: #0fbd8c;
+  background: #328554;
   color: #fff;
 }
 #brdheader > .box-head {
@@ -337,10 +337,10 @@ body > #pagewrapper {
 .my-ocular-reaction-button,
 .my-ocular-reaction-button:hover {
   color: var(--darkWww-gray-text, #575e75);
-  box-shadow: 0 0 2px #0fbd8c;
+  box-shadow: 0 0 2px #328554;
 }
 .my-ocular-reaction-button.selected {
-  background-color: #0fbd8c;
+  background-color: #328554;
   color: white;
 }
 .my-ocular-popup {


### PR DESCRIPTION
### Changes

Makes Scratch Addons' aqua color match the new aqua color from Scratch.
`#0fbd8c` → `#328554`

### Reason for changes

To improve text contrast.

### Tests

Tested on Edge 110.

### To Do

If we can:

- [x] Adapt to dark themes (for selected tabs on Explore, Search, horizontal My Stuff addon, and old studio layout addon)
