### PR TITLE
Add AprilFools2023 addon: "featured dangos"

### DIFF
--- a/addons-l10n/en/featured-dangos.json
+++ b/addons-l10n/en/featured-dangos.json
@@ -1,0 +1,4 @@
+{
+  "featured-dangos/row-title": "Featured Dangos",
+  "featured-dangos/note": "Added by Scratch Addons browser extension"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -136,6 +136,7 @@
   "number-pad",
   "copy-reporter",
   "share-through-mystuff",
+  "featured-dangos",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/featured-dangos/addon.json
+++ b/addons/featured-dangos/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Featured Dangos (April Fools 2023)",
-  "description": "(description TODO)",
+  "description": "Adds some dango-related projects to the front page.",
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/featured-dangos/addon.json
+++ b/addons/featured-dangos/addon.json
@@ -14,5 +14,6 @@
     }
   ],
   "tags": ["community"],
+  "versionAdded": "1.31.1",
   "enabledByDefault": true
 }

--- a/addons/featured-dangos/addon.json
+++ b/addons/featured-dangos/addon.json
@@ -13,7 +13,7 @@
       "matches": ["https://scratch.mit.edu/"]
     }
   ],
-  "tags": ["community"],
+  "tags": ["community", "easterEgg", "featured"],
   "versionAdded": "1.31.1",
   "enabledByDefault": true
 }

--- a/addons/featured-dangos/addon.json
+++ b/addons/featured-dangos/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Featured Dangos (April Fools 2023)",
+  "description": "(description TODO)",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "style.css",
+      "matches": ["https://scratch.mit.edu/"]
+    }
+  ],
+  "tags": ["community"],
+  "enabledByDefault": true
+}

--- a/addons/featured-dangos/style.css
+++ b/addons/featured-dangos/style.css
@@ -1,0 +1,14 @@
+/* Hide back and forward buttons in our row */
+.sa-featured-dangos-row button {
+  display: none !important;
+}
+
+/* Hide project author in our row */
+/* Only will have effect if real featured projects happened to load before we cloned */
+.sa-featured-dangos-row .thumbnail-creator {
+  display: none;
+}
+
+.sa-featured-dangos-message {
+  font-size: 0.6rem !important;
+}

--- a/addons/featured-dangos/userscript.js
+++ b/addons/featured-dangos/userscript.js
@@ -1,0 +1,62 @@
+const featuredDangoProjects = [
+  {
+    projectId: 683954771,
+    projectTitle: "Dango Clicker",
+  },
+  {
+    projectId: 297794351,
+    projectTitle: "❤️How to make Japanese Dango❤️",
+  },
+  {
+    projectId: 538669082,
+    projectTitle: "dango: the game",
+  },
+  {
+    projectId: 754385820,
+    projectTitle: "dango clicker",
+  },
+  {
+    projectId: 619174229,
+    projectTitle: "Kawaii Dango Creator!",
+  },
+];
+
+export default async function ({ addon, console, msg }) {
+  // Wait until Featured Projects row loads
+  const firstThumbnail = await addon.tab.waitForElement(".carousel .thumbnail");
+
+  // Get Featured Projects row <div>
+  const featuredProjectsRow = firstThumbnail.closest(".box");
+
+  // Clone Featured Projects row and its children
+  const featuredDangosRow = featuredProjectsRow.cloneNode(true);
+  featuredDangosRow.classList.add("sa-featured-dangos-row");
+
+  // At this point, the Featured Dangos row might be 5 "Project" placeholders linking to
+  // /projects/1, or possibly the actual featured projects. We will be handling both cases.
+
+  // Change row title
+  featuredDangosRow.querySelector(".box-header > h4").textContent = msg("row-title");
+
+  // Take advantage of existing empty <p> to add our own message
+  featuredDangosRow.querySelector(".box-header > p").classList.add("sa-featured-dangos-message");
+  featuredDangosRow.querySelector(".box-header > p").textContent = msg("note");
+
+  featuredDangosRow.querySelectorAll(".thumbnail").forEach((project, i) => {
+    // For each project
+    const { projectId, projectTitle } = featuredDangoProjects[i];
+
+    // Link to correct project
+    project.querySelectorAll("a").forEach((link) => (link.href = `/projects/${projectId}/`));
+
+    // Use correct project thumbnail
+    project.querySelector("img").src = `//uploads.scratch.mit.edu/projects/thumbnails/${projectId}.png`;
+
+    // Use correct project title
+    project.querySelector("a[title]").textContent = projectTitle;
+    project.querySelector("a[title]").title = projectTitle;
+  });
+
+  // Add our own row after the Featured Projects row
+  featuredProjectsRow.after(featuredDangosRow);
+}

--- a/addons/featured-dangos/userscript.js
+++ b/addons/featured-dangos/userscript.js
@@ -21,7 +21,16 @@ const featuredDangoProjects = [
   },
 ];
 
+// Our April Fools changes have historically lasted 48 hours
+const MARCH_31_TIMESTAMP = 1680264000; // Fri, 31 Mar 2023 12:00:00 GMT
+const APRIL_2_TIMESTAMP = 1680436800; // Sun, 2 Apr 2023 12:00:00 GMT
+// Go to scratch.mit.edu/#dangos to bypass date check
+
 export default async function ({ addon, console, msg }) {
+  const now = new Date().getTime() / 1000;
+  const runDangos = location.hash === "#dangos" || (now < APRIL_2_TIMESTAMP && now > MARCH_31_TIMESTAMP);
+  if (!runDangos) return;
+
   // Wait until Featured Projects row loads
   const firstThumbnail = await addon.tab.waitForElement(".carousel .thumbnail");
 

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -633,7 +633,7 @@ let fuse;
         obj.manifest = vue.manifestsById[addonId];
         obj.group = group;
         obj.matchesSearch = false; // Later set to true by vue.addonList if needed
-        const shouldHideAsEasterEgg = obj.manifest._categories[0] === "easterEgg" && obj.manifest._enabled === false;
+        let shouldHideAsEasterEgg = obj.manifest._categories[0] === "easterEgg" && obj.manifest._enabled === false;
         obj.matchesCategory = !shouldHideAsEasterEgg;
         obj.naturalIndex = naturalIndex;
         obj.headerAbove = groupIndex === 0;

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -634,6 +634,15 @@ let fuse;
         obj.group = group;
         obj.matchesSearch = false; // Later set to true by vue.addonList if needed
         let shouldHideAsEasterEgg = obj.manifest._categories[0] === "easterEgg" && obj.manifest._enabled === false;
+        if (addonId === "featured-dangos") {
+          // April Fools 2023 addon
+          const MARCH_31_TIMESTAMP = 1680264000;
+          const APRIL_2_TIMESTAMP = 1680436800;
+          const now = new Date().getTime() / 1000;
+          // Hide as easter egg if addon is enabled but not functional
+          // Also, show even if disabled while it's April Fools
+          shouldHideAsEasterEgg = !(now < APRIL_2_TIMESTAMP && now > MARCH_31_TIMESTAMP);
+        }
         obj.matchesCategory = !shouldHideAsEasterEgg;
         obj.naturalIndex = naturalIndex;
         obj.headerAbove = groupIndex === 0;


### PR DESCRIPTION
Resolves #5807

### Changes

New addon that adds a "Featured Dangos" row to the front page. It includes 5 hand-picked projects.
It will be enabled by default, but it won't be visible in the settings page unless it's April Fools.

![image](https://user-images.githubusercontent.com/17484114/226216667-d519047a-03b0-4915-be35-6ad3ceb8d5e7.png)

TODOs:

- [x] Addon name / description
- [x] Hide addon from settings page unless current timestamp matches April Fools
- [x] Early return in userscript if current timestamp doesn't match April Fools

### Reason for changes

This idea appeared to receive positive feedback in the April Fools discussion issue.

### Tests

Works correctly in Chromium
The layout doesn't work very well in mobile portrait view.