### PR TITLE
message-filters: fix load more spam

### DIFF
--- a/addons/message-filters/userscript.js
+++ b/addons/message-filters/userscript.js
@@ -121,22 +121,23 @@ export default async function ({ addon, console, msg }) {
     localStorage.setItem("scratchAddonsMessageFiltersSettings", JSON.stringify(active));
     // Log how many messages are showing.
     console.log(`${count} messages showing.`);
-  }
-  // Add the checkboxes element.
-  document.querySelector(".messages-social-title").appendChild(container);
-  // Loop waiting for more messages then load more messages and/or display them appropriately.
-  while (true) {
+    // Load more messages if there are less than 40 (1 page).
     if (count < 40) {
       console.log("Loading more messages...");
       // Click the load more button.
       document.querySelector(".messages-social-loadmore").click();
-      await addon.tab.waitForElement(".social-message", {
-        markAsSeen: true,
-      });
     }
-    await addon.tab.waitForElement(".social-message", {
-      markAsSeen: true,
-    });
-    update();
   }
+  // Add the checkboxes element.
+  document.querySelector(".messages-social-title").appendChild(container);
+  // Handle first page of messages.
+  update();
+  // Update when more messages are loaded.
+  addon.tab.redux.initialize();
+  addon.tab.redux.addEventListener("statechanged", (e) => {
+    if (e.detail.action.type === "SET_MESSAGES") {
+      // Timeout because messages aren't rendered yet when the event is triggered
+      setTimeout(update, 0);
+    }
+  });
 }


### PR DESCRIPTION
Resolves #5697
Closes #5783

### Changes

Fixes incorrect logic in the `message-filters` userscript. The previous code used an infinite loop with `waitForElement`, which caused the button to be clicked for every message until there were at least 40. This PR uses Redux to detect messages being loaded instead.

### Tests

Tested on Edge and Firefox. Verified that every request is sent only once using the network log.