### PR TITLE
New addon: "Move sprite to front layer"

### DIFF
--- a/addons-l10n/en/move-to-top-layer.json
+++ b/addons-l10n/en/move-to-top-layer.json
@@ -1,0 +1,3 @@
+{
+  "move-to-top-layer/move-to-front-layer": "move to front layer"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -99,6 +99,7 @@
   "block-cherry-picking",
   "hide-new-variables",
   "move-to-top-bottom",
+  "move-to-top-layer",
   "search-my-stuff",
   "fullscreen",
   "echo-effect",

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -1,0 +1,31 @@
+{
+  "name":"Move Sprite to Top Layer",
+  "description":"This addon allows you to move a selected sprite to the top layer",
+  "info": [
+    {
+      "type": "notice",
+      "text": "Press \"Shift\" while clicking a sprite in the sprite list to both select and move it to the top layer.",
+      "id": "shortcuts"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Norbiros",
+      "link": "https://scratch.mit.edu/users/Norbir/"
+    },
+    {
+      "name": "s_federici",
+      "link": "https://scratch.mit.edu/users/s_federici/"
+    }
+  ],
+  "userscripts":[
+    {
+      "url":"userscript.js",
+      "matches":["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "tags": ["editor", "codeEditor", "beta"],
+  "versionAdded": "1.30.1"
+}

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -19,6 +19,6 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "tags": ["editor", "codeEditor", "beta"],
+  "tags": ["editor", "featured"],
   "versionAdded": "1.32.0"
 }

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -1,5 +1,5 @@
 {
-  "name":"Move Sprite to Top Layer",
+  "name":"Move sprite to front layer",
   "description":"This addon allows you to move a selected sprite to the top layer",
   "info": [
     {

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -1,13 +1,6 @@
 {
   "name": "Move sprite to front layer",
   "description": "Shift+Click a sprite within the sprite pane to move it to the front (top layer) of the stage.",
-  "info": [
-    {
-      "type": "notice",
-      "text": "Press \"Shift\" while clicking a sprite in the sprite list to both select and move it to the top layer.",
-      "id": "shortcuts"
-    }
-  ],
   "credits": [
     {
       "name": "Norbiros",

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -1,5 +1,5 @@
 {
-  "name":"Move sprite to front layer",
+  "name": "Move sprite to front layer",
   "description": "Shift+Click a sprite within the sprite pane to move it to the front (top layer) of the stage.",
   "info": [
     {
@@ -18,10 +18,10 @@
       "link": "https://scratch.mit.edu/users/s_federici/"
     }
   ],
-  "userscripts":[
+  "userscripts": [
     {
-      "url":"userscript.js",
-      "matches":["projects"]
+      "url": "userscript.js",
+      "matches": ["projects"]
     }
   ],
   "dynamicEnable": true,

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -27,5 +27,5 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "tags": ["editor", "codeEditor", "beta"],
-  "versionAdded": "1.30.1"
+  "versionAdded": "1.32.0"
 }

--- a/addons/move-to-top-layer/addon.json
+++ b/addons/move-to-top-layer/addon.json
@@ -1,6 +1,6 @@
 {
   "name":"Move sprite to front layer",
-  "description":"This addon allows you to move a selected sprite to the top layer",
+  "description": "Shift+Click a sprite within the sprite pane to move it to the front (top layer) of the stage.",
   "info": [
     {
       "type": "notice",

--- a/addons/move-to-top-layer/userscript.js
+++ b/addons/move-to-top-layer/userscript.js
@@ -1,0 +1,27 @@
+// Welcome to Move to Top Layer code!
+// Code was written by Norbiros
+//
+// If you find any bugs, or you want to change anything
+// create an issue on the Scratch Addon github repository (or create a PR)!
+
+export default async function ({ addon, global, console, msg }) {  
+  const vm = addon.tab.traps.vm;
+
+  // look for sprite list
+  let spriteList = document.getElementsByClassName("sprite-selector_items-wrapper_4bcOj box_box_2jjDp");
+  // add event triggered by mouse click on sprite list
+  spriteList[0].addEventListener("click",
+    // when the sprite list is clicked
+    function(e) {
+      // if shift is pressed
+      if (e.shiftKey) {
+        // get the sprite thumbnail closest to the click
+        let parentDiv = event.target.closest(".sprite-selector_sprite-wrapper_1C5Mq")
+        // get the name of the sprite
+        let name = parentDiv.querySelector('.sprite-selector-item_sprite-name_1PXjh').innerText;
+        // move the sprite with that name to front
+        vm.runtime.getSpriteTargetByName(name).goToFront();
+      }
+    },
+    false);
+}

--- a/addons/move-to-top-layer/userscript.js
+++ b/addons/move-to-top-layer/userscript.js
@@ -11,7 +11,7 @@ export default async function ({ addon, console }) {
     });
 
     spriteList.addEventListener("click", (e) => {
-      if (e.shiftKey) {
+      if (e.shiftKey && !addon.self.disabled) {
         // get the sprite thumbnail closest to the click
         const parentDiv = e.target.closest("div[class^='sprite-selector_sprite-wrapper']");
         const spriteName = parentDiv.querySelector("div[class^='sprite-selector-item_sprite-name']").innerText;

--- a/addons/move-to-top-layer/userscript.js
+++ b/addons/move-to-top-layer/userscript.js
@@ -2,22 +2,14 @@
 
 export default async function ({ addon, console }) {
   const vm = addon.tab.traps.vm;
-
-  while (true) {
-    const spriteList = await addon.tab.waitForElement("div[class^='sprite-selector_items-wrapper']", {
-      markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
-      reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
-    });
-
-    spriteList.addEventListener("click", (e) => {
-      if (e.shiftKey && !addon.self.disabled) {
-        // get the sprite thumbnail closest to the click
-        const parentDiv = e.target.closest("div[class^='sprite-selector_sprite-wrapper']");
+  document.body.addEventListener("click", (e) => {
+    if (e.shiftKey && !addon.self.disabled) {
+      const parentDiv = e.target.closest("div[class^='sprite-selector_sprite-wrapper']");
+      if (parentDiv) {
         const spriteName = parentDiv.querySelector("div[class^='sprite-selector-item_sprite-name']").innerText;
         // move the sprite with that name to front
         vm.runtime.getSpriteTargetByName(spriteName).goToFront();
       }
-    });
-  }
+    }
+  });
 }

--- a/addons/move-to-top-layer/userscript.js
+++ b/addons/move-to-top-layer/userscript.js
@@ -3,23 +3,21 @@
 export default async function ({ addon, console }) {
   const vm = addon.tab.traps.vm;
 
-  // look for sprite list
-  let spriteList = document.getElementsByClassName("sprite-selector_items-wrapper_4bcOj box_box_2jjDp");
-  // add event triggered by mouse click on sprite list
-  spriteList[0].addEventListener(
-    "click",
-    // when the sprite list is clicked
-    function (e) {
-      // if shift is pressed
+  while (true) {
+    const spriteList = await addon.tab.waitForElement("div[class^='sprite-selector_items-wrapper']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
+    });
+
+    spriteList.addEventListener("click", (e) => {
       if (e.shiftKey) {
         // get the sprite thumbnail closest to the click
-        let parentDiv = event.target.closest(".sprite-selector_sprite-wrapper_1C5Mq");
-        // get the name of the sprite
-        let name = parentDiv.querySelector(".sprite-selector-item_sprite-name_1PXjh").innerText;
+        const parentDiv = e.target.closest("div[class^='sprite-selector_sprite-wrapper']");
+        const spriteName = parentDiv.querySelector("div[class^='sprite-selector-item_sprite-name']").innerText;
         // move the sprite with that name to front
-        vm.runtime.getSpriteTargetByName(name).goToFront();
+        vm.runtime.getSpriteTargetByName(spriteName).goToFront();
       }
-    },
-    false
-  );
+    });
+  }
 }

--- a/addons/move-to-top-layer/userscript.js
+++ b/addons/move-to-top-layer/userscript.js
@@ -1,27 +1,25 @@
-// Welcome to Move to Top Layer code!
-// Code was written by Norbiros
-//
-// If you find any bugs, or you want to change anything
-// create an issue on the Scratch Addon github repository (or create a PR)!
+// Initial code was written by Norbiros
 
-export default async function ({ addon, global, console, msg }) {  
+export default async function ({ addon, console }) {
   const vm = addon.tab.traps.vm;
 
   // look for sprite list
   let spriteList = document.getElementsByClassName("sprite-selector_items-wrapper_4bcOj box_box_2jjDp");
   // add event triggered by mouse click on sprite list
-  spriteList[0].addEventListener("click",
+  spriteList[0].addEventListener(
+    "click",
     // when the sprite list is clicked
-    function(e) {
+    function (e) {
       // if shift is pressed
       if (e.shiftKey) {
         // get the sprite thumbnail closest to the click
-        let parentDiv = event.target.closest(".sprite-selector_sprite-wrapper_1C5Mq")
+        let parentDiv = event.target.closest(".sprite-selector_sprite-wrapper_1C5Mq");
         // get the name of the sprite
-        let name = parentDiv.querySelector('.sprite-selector-item_sprite-name_1PXjh').innerText;
+        let name = parentDiv.querySelector(".sprite-selector-item_sprite-name_1PXjh").innerText;
         // move the sprite with that name to front
         vm.runtime.getSpriteTargetByName(name).goToFront();
       }
     },
-    false);
+    false
+  );
 }


### PR DESCRIPTION
## See original PR: #5673 (sfederici)

New addon "Move to Top Layer" to move a sprite to the top layer when shift-clicking its thumbnail in the sprite list. I extracted the code for this addon from a larger addon created by Norbiros that wasn't fully accepted by ScratchAddons.

Resolves #4231

### Changes

Created new addon "move-to-top-layer"

### Reason for changes

When a sprite is covered by other sprites on the Stage so that it is not visible, to make it visible you have to go to the palette and run a "go to front layer" block. By enabling this extension it can be quickly brought to the front layer by simply shift-clicking its thumbnail in the sprite list

### Tests

I tested this extension locally as an unpacked extension.
