### PR TITLE
Fix konami-code in settings page not working properly on non-qwerty layouts

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -714,19 +714,19 @@ let fuse;
   // Konami code easter egg
   let cursor = 0;
   const KONAMI_CODE = [
-    "ArrowUp",
-    "ArrowUp",
-    "ArrowDown",
-    "ArrowDown",
-    "ArrowLeft",
-    "ArrowRight",
-    "ArrowLeft",
-    "ArrowRight",
-    "KeyB",
-    "KeyA",
+    "arrowup",
+    "arrowup",
+    "arrowdown",
+    "arrowdown",
+    "arrowleft",
+    "arrowright",
+    "arrowleft",
+    "arrowright",
+    "b",
+    "a",
   ];
   document.addEventListener("keydown", (e) => {
-    cursor = e.code === KONAMI_CODE[cursor] ? cursor + 1 : 0;
+    cursor = e.key.toLowerCase() === KONAMI_CODE[cursor] ? cursor + 1 : 0;
     if (cursor === KONAMI_CODE.length) {
       vue.selectedCategory = "easterEgg";
       setTimeout(() => (vue.searchInputReal = ""), 0); // Allow konami code in autofocused search bar


### PR DESCRIPTION
### Changes

Use `eventObject.key` instead of `eventObject.code`.

### Reason for changes

On non qwerty keyboards, the konami code to activate the easter egg addons did not work.

### Tests

[Video of the fix](https://clipchamp.com/watch/k6Ytjiw9atA/embed)