### PR TITLE
Split "addonSettings" storage item into 3 different items

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -59,7 +59,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
     return;
   }
   const addonsEnabled = storageItems.addonsEnabled || {};
-  const areAddonSettingsEmpty = storageItems["addonSettings3"];
+  const areAddonSettingsEmpty = !storageItems["addonSettings3"];
   const addonSettings = areAddonSettingsEmpty
     ? {} // Default value
     : { ...storageItems.addonSettings1, ...storageItems.addonSettings2, ...storageItems.addonSettings3 };

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -59,7 +59,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
     return;
   }
   const addonsEnabled = storageItems.addonsEnabled || {};
-  const areAddonSettingsEmpty = !storageItems["addonSettings3"];
+  const areAddonSettingsEmpty = !storageItems["addonSettings3"]; // Would be indistinct to check any of the three
   const addonSettings = areAddonSettingsEmpty
     ? {} // Default value
     : { ...storageItems.addonSettings1, ...storageItems.addonSettings2, ...storageItems.addonSettings3 };

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -29,10 +29,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
     chrome.storage.sync.set({
       // Store target so arrays don't become objects
-      ...minifySettings(
-        scratchAddons.globalState.addonSettings._target,
-        prerelease ? null : scratchAddons.manifests
-      ),
+      ...minifySettings(scratchAddons.globalState.addonSettings._target, prerelease ? null : scratchAddons.manifests),
     });
 
     const manifest = scratchAddons.manifests.find((addon) => addon.addonId === addonId).manifest;

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -29,7 +29,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
     chrome.storage.sync.set({
       // Store target so arrays don't become objects
-      addonSettings: minifySettings(
+      ...minifySettings(
         scratchAddons.globalState.addonSettings._target,
         prerelease ? null : scratchAddons.manifests
       ),

--- a/libraries/common/minify-settings.js
+++ b/libraries/common/minify-settings.js
@@ -1,3 +1,7 @@
+const STORE_1_REGEX = /\d|[a-d]/;
+const STORE_2_REGEX = /[e-k]/;
+// Store 3 is used for all other cases (when addon ID starts with L-Z).
+
 /**
  * Removes unnecessary settings entry to reduce storage size.
  * @param {object} settings the settings object
@@ -42,8 +46,8 @@ export default (settings, manifests) => {
       }
     }
 
-    if (addonId[0].match(/[a-d]/)) storageItems.addonSettings1[addonId] = newSettings[addonId];
-    else if (addonId[0].match(/[f-m]/)) storageItems.addonSettings2[addonId] = newSettings[addonId];
+    if (addonId[0].match(STORE_1_REGEX)) storageItems.addonSettings1[addonId] = newSettings[addonId];
+    else if (addonId[0].match(STORE_2_REGEX)) storageItems.addonSettings2[addonId] = newSettings[addonId];
     else storageItems.addonSettings3[addonId] = newSettings[addonId];
   }
   return storageItems;

--- a/libraries/common/minify-settings.js
+++ b/libraries/common/minify-settings.js
@@ -12,6 +12,13 @@ export default (settings, manifests) => {
       a[b._addonId || b.addonId] = b.manifest || b;
       return a;
     }, {});
+
+  const storageItems = {
+    addonSettings1: {},
+    addonSettings2: {},
+    addonSettings3: {},
+  };
+
   for (const [addonId, setting] of Object.entries(newSettings)) {
     if (manifestObj && !manifestObj[addonId]) {
       // Delete settings from addons that no longer exist
@@ -34,6 +41,10 @@ export default (settings, manifests) => {
         delete newSettings[addonId];
       }
     }
+
+    if (addonId[0].match(/[a-d]/)) storageItems.addonSettings1[addonId] = newSettings[addonId];
+    else if (addonId[0].match(/[f-m]/)) storageItems.addonSettings2[addonId] = newSettings[addonId];
+    else storageItems.addonSettings3[addonId] = newSettings[addonId];
   }
-  return newSettings;
+  return storageItems;
 };

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -108,7 +108,12 @@ let fuse;
     const obj = JSON.parse(str);
     const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
     const syncSet = promisify(chrome.storage.sync.set.bind(chrome.storage.sync));
-    const {addonsEnabled, ...storageItems} = await syncGet(["addonSettings1", "addonSettings2", "addonSettings3", "addonsEnabled"]);
+    const { addonsEnabled, ...storageItems } = await syncGet([
+      "addonSettings1",
+      "addonSettings2",
+      "addonSettings3",
+      "addonsEnabled",
+    ]);
     const addonSettings = {
       ...storageItems.addonSettings1,
       ...storageItems.addonSettings2,

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -76,7 +76,18 @@ let fuse;
 
   const serializeSettings = async () => {
     const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
-    const storedSettings = await syncGet(["globalTheme", "addonSettings", "addonsEnabled"]);
+    const storedSettings = await syncGet([
+      "globalTheme",
+      "addonSettings1",
+      "addonSettings2",
+      "addonSettings3",
+      "addonsEnabled",
+    ]);
+    const addonSettings = {
+      ...storedSettings.addonSettings1,
+      ...storedSettings.addonSettings2,
+      ...storedSettings.addonSettings3,
+    };
     const serialized = {
       core: {
         lightTheme: storedSettings.globalTheme,
@@ -87,7 +98,7 @@ let fuse;
     for (const addonId of Object.keys(storedSettings.addonsEnabled)) {
       serialized.addons[addonId] = {
         enabled: storedSettings.addonsEnabled[addonId],
-        settings: storedSettings.addonSettings[addonId] || {},
+        settings: addonSettings[addonId] || {},
       };
     }
     return JSON.stringify(serialized);
@@ -97,7 +108,12 @@ let fuse;
     const obj = JSON.parse(str);
     const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
     const syncSet = promisify(chrome.storage.sync.set.bind(chrome.storage.sync));
-    const { addonSettings, addonsEnabled } = await syncGet(["addonSettings", "addonsEnabled"]);
+    const storageItems = await syncGet(["addonSettings1", "addonSettings2", "addonSettings3", "addonsEnabled"]);
+    const addonSettings = {
+      ...storageItems.addonSettings1,
+      ...storageItems.addonSettings2,
+      ...storageItems.addonSettings3,
+    };
     const pendingPermissions = {};
     for (const addonId of Object.keys(obj.addons)) {
       const addonValue = obj.addons[addonId];
@@ -133,7 +149,7 @@ let fuse;
       await syncSet({
         globalTheme: !!obj.core.lightTheme,
         addonsEnabled,
-        addonSettings: minifySettings(addonSettings, prerelease ? null : manifests),
+        ...minifySettings(addonSettings, prerelease ? null : manifests),
       });
       resolvePromise();
     };

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -108,7 +108,7 @@ let fuse;
     const obj = JSON.parse(str);
     const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
     const syncSet = promisify(chrome.storage.sync.set.bind(chrome.storage.sync));
-    const storageItems = await syncGet(["addonSettings1", "addonSettings2", "addonSettings3", "addonsEnabled"]);
+    const {addonsEnabled, ...storageItems} = await syncGet(["addonSettings1", "addonSettings2", "addonSettings3", "addonsEnabled"]);
     const addonSettings = {
       ...storageItems.addonSettings1,
       ...storageItems.addonSettings2,


### PR DESCRIPTION
Resolves #5849

### Changes

For new users, it creates three different storage items for addon settings: addonSettings1, addonSettings2 and addonSettings3.
For existing users, it splits the addonSettings storage item in three parts (using the first character of the addon ID) and reloads the extension.
The structure of settings JSON files (which can be exported/imported) remains untouched.

### Reason for changes

See #5849. There's a very low size per-key limit.

### Tests

Still a draft, so not tested yet.
Will need deep testing in both Chromium and Firefox.
