### PR TITLE
Move high contrast blocks preset up

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -327,6 +327,28 @@
   "enabledByDefault": false,
   "presets": [
     {
+      "name": "High contrast",
+      "id": "contrast",
+      "description": "Scratch 3.0's high contrast block color palette",
+      "values": {
+        "motion-color": "#80B5FF",
+        "looks-color": "#CCB3FF",
+        "sounds-color": "#E19DE1",
+        "events-color": "#FFD966",
+        "control-color": "#FFBE4C",
+        "sensing-color": "#85C4E0",
+        "operators-color": "#7ECE7E",
+        "data-color": "#FFA54C",
+        "data-lists-color": "#FF9966",
+        "custom-color": "#FF99AA",
+        "Pen-color": "#13ECAF",
+        "sa-color": "#34E4D0",
+        "comment-color": "#FEF49C",
+        "input-color": "#FFFFFF",
+        "text": "black"
+      }
+    },
+    {
       "name": "Dark",
       "id": "new-dark",
       "description": "Dark versions of the default colors that look good in dark themes",
@@ -434,28 +456,6 @@
         "comment-color": "#FEF49C",
         "input-color": "#202020",
         "text": "colorOnBlack"
-      }
-    },
-    {
-      "name": "High contrast",
-      "id": "contrast",
-      "description": "Scratch 3.0's new, high-contrast block color palette shown in Scratch Lab",
-      "values": {
-        "motion-color": "#80B5FF",
-        "looks-color": "#CCB3FF",
-        "sounds-color": "#E19DE1",
-        "events-color": "#FFD966",
-        "control-color": "#FFBE4C",
-        "sensing-color": "#85C4E0",
-        "operators-color": "#7ECE7E",
-        "data-color": "#FFA54C",
-        "data-lists-color": "#FF9966",
-        "custom-color": "#FF99AA",
-        "Pen-color": "#13ECAF",
-        "sa-color": "#34E4D0",
-        "comment-color": "#FEF49C",
-        "input-color": "#FFFFFF",
-        "text": "black"
       }
     }
   ],


### PR DESCRIPTION
### Changes

Moves the "High contrast" preset in `editor-theme3` up to the top of the list for easier access. This will become a much more important preset after Scratch's update that we already know about. Also removes a reference to Scratch Lab from the preset tooltip.

### Tests

Tested.
