### PR TITLE
Temporal bug fix for #5762 ("folders" editor crash)

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -1218,6 +1218,19 @@ export default async function ({ addon, console, msg }) {
         newIndex
       );
     };
+
+    // Temporal bug fix for #5762
+    const originalShareSoundToTarget = vm.shareSoundToTarget;
+    vm.shareSoundToTarget = function (...args) {
+      const target = this.runtime.getTargetById(args[1]);
+      if (!target) {
+        // Avoid reading property from null
+        return Promise.reject();
+        // This would also work no matter what we returned, probably
+        // Original method returns a promise, so here too
+      }
+      return originalShareSoundToTarget.call(this, ...args);
+    };
   };
 
   const patchBackpack = (backpackInstance) => {


### PR DESCRIPTION
Temporal bug fix for #5762, hoping to avoid to make a new release that can crash the editor. But the bug has probably been here for months.

Appears to avoid crashes. Sharing sounds between sprites appears to work normally after this fix.