### PR TITLE
Fix `addon.tab.scratchClass` regression breaking folders addon

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -708,6 +708,7 @@ export default async function ({ addon, console, msg }) {
     });
   };
 
+  await addon.tab.scratchClassReady();
   addon.tab.createEditorContextMenu((ctxType, ctx) => {
     if (ctxType !== "sprite" && ctxType !== "costume" && ctxType !== "sound") return;
     const component = ctx.target[addon.tab.traps.getInternalKey(ctx.target)].return.return.return.stateNode;


### PR DESCRIPTION
### Changes

Resolves https://github.com/ScratchAddons/ScratchAddons/pull/6137#issuecomment-1584936150
Userscripts that call `addon.tab.createEditorContextMenu()` and that run before complete need to wait until scratchClass is ready.
It was reported that `move-to-top-bottom` was broken, but it was a byproduct of the "sprite folders" addon breaking.

### Tests

Hopefully adding this `await` doesn't break anything (it's now the first one in the file). We can use `.then()` instead in that case.