### PR TITLE
editor-comment-previews: Fix dynamic disable

### DIFF
--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -32,6 +32,7 @@ export default async function ({ addon, console }) {
   previewInner.classList.add("sa-comment-preview-hidden");
   updateStyles();
   addon.settings.addEventListener("change", updateStyles);
+  addon.tab.displayNoneWhileDisabled(previewOuter);
   previewOuter.appendChild(previewInner);
   document.body.appendChild(previewOuter);
 


### PR DESCRIPTION
Resolves #6000

### Changes

Fixes a bug in `editor-comment-previews` that caused the `sa-comment-preview-outer` element to stay visible after the addon was dynamically disabled.

### Tests

Tested in Edge 114.
