### PR TITLE
Fix preset migration logic edge-cases and migrate `editor-theme3` & `editor-dark-mode`

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -183,7 +183,8 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
         }
 
         if (addonId === "editor-dark-mode") {
-          madeAnyChanges = madeChangesToAddon = true;
+          const migratingPresetsV1_32 = settings._version && settings._version < 3;
+          let newPopupSettingValue = null;
           updatePresetIfMatching(
             settings,
             3,
@@ -206,9 +207,95 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
               border: "#111111",
             },
             () => {
-              settings.popup = "#47566be6";
+              newPopupSettingValue = "#47566be6";
             }
           );
+          updatePresetIfMatching(
+            settings,
+            4,
+            {
+              // "TurboWarp dark" preset
+              page: "#111111",
+              primary: "#ff4d4d",
+              highlightText: "#ff4d4d",
+              menuBar: "#333333",
+              activeTab: "#1e1e1e",
+              tab: "#2e2e2e",
+              selector: "#1e1e1e",
+              selector2: "#2e2e2e",
+              selectorSelection: "#111111",
+              accent: "#111111",
+              input: "#1e1e1e",
+              workspace: "#1e1e1e",
+              categoryMenu: "#111111",
+              palette: "#111111cc",
+              border: "#ffffff26",
+            },
+            () => {
+              newPopupSettingValue = "#333a";
+            }
+          );
+          updatePresetIfMatching(
+            settings,
+            5,
+            {
+              // "Scratch 2.0" preset
+              page: "#ffffffff",
+              primary: "#179fd7ff",
+              highlightText: "#1e9ed6",
+              menuBar: "#9c9ea2ff",
+              activeTab: "#e6e8e8",
+              tab: "#f1f2f2ff",
+              selector: "#e6e8e8",
+              selector2: "#e6e8e8",
+              selectorSelection: "#d0d0d0ff",
+              accent: "#f2f2f2",
+              input: "#ffffffff",
+              workspace: "#dddedeff",
+              categoryMenu: "#e6e8e8ff",
+              palette: "#e6e8e8cc",
+              border: "#d0d1d2",
+            },
+            () => {
+              newPopupSettingValue = "#00000099";
+            }
+          );
+          updatePresetIfMatching(
+            settings,
+            6,
+            {
+              // "Scratch 1.x" preset
+              page: "#c0c3c6",
+              primary: "#5498c7",
+              highlightText: "#21211f",
+              menuBar: "#c0c3c6",
+              activeTab: "#b9d7e5",
+              tab: "#adadb5",
+              selector: "#6a6a6a",
+              selector2: "#7c8083",
+              selectorSelection: "#404143",
+              accent: "#959a9f",
+              input: "#5f6265",
+              workspace: "#7c8083",
+              categoryMenu: "#969a9f",
+              palette: "#7c8083cc",
+              border: "#0000006b",
+            },
+            () => {
+              newPopupSettingValue = "#00000099";
+            }
+          );
+
+          if (!newPopupSettingValue && migratingPresetsV1_32) {
+            // https://github.com/ScratchAddons/ScratchAddons/pull/5931#issuecomment-1529426595
+            if (settings.highlightText) newPopupSettingValue = settings.highlightText.substring(0, 7) + "e6";
+          }
+
+          if (newPopupSettingValue) {
+            console.log("Migrated `popup` setting from editor-dark-mode to: ", newPopupSettingValue);
+            settings.popup = newPopupSettingValue;
+            madeAnyChanges = madeChangesToAddon = true;
+          }
         }
 
         if (addonId === "editor-theme3") {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -24,10 +24,10 @@ const areColorsEqual = (currentColor, oldPresetColor) => {
       : hexColor;
 
   // Convert both colors to #{rr}{gg}{bb}{aa}
-  const currentColorRGBA = getRRGGBBAA(currentColorLowercase);
-  const oldPresetColorRGBA = getRRGGBBAA(oldPresetLowercase);
+  const currentColorRRGGBBAA = getRRGGBBAA(currentColorLowercase);
+  const oldPresetColorRRGGBBAA = getRRGGBBAA(oldPresetLowercase);
 
-  return currentColorRGBA === oldPresetColorRGBA;
+  return currentColorRRGGBBAA === oldPresetColorRRGGBBAA;
 };
 
 const areSettingsEqual = (currentValue, oldPresetValue) => {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -4,7 +4,7 @@ import minifySettings from "../libraries/common/minify-settings.js";
  Since presets can change independently of others, we have to keep track of
  the versions separately. Current versions:
 
- - editor-dark-mode 2 (bumped in v1.23 twice)
+ - editor-dark-mode 2 (bumped in v1.23 twice) (TODO: update this line)
  - editor-theme3 3 (last bumped in v1.32)
  */
 
@@ -178,7 +178,30 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
           }
         }
 
-        if (addonId === "editor-dark-mode") updatePresetIfMatching(settings, 2);
+        if (addonId === "editor-dark-mode") {
+          updatePresetIfMatching(
+            settings,
+            3,
+            {
+              page: "#2e2e2e",
+              primary: "#47566b",
+              highlightText: "#4d97ff",
+              menuBar: "#47566b",
+              activeTab: "#555555",
+              tab: "#444444",
+              selector: "#333333",
+              selector2: "#333333",
+              selectorSelection: "#3a3a3a",
+              accent: "#333333",
+              input: "#444444",
+              workspace: "#444444",
+              categoryMenu: "#333333",
+              palette: "#222222cc",
+              border: "#111111",
+            },
+            manifest.presets.find((p) => p.id === "darkEditor")
+          );
+        }
 
         if (addonId === "editor-theme3") {
           madeAnyChanges = madeChangesToAddon = true;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -5,7 +5,7 @@ import minifySettings from "../libraries/common/minify-settings.js";
  the versions separately. Current versions:
 
  - editor-dark-mode 2 (bumped in v1.23 twice)
- - editor-theme3 4 (last bumped in v1.29)
+ - editor-theme3 3 (last bumped in v1.32)
  */
 
 const areColorsEqual = (currentColor, oldPresetColor) => {
@@ -223,6 +223,28 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
               text: "white",
             },
             manifest.presets.find((p) => p.id === "dark")
+          );
+          updatePresetIfMatching(
+            settings,
+            3,
+            {
+              "motion-color": "#4C97FF",
+              "looks-color": "#9966FF",
+              "sounds-color": "#CF63CF",
+              "events-color": "#FFBF00",
+              "control-color": "#FFAB19",
+              "sensing-color": "#5CB1D6",
+              "operators-color": "#59C059",
+              "data-color": "#FF8C1A",
+              "data-lists-color": "#FF661A",
+              "custom-color": "#FF6680",
+              "Pen-color": "#0FBD8C",
+              "sa-color": "#29BEB8",
+              "comment-color": "#FEF49C",
+              "input-color": "#202020",
+              text: "colorOnBlack",
+            },
+            manifest.presets.find((p) => p.id === "black")
           );
 
           if (addonSettings["editor-dark-mode"]?.darkComments === false) {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -4,7 +4,7 @@ import minifySettings from "../libraries/common/minify-settings.js";
  Since presets can change independently of others, we have to keep track of
  the versions separately. Current versions:
 
- - editor-dark-mode 2 (bumped in v1.23 twice) (TODO: update this line)
+ - editor-dark-mode 6 (bumped in v1.32 four times)
  - editor-theme3 3 (last bumped in v1.32)
  */
 

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -288,7 +288,7 @@ chrome.storage.sync.get(["addonSettings", "addonsEnabled"], ({ addonSettings = {
 
           if (!newPopupSettingValue && migratingPresetsV1_32) {
             // https://github.com/ScratchAddons/ScratchAddons/pull/5931#issuecomment-1529426595
-            if (settings.highlightText) newPopupSettingValue = settings.highlightText.substring(0, 7) + "e6";
+            if (settings.primary) newPopupSettingValue = settings.primary.substring(0, 7) + "e6";
           }
 
           if (newPopupSettingValue) {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -8,6 +8,36 @@ import minifySettings from "../libraries/common/minify-settings.js";
  - editor-theme3 4 (last bumped in v1.29)
  */
 
+const areColorsEqual = (currentColor, oldPresetColor) => {
+  // Case insensitive
+  const currentColorLowercase = currentColor.toLowerCase();
+  const oldPresetLowercase = oldPresetColor.toLowerCase();
+
+  // Converts  three/four/six value syntax into eight value syntax
+  const getRRGGBBAA = (hexColor) =>
+    hexColor.length === 7 // #{rr}{gg}{bb}  →  #{rr}{gg}{bb}ff
+      ? `${hexColor}ff`
+      : hexColor.length === 5 // #{r}{g}{b}{a}  →  #{rr}{gg}{bb}{aa}
+      ? `#${hexColor[1].repeat(2)}${hexColor[2].repeat(2)}${hexColor[3].repeat(2)}${hexColor[4].repeat(2)}`
+      : hexColor.length === 4 // #{r}{g}{b}  →  #{rr}{gg}{bb}ff
+      ? `#${hexColor[1].repeat(2)}${hexColor[2].repeat(2)}${hexColor[3].repeat(2)}ff`
+      : hexColor;
+
+  // Convert both colors to #{rr}{gg}{bb}{aa}
+  const currentColorRGBA = getRRGGBBAA(currentColorLowercase);
+  const oldPresetColorRGBA = getRRGGBBAA(oldPresetLowercase);
+
+  return currentColorRGBA === oldPresetColorRGBA;
+};
+
+const areSettingsEqual = (currentValue, oldPresetValue) => {
+  if (typeof oldPresetValue === "string" && oldPresetValue.startsWith("#")) {
+    // We assume this is a color setting.
+    return areColorsEqual(currentValue, oldPresetValue);
+  }
+  return currentValue === oldPresetValue;
+};
+
 const updatePresetIfMatching = (settings, version, oldPreset = null, preset = null) => {
   if ((settings._version || 0) < version) {
     /**
@@ -24,7 +54,7 @@ const updatePresetIfMatching = (settings, version, oldPreset = null, preset = nu
     if (preset === null) return;
     const map = {};
     for (const key of Object.keys(oldPreset)) {
-      if (settings[key] !== oldPreset[key]) return console.log(settings, oldPreset, key);
+      if (!areSettingsEqual(settings[key], oldPreset[key])) return console.log(settings, oldPreset, key);
       map[key] = preset.values[key];
     }
 

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -33,7 +33,7 @@ const areColorsEqual = (currentColor, oldPresetColor) => {
 const areSettingsEqual = (currentValue, oldPresetValue) => {
   if (typeof oldPresetValue === "string" && oldPresetValue.startsWith("#")) {
     // We assume this is a color setting.
-    return areColorsEqual(currentValue, oldPresetValue);
+    if (typeof currentValue === "string") return areColorsEqual(currentValue, oldPresetValue);
   }
   return currentValue === oldPresetValue;
 };


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #5992

See https://github.com/ScratchAddons/ScratchAddons/pull/5896#discussion_r1181981293 for more information about the bug this fixes.

### Changes

Converts all colors (in memory) to `#{rr}{gg}{bb}{aa}` format before comparing them.
Adds preset migrations for #5896 and #5931

TODOs:

- [x] Migrate `TurboWarp Dark` preset
- [x] Migrate `Scratch 2.0` preset
- [x] Migrate all other states. See comment https://github.com/ScratchAddons/ScratchAddons/pull/5931#issuecomment-1529426595
- [x] Test all changes carefully

### Reason for changes

See above.

### Tests

All cases tested in Chromium.