### PR TITLE
Add `SET_THEME` to `reduxEvents` list in some addons

### DIFF
--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -229,7 +229,12 @@ export default async function ({ addon, console, msg }) {
   while (true) {
     flyOut = await addon.tab.waitForElement(".blocklyFlyout", {
       markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "scratch-gui/locales/SELECT_LOCALE", "fontsLoaded/SET_FONTS_LOADED"],
+      reduxEvents: [
+        "scratch-gui/mode/SET_PLAYER",
+        "scratch-gui/locales/SELECT_LOCALE",
+        "scratch-gui/theme/SET_THEME",
+        "fontsLoaded/SET_FONTS_LOADED",
+      ],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     scrollBar = document.querySelector(".blocklyFlyoutScrollbar");

--- a/addons/zebra-striping/userscript.js
+++ b/addons/zebra-striping/userscript.js
@@ -57,7 +57,12 @@ export default async function ({ addon, msg, console }) {
   while (true) {
     const replacementGlowEl = await addon.tab.waitForElement('filter[id*="blocklyReplacementGlowFilter"]', {
       markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      reduxEvents: [
+        "scratch-gui/mode/SET_PLAYER",
+        "fontsLoaded/SET_FONTS_LOADED",
+        "scratch-gui/locales/SELECT_LOCALE",
+        "scratch-gui/theme/SET_THEME",
+      ],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
     });
     document.documentElement.style.setProperty("--zebraStriping-replacementGlow", `url(#${replacementGlowEl.id})`);


### PR DESCRIPTION
Fixes two bugs that happened when switching theme:
* `hide-flyout` stopped working.
* The `zebra-striping` bug happened when a reporter inside another block from the same category was being replaced:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/d084aa8a-141c-4fa5-b3bc-4f9d9718f7af)
When doing this after changing the theme, the replacement glow wouldn't appear.

### Tests

Tested on https://scratchfoundation.github.io/scratch-gui/beta/ and on the Scratch website.