### PR TITLE
Fix "collapse when mouse leaves sprite panel" bug (sprite-properties)

### DIFF
--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -35,12 +35,14 @@ export default async function ({ addon, console, msg }) {
       setPropertiesPanelVisible(false);
     }
   }
+  const isDirectionPopoverOpen = () =>
+    document.querySelector("body > div.Popover > div > div > [class*=direction-picker_button-row_]");
   // Close properties panel when mouse leaves the entire sprite panel
   document.body.addEventListener(
     "mouseleave",
     (e) => {
       if (e.target.matches('[class*="sprite-selector_sprite-selector_2KgCX"]')) {
-        autoHidePanel();
+        if (!isDirectionPopoverOpen()) autoHidePanel();
       }
     },
     {

--- a/addons/sprite-properties/userscript.js
+++ b/addons/sprite-properties/userscript.js
@@ -41,7 +41,7 @@ export default async function ({ addon, console, msg }) {
   document.body.addEventListener(
     "mouseleave",
     (e) => {
-      if (e.target.matches('[class*="sprite-selector_sprite-selector_2KgCX"]')) {
+      if (e.target.matches('[class*="sprite-selector_sprite-selector_"]')) {
         if (!isDirectionPopoverOpen()) autoHidePanel();
       }
     },


### PR DESCRIPTION
Resolves #5898

### Changes

The sprite properties won't hide if the mouse left them as a result of the user changing the direction of a sprite by dragging the dial.
The sprite properties will stay visible until the cursor leaves the sprite properties again (excluding the direction dial). I don't think it makes sense to try to do better in this case.

### Reason for changes

Fixes an important bug.

### Tests

Tested in Chromium in scratch.mit.edu and https://scratchfoundation.github.io/scratch-gui/beta/