### PR TITLE
Dynamic enable and disable for sounds-duration

### DIFF
--- a/addons/sounds-duration/addon.json
+++ b/addons/sounds-duration/addon.json
@@ -20,5 +20,7 @@
       "matches": ["projects"]
     }
   ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
   "versionAdded": "1.26.0"
 }

--- a/addons/sounds-duration/userscript.js
+++ b/addons/sounds-duration/userscript.js
@@ -9,6 +9,8 @@ export default async function ({ addon, msg, console }) {
         className: "sa-sound-duration",
       })
     );
+    addon.tab.displayNoneWhileDisabled(el);
+
     const state = container[addon.tab.traps.getInternalKey(container)].return.return.return.stateNode;
 
     function setText(running, selected) {


### PR DESCRIPTION
A step towards https://github.com/ScratchAddons/ScratchAddons/issues/1673

### Changes

Added dynamic enable and disable support to `sounds-duration`. The addon actually continues running in the background but is invisible while disabled.

### Reason for changes

We're trying to add dynamic enable/disable support to all addons at some point.

### Tests

Tested on Edge 113.
