### PR TITLE
editor-buttons-reverse-order: change order

### DIFF
--- a/addons/editor-buttons-reverse-order/userstyle.css
+++ b/addons/editor-buttons-reverse-order/userstyle.css
@@ -1,4 +1,5 @@
 [class*="stage-header_stage-menu-wrapper"],
+[class*="controls_controls-container_"],
 [class*="stage-header_stage-size-row"],
 .sa-vol-slider-inner {
   flex-direction: row-reverse;
@@ -18,16 +19,16 @@
   margin-right: 0.2rem;
 }
 
-.sa-vol-slider {
-  /* Move slider after mouse position and clone counter:
-     it should cover those when hovered */
-  order: 1;
+[class*="green-flag_green-flag_"] {
+  order: -1;
 }
 
-[class*="green-flag_green-flag_"],
-[class*="stop-all_stop-all_"],
 .pause-btn {
-  order: 2;
+  order: -2;
+}
+
+[class*="stop-all_stop-all_"] {
+  order: -3;
 }
 
 [dir="ltr"] .sa-vol-slider-input {


### PR DESCRIPTION
### Changes

Changes the order of elements when "reverse order of project controls" is enabled.

### Reason for changes

https://github.com/ScratchAddons/ScratchAddons/pull/6061#issuecomment-1551769458

> ... it would prevent the clone counter, which doesn't have a fixed width, from causing the mouse position to move.

### Tests

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/a4409df0-e014-4da6-80c5-de81cb80c5df)