### PR TITLE
"Adding blocks by name improvement" improvement

### DIFF
--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -471,14 +471,11 @@ class TokenTypeStringEnum extends TokenType {
           yieldedToken = true;
         }
       } else {
-        if (query.lowercase.startsWith(valueInfo.lower, idx) && TokenTypeStringLiteral.TERMINATORS.indexOf(query.lowercase[idx + valueInfo.lower.length]) !== -1) {
-          yield new Token(
-            idx,
-            idx + valueInfo.lower.length,
-            this,
-            { griff: false, valueInfo },
-            100000
-          );
+        if (
+          query.lowercase.startsWith(valueInfo.lower, idx) &&
+          TokenTypeStringLiteral.TERMINATORS.indexOf(query.lowercase[idx + valueInfo.lower.length]) !== -1
+        ) {
+          yield new Token(idx, idx + valueInfo.lower.length, this, { griff: false, valueInfo }, 100000);
           yieldedToken = true;
         }
       }
@@ -531,7 +528,7 @@ class TokenTypeStringEnum extends TokenType {
     const part = token.value.valueInfo.parts[token.value.part];
     return str + part;
   }
-};
+}
 
 /**
  * The token type for a litteral string, like 'Hello World' in the query `say Hello World`
@@ -736,7 +733,7 @@ class TokenTypeBlock extends TokenType {
             } else {
               fullTokenProvider = new TokenTypeStringEnum(blockPart.values, false);
               griffTokenProvider = new TokenTypeStringEnum(blockPart.values, true);
-              hasGriffToken = true;    
+              hasGriffToken = true;
             }
             if (blockPart.isRound) {
               const enumGroup = new TokenProviderGroup();
@@ -791,14 +788,14 @@ class TokenTypeBlock extends TokenType {
           inputs.push(null);
         }
       }
-      const score = -100 * strings.flatMap(s => s.length).reduce((a, b) => a + b + 1);
+      const score = -100 * strings.flatMap((s) => s.length).reduce((a, b) => a + b + 1);
       this.stringForms.push({ strings, inputs, score });
     };
 
     enumerateStringForms();
   }
 
-  * parseTokens(query, idx) {
+  *parseTokens(query, idx) {
     let yieldedTokens = false;
 
     for (const subtokens of this._parseSubtokens(query, idx, this.fullTokenProviders)) {
@@ -851,7 +848,7 @@ class TokenTypeBlock extends TokenType {
    * @param {QueryInfo} query
    * @param {number} idx
    * @param {TokenProvider[]} subtokenProviders
-   * @param {Token[]} subtokens 
+   * @param {Token[]} subtokens
    * @returns {Token?}
    */
   _createToken(query, idx, subtokenProviders, subtokens) {
@@ -894,7 +891,7 @@ class TokenTypeBlock extends TokenType {
    * @param {boolean} parseSubSubTokens
    * @yields {Token[]}
    */
-  * _parseSubtokens(query, idx, subtokenProviders, tokenProviderIdx = 0, parseSubSubTokens = true) {
+  *_parseSubtokens(query, idx, subtokenProviders, tokenProviderIdx = 0, parseSubSubTokens = true) {
     idx = query.skipIgnorable(idx);
     let tokenProvider = subtokenProviders[tokenProviderIdx];
 
@@ -919,7 +916,13 @@ class TokenTypeBlock extends TokenType {
       if (!parseSubSubTokens || !token.isLegal || tokenProviderIdx === subtokenProviders.length - 1) {
         yield [token];
       } else {
-        for (const subTokenArr of this._parseSubtokens(query, token.end, subtokenProviders, tokenProviderIdx + 1, !token.isTruncated)) {
+        for (const subTokenArr of this._parseSubtokens(
+          query,
+          token.end,
+          subtokenProviders,
+          tokenProviderIdx + 1,
+          !token.isTruncated
+        )) {
           subTokenArr.push(token);
           yield subTokenArr;
         }
@@ -943,7 +946,6 @@ class TokenTypeBlock extends TokenType {
       while (blockInputs.length < this.block.inputs.length) blockInputs.push(null);
     }
 
-
     return this.block.createBlock(...blockInputs);
   }
 
@@ -954,9 +956,11 @@ class TokenTypeBlock extends TokenType {
         if (token.value.sequence === -1) {
           return query.str.substring(token.start, token.end);
         } else {
-          return query.str.substring(token.start, token.end) +
-            (query.str[query.length - 1] === ' ' ? "" : " ") +
-            token.value.stringForm.strings.slice(token.value.sequence + 1).join(" ");
+          return (
+            query.str.substring(token.start, token.end) +
+            (query.str[query.length - 1] === " " ? "" : " ") +
+            token.value.stringForm.strings.slice(token.value.sequence + 1).join(" ")
+          );
         }
       }
 
@@ -1049,7 +1053,7 @@ class QueryInfo {
     /** @type {string} A lowercase version of the query. Used for case insensitive comparisons. */
     this.lowercase = this.str.toLowerCase();
     /** @type {string} The lowercase query split up by spaces */
-    this.parts = this.lowercase.split(" ").filter(part => part.trim().length !== 0);
+    this.parts = this.lowercase.split(" ").filter((part) => part.trim().length !== 0);
     /** @type {number} A unique identifier for this query */
     this.id = id;
     /** @type{number} The number of tokens we've found so far */

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -418,115 +418,7 @@ class TokenTypeBlank extends TokenType {
  * String enums are also used for values that can only be one specific value (like the 'set' from
  * `set [my variable] to x`). These cases are just string enums with one possible value.
  */
-class StringEnum {
-  /**
-   * The simple implimentation of TokenType for this string enum.
-   */
-  static FullTokenType = class extends TokenType {
-    /**
-     * @param {StringEnum} stringEnum
-     */
-    constructor(stringEnum) {
-      super();
-      this.stringEnum = stringEnum;
-      this.isDefiningFeature = true;
-      this.isConstant = stringEnum.isConstant;
-    }
-
-    *parseTokens(query, idx) {
-      for (const token of this.stringEnum.getFullValues(query, idx)) {
-        if (token) yield token;
-      }
-    }
-
-    createText(token, query, endOnly) {
-      return token.value.lower;
-    }
-
-    createBlockValue(token, query) {
-      return token.value.value;
-    }
-  };
-
-  /**
-   * Griffpatch waneted to be able to query things like 'br p b' and have it suggest
-   * `broadcast [Paint Block]`. GriffTokenType tokens are for these instances where
-   * everything but the first letter can be ommited (hense, this is called the
-   * GriffTokenType™)
-   *
-   * These results cannot just be a part of {@link FullTokenType} because they are used in
-   * different places. See {@link TokenTypeBlock.createBlockTokenTypes} for more info on how griff
-   * tokens work.
-   */
-  static GriffTokenType = class extends TokenType {
-    /**
-     * @param {StringEnum} stringEnum
-     */
-    constructor(enumValues) {
-      super();
-      this.values = enumValues;
-      this.isConstant = this.values.length === 1;
-      this.isDefiningFeature = this.isConstant;
-    }
-
-    /**
-     * Importantly, this does not return a token if {@link FullTokenType} would have already returned
-     * an identical token. If it did, there would be duplicate results for every block, one which internally
-     * uses griff tokens the other which uses full tokens.
-     */
-    *parseTokens(query, idx) {
-      const fullValues = this.values.getFullValues(query, idx);
-      outer: for (let valueIdx = 0; valueIdx < this.values.length; valueIdx++) {
-        if (fullValues[valueIdx]) continue;
-        const valueInfo = this.values.values[valueIdx];
-        let i = idx;
-
-        for (let j = 0; j < valueInfo.parts.length; j++) {
-          const part = valueInfo.parts[j];
-          let queryPartEnd = query.skipUnignorable(i);
-          const queryPart = query.lowercase.substring(i, queryPartEnd);
-          const queryMatch = part.startsWith(queryPart);
-          if (!queryMatch || queryPartEnd >= query.length) {
-            if (j !== 0) {
-              if (!queryMatch) queryPartEnd = i;
-              yield new Token(
-                idx,
-                queryPartEnd,
-                this,
-                {
-                  valueInfo,
-                  part: j,
-                  length: queryPartEnd - i,
-                },
-                10000,
-                undefined,
-                queryPartEnd >= query.length
-              );
-            }
-            continue outer;
-          }
-          i = query.skipIgnorable(queryPartEnd);
-        }
-
-        yield new Token(idx, i, this, { valueInfo }, 10000);
-      }
-    }
-
-    createBlockValue(token, query) {
-      return token.value.valueInfo.value; // I may have named too many things 'value'
-    }
-
-    createText(token, query, endOnly) {
-      if (!endOnly) return token.value.valueInfo.lower;
-      if (!token.isTruncated) {
-        return query.str.substring(token.start, token.end);
-      }
-      const str = query.str.substring(token.start, token.end - token.value.length);
-      const part = token.value.valueInfo.parts[token.value.part];
-      return str + part;
-    }
-  };
-
+class TokenTypeStringEnum extends TokenType {
   /**
    * @typedef StringEnumValue
    * @property {string} value The string that needs to be in the query
@@ -536,8 +428,14 @@ class StringEnum {
 
   /**
    * @param {(import("./BlockTypeInfo").BlockInputEnumOption[]} values
+   * @param {boolean} allowGriff
    */
-  constructor(values) {
+  constructor(values, allowGriff) {
+    super();
+    this.isConstant = values.length === 1;
+    this.isDefiningFeature = this.isConstant;
+    this.allowGriff = allowGriff;
+
     /** @type {StringEnumValue[]} */
     this.values = [];
     for (const value of values) {
@@ -558,72 +456,82 @@ class StringEnum {
       }
       this.values.push({ lower, parts, value });
     }
-    /** @type {Token?[][]?} */
-    this.cache = null;
-    /** @type {number?} */
-    this.cacheQueryID = null;
-
-    /** @type {StringEnum.FullTokenType} */
-    this.fullTokenProvider = new StringEnum.FullTokenType(this);
-    /** @type {StringEnum.GriffTokenType} */
-    this.griffTokenProvider = new StringEnum.GriffTokenType(this);
-    /** @type {TokenProviderGroup} A token provider group for either the full token or a griff abreviation */
-    this.bothTokenProvider = new TokenProviderGroup();
-    this.bothTokenProvider.pushProviders([this.fullTokenProvider, this.griffTokenProvider]);
   }
 
-  /**
-   * Gets a list of FullTokenType tokens for this string enum at idx. This can be though of as an
-   * implimentation of {@link FullTokenType.parseTokens}, but it's cached so {@link GriffTokenType} can use
-   * it to without repeating the search.
-   * @param {QueryInfo} query
-   * @param {number} idx
-   * @returns {Token?[]} Map of value indecies to their corresponding tokens.
-   */
-  getFullValues(query, idx) {
-    if (this.cacheQueryID !== query.id) {
-      this.cacheQueryID = query.id;
-      this.cache = [];
-    }
-    let cacheEntry = this.cache[idx];
-    if (cacheEntry) return cacheEntry;
-    cacheEntry = this.cache[idx] = [];
-
-    for (let valueIdx = 0; valueIdx < this.length; valueIdx++) {
+  *parseTokens(query, idx) {
+    outer: for (let valueIdx = 0; valueIdx < this.values.length; valueIdx++) {
       const valueInfo = this.values[valueIdx];
-      cacheEntry.push(null);
+      let yieldedToken = false;
+
       const remainingChar = query.length - idx;
       if (remainingChar < valueInfo.lower.length) {
         if (valueInfo.lower.startsWith(query.lowercase.substring(idx))) {
           const end = remainingChar < 0 ? 0 : query.length;
-          cacheEntry[valueIdx] = new Token(idx, end, this.fullTokenProvider, valueInfo, 100000, undefined, true);
+          yield new Token(idx, end, this, { griff: false, valueInfo }, 100000, undefined, true);
+          yieldedToken = true;
         }
       } else {
-        if (query.lowercase.startsWith(valueInfo.lower, idx)) {
-          cacheEntry[valueIdx] = new Token(
+        if (query.lowercase.startsWith(valueInfo.lower, idx) && TokenTypeStringLiteral.TERMINATORS.indexOf(query.lowercase[idx + valueInfo.lower.length]) !== -1) {
+          yield new Token(
             idx,
             idx + valueInfo.lower.length,
-            this.fullTokenProvider,
-            valueInfo,
+            this,
+            { griff: false, valueInfo },
             100000
           );
+          yieldedToken = true;
         }
       }
+
+      if (!yieldedToken && this.allowGriff) {
+        let i = idx;
+        for (let j = 0; j < valueInfo.parts.length; j++) {
+          const part = valueInfo.parts[j];
+          let queryPartEnd = query.skipUnignorable(i);
+          const queryPart = query.lowercase.substring(i, queryPartEnd);
+          const queryMatch = part.startsWith(queryPart);
+          if (!queryMatch || queryPartEnd >= query.length) {
+            if (j !== 0) {
+              if (!queryMatch) queryPartEnd = i;
+              yield new Token(
+                idx,
+                queryPartEnd,
+                this,
+                {
+                  griff: true,
+                  valueInfo,
+                  part: j,
+                  length: queryPartEnd - i,
+                },
+                10000,
+                undefined,
+                queryPartEnd > query.length
+              );
+            }
+            continue outer;
+          }
+          i = query.skipIgnorable(queryPartEnd);
+        }
+        yield new Token(idx, i, this, { griff: true, valueInfo }, 10000);
+      }
     }
-    return cacheEntry;
   }
 
-  /**
-   * @returns {number} The number of values in this enum.
-   */
-  get length() {
-    return this.values.length;
+  createBlockValue(token, query) {
+    return token.value.valueInfo.value; // I may have named too many things 'value'
   }
 
-  get isConstant() {
-    return this.length === 1;
+  createText(token, query, endOnly) {
+    if (!token.value.griff) return token.value.valueInfo.lower;
+    if (!endOnly) return token.value.valueInfo.lower;
+    if (!token.isTruncated) {
+      return query.str.substring(token.start, token.end);
+    }
+    const str = query.str.substring(token.start, token.end - token.value.length);
+    const part = token.value.valueInfo.parts[token.value.part];
+    return str + part;
   }
-}
+};
 
 /**
  * The token type for a litteral string, like 'Hello World' in the query `say Hello World`
@@ -699,7 +607,7 @@ class TokenTypeNumberLiteral extends TokenType {
   }
 
   createText(token, query, endOnly) {
-    return query.query.substring(token.start, token.end);
+    return query.str.substring(token.start, token.end);
   }
 }
 
@@ -718,7 +626,7 @@ class TokenTypeColor extends TokenType {
   }
 
   createText(token, query, endOnly) {
-    return query.query.substring(token.start, token.end);
+    return query.str.substring(token.start, token.end);
   }
 }
 
@@ -778,51 +686,62 @@ class TokenTypeBrackets extends TokenType {
  */
 class TokenTypeBlock extends TokenType {
   /**
-   * Creates all the possible block token types for a given block.
-   *
-   * Note that each block has two token types, one version is allowed to use griff
-   * tokens and the other isn't. The block that supports griff tokens doesn't support
-   * nested blocks. This is needed because queries like 'i t = t' have a rediculus number
-   * of possible interpertations ('i t = t' has 4941), so to avoid this we disallow
-   * nested blocks when you're using griff tokens.
-   *
    * @param {WorkspaceQuerier} querier
-   * @param {*} block
-   * @returns {TokenTypeBlock[]} The possible block token types.
+   * @param {BlockInstance} block
+   * @private
    */
-  static createBlockTokenTypes(querier, block) {
-    let fullTokenProviders = [];
-    let griffTokenProviders = [];
+  constructor(querier, block) {
+    super();
+    this.block = block;
+    this.hasSubTokens = true;
+    /**
+     * The list of token types that make up this block.
+     *
+     * For example, for the non-griff version of the 'say' block this array would contains two
+     * providers, the first is a {@link StringEnum.FullTokenType} containing only the value 'say'
+     * and the second is equal to querier.tokenGroupString.
+     *
+     * @type {TokenProvider[]}
+     */
+    this.fullTokenProviders = [];
+    /**
+     * The list of token types that make up this block, but without allowing other blocks as subtokens.
+     *
+     * For example, for the non-griff version of the 'say' block this array would contains two
+     * providers, the first is a {@link StringEnum.FullTokenType} containing only the value 'say'
+     * and the second is equal to querier.tokenGroupString.
+     *
+     * @type {TokenProvider[]}
+     */
+    this.griffTokenProviders = [];
 
-    let hasGriffableToken = false;
+    let hasGriffToken = false;
 
     for (const blockPart of block.parts) {
       let fullTokenProvider;
       let griffTokenProvider;
       if (typeof blockPart === "string") {
-        const stringEnum = new StringEnum([{ value: null, string: blockPart }]);
-        fullTokenProvider = stringEnum.fullTokenProvider;
-        if (hasGriffableToken) {
-          griffTokenProvider = stringEnum.bothTokenProvider;
+        if (hasGriffToken) {
+          fullTokenProvider = griffTokenProvider = new TokenTypeStringEnum([{ value: null, string: blockPart }], true);
         } else {
-          griffTokenProvider = stringEnum.griffTokenProvider;
-          hasGriffableToken = true;
+          fullTokenProvider = new TokenTypeStringEnum([{ value: null, string: blockPart }], false);
+          griffTokenProvider = new TokenTypeStringEnum([{ value: null, string: blockPart }], true);
+          hasGriffToken = true;
         }
       } else {
         switch (blockPart.type) {
           case BlockInputType.ENUM:
-            const stringEnum = new StringEnum(blockPart.values);
-            fullTokenProvider = stringEnum.bothTokenProvider;
+            if (hasGriffToken) {
+              fullTokenProvider = griffTokenProvider = new TokenTypeStringEnum(blockPart.values, true);
+            } else {
+              fullTokenProvider = new TokenTypeStringEnum(blockPart.values, false);
+              griffTokenProvider = new TokenTypeStringEnum(blockPart.values, true);
+              hasGriffToken = true;    
+            }
             if (blockPart.isRound) {
               const enumGroup = new TokenProviderGroup();
               enumGroup.pushProviders([fullTokenProvider, querier.tokenGroupRoundBlocks]);
               fullTokenProvider = enumGroup;
-            }
-            if (hasGriffableToken) {
-              griffTokenProvider = stringEnum.bothTokenProvider;
-            } else {
-              griffTokenProvider = stringEnum.griffTokenProvider;
-              hasGriffableToken = true;
             }
             break;
           case BlockInputType.STRING:
@@ -849,58 +768,114 @@ class TokenTypeBlock extends TokenType {
             break;
         }
       }
-      fullTokenProviders.push(fullTokenProvider);
-      griffTokenProviders.push(griffTokenProvider);
+      this.fullTokenProviders.push(fullTokenProvider);
+      this.griffTokenProviders.push(griffTokenProvider);
     }
 
-    return [new TokenTypeBlock(block, fullTokenProviders), new TokenTypeBlock(block, griffTokenProviders)];
+    /**
+     * @type {{strings: string[], inputs: [], score: number}[]}
+     */
+    this.stringForms = [];
+
+    const enumerateStringForms = (partIdx = 0, strings = [], inputs = []) => {
+      for (; partIdx < block.parts.length; partIdx++) {
+        let blockPart = block.parts[partIdx];
+        if (typeof blockPart === "string") {
+          strings.push(...blockPart.toLowerCase().split(" "));
+        } else if (blockPart.type === BlockInputType.ENUM) {
+          for (const enumValue of blockPart.values) {
+            enumerateStringForms(partIdx + 1, [...strings, enumValue.string.toLowerCase()], [...inputs, enumValue]);
+          }
+          return;
+        } else {
+          inputs.push(null);
+        }
+      }
+      const score = -100 * strings.flatMap(s => s.length).reduce((a, b) => a + b + 1);
+      this.stringForms.push({ strings, inputs, score });
+    };
+
+    enumerateStringForms();
+  }
+
+  * parseTokens(query, idx) {
+    let yieldedTokens = false;
+
+    for (const subtokens of this._parseSubtokens(query, idx, this.fullTokenProviders)) {
+      let token = this._createToken(query, idx, this.fullTokenProviders, subtokens);
+      if (token) {
+        yield token;
+        yieldedTokens = true;
+      }
+    }
+
+    if (yieldedTokens) return;
+
+    for (const subtokens of this._parseSubtokens(query, idx, this.griffTokenProviders)) {
+      let token = this._createToken(query, idx, this.griffTokenProviders, subtokens);
+      if (token) {
+        yield token;
+        yieldedTokens = true;
+      }
+    }
+
+    if (yieldedTokens) return;
+    if (idx !== 0) return;
+
+    outer: for (const stringForm of this.stringForms) {
+      let sequence = null;
+
+      for (const queryPart of query.parts) {
+        let match = -1;
+
+        for (let formPartIdx = 0; formPartIdx < stringForm.strings.length; formPartIdx++) {
+          const stringFormPart = stringForm.strings[formPartIdx];
+
+          if (stringFormPart.startsWith(queryPart)) {
+            match = formPartIdx;
+            break;
+          }
+        }
+
+        if (match === -1) continue outer;
+        if (match < sequence) sequence = -1;
+        else sequence = match;
+      }
+
+      yield new Token(0, query.length, this, { stringForm, sequence }, stringForm.score, -1, true);
+    }
   }
 
   /**
-   * @param {BlockInstance} block
-   * @param {TokenProvider[]} tokenProviders
    * @private
+   * @param {QueryInfo} query
+   * @param {number} idx
+   * @param {TokenProvider[]} subtokenProviders
+   * @param {Token[]} subtokens 
+   * @returns {Token?}
    */
-  constructor(block, tokenProviders) {
-    super();
-    this.block = block;
-    /**
-     * The list of token types that make up this block.
-     *
-     * For example, for the non-griff version of the 'say' block this array would contains two
-     * providers, the first is a {@link StringEnum.FullTokenType} containing only the value 'say'
-     * and the second is equal to querier.tokenGroupString.
-     *
-     * @type {TokenProvider[]}
-     */
-    this.tokenProviders = tokenProviders;
-    this.hasSubTokens = true;
-  }
+  _createToken(query, idx, subtokenProviders, subtokens) {
+    subtokens.reverse();
+    let score = 0;
+    let isLegal = true;
+    let isTruncated = subtokens.length < subtokenProviders.length;
+    let hasDefiningFeature = false;
 
-  *parseTokens(query, idx) {
-    for (const subtokens of this._parseSubtokens(idx, 0, query)) {
-      subtokens.reverse();
-      let score = 0;
-      let isLegal = true;
-      let isTruncated = subtokens.length < this.tokenProviders.length;
-      let hasDefiningFeature = false;
+    // Calculate the score of this block, through a lot of arbitrary math that seems to work ok.
 
-      // Calculate the score of this block, through a lot of arbitrary math that seems to work ok.
-
-      for (const subtoken of subtokens) {
-        isTruncated |= subtoken.isTruncated; // If any of our kids are trauncated, so are we
-        isLegal &&= subtoken.isLegal; // If any of our kids are illegal, so are we
-        if (!subtoken.isTruncated) score += subtoken.score;
-        else score += subtoken.score / 100000 - 10; // Big score penalty if trauncated
-        if (subtoken.type.isDefiningFeature && subtoken.start < query.length) hasDefiningFeature = true;
-      }
-      score += Math.floor(1000 * (subtokens.length / this.tokenProviders.length));
-
-      /** See {@link TokenType.isDefiningFeature} */
-      if (!hasDefiningFeature) continue;
-      const end = query.skipIgnorable(subtokens[subtokens.length - 1].end);
-      yield new Token(idx, end, this, subtokens, score, this.block.precedence, isTruncated, isLegal);
+    for (const subtoken of subtokens) {
+      isTruncated |= subtoken.isTruncated; // If any of our kids are trauncated, so are we
+      isLegal &&= subtoken.isLegal; // If any of our kids are illegal, so are we
+      if (!subtoken.isTruncated) score += subtoken.score;
+      else score += subtoken.score / 100000 - 10; // Big score penalty if trauncated
+      if (subtoken.type.isDefiningFeature && subtoken.start < query.length) hasDefiningFeature = true;
     }
+    score += Math.floor(1000 * (subtokens.length / subtokenProviders.length));
+
+    /** See {@link TokenType.isDefiningFeature} */
+    if (!hasDefiningFeature) return null;
+    const end = query.skipIgnorable(subtokens[subtokens.length - 1].end);
+    return new Token(idx, end, this, { subtokens }, score, this.block.precedence, isTruncated, isLegal);
   }
 
   /**
@@ -911,15 +886,17 @@ class TokenTypeBlock extends TokenType {
    * Note that the tokens in the returned token arrays are in reverse to the
    * order of their providers in this.tokenProviders, just to confuse you :P
    *
-   * @param {number} idx
-   * @param {number} tokenProviderIdx
+   * @private
    * @param {QueryInfo} query
+   * @param {number} idx
+   * @param {TokenProvider[]} subtokenProviders
+   * @param {number} tokenProviderIdx
    * @param {boolean} parseSubSubTokens
    * @yields {Token[]}
    */
-  *_parseSubtokens(idx, tokenProviderIdx, query, parseSubSubTokens = true) {
+  * _parseSubtokens(query, idx, subtokenProviders, tokenProviderIdx = 0, parseSubSubTokens = true) {
     idx = query.skipIgnorable(idx);
-    let tokenProvider = this.tokenProviders[tokenProviderIdx];
+    let tokenProvider = subtokenProviders[tokenProviderIdx];
 
     for (const token of tokenProvider.parseTokens(query, idx)) {
       ++query.tokenCount;
@@ -939,10 +916,10 @@ class TokenTypeBlock extends TokenType {
         if (token.precedence === this.block.precedence && tokenProviderIdx !== 0) continue;
       }
 
-      if (!parseSubSubTokens || !token.isLegal || tokenProviderIdx === this.tokenProviders.length - 1) {
+      if (!parseSubSubTokens || !token.isLegal || tokenProviderIdx === subtokenProviders.length - 1) {
         yield [token];
       } else {
-        for (const subTokenArr of this._parseSubtokens(token.end, tokenProviderIdx + 1, query, !token.isTruncated)) {
+        for (const subTokenArr of this._parseSubtokens(query, token.end, subtokenProviders, tokenProviderIdx + 1, !token.isTruncated)) {
           subTokenArr.push(token);
           yield subTokenArr;
         }
@@ -952,29 +929,50 @@ class TokenTypeBlock extends TokenType {
 
   createBlockValue(token, query) {
     if (!token.isLegal) throw new Error("Cannot create a block from an illegal token.");
-    const blockInputs = [];
+    let blockInputs;
 
-    for (let i = 0; i < token.value.length; i++) {
-      const blockPart = this.block.parts[i];
-      if (typeof blockPart !== "string") blockInputs.push(token.value[i].createBlockValue(query));
+    if (token.value.stringForm) {
+      blockInputs = token.value.stringForm.inputs;
+    } else {
+      const subtokens = token.value.subtokens;
+      blockInputs = [];
+      for (let i = 0; i < subtokens.length; i++) {
+        const blockPart = this.block.parts[i];
+        if (typeof blockPart !== "string") blockInputs.push(subtokens[i].createBlockValue(query));
+      }
+      while (blockInputs.length < this.block.inputs.length) blockInputs.push(null);
     }
-    while (blockInputs.length < this.block.inputs.length) blockInputs.push(null);
+
 
     return this.block.createBlock(...blockInputs);
   }
 
   createText(token, query, endOnly) {
     if (!token.isTruncated && endOnly) return query.str.substring(token.start, token.end);
-    let text = "";
-    if (token.start !== token.value[0].start) {
-      text += query.str.substring(token.start, token.value[0].start);
+    if (token.value.stringForm) {
+      if (endOnly) {
+        if (token.value.sequence === -1) {
+          return query.str.substring(token.start, token.end);
+        } else {
+          return query.str.substring(token.start, token.end) +
+            (query.str[query.length - 1] === ' ' ? "" : " ") +
+            token.value.stringForm.strings.slice(token.value.sequence + 1).join(" ");
+        }
+      }
+
+      return token.value.stringForm.strings.join(" ");
     }
-    for (let i = 0; i < token.value.length; i++) {
-      const subtoken = token.value[i];
+    const subtokens = token.value.subtokens;
+    let text = "";
+    if (token.start !== subtokens[0].start) {
+      text += query.str.substring(token.start, subtokens[0].start);
+    }
+    for (let i = 0; i < subtokens.length; i++) {
+      const subtoken = subtokens[i];
       const subtokenText = subtoken.type.createText(subtoken, query, endOnly) ?? "";
       text += subtokenText;
-      if (i !== token.value.length - 1) {
-        const next = token.value[i + 1];
+      if (i !== subtokens.length - 1) {
+        const next = subtokens[i + 1];
         const nextStart = next.start;
         if (nextStart !== subtoken.end) {
           text += query.str.substring(subtoken.end, nextStart);
@@ -992,7 +990,7 @@ class TokenTypeBlock extends TokenType {
   }
 
   getSubtokens(token, query) {
-    return token.value;
+    return token.value.subtokens;
   }
 }
 
@@ -1047,9 +1045,11 @@ class QueryInfo {
     /** @type {WorkspaceQuerier} */
     this.querier = querier;
     /** @type {string} The query */
-    this.query = query.replaceAll(String.fromCharCode(160), " ");
+    this.str = query.replaceAll(String.fromCharCode(160), " ");
     /** @type {string} A lowercase version of the query. Used for case insensitive comparisons. */
-    this.queryLc = this.query.toLowerCase();
+    this.lowercase = this.str.toLowerCase();
+    /** @type {string} The lowercase query split up by spaces */
+    this.parts = this.lowercase.split(" ").filter(part => part.trim().length !== 0);
     /** @type {number} A unique identifier for this query */
     this.id = id;
     /** @type{number} The number of tokens we've found so far */
@@ -1071,7 +1071,7 @@ class QueryInfo {
    * @returns {number} The index of the next non-ignorable character in the query, after idx.
    */
   skipIgnorable(idx) {
-    return QueryInfo.skipIgnorable(this.queryLc, idx);
+    return QueryInfo.skipIgnorable(this.lowercase, idx);
   }
 
   /**
@@ -1089,22 +1089,12 @@ class QueryInfo {
    * @returns {number} The index of the next ignorable character in the query, after idx.
    */
   skipUnignorable(idx) {
-    return QueryInfo.skipUnignorable(this.queryLc, idx);
+    return QueryInfo.skipUnignorable(this.lowercase, idx);
   }
 
   /** @type {number} The length in characters of the query. */
   get length() {
-    return this.query.length;
-  }
-
-  /** @type {string} The query. */
-  get str() {
-    return this.query;
-  }
-
-  /** @type {string} The lowercase version of the query. */
-  get lowercase() {
-    return this.queryLc;
+    return this.str.length;
   }
 
   canCreateMoreTokens() {
@@ -1232,7 +1222,6 @@ export default class WorkspaceQuerier {
       illegalResult: bestIllegalResult,
       limited,
     };
-    // return results.sort((a, b) => b.token.score - a.token.score);
   }
 
   /**
@@ -1352,22 +1341,21 @@ export default class WorkspaceQuerier {
     }
 
     for (const block of blocks) {
-      for (const blockTokenType of TokenTypeBlock.createBlockTokenTypes(this, block)) {
-        switch (block.shape) {
-          case BlockShape.Round:
-            this.tokenGroupRoundBlocks.pushProviders([blockTokenType]);
-            break;
-          case BlockShape.Boolean:
-            this.tokenGroupBooleanBlocks.pushProviders([blockTokenType]);
-            break;
-          case BlockShape.Stack:
-          case BlockShape.End:
-            this.tokenGroupStackBlocks.pushProviders([blockTokenType]);
-            break;
-          case BlockShape.Hat:
-            this.tokenGroupHatBlocks.pushProviders([blockTokenType]);
-            break;
-        }
+      const blockTokenType = new TokenTypeBlock(this, block);
+      switch (block.shape) {
+        case BlockShape.Round:
+          this.tokenGroupRoundBlocks.pushProviders([blockTokenType]);
+          break;
+        case BlockShape.Boolean:
+          this.tokenGroupBooleanBlocks.pushProviders([blockTokenType]);
+          break;
+        case BlockShape.Stack:
+        case BlockShape.End:
+          this.tokenGroupStackBlocks.pushProviders([blockTokenType]);
+          break;
+        case BlockShape.Hat:
+          this.tokenGroupHatBlocks.pushProviders([blockTokenType]);
+          break;
       }
     }
   }


### PR DESCRIPTION
It finally dawned on me how to make it so not typing the first part of a block (like just the word `clones`) could return all the blocks that string in them, and not turn the whole codebase into a cluster*frick*. Griffpatch suggested this and I think this is a important change which (should) mean users have no reason to go back to the old version. 