### PR TITLE
"Variable manager" addon: trigger resize event after switching to another tab

### DIFF
--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -295,7 +295,6 @@ export default async function ({ addon, console, msg }) {
         type: "scratch-gui/navigation/ACTIVATE_TAB",
         activeTabIndex: 0,
       });
-      window.dispatchEvent(new Event("resize"));
     }
   };
 

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -295,6 +295,7 @@ export default async function ({ addon, console, msg }) {
         type: "scratch-gui/navigation/ACTIVATE_TAB",
         activeTabIndex: 0,
       });
+      window.dispatchEvent(new Event("resize"));
     }
   };
 

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -354,7 +354,15 @@ export default async function ({ addon, console, msg }) {
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", ({ detail }) => {
     if (detail.action.type === "scratch-gui/navigation/ACTIVATE_TAB") {
-      setVisible(detail.action.activeTabIndex === 3);
+      const varManagerWasSelected = document.body.contains(manager);
+      const switchedToVarManager = detail.action.activeTabIndex === 3;
+
+      if (varManagerWasSelected && !switchedToVarManager) {
+        // Fixes #5773
+        queueMicrotask(() => window.dispatchEvent(new Event("resize")));
+      }
+
+      setVisible(switchedToVarManager);
     } else if (detail.action.type === "scratch-gui/mode/SET_PLAYER") {
       if (!detail.action.isPlayerOnly && addon.tab.redux.state.scratchGui.editorTab.activeTabIndex === 3) {
         // DOM doesn't actually exist yet


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves bug report from feedback:

> When I'm in the variable tab and I click on a link to a block in the deguger a poster bug happens.

[scrnli_04_03_2023_12-33-48.webm](https://user-images.githubusercontent.com/17484114/222927479-0826c6fa-df7c-4393-858e-7328d6ddd1c4.webm)


### Changes

`variable-manager` now dispatches a "resize" event if it detects that the user (or an addon) navigated away from the varmanager tab into a different tab.

~~Dispatch a "resize" event on the window object after the redux dispatch that changes the tab.~~

~~**It's possible that we're also missing this in other parts where we dispatch ACTIVATE_TAB**. I still have to check this.
I'm also wondering if maybe dispatching ACTIVATE_TAB is the right way to change the selected tab. Does vanilla Scratch also have this bug?~~

### Tests

Fixes the bug in Chromium