### PR TITLE
Fix `isProject` (is project page) logic

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -316,7 +316,9 @@ export default class Tab extends Listenable {
 
   scratchClassReady() {
     // Make sure to return a resolved promise if this is not a project!
-    const isProject = location.pathname.split("/")[1] === "projects" && location.pathname.split("/")[3] !== "embed";
+    const isProject =
+      location.pathname.split("/")[1] === "projects" &&
+      !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
     const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
     if (!isProject && !isScratchGui) return Promise.resolve();
 

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -303,7 +303,9 @@ function loadClasses() {
   window.dispatchEvent(new CustomEvent("scratchAddonsClassNamesReady"));
 }
 
-const isProject = location.pathname.split("/")[1] === "projects" && location.pathname.split("/")[3] !== "embed";
+const isProject =
+  location.pathname.split("/")[1] === "projects" &&
+  !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
 const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
 if (isScratchGui || isProject) {
   // Stylesheets are considered to have loaded if this element exists


### PR DESCRIPTION
Fixes bug introduced here: https://github.com/ScratchAddons/ScratchAddons/pull/6105/files#r1208669440

### Changes

Considers URLs such as https://scratch.mit.edu/projects/104/remixes/ and https://scratch.mit.edu/projects/104/studios/ not to be project pages. Project embeds were already excluded.