### PR TITLE
Hide Turbo Mode label when volume slider hovered

### DIFF
--- a/addons/vol-slider/hover.css
+++ b/addons/vol-slider/hover.css
@@ -37,11 +37,13 @@
 }
 
 .pos-container-container,
-.clone-container-container {
+.clone-container-container,
+[class*="turbo-mode_turbo-container"] {
   transition: opacity 0.25s ease;
 }
 
 .sa-vol-slider:hover ~ .pos-container-container,
-.sa-vol-slider:hover ~ .clone-container-container {
+.sa-vol-slider:hover ~ .clone-container-container,
+.sa-vol-slider:hover ~ [class*="turbo-mode_turbo-container"] {
   opacity: 0;
 }


### PR DESCRIPTION
Resolves #6184

### Changes

Made it so that the Turbo Mode label that appears next to the stop sign when Turbo Mode is enabled hides when hovering over the volume slider, just like the clone counter and mouse position display.

### Tests

Tested in Edge 114. Code modified using browser developer tools during testing.
