### PR TITLE
Fix unable to insert sprites from backpack

### DIFF
--- a/addons/faster-project-loading/userscript.js
+++ b/addons/faster-project-loading/userscript.js
@@ -2,10 +2,12 @@
 
 export default async function ({ addon }) {
   const BACKPACK_URL = "https://backpack.scratch.mit.edu/";
+  // Inserting sprites from the backpack requests a ZIP archive from backpack.scratch.mit.edu, so we want to allow those
+  const SPRITE_FILE_EXTENSION = ".zip";
 
   const originalOpen = XMLHttpRequest.prototype.open;
   XMLHttpRequest.prototype.open = function (method, url, ...moreArgs) {
-    if (!addon.self.disabled && method === "GET" && url.startsWith(BACKPACK_URL)) {
+    if (!addon.self.disabled && method === "GET" && url.startsWith(BACKPACK_URL) && !url.endsWith(SPRITE_FILE_EXTENSION)) {
       /*
               We don't want to block actual requests for backpack assets.
               A backpack request URL looks like:
@@ -21,7 +23,7 @@ export default async function ({ addon }) {
   const originalPostMessage = Worker.prototype.postMessage;
   Worker.prototype.postMessage = function (message, options, ...moreArgs) {
     if (!addon.self.disabled && message && typeof message.id === "string" && typeof message.url === "string") {
-      if (message.url.startsWith(BACKPACK_URL)) {
+      if (message.url.startsWith(BACKPACK_URL) && !message.url.endsWith(SPRITE_FILE_EXTENSION)) {
         throw new Error("Request blocked by Scratch Addons faster project loading.");
       }
     }

--- a/addons/faster-project-loading/userscript.js
+++ b/addons/faster-project-loading/userscript.js
@@ -7,7 +7,12 @@ export default async function ({ addon }) {
 
   const originalOpen = XMLHttpRequest.prototype.open;
   XMLHttpRequest.prototype.open = function (method, url, ...moreArgs) {
-    if (!addon.self.disabled && method === "GET" && url.startsWith(BACKPACK_URL) && !url.endsWith(SPRITE_FILE_EXTENSION)) {
+    if (
+      !addon.self.disabled &&
+      method === "GET" &&
+      url.startsWith(BACKPACK_URL) &&
+      !url.endsWith(SPRITE_FILE_EXTENSION)
+    ) {
       /*
               We don't want to block actual requests for backpack assets.
               A backpack request URL looks like:


### PR DESCRIPTION
Resolves #6062

### Changes

`faster-project-loading` blocks requests to insert sprites from the backpack. To my understanding, these requests always look like this: `https://backpack.scratch.mit.edu/*.zip`. Because they begin with backpack.scratch.mit.edu, this addon blocks them, but that was not the intended behavior. This change should fix that but not affect project load speed.

### Tests

Tested in Edge 113.
