### PR TITLE
Default mouse pointer cursor when interacting with blocks

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -142,6 +142,7 @@
   "auto-follow-topics",
   "featured-dangos",
   "remember-collapsed-categories",
+  "default-pointer-block-interact",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/default-pointer-block-interact/addon.json
+++ b/addons/default-pointer-block-interact/addon.json
@@ -1,0 +1,21 @@
+{
+  "name": "Default mouse pointer cursor when interacting with blocks",
+  "description": "Shows the default mouse cursor when interacting with blocks, like hovering and dragging them.",
+  "tags": ["editor"],
+  "credits": [
+    {
+      "name": "Valer",
+      "link": "https://github.com/Valer100"
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "userstyle.css",
+      "matches": ["projects"]
+    }
+  ],
+  "versionAdded": "1.33.0",
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "enabledByDefault": false
+}

--- a/addons/default-pointer-block-interact/userstyle.css
+++ b/addons/default-pointer-block-interact/userstyle.css
@@ -1,0 +1,13 @@
+/*Set the cursor to default when hovering and dragging blocks*/
+
+path.blocklyPath.blocklyBlockBackground {
+  cursor: default;
+}
+
+text.blocklyText {
+  cursor: default;
+}
+
+g g image {
+  cursor: default;
+}

--- a/addons/default-pointer-block-interact/userstyle.css
+++ b/addons/default-pointer-block-interact/userstyle.css
@@ -1,5 +1,6 @@
 /*Set the cursor to default when hovering and dragging blocks*/
 
+/* For blocks */
 path.blocklyPath.blocklyBlockBackground {
   cursor: default;
 }
@@ -9,5 +10,10 @@ text.blocklyText {
 }
 
 g g image {
+  cursor: default;
+}
+
+/* For comments */
+rect.blocklyDraggable.scratchCommentTopBar {
   cursor: default;
 }


### PR DESCRIPTION
### Changes
This addon shows the default mouse cursor when interacting with blocks, like hovering and dragging.

Here's a GIF to better understand how my addon works:

![demo](https://github.com/ScratchAddons/ScratchAddons/assets/122545522/ee07bd4f-cc63-4796-8556-295d1a925aaf)

### Reason for changes
I made this addon, because I don't like the default cursor used by browsers when you interact with the blocks.

### Tests
Tested on Firefox 113.0.2.

### Issue Link
Resolves https://github.com/ScratchAddons/ScratchAddons/issues/6117
