### PR TITLE
Add option to disable-stage-drag-select

### DIFF
--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -8,6 +8,10 @@
     },
     {
       "name": "GarboMuffin"
+    },
+    {
+      "name": "Mr_MPH",
+      "link": "https://scratch.mit.edu/users/Mr_MPH/"
     }
   ],
   "userscripts": [

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -16,6 +16,14 @@
       "matches": ["projects"]
     }
   ],
+  "settings": [
+    {
+      "name": "Allow dragging while project is stopped",
+      "id": "drag_while_stopped",
+      "type": "boolean",
+      "default": false
+    }
+  ],
   "tags": ["editor", "featured"],
   "enabledByDefault": false,
   "dynamicDisable": true,

--- a/addons/disable-stage-drag-select/addon.json
+++ b/addons/disable-stage-drag-select/addon.json
@@ -32,5 +32,9 @@
   "enabledByDefault": false,
   "dynamicDisable": true,
   "dynamicEnable": true,
-  "versionAdded": "1.17.0"
+  "versionAdded": "1.17.0",
+  "latestUpdate": {
+    "version": "1.34.0",
+    "newSettings": ["drag_while_stopped"]
+  }
 }

--- a/addons/disable-stage-drag-select/userscript.js
+++ b/addons/disable-stage-drag-select/userscript.js
@@ -15,7 +15,11 @@ export default async ({ addon, console }) => {
   // Do not focus sprite after dragging it
   const oldStopDrag = vm.stopDrag;
   vm.stopDrag = function (...args) {
-    if (shiftKeyPressed || addon.self.disabled) return oldStopDrag.call(this, ...args);
+    const allowDrag =
+      shiftKeyPressed ||
+      (addon.settings.get("drag_while_stopped") && !addon.tab.redux.state.scratchGui.vmStatus.running);
+    console.log(allowDrag);
+    if (allowDrag || addon.self.disabled) return oldStopDrag.call(this, ...args);
     const setEditingTarget = this.setEditingTarget;
     this.setEditingTarget = () => {};
     const r = oldStopDrag.call(this, ...args);
@@ -26,8 +30,11 @@ export default async ({ addon, console }) => {
   // Don't let the editor drag sprites that aren't marked as draggable
   const oldGetTargetIdForDrawableId = vm.getTargetIdForDrawableId;
   vm.getTargetIdForDrawableId = function (...args) {
+    const allowDrag =
+      shiftKeyPressed ||
+      (addon.settings.get("drag_while_stopped") && !addon.tab.redux.state.scratchGui.vmStatus.running);
     const targetId = oldGetTargetIdForDrawableId.call(this, ...args);
-    if (shiftKeyPressed || addon.self.disabled) return targetId;
+    if (allowDrag || addon.self.disabled) return targetId;
     if (targetId !== null) {
       const target = this.runtime.getTargetById(targetId);
       if (target && !target.draggable) {

--- a/addons/disable-stage-drag-select/userscript.js
+++ b/addons/disable-stage-drag-select/userscript.js
@@ -18,7 +18,6 @@ export default async ({ addon, console }) => {
     const allowDrag =
       shiftKeyPressed ||
       (addon.settings.get("drag_while_stopped") && !addon.tab.redux.state.scratchGui.vmStatus.running);
-    console.log(allowDrag);
     if (allowDrag || addon.self.disabled) return oldStopDrag.call(this, ...args);
     const setEditingTarget = this.setEditingTarget;
     this.setEditingTarget = () => {};


### PR DESCRIPTION
### Changes

Added a new setting in the _Non-draggable sprites in editor_ addon that allows the user to enable dragging while the project is stopped.

### Reason for changes

Gives users more options for customization.

### Tests

Tested in Chrome 114.0.5735.106