### PR TITLE
Change color of selected single-select buttons

### DIFF
--- a/webpages/styles/components/filter.css
+++ b/webpages/styles/components/filter.css
@@ -35,7 +35,7 @@
   border-inline-end: none;
 }
 .filter-option.sel {
-  background: var(--brand-orange);
+  background: var(--blue);
   color: var(--white-text);
 }
 .filter-option.disabled {


### PR DESCRIPTION
A step towards #5616

### Changes

Changed the color of selected single-select button options found in addon settings and the light/dark switch on the More Settings menu from `--brand-orange` to `--blue`.

![sa-orangesingleselect](https://user-images.githubusercontent.com/106490990/231248566-e4dc2a4a-bf7b-4bd7-8475-6fe197346cb9.png)
![sa-bluesingleselect](https://user-images.githubusercontent.com/106490990/231248563-7449e537-001f-4fc5-b8ea-4cb2d33348aa.png)

### Reason for changes

To increase text contrast.

### Tests

Tested on Edge 111.
