### PR TITLE
Support new cookie policy page

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -619,7 +619,8 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button:checked {
 .conf2017-title-band,
 .sa-annual-report-2019 .subnavigation,
 .sa-annual-report-2020 .initiatives-section .initiatives-subsection-header.community,
-.initiatives-section .initiatives-subsection-header.SEC {
+.initiatives-section .initiatives-subsection-header.SEC,
+.privacy-banner {
   background-color: var(--darkWww-button-bannerVariant);
 }
 
@@ -671,6 +672,7 @@ a:hover,
   color: var(--darkWww-link-variant);
 }
 .banner a,
+.privacy-banner a,
 .subnavigation a,
 .subnavigation a:active {
   color: white;
@@ -791,6 +793,8 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button,
 .extension-landing .project-card,
 .extension-landing .hardware-card,
 .transfer-host-modal .transfer-password-input,
+.cookies-table td,
+.cookies-table th,
 .comments-container .sa-emoji-picker,
 .studio-compose-container .sa-emoji-picker,
 .sa-emoji-picker-divider {

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -345,7 +345,7 @@ const WELL_KNOWN_PATTERNS = {
   // scratch-www routes, not including project pages
   // Matches /projects (an error page) but not /projects/<id>
   scratchWWWNoProject:
-    /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher|projects)\/?)?$/,
+    /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher|projects|cookies)\/?)?$/,
 };
 
 const WELL_KNOWN_MATCHERS = {


### PR DESCRIPTION
The ST is working on an updated privacy policy that will include a new "Cookies" page. There will also be a notification banner about the update.

Tested by running scratch-www locally.