### PR TITLE
Fix potential remix-tree-button bug (button showing twice)

### DIFF
--- a/addons/remix-tree-button/main.js
+++ b/addons/remix-tree-button/main.js
@@ -9,6 +9,7 @@ export default async function ({ addon, console, msg }) {
         })
         .then(() => {
           if (!document.querySelector(".copy-link-button")) return;
+          if (document.querySelector("#scratchAddonsRemixTreeBtn")) return; // Check again because we're inside a promise
           const remixtree = document.createElement("button");
 
           const remixtreeSpan = document.createElement("span");


### PR DESCRIPTION
Potentially resolves bug reported through Discord:

![image](https://user-images.githubusercontent.com/17484114/236634845-d9232ade-f838-4131-b15a-9b51870f52aa.png)

### Changes

Checks if the button already exists in the page before trying to add it.
Old code had the intention to do this, but failed to do so properly because of the async nature of waitForElement.

### Reason for changes

Fix a potential bug.

### Tests

I didn't try to reproduce the bug nor tested for regressions.