### PR TITLE
search-my-stuff: prevent input autofocus from scrolling page

### DIFF
--- a/addons/search-my-stuff/userscript.js
+++ b/addons/search-my-stuff/userscript.js
@@ -128,7 +128,9 @@ export default async function ({ addon, console, msg }) {
       autoLoadMore();
     });
     // Auto-focus the search bar
-    searchBar.focus();
+    searchBar.focus({
+      preventScroll: true,
+    });
   }
 
   /**


### PR DESCRIPTION
Resolves bug from Discord server feedback:
> Minor annoyance where the my stuff page scrolls to the very top when it loads the share buttons

https://user-images.githubusercontent.com/17484114/225464455-3fc83973-7de2-4844-b8bb-4a98d774911d.mp4

### Changes

Adds `{preventScroll: true}` to the `element.focus()` call that focuses the search bar. Pretty nice that this toggle is built-in into the browser APIs!

### Reason for changes

I don't believe the intention of the original call was to scroll the page, it was probably just to let the user begin typing to search.

### Tests

Not tested yet