### PR TITLE
Run addons on `scratchfoundation.github.io` for testing

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -207,7 +207,7 @@ export default class Tab extends Listenable {
    * @type {?string}
    */
   get editorMode() {
-    if (location.origin === "https://scratchfoundation.github.io") return "editor";
+    if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601") return "editor";
     const pathname = location.pathname.toLowerCase();
     const split = pathname.split("/").filter(Boolean);
     if (!split[0] || split[0] !== "projects") return null;

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -207,6 +207,7 @@ export default class Tab extends Listenable {
    * @type {?string}
    */
   get editorMode() {
+    if (location.origin === "https://scratchfoundation.github.io") return "editor";
     const pathname = location.pathname.toLowerCase();
     const split = pathname.split("/").filter(Boolean);
     if (!split[0] || split[0] !== "projects") return null;
@@ -307,6 +308,12 @@ export default class Tab extends Listenable {
     res = res.slice(0, -1);
     // Sanitize just in case
     res = res.replace(/"/g, "");
+
+    if (res === "" && location.origin === "https://scratchfoundation.github.io" && !window._scratchClassAlert) {
+      window._scratchClassAlert = true;
+      alert("addon.tab.scratchClass might have failed in this page load. Please reload.");
+    }
+
     return res;
   }
 

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -308,12 +308,6 @@ export default class Tab extends Listenable {
     res = res.slice(0, -1);
     // Sanitize just in case
     res = res.replace(/"/g, "");
-
-    if (res === "" && location.origin === "https://scratchfoundation.github.io" && !window._scratchClassAlert) {
-      window._scratchClassAlert = true;
-      alert("addon.tab.scratchClass might have failed in this page load. Please reload.");
-    }
-
     return res;
   }
 

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -406,7 +406,7 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
   */
   let url = data.url;
   let parsedURL = new URL(url);
-  if (parsedURL.origin === "https://scratchfoundation.github.io" && parsedURL.pathname.startsWith("/scratch-gui")) {
+  if (parsedURL.origin === "https://scratchfoundation.github.io" || parsedURL.port === "8601") {
     url = "https://scratch.mit.edu/projects/104/editor";
     parsedURL = new URL(url);
   }
@@ -415,7 +415,7 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
   const parsedOrigin = parsedURL.origin;
   const originPath = parsedOrigin + parsedPathname;
   const matchURL = _scratchDomainImplied ? parsedPathname : originPath;
-  const scratchOrigin = "https://scratch.mit.edu";
+  const scratchOrigin = parsedURL.port === "8333" ? "http://localhost:8333" : "https://scratch.mit.edu";
   const isScratchOrigin = parsedOrigin === scratchOrigin;
   // "*" is used for any URL on Scratch origin
   if (matches === "*") return isScratchOrigin;

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -400,8 +400,16 @@ function matchesIf(injectable, settings) {
 function userscriptMatches(data, scriptOrStyle, addonId) {
   if (scriptOrStyle.if && !matchesIf(scriptOrStyle, scratchAddons.globalState.addonSettings[addonId])) return false;
 
+  /*
   const url = data.url;
   const parsedURL = new URL(url);
+  */
+  let url = data.url;
+  let parsedURL = new URL(url);
+  if (parsedURL.origin === "https://scratchfoundation.github.io" && parsedURL.pathname.startsWith("/scratch-gui")) {
+    url = "https://scratch.mit.edu/projects/104/editor";
+    parsedURL = new URL(url);
+  }
   const { matches, _scratchDomainImplied } = scriptOrStyle;
   const parsedPathname = parsedURL.pathname;
   const parsedOrigin = parsedURL.origin;

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -223,7 +223,8 @@ function onDataReady() {
 }
 
 function bodyIsEditorClassCheck() {
-  if (location.origin === "https://scratchfoundation.github.io") return document.body.classList.add("sa-body-editor");
+  if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601")
+    return document.body.classList.add("sa-body-editor");
   const pathname = location.pathname.toLowerCase();
   const split = pathname.split("/").filter(Boolean);
   if (!split[0] || split[0] !== "projects") return;

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -91,6 +91,7 @@ const page = {
   },
   isFetching: false,
   async refetchSession() {
+    if (location.origin === "https://scratchfoundation.github.io") return;
     let res;
     let d;
     if (this.isFetching) return;
@@ -222,6 +223,7 @@ function onDataReady() {
 }
 
 function bodyIsEditorClassCheck() {
+  if (location.origin === "https://scratchfoundation.github.io") return document.body.classList.add("sa-body-editor");
   const pathname = location.pathname.toLowerCase();
   const split = pathname.split("/").filter(Boolean);
   if (!split[0] || split[0] !== "projects") return;

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -91,14 +91,14 @@ const page = {
   },
   isFetching: false,
   async refetchSession() {
-    if (location.origin === "https://scratchfoundation.github.io") return;
+    if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601") return;
     let res;
     let d;
     if (this.isFetching) return;
     this.isFetching = true;
     scratchAddons.eventTargets.auth.forEach((auth) => auth._refresh());
     try {
-      res = await fetch("https://scratch.mit.edu/session/", {
+      res = await fetch("/session/", {
         headers: {
           "X-Requested-With": "XMLHttpRequest",
         },

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -23,8 +23,9 @@ function injectPrototype() {
   };
 }
 
-const isSF = location.origin === "https://scratchfoundation.github.io";
-if ((!(document.documentElement instanceof SVGElement) && location.pathname.split("/")[1] === "projects") || isSF) {
+const isLocal =
+  location.origin === "https://scratchfoundation.github.io" || location.origin.startsWith("http://localhost:");
+if ((!(document.documentElement instanceof SVGElement) && location.pathname.split("/")[1] === "projects") || isLocal) {
   const injectPrototypeScript = document.createElement("script");
   injectPrototypeScript.append(document.createTextNode("(" + injectPrototype + ")()"));
   (document.head || document.documentElement).appendChild(injectPrototypeScript);

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -23,7 +23,8 @@ function injectPrototype() {
   };
 }
 
-if (!(document.documentElement instanceof SVGElement) && location.pathname.split("/")[1] === "projects") {
+const isSF = location.origin === "https://scratchfoundation.github.io";
+if ((!(document.documentElement instanceof SVGElement) && location.pathname.split("/")[1] === "projects") || isSF) {
   const injectPrototypeScript = document.createElement("script");
   injectPrototypeScript.append(document.createTextNode("(" + injectPrototype + ")()"));
   (document.head || document.documentElement).appendChild(injectPrototypeScript);

--- a/manifest.json
+++ b/manifest.json
@@ -16,13 +16,13 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://scratch.mit.edu/*"],
+      "matches": ["https://scratch.mit.edu/*", "https://scratchfoundation.github.io/scratch-gui/*"],
       "run_at": "document_start",
       "js": ["libraries/thirdparty/cs/comlink.js", "libraries/common/cs/text-color.js", "content-scripts/cs.js"],
       "all_frames": true
     },
     {
-      "matches": ["https://scratch.mit.edu/*"],
+      "matches": ["https://scratch.mit.edu/*", "https://scratchfoundation.github.io/scratch-gui/*"],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],
       "all_frames": true
@@ -38,6 +38,7 @@
     "https://scratch.mit.edu/*",
     "https://api.scratch.mit.edu/*",
     "https://clouddata.scratch.mit.edu/*",
+    "https://scratchfoundation.github.io/scratch-gui/*",
     "cookies",
     "webRequest",
     "webRequestBlocking",

--- a/manifest.json
+++ b/manifest.json
@@ -16,13 +16,23 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://scratch.mit.edu/*", "https://scratchfoundation.github.io/scratch-gui/*"],
+      "matches": [
+        "https://scratch.mit.edu/*",
+        "https://scratchfoundation.github.io/scratch-gui/*",
+        "http://localhost:8333/*",
+        "http://localhost:8601/*"
+      ],
       "run_at": "document_start",
       "js": ["libraries/thirdparty/cs/comlink.js", "libraries/common/cs/text-color.js", "content-scripts/cs.js"],
       "all_frames": true
     },
     {
-      "matches": ["https://scratch.mit.edu/*", "https://scratchfoundation.github.io/scratch-gui/*"],
+      "matches": [
+        "https://scratch.mit.edu/*",
+        "https://scratchfoundation.github.io/scratch-gui/*",
+        "http://localhost:8333/*",
+        "http://localhost:8601/*"
+      ],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],
       "all_frames": true
@@ -39,6 +49,8 @@
     "https://api.scratch.mit.edu/*",
     "https://clouddata.scratch.mit.edu/*",
     "https://scratchfoundation.github.io/scratch-gui/*",
+    "http://localhost:8333/*",
+    "http://localhost:8601/*",
     "cookies",
     "webRequest",
     "webRequestBlocking",


### PR DESCRIPTION
### Changes

Runs addons on https://scratchfoundation.github.io/scratch-gui/beta/ and https://scratchfoundation.github.io/scratch-gui/develop/

Related: #5281

### Reason for changes

Makes it easier to test the upcoming changes.
This will be reverted before v1.33.0 release.

### Tests

Most things work normally in Chromium and Firefox. This includes dynamic enable, dynamic disable and dynamic setting changes.
There's some problems with `addon.tab.scratchClass` but a reload often fixes it. If, for example, the find bar lacks CSS, a reload will often fix it. It's not a bug that will happen this often in real scratch.mit.edu.