### PR TITLE
Add `makeymakey` to `load-extensions`

### DIFF
--- a/addons/load-extensions/addon.json
+++ b/addons/load-extensions/addon.json
@@ -31,10 +31,20 @@
       "id": "translate",
       "type": "boolean",
       "default": false
+    },
+    {
+      "name": "Makey Makey",
+      "id": "makeymakey",
+      "type": "boolean",
+      "default": false
     }
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.10.0",
+  "latestUpdate": {
+    "version": "1.32.0",
+    "newSettings": ["makeymakey"]
+  },
   "tags": ["editor", "codeEditor", "featured"]
 }

--- a/addons/load-extensions/userscript.js
+++ b/addons/load-extensions/userscript.js
@@ -3,7 +3,7 @@ export default async function ({ addon, console }) {
   const loadExtensions = () => {
     if (addon.self.disabled) return;
     // IDs are taken from https://github.com/LLK/scratch-vm/blob/ffa78b91b8645b6a8c80f698a3637bb73abf2931/src/extension-support/extension-manager.js#L11
-    const EXTENSIONS = ["music", "pen", "text2speech", "translate"];
+    const EXTENSIONS = ["music", "pen", "text2speech", "translate", "makeymakey"];
     for (let ext of EXTENSIONS) {
       // Check if setting enabled and it's not already loaded
       if (addon.settings.get(ext) && !vm.extensionManager.isExtensionLoaded(ext)) {


### PR DESCRIPTION
Resolves #5876

### Changes

Adds the Makey Makey extension to the automatically add extensions addon.

### Reason for changes

Someone want the extension added and it's simple to add.

### Tests

Tested on Firefox.
