### PR TITLE
Lowercase reply button in scratchr2 addon

### DIFF
--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -128,6 +128,7 @@
 }
 #comments .comment .info .reply {
   float: right;
+  text-transform: lowercase;
 }
 #comments .comment .info .reply::after {
   content: "";


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves #5912

### Changes

<!-- Please describe the changes you've made. -->

Add `text-transform: lowercase` to the reply button in the scratchr2 addon.

### Reason for changes

<!-- Why should these changes be made? -->

To make the button more similar to the scratch-www button.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->

Tested on 113.0.1774.3 (Official build) dev (64-bit). I do not have the ability to test more.