### PR TITLE
Change default website highlight color to purple

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2353,7 +2353,7 @@
     {
       "name": "Scratch's default colors (blue)",
       "id": "scratch",
-      "description": "The colors normally used by Scratch",
+      "description": "The colors originally used by Scratch",
       "values": {
         "page": "#fcfcfc",
         "navbar": "#4d97ff",

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2214,7 +2214,7 @@
       "id": "navbar",
       "type": "color",
       "allowTransparency": true,
-      "default": "#4d97ff"
+      "default": "#855cd6"
     },
     {
       "name": "Content background",
@@ -2244,13 +2244,13 @@
       "name": "Highlight color",
       "id": "button",
       "type": "color",
-      "default": "#4d97ff"
+      "default": "#855cd6"
     },
     {
       "name": "Link color",
       "id": "link",
       "type": "color",
-      "default": "#4d97ff"
+      "default": "#ccb3ff"
     },
     {
       "name": "Footer background",
@@ -2299,13 +2299,13 @@
       "description": "A dark theme by Maximouse based on a userstyle. Not experimental",
       "values": {
         "page": "#202020",
-        "navbar": "#4d97ff",
+        "navbar": "#855cd6",
         "box": "#282828",
         "gray": "#333333",
         "blue": "#252c37",
         "input": "#202020",
-        "button": "#4d97ff",
-        "link": "#4d97ff",
+        "button": "#855cd6",
+        "link": "#ccb3ff",
         "footer": "#333333",
         "border": "#606060",
         "darkBanners": "darker",
@@ -2318,13 +2318,13 @@
       "description": "A dark theme by Ucrash",
       "values": {
         "page": "#242527",
-        "navbar": "#4d97ff",
+        "navbar": "#855cd6",
         "box": "#2f3137",
         "gray": "#424346",
         "blue": "#1b1d1f",
         "input": "#3a3a3a",
-        "button": "#4d97ff",
-        "link": "#4d97ff",
+        "button": "#855cd6",
+        "link": "#ccb3ff",
         "footer": "#17181a",
         "border": "#000000",
         "darkBanners": "desaturated",
@@ -2337,13 +2337,32 @@
       "description": "The colors normally used by Scratch",
       "values": {
         "page": "#fcfcfc",
+        "navbar": "#855cd6",
+        "box": "#ffffff",
+        "gray": "#f2f2f2",
+        "blue": "#e9f1fc",
+        "input": "#fafafa",
+        "button": "#855cd6",
+        "link": "#855cd6",
+        "footer": "#f2f2f2",
+        "border": "#0000001a",
+        "darkBanners": "off",
+        "darkForumCode": false
+      }
+    },
+    {
+      "name": "Scratch's default colors (blue)",
+      "id": "scratch",
+      "description": "The colors normally used by Scratch",
+      "values": {
+        "page": "#fcfcfc",
         "navbar": "#4d97ff",
         "box": "#ffffff",
         "gray": "#f2f2f2",
         "blue": "#e9f1fc",
         "input": "#fafafa",
         "button": "#4d97ff",
-        "link": "#4d97ff",
+        "link": "#2a77e4",
         "footer": "#f2f2f2",
         "border": "#0000001a",
         "darkBanners": "off",


### PR DESCRIPTION
Part of #6115

### Changes

Scratch's editor accent color is updating to `#855cd6`. This updates each preset in `dark-www` to use purple instead of blue. I also kept a blue version of Scratch's default colors in case that's anyone's preference, but all other presets have had their blue changed to purple.

We'll need to do a bit more work to make it look good, but that can be a separate pull request if that's okay.

### Tests

Tested in Edge 113.

### Tasks

- [ ] Add migration code
