### PR TITLE
Enhance `addon.tab.scratchClass` performance and consistency

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -316,7 +316,7 @@ export default class Tab extends Listenable {
 
   scratchClassReady() {
     // Make sure to return a resolved promise if this is not a project!
-    const isProject = location.pathname.split("/")[1] === "projects";
+    const isProject = location.pathname.split("/")[1] === "projects" && location.pathname.split("/")[3] !== "embed";
     const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
     if (!isProject && !isScratchGui) return Promise.resolve();
 

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -285,6 +285,9 @@ export default class Tab extends Listenable {
    * @returns {string} Hashed class names.
    */
   scratchClass(...args) {
+    if (!this._calledScratchClassReady)
+      throw new Error("Wait until addon.tab.scratchClassReady() resolves before using addon.tab.scratchClass");
+
     let res = "";
     args
       .filter((arg) => typeof arg === "string")
@@ -296,7 +299,7 @@ export default class Tab extends Listenable {
                 className.startsWith(classNameToFind + "_") && className.length === classNameToFind.length + 6
             ) || "";
         } else {
-          res += `scratchAddonsScratchClass/${classNameToFind}`;
+          throw new Error("addon.tab.scratchClass call failed. Class names are not ready yet");
         }
         res += " ";
       });
@@ -309,6 +312,19 @@ export default class Tab extends Listenable {
     // Sanitize just in case
     res = res.replace(/"/g, "");
     return res;
+  }
+
+  scratchClassReady() {
+    // Make sure to return a resolved promise if this is not a project!
+    const isProject = location.pathname.split("/")[1] === "projects";
+    const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
+    if (!isProject && !isScratchGui) return Promise.resolve();
+
+    this._calledScratchClassReady = true;
+    if (scratchAddons.classNames.loaded) return Promise.resolve();
+    return new Promise((resolve) => {
+      window.addEventListener("scratchAddonsClassNamesReady", resolve, { once: true });
+    });
   }
 
   /**

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -303,7 +303,7 @@ function loadClasses() {
   window.dispatchEvent(new CustomEvent("scratchAddonsClassNamesReady"));
 }
 
-const isProject = location.pathname.split("/")[1] === "projects";
+const isProject = location.pathname.split("/")[1] === "projects" && location.pathname.split("/")[3] !== "embed";
 const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
 if (isScratchGui || isProject) {
   // Stylesheets are considered to have loaded if this element exists

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -300,40 +300,25 @@ function loadClasses() {
     ),
   ];
   scratchAddons.classNames.loaded = true;
-
-  const fixPlaceHolderClasses = () =>
-    document.querySelectorAll("[class*='scratchAddonsScratchClass/']").forEach((el) => {
-      [...el.classList]
-        .filter((className) => className.startsWith("scratchAddonsScratchClass"))
-        .map((className) => className.substring(className.indexOf("/") + 1))
-        .forEach((classNameToFind) =>
-          el.classList.replace(
-            `scratchAddonsScratchClass/${classNameToFind}`,
-            scratchAddons.classNames.arr.find(
-              (className) =>
-                className.startsWith(classNameToFind + "_") && className.length === classNameToFind.length + 6
-            ) || `scratchAddonsScratchClass/${classNameToFind}`
-          )
-        );
-    });
-
-  fixPlaceHolderClasses();
-  new MutationObserver(() => fixPlaceHolderClasses()).observe(document.documentElement, {
-    attributes: false,
-    childList: true,
-    subtree: true,
-  });
+  window.dispatchEvent(new CustomEvent("scratchAddonsClassNamesReady"));
 }
 
-if (document.querySelector("title")) loadClasses();
-else {
-  const stylesObserver = new MutationObserver((mutationsList) => {
-    if (document.querySelector("title")) {
-      stylesObserver.disconnect();
-      loadClasses();
-    }
-  });
-  stylesObserver.observe(document.documentElement, { childList: true, subtree: true });
+const isProject = location.pathname.split("/")[1] === "projects";
+const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
+if (isScratchGui || isProject) {
+  // Stylesheets are considered to have loaded if this element exists
+  const elementSelector = isScratchGui ? "div[class*=index_app_]" : ":root > body > .ReactModalPortal";
+
+  if (document.querySelector(elementSelector)) loadClasses();
+  else {
+    const stylesObserver = new MutationObserver((mutationsList) => {
+      if (document.querySelector(elementSelector)) {
+        stylesObserver.disconnect();
+        loadClasses();
+      }
+    });
+    stylesObserver.observe(document.documentElement, { childList: true, subtree: true });
+  }
 }
 
 if (location.pathname === "/discuss/3/topic/add/") {

--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -29,7 +29,7 @@ export default async function runAddonUserscripts({ addonId, scripts, enabledLat
       });
     };
     if (runAtComplete && document.readyState !== "complete") {
-      window.addEventListener("load", () => loadUserscript(), { once: true });
+      window.addEventListener("load", () => addonObj.tab.scratchClassReady().then(loadUserscript), { once: true });
     } else {
       await loadUserscript();
     }


### PR DESCRIPTION
Resolves #4106

### Changes

- Userscripts that don't specify runAtComplete (or that explicitly set runAtComplete:true) won't run until `addon.tab.scratchClass()` is guaranteed to work properly.
- A persistent mutation observer that made a somehow expensive (haven't measured) document.querySelector call in the callback has been removed as a consequence of the above.
- Previously, `addon.tab.scratchClass()` failed often (depending on computer and internet speeds) when running scratch-gui locally or visiting https://scratchfoundation.github.io/scratch-gui/beta/ or https://scratchfoundation.github.io/scratch-gui/develop/. Now, it should always work properly. Exceptionally, some users suffered from this bug on scratch.mit.edu too in the release version (not 100% confirmed whether this PR should fix those cases, but surely it doesn't make them worse).
- Userscripts that run before complete will need to call `await addon.tab.scratchClassReady()` before using `addon.tab.scratchClass()`.

The algorithm that matches Scratch classes with the provided string remains unchanged.
TurboWarp only needs to implement `addon.tab.scratchClassReady = () => Promise.resolve()`.

### Reason for changes

Performance and bugs like this (find bar lacks styling, etc.):
![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/dc02120c-8153-4eeb-9695-e9d1c8c527b1)

### Tests

Tested in Chromium, in both scratch.mit.edu and /scratch-gui/beta