### PR TITLE
Shorten URLs for Cloud Games

### DIFF
--- a/addons/cloud-games/addon.json
+++ b/addons/cloud-games/addon.json
@@ -29,7 +29,7 @@
       "type": "table",
       "default": [
         {
-          "url": "https://scratch.mit.edu/studios/539952/"
+          "url": "studios/539952"
         }
       ],
       "row": [
@@ -44,31 +44,31 @@
         {
           "name": "Griffpatch's Multiplayer Games",
           "values": {
-            "url": "https://scratch.mit.edu/studios/539952/"
+            "url": "studios/539952"
           }
         },
         {
           "name": "Massive Multiplayer Platformer",
           "values": {
-            "url": "https://scratch.mit.edu/projects/612229554/"
+            "url": "projects/612229554"
           }
         },
         {
           "name": "Cloud Platformer Multiplayer Fun",
           "values": {
-            "url": "https://scratch.mit.edu/projects/378507713/"
+            "url": "projects/378507713"
           }
         },
         {
           "name": "slither.io",
           "values": {
-            "url": "https://scratch.mit.edu/projects/108566337/"
+            "url": "projects/108566337"
           }
         },
         {
           "name": "diep.io",
           "values": {
-            "url": "https://scratch.mit.edu/projects/131270192/"
+            "url": "projects/131270192"
           }
         }
       ]


### PR DESCRIPTION
Resolves comment https://github.com/ScratchAddons/ScratchAddons/issues/5190#issuecomment-1404142737

### Changes

Removed the common start `https://scratch.mit.edu/` from URLs in the Cloud Games addon's preset URLs, so instead of having a URL like `https://scratch.mit.edu/studios/539952`, it will just be `studios/539952`.

From my testing, Cloud Games is already capable of processing shortened URLs acting as relative paths to parts of `scratch.mit.edu`, so no code changes were required.

Note that the project URLs don't need to begin with `projects/` (if they don't specify whether to load a project or a studio, the default will be a project), but I kept them there for simplicity.

### Reason for changes

To save space in the input boxes in the settings page and take up less space in storage.

### Tests

Tested in Edge 113.

### Tasks

- [ ] Ideally, we should have migration code set up to remove it for existing users.
