### PR TITLE
Fix "confirmations" addon project sharing confirmation not working

### DIFF
--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -62,6 +62,7 @@ export default async function ({ addon, console, msg }) {
       if (cancelMessage !== null) {
         e.preventDefault();
         e.stopPropagation();
+        addon.tab.scratchClassReady().then(() => {
         addon.tab
           .confirm(title, cancelMessage, {
             okButtonLabel: msg("yes"),
@@ -74,6 +75,7 @@ export default async function ({ addon, console, msg }) {
               e.target.click();
             }
           });
+        });
       }
     },
     { capture: true }

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -63,18 +63,18 @@ export default async function ({ addon, console, msg }) {
         e.preventDefault();
         e.stopPropagation();
         addon.tab.scratchClassReady().then(() => {
-        addon.tab
-          .confirm(title, cancelMessage, {
-            okButtonLabel: msg("yes"),
-            cancelButtonLabel: msg("no"),
-            useEditorClasses: addon.tab.editorMode === "editor",
-          })
-          .then((confirmed) => {
-            if (confirmed) {
-              override = true;
-              e.target.click();
-            }
-          });
+          addon.tab
+            .confirm(title, cancelMessage, {
+              okButtonLabel: msg("yes"),
+              cancelButtonLabel: msg("no"),
+              useEditorClasses: addon.tab.editorMode === "editor",
+            })
+            .then((confirmed) => {
+              if (confirmed) {
+                override = true;
+                e.target.click();
+              }
+            });
         });
       }
     },


### PR DESCRIPTION
Resolves #6219

### Tests

Tested in Chromium:
- Share confirmation works inside the editor.
- Share confirmation works in the project page.
- Share confirmation continues to work outside projects, such as the follow/unfollow confirmation (note that this type of confirmation is disabled by default in the settings)