### PR TITLE
Bump version v1.31.1-prerelase

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.31.0",
-  "version_name": "1.31.0",
+  "version": "1.31.1",
+  "version_name": "1.31.1-prerelease",
   "default_locale": "en",
   "background": {
     "page": "background/background.html"


### PR DESCRIPTION
Bumps version.
See [v1.31.1 milestone](https://github.com/ScratchAddons/ScratchAddons/milestone/46).