### PR TITLE
Strip localhost permission and include DNRWHA in generated manifest

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "ignorePatterns": ["node_modules/*", "_locales/*", ".github/*", "addons-l10n/*", "libraries/thirdparty/*"],
+  "ignorePatterns": ["node_modules/*", "_locales/*", ".github/workflows/*", "addons-l10n/*", "libraries/thirdparty/*"],
   "parserOptions": {
     "sourceType": "module"
   },

--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -1,5 +1,6 @@
 const PERMISSIONS_IGNORED_IN_CHROME = ["clipboardWrite"];
-const PERMISSIONS_IGNORED_IN_FIREFOX = ["declarativeNetRequestWithHostAccess"];
+// Previously included declarativeNetRequestWithHostAccess.
+const PERMISSIONS_IGNORED_IN_FIREFOX = [];
 // These should be removed during production manifest gen.
 const PERMISSIONS_ALWAYS_IGNORED = [
   "https://scratchfoundation.github.io/scratch-gui/*",

--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -1,5 +1,11 @@
 const PERMISSIONS_IGNORED_IN_CHROME = ["clipboardWrite"];
 const PERMISSIONS_IGNORED_IN_FIREFOX = ["declarativeNetRequestWithHostAccess"];
+// These should be removed during production manifest gen.
+const PERMISSIONS_ALWAYS_IGNORED = [
+  "https://scratchfoundation.github.io/scratch-gui/*",
+  "http://localhost:8333/*",
+  "http://localhost:8601/*",
+];
 
 /**
  * Generates a manifest for specific browsers.
@@ -14,6 +20,12 @@ export default (env, manifest) => {
   manifest.icons["1024"] = "images/icon.png";
   manifest.icons["32"] = "images/icon-32.png";
   manifest.icons["16"] = "images/icon-16.png";
+  manifest.permissions = manifest.permissions.filter((permission) => !PERMISSIONS_ALWAYS_IGNORED.includes(permission));
+  manifest.content_scripts.forEach((content_script) => {
+    content_script.matches = content_script.matches.filter(
+      (permission) => !PERMISSIONS_ALWAYS_IGNORED.includes(permission)
+    );
+  });
   switch (env) {
     case "chrome": {
       delete manifest.browser_specific_settings;

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ _locales/*/messages.json
 !_locales/en/messages.json
 
 .github/*
+!.github/*.mjs


### PR DESCRIPTION
Resolves #6084

Three changes:

- localhost and `scratchfoundation.github.io` permissions are now removed during gen-manifest execution, from both the permissions section and the CS section.
- In Firefox, DNRWHA permission is no longer removed. FF113+ supports DNRWHA, and development build (without this being removed) works fine.
- Linter configuration changes.
