### PR TITLE
Support updated tabs on search and Explore pages

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -131,7 +131,7 @@ body {
 .tab-background,
 .outer .tab-background,
 .tabs,
-.tabs li:hover,
+.tabs button:hover,
 .os-chooser,
 .studio-tab-nav li,
 .user-projects-modal .user-projects-modal-nav button,
@@ -216,9 +216,9 @@ body:not(.sa-body-editor) .button.white,
 .thumbnail .thumbnail-favorites,
 .thumbnail .thumbnail-remixes,
 .thumbnail .thumbnail-views,
-.tabs li,
-.tabs li:hover,
-.tabs li.active:hover,
+.tabs button,
+.tabs button:hover,
+.tabs button.active:hover,
 .grid .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .unsupported-browser .faq-link-text,
 a.social-messages-profile-link:visited,
@@ -249,7 +249,7 @@ body:not(.sa-body-editor) .join-flow-privacy-message,
 .thumbnail .thumbnail-remixes::before,
 .thumbnail .thumbnail-views::before,
 .ttt-item img,
-.tabs li:not(.active) .tab-icon,
+.tabs button:not(.active) .tab-icon,
 body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .overflow-menu-container .overflow-menu-trigger img {
   filter: var(--darkWww-box-filter);
@@ -264,11 +264,14 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .os-chooser .button {
   background-color: var(--darkWww-box-tab);
 }
-.tabs li:hover {
+.sub-nav button:active {
+  background-color: var(--darkWww-box-tabHover);
+}
+.tabs button:hover {
   border-color: var(--darkWww-box-tabHover);
 }
-.tabs li.active,
-.tabs li.active:hover {
+.tabs button.active,
+.tabs button.active:hover {
   border-color: var(--darkWww-box-tabSelected);
 }
 .social-message-icon {

--- a/addons/search-profile/style.css
+++ b/addons/search-profile/style.css
@@ -1,10 +1,10 @@
-.sa-search-profile-invalid {
+.tabs button:disabled {
   opacity: 0.5;
   cursor: default;
 }
 
-.sa-search-profile-invalid li:hover,
-.sa-search-profile-invalid li:active {
+.tabs button:disabled:hover,
+.tabs button:disabled:active {
   background-color: transparent;
   border: none;
 }

--- a/addons/search-profile/userscript.js
+++ b/addons/search-profile/userscript.js
@@ -1,21 +1,63 @@
 export default async function ({ addon, console, msg }) {
   const nav = await addon.tab.waitForElement(".sub-nav.tabs");
-  //Create elements for tab
-  const tab = nav.appendChild(document.createElement("a")),
-    li = tab.appendChild(document.createElement("li")),
-    img = li.appendChild(document.createElement("img")),
-    span = li.appendChild(document.createElement("span")),
+
+  const tab = nav.appendChild(document.createElement("button")),
+    img = tab.appendChild(document.createElement("img")),
+    span = tab.appendChild(document.createElement("span")),
     user = document.querySelector('[name="q"]').value.trim(),
     valid = /^[\w-]{3,20}$/g.test(user);
-  //Set up elements
+  tab.type = "button";
+  tab.role = "tab";
+  tab.tabIndex = -1; // unselected tabs should only be focusable using arrow keys
+  tab.ariaSelected = false;
   img.src = addon.self.dir + "/user.svg";
   img.className = "tab-icon";
   span.innerText = msg("profile");
   addon.tab.displayNoneWhileDisabled(tab);
-  if (valid) tab.href = "/users/" + user + "/";
-  //Check if whats entered is a valid username
-  if (!valid) {
-    tab.classList.add("sa-search-profile-invalid");
-    li.title = msg("invalid-username", { username: user });
+
+  // Check if a valid username is entered
+  if (valid) {
+    tab.addEventListener("click", () => {
+      location = `/users/${user}/`;
+    });
+    nav.addEventListener("keydown", (event) => {
+      // Keyboard navigation
+      // Modified code from scratch-www/src/components/tabs/tabs.jsx
+      if (!["ArrowLeft", "ArrowRight", "Home", "End", "Enter", " "].includes(event.key)) {
+        return;
+      }
+      const tabElements = Array.from(nav.children);
+      const focusedIndex = tabElements.findIndex((el) => el === document.activeElement);
+      if (focusedIndex === -1) return;
+      event.preventDefault();
+      // Disable Scratch's event listener, which is set on the parent element
+      event.stopPropagation();
+      if (event.key === "ArrowLeft") {
+        let nextIndex;
+        if (focusedIndex === 0) {
+          nextIndex = tabElements.length - 1;
+        } else {
+          nextIndex = focusedIndex - 1;
+        }
+        tabElements[nextIndex].focus();
+      } else if (event.key === "ArrowRight") {
+        let nextIndex;
+        if (focusedIndex === tabElements.length - 1) {
+          nextIndex = 0;
+        } else {
+          nextIndex = focusedIndex + 1;
+        }
+        tabElements[nextIndex].focus();
+      } else if (event.key === "Home") {
+        tabElements[0].focus();
+      } else if (event.key === "End") {
+        tabElements.at(-1).focus();
+      } else if (event.key === "Enter" || event.key === " ") {
+        tabElements[focusedIndex].click();
+      }
+    });
+  } else {
+    tab.disabled = true;
+    tab.title = msg("invalid-username", { username: user });
   }
 }


### PR DESCRIPTION
Resolves #5925

### Changes

Makes `dark-www` and `search-profile` compatible with Scratch's recent changes to tabs in search results and on the Explore page.

### Reason for changes

Scratch changed the implementation of tabs to improve accessibility, which caused bugs in these addons.

### Tests

Tested on Edge and Firefox.