### PR TITLE
custom-zoom: respond to theme and language changes

### DIFF
--- a/addons/custom-zoom/userscript.js
+++ b/addons/custom-zoom/userscript.js
@@ -63,12 +63,22 @@ export default async function ({ addon, console }) {
     }
   }
 
-  await addon.tab.waitForElement(".blocklyZoom");
   if (document.querySelector('[class^="backpack_backpack-container"]')) {
     window.dispatchEvent(new Event("resize"));
   }
-  update();
-  addon.tab.addEventListener("urlChange", update);
   addon.settings.addEventListener("change", update);
   window.addEventListener("resize", onResize);
+  while (true) {
+    await addon.tab.waitForElement(".blocklyZoom", {
+      markAsSeen: true,
+      reduxEvents: [
+        "scratch-gui/mode/SET_PLAYER",
+        "scratch-gui/locales/SELECT_LOCALE",
+        "scratch-gui/theme/SET_THEME",
+        "fontsLoaded/SET_FONTS_LOADED",
+      ],
+      reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
+    });
+    update();
+  }
 }


### PR DESCRIPTION
Resolves #6191

### Changes

Fixes bugs in `custom-zoom` that happened when changing the Scratch language or theme.

### Tests

Tested on the Scratch website and in the GUI playground.