### PR TITLE
share-through-mystuff: simplify CSS

### DIFF
--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -184,11 +184,14 @@
   text-align: right;
 }
 .media-item-content .media-action {
-  top: 28px;
+  top: 50%;
   right: 12px;
+  transform: translateY(-50%);
   width: auto;
 }
-.media-item-content .media-trash {
+.media-item-content .media-trash,
+.sa-share-button {
+  float: right;
   top: 0;
   left: 0;
 }

--- a/addons/share-through-mystuff/addon.json
+++ b/addons/share-through-mystuff/addon.json
@@ -11,13 +11,6 @@
     {
       "url": "userstyle.css",
       "matches": ["https://scratch.mit.edu/mystuff"]
-    },
-    {
-      "url": "scratchr2.css",
-      "matches": ["https://scratch.mit.edu/mystuff"],
-      "if": {
-        "addonEnabled": ["scratchr2"]
-      }
     }
   ],
   "userscripts": [

--- a/addons/share-through-mystuff/scratchr2.css
+++ b/addons/share-through-mystuff/scratchr2.css
@@ -1,3 +1,0 @@
-.media-item-content.not-shared .media-action {
-  width: 75px;
-}

--- a/addons/share-through-mystuff/userscript.js
+++ b/addons/share-through-mystuff/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, console, msg }) {
-  Scratch.MyStuff.ProjectThumbnailCollectionView.prototype.shared = function(project) {
+  Scratch.MyStuff.ProjectThumbnailCollectionView.prototype.shared = function (project) {
     // Scratch's implementation incorrectly calls fadeOut on the entire list
     if (this.model.options.collectionType === "notshared") {
       project.$el.fadeOut();

--- a/addons/share-through-mystuff/userscript.js
+++ b/addons/share-through-mystuff/userscript.js
@@ -1,4 +1,11 @@
 export default async function ({ addon, console, msg }) {
+  Scratch.MyStuff.ProjectThumbnailCollectionView.prototype.shared = function(project) {
+    // Scratch's implementation incorrectly calls fadeOut on the entire list
+    if (this.model.options.collectionType === "notshared") {
+      project.$el.fadeOut();
+    }
+  };
+
   const shareFunction = document.createElement("a");
   shareFunction.classList.add("media-share");
   shareFunction.dataset.control = "share";
@@ -13,10 +20,6 @@ export default async function ({ addon, console, msg }) {
     event.preventDefault();
     const confirmation = await addon.tab.confirm(msg("confirmation-title"), msg("confirmation"));
     if (confirmation) {
-      if (location.hash === "#unshared") {
-        let container = event.target.closest(".media-list > li");
-        container.classList.add("sa-just-shared");
-      }
       event.target.parentElement.querySelector(".media-share").click();
     }
   }

--- a/addons/share-through-mystuff/userstyle.css
+++ b/addons/share-through-mystuff/userstyle.css
@@ -1,37 +1,11 @@
-.media-item-content.not-shared .media-action {
-  top: 20px;
-}
-
-.media-list {
-  display: block !important;
-  opacity: 1 !important;
-}
-
-.sa-just-shared {
-  animation: sa-STMS-fadeOut 1s;
-  animation-fill-mode: forwards;
-}
-
 .sa-share-button {
+  /* Same styles as .media-trash */
+  float: left;
+  clear: both;
   position: relative;
-  display: block;
-  left: 20px;
+  left: 10px;
 }
 
 .media-item-content.not-shared .media-trash {
-  position: relative;
-  float: none;
-  top: 0px;
-  left: 20px;
-}
-
-@keyframes sa-STMS-fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-    visibility: hidden;
-    position: absolute;
-  }
+  top: 0;
 }


### PR DESCRIPTION
### Changes

* Moves 2.0 → 3.0 compatibility code to `addons/scratchr2/mystuff.css`.
* Replaces a workaround for a Scratch bug with a much simpler one that doesn't need CSS.
* The addon currently tries to align the Delete and Share buttons on unshared projects with the Unshare button on shared projects. This is implemented in a way that doesn't work in languages other than English. I removed it in this PR because I don't think visual changes belong in this addon.

### Tests

Tested on Edge and Firefox.