### PR TITLE
Clarify support for Cmd key in turbowarp-player info

### DIFF
--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "info",
-      "text": "If the \"Replace player\" mode is selected, you can Ctrl+Click (on macOS Cmd+Click) the button to open the project in a new TurboWarp tab.",
+      "text": "If the \"Replace player\" mode is selected, you can Ctrl+Click (Cmd+Click on macOS) the button to open the project in a new TurboWarp tab.",
       "id": "ctrlToOpen"
     }
   ],

--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "info",
-      "text": "If the \"Replace player\" mode is selected, you can Ctrl+Click the button to open the project in a new TurboWarp tab.",
+      "text": "If the \"Replace player\" mode is selected, you can Ctrl+Click (on macOS Cmd+Click) the button to open the project in a new TurboWarp tab.",
       "id": "ctrlToOpen"
     }
   ],


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Small string change for https://github.com/ScratchAddons/ScratchAddons/pull/5738

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->

Clarified support for Cmd+Click on button for macOS users.

### Reason for changes

<!-- Why should these changes be made? -->
Mac users might think the Ctrl+Click for new tab feature won't work for them.