### PR TITLE
Add some setting descriptions

### DIFF
--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -5,10 +5,6 @@
     {
       "text": "On macOS, use the Cmd key instead of the Ctrl key.",
       "id": "macContextDisabled"
-    },
-    {
-      "text": "If \"flip controls\" is enabled, grabbing blocks individually will be the default behavior. Hold Ctrl to drag the entire stack.",
-      "id": "flipControls"
     }
   ],
   "credits": [
@@ -30,6 +26,7 @@
     {
       "name": "Flip controls",
       "id": "invertDrag",
+      "description": "Make grabbing blocks individually the default behavior. Hold Ctrl to drag entire stacks.",
       "type": "boolean",
       "default": false
     }

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2288,6 +2288,7 @@
     {
       "name": "Dark code blocks on the forums",
       "id": "darkForumCode",
+      "description": "Makes [code][/code] blocks dark.",
       "type": "boolean",
       "default": true
     }

--- a/addons/editor-extra-keys/addon.json
+++ b/addons/editor-extra-keys/addon.json
@@ -11,25 +11,22 @@
   "info": [
     {
       "type": "notice",
-      "text": "The \"experimental keys\" include equals, slash, semicolon and more. They may not work on all operating systems or keyboard layouts.",
-      "id": "experimentalKeysWarn"
-    },
-    {
-      "type": "notice",
-      "text": "The \"Shift keys\" include keys which typically require the Shift key and a number key, like hashtag, exclamation mark and more. These keys only work with the \"when () key pressed\" block and do not work on all operating systems or keyboard layouts.",
-      "id": "shiftKeysWarn"
+      "text": "Some of these keys may not work on all operating systems or keyboard layouts.",
+      "id": "OSWarn"
     }
   ],
   "settings": [
     {
       "name": "Show experimental keys",
       "id": "experimentalKeys",
+      "description": "Includes equals, slash, semicolon and more.",
       "type": "boolean",
       "default": false
     },
     {
       "name": "Show Shift keys",
       "id": "shiftKeys",
+      "description": "Includes keys which typically require the Shift key and a number key, like hashtag, exclamation mark and more. These keys only work with the \"when () key pressed\" block.",
       "type": "boolean",
       "default": false
     }

--- a/addons/fix-editor-comments/addon.json
+++ b/addons/fix-editor-comments/addon.json
@@ -38,30 +38,35 @@
     {
       "name": "Fix dragging blocks with comments",
       "id": "fix-drag",
+      "description": "Fixes a bug where if you move a block with a comment attached to it, the comment will appear to move with it initially, but then jump back to where it was before after switching sprites or reloading.",
       "type": "boolean",
       "default": true
     },
     {
       "name": "Add scroll bars to clipped comments",
       "id": "scroll",
+      "description": "Adds scroll bars to long comments and allows you to scroll through them with the scroll wheel.",
       "type": "boolean",
       "default": true
     },
     {
       "name": "Directly edit standalone comments",
       "id": "standalone-edit",
+      "description": "Fixes a problem with comments that are not attached to blocks where if you click to edit a comment's contents, the text caret will not always get placed where you click.",
       "type": "boolean",
       "default": true
     },
     {
       "name": "Always spawn block comments next to block",
       "id": "leash",
+      "description": "If you add a comment attached to a block and there are any blocks below it that are longer, the comment will be placed to the right of those blocks and potentially end up off-screen, even if it has room to be placed next to the block you're attaching it to. With this setting, comments will always be inserted right next to the block you're attaching it to.",
       "type": "boolean",
       "default": true
     },
     {
       "name": "Keep block comment connections straight",
       "id": "straighten",
+      "description": "Keeps the line connecting comments to blocks horizontal.",
       "type": "boolean",
       "default": false
     }

--- a/addons/paint-snap/addon.json
+++ b/addons/paint-snap/addon.json
@@ -40,6 +40,7 @@
       "type": "boolean",
       "id": "pageAxes",
       "name": "Snap to page x and y axes",
+      "description": "Allow objects to snap to the midlines of the canvas.",
       "default": true
     },
     {
@@ -82,18 +83,21 @@
       "type": "boolean",
       "id": "boxCenter",
       "name": "Snap from selection box center",
+      "description": "Allow the center of the selected group of objects to snap to other objects.",
       "default": true
     },
     {
       "type": "boolean",
       "id": "boxCorners",
       "name": "Snap from selection box corners",
+      "description": "Allow the corners of the selected group of objects to snap to other objects.",
       "default": false
     },
     {
       "type": "boolean",
       "id": "boxEdgeMids",
       "name": "Snap from selection box edge midpoints",
+      "description": "Allow the edge midpoints of the selected group of objects to snap to other objects.",
       "default": false
     },
     {


### PR DESCRIPTION
A step towards #5320

### Changes

Added several extended setting descriptions across a few addons. These will be available once setting descriptions are supported by Scratch Addons. Related discussion is available in the issue linked above.

### Reason for changes

To clarify some settings.

### Tests

Scratch Addons loads fine with these changes (although, of course, they are invisible because we haven't added the feature yet).