### PR TITLE
Fix popup layout bug in Chrome

### DIFF
--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -32,6 +32,7 @@ body {
   padding: 0 20px;
 }
 #logo {
+  width: 30px;
   height: 30px;
   margin-inline-end: 20px;
   vertical-align: middle;
@@ -44,6 +45,7 @@ body {
   justify-content: center;
 }
 #settings > img {
+  width: 24px;
   height: 24px;
 }
 
@@ -96,6 +98,7 @@ body {
 .popup-name img {
   vertical-align: middle;
   filter: var(--content-icon-filter);
+  width: 18px;
   height: 18px;
 }
 .popup-name.sel img {
@@ -107,6 +110,7 @@ body {
 .popout > .popout-img {
   display: inline-block;
   vertical-align: -3px;
+  width: 10px;
   height: 10px;
   padding: 2px;
   margin-inline-start: 3px;


### PR DESCRIPTION
Resolves #2593

### Changes

Adds a `width` to some `img` elements.

### Reason for changes

Chrome sometimes doesn't update the layout properly when the image loads, which causes weird bugs.

### Tests

I wasn't able to reproduce the issue with this change. It happens quite often on v1.31.2, so I believe that means it's fixed.