### PR TITLE
Fix unshared projects not always getting their iframes removed in `live-forum-preview`

### DIFF
--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -63,15 +63,6 @@
       }
     },
     {
-      "id": "forceAlternative",
-      "name": "Force using alternative player",
-      "type": "boolean",
-      "default": false,
-      "if": {
-        "settings": { "alternativePlayer": ["turbowarp", "forkphorus"] }
-      }
-    },
-    {
       "id": "enableTWAddons",
       "name": "Enable TurboWarp addons",
       "type": "boolean",

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -95,12 +95,20 @@ export default async function ({ addon, msg }) {
     else if (alternativePlayer === "forkphorus") loadForkphorus();
   } else {
     loadScratch();
-    iframeElement.addEventListener("load", () => {
-      if (iframeElement.contentDocument.querySelector(".not-available-outer") !== null) {
-        if (alternativePlayer === "turbowarp") loadTurboWarp();
-        else if (alternativePlayer === "forkphorus") loadForkphorus();
-        else stageElement.removeChild(wrapperElement);
+    let interval;
+    const hideOn404 = () => {
+      if (iframeElement.contentDocument.querySelector("[class^=stage]")) {
+        clearInterval(interval);
+        return;
       }
+      if (iframeElement.contentDocument.querySelector(".not-available-outer") !== null) {
+        stageElement.removeChild(wrapperElement);
+        clearInterval(interval);
+        return;
+      }
+    };
+    iframeElement.addEventListener("load", () => {
+      interval = setInterval(hideOn404);
     });
   }
 }

--- a/addons/live-featured-project/script.js
+++ b/addons/live-featured-project/script.js
@@ -1,6 +1,5 @@
 export default async function ({ addon, msg }) {
   const showMenu = addon.settings.get("showMenu");
-  const forceAlternative = addon.settings.get("forceAlternative");
   const alternativePlayer = addon.settings.get("alternativePlayer");
   const autoPlay = addon.settings.get("autoPlay");
   const enableTWAddons = addon.settings.get("enableTWAddons");
@@ -90,7 +89,7 @@ export default async function ({ addon, msg }) {
 
   // Start loading the players
 
-  if (forceAlternative && alternativePlayer !== "none") {
+  if (alternativePlayer !== "none") {
     if (alternativePlayer === "turbowarp") loadTurboWarp();
     else if (alternativePlayer === "forkphorus") loadForkphorus();
   } else {


### PR DESCRIPTION
Resolves #6086

### Changes

Change the code to remove unshared projects so that it waits until the page has actually loaded before checking if a project is unshared. This also gets rid of the fallback to alternative editors when an unshared project is present, as that no longer works, and therefore also the `forceAlternative` setting.

### Reason for changes

To fix a bug.

### Tests
Tested in Microsoft Edge 115.0.1851.0 (Official build) dev (64-bit).