### PR TITLE
New Feature: Old Shaped Categories

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -136,6 +136,7 @@
   "number-pad",
   "copy-reporter",
   "share-through-mystuff",
+  "shape-categories",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/shape-categories/addon.json
+++ b/addons/shape-categories/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Old Shaped Categories",
     "description": "Removes the round shape of categories and change into thin square, just like Scratch 2.0",
-    "tags": ["editor", "theme", "category"],
+    "tags": ["editor", "theme"],
     "credits": [
       {
         "name": "Wildmonk",

--- a/addons/shape-categories/addon.json
+++ b/addons/shape-categories/addon.json
@@ -1,5 +1,5 @@
 {
-    "name": "Old Shaped Categories",
+    "name": "Old shaped categories",
     "description": "Removes the round shape of categories and change into thin square, just like Scratch 2.0",
     "tags": ["editor", "theme"],
     "credits": [
@@ -11,7 +11,7 @@
     "enabledByDefault": false,
     "dynamicDisable": true,
     "dynamicEnable": true,
-    "versionAdded": "1.31.1",
+    "versionAdded": "1.31.0",
     "userstyles": [
       {
         "url": "userstyle.css",

--- a/addons/shape-categories/addon.json
+++ b/addons/shape-categories/addon.json
@@ -1,0 +1,21 @@
+{
+    "name": "Old Shaped Categories",
+    "description": "Removes the round shape of categories and change into thin square, just like Scratch 2.0",
+    "tags": ["editor", "theme", "category"],
+    "credits": [
+      {
+        "name": "Wildmonk",
+        "link": "https://scratch.mit.edu/users/Wildmonk-2"
+      }
+    ],
+    "enabledByDefault": false,
+    "dynamicDisable": true,
+    "dynamicEnable": true,
+    "versionAdded": "1.31.1",
+    "userstyles": [
+      {
+        "url": "userstyle.css",
+        "matches": ["projects"]
+      }
+    ]
+}

--- a/addons/shape-categories/userstyle.css
+++ b/addons/shape-categories/userstyle.css
@@ -1,0 +1,6 @@
+.scratchCategoryItemBubble {
+    border-radius:0cm;
+    width:0.25cm;
+    height:0.68cm;
+    border: none;
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves # This will bring the nostalgic of Scratch 2.0, because there are so many options in SA to make Scratch 3 look like Scratch 2. I've added one more feature that changes the shape of categories from round to a thin square.
![Screenshot 2023-03-26 135303](https://user-images.githubusercontent.com/114974010/227764412-cf01632c-c468-452a-98d2-20c3c957f3e9.png)

### Changes

<!-- Please describe the changes you've made. -->

This feature is pre-release.

### Reason for changes

<!-- Why should these changes be made? -->

I found this idea when I saw some tutorials that how to make Scratch 3 look like Scratch 2 using SA, so I notice that there is one thing missing, and I made that - "Old Shaped Categories".

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->

I have tested this, there is no issue.