### PR TITLE
Fix Comlink not defined in module.js (race condition)

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -123,10 +123,6 @@ const cs = {
 };
 Comlink.expose(cs, Comlink.windowEndpoint(comlinkIframe1.contentWindow, comlinkIframe2.contentWindow));
 
-const pageComlinkScript = document.createElement("script");
-pageComlinkScript.src = chrome.runtime.getURL("libraries/thirdparty/cs/comlink.js");
-document.documentElement.appendChild(pageComlinkScript);
-
 const moduleScript = document.createElement("script");
 moduleScript.type = "module";
 moduleScript.src = chrome.runtime.getURL("content-scripts/inject/module.js");

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -1,5 +1,6 @@
 import runAddonUserscripts from "./run-userscript.js";
 import Localization from "./l10n.js";
+import "/libraries/thirdparty/cs/comlink.js";
 
 window.scratchAddons = {};
 scratchAddons.classNames = { loaded: false };


### PR DESCRIPTION
Resolves #5753

### Changes

Converts comlink.js to a module dependency. It will now be impossible for our own code in module.js to run if comlink.js hasn't executed fully yet.

### Reason for changes

We need to ensure module.js code has access to `window.Comlink` when executing. The previous approach to load comlink.js did not ensure that in 100% of cases.
If you've experienced that userstyles run but userscripts don't, and it gets fixed after a reload, this was probably the root cause.

### Tests

Needs some more testing, since we're changing the execution environment of comlink.js to strict mode.