### PR TITLE
Change message when user posts "Scratch Addons"

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -344,7 +344,7 @@
     "message": "No results found in \"$1\". Perhaps try different keywords?"
   },
   "captureCommentError": {
-    "message": "Message added by Scratch Addons: it appears that your comment doesn't follow $1, which asks Scratchers not to advertise or name browser extensions. This comment wasn't posted because it will probably result in your account getting muted from commenting for 5 minutes."
+    "message": "Message added by Scratch Addons: it appears that your comment doesn't follow $1, which asks Scratchers not to advertise or name browser extensions for safety reasons. This comment wasn't posted because mentioning the name of browser extensions violates the aforementioned policy."
   },
   "captureCommentPolicy": {
     "message": "Scratch Community's Browser Extension/Userscript Policy"
@@ -353,7 +353,7 @@
     "message": "Post anyway"
   },
   "captureCommentConfirm": {
-    "message": "Are you sure you want to post this comment? Scratch will probably mute your account from commenting anywhere on Scratch for at least 5 minutes."
+    "message": "Are you sure you want to post this comment?"
   },
   "extensionStoreDescription1": {
     "message": "Choose from 100+ options:",


### PR DESCRIPTION
### Changes

Modified the message that appears when you try to post a comment containing "Scratch Addons".

### Reason for changes

To encourage internal motivation. While bans and mutes do stop users from continuing harmful behavior, punishments can also make them avoid situations _because they don't want to be punished again_, when the actual reason is, in this case, to keep kids with little to no experience with staying safe from dangerous/malicious software, safe. This new message takes the focus away from the "punishment" of being muted and moves it towards keeping other kids safe by not talking about being muted.

### Tests

Not tested, but it should work.
