### PR TITLE
Warn users before posting "scratch addons" on forums

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -901,6 +901,7 @@ if (isProfile || isStudio || isProject || isForums) {
         const errorTip = document.createElement("li");
         errorTip.classList.add("errorlist", "sa-extension-policy-warning");
         errorTip.style.scrollMarginTop = "50px";
+        errorTip.style.fontWeight = "bold";
         errorTip.innerHTML = errorMsgHtml + " ";
         const sendAnyway = document.createElement("a");
         sendAnyway.onclick = () => {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -753,8 +753,9 @@ if (document.readyState !== "loading") {
 const isProfile = pathArr[0] === "users" && pathArr[2] === "";
 const isStudio = pathArr[0] === "studios";
 const isProject = pathArr[0] === "projects";
+const isForums = pathArr[0] === "discuss";
 
-if (isProfile || isStudio || isProject) {
+if (isProfile || isStudio || isProject || isForums) {
   const removeReiteratedChars = (string) =>
     string
       .split("")
@@ -773,7 +774,7 @@ if (isProfile || isStudio || isProject) {
   extensionPolicyLink.innerText = chrome.i18n.getMessage("captureCommentPolicy");
   Object.assign(extensionPolicyLink.style, {
     textDecoration: "underline",
-    color: "white",
+    color: isForums ? "" : "white",
   });
   const errorMsgHtml = escapeHTML(chrome.i18n.getMessage("captureCommentError", DOLLARS)).replace(
     "$1",
@@ -877,5 +878,62 @@ if (isProfile || isStudio || isProject) {
       },
       { capture: true }
     );
+  } else if (isForums) {
+    window.addEventListener("click", (e) => {
+      const potentialPostButton = e.target.closest("button[type=submit]");
+      if (!potentialPostButton) return;
+      const form = e.target.closest("form");
+      if (!form) return;
+      if (form.hasAttribute("data-sa-send-anyway")) {
+        form.removeAttribute("data-sa-send-anyway");
+        return;
+      }
+      const existingWarning = form.parentElement.querySelector(".sa-extension-policy-warning");
+      if (existingWarning) {
+        // Do nothing. The warning automatically disappears after typing into the form.
+        e.preventDefault();
+        existingWarning.scrollIntoView({ behavior: "smooth" });
+        return;
+      }
+      const textarea = form.querySelector("textarea .markItUpEditor");
+      if (!textarea) return;
+      if (shouldCaptureComment(textarea.value)) {
+        e.preventDefault();
+        const errorTip = document.createElement("li");
+        errorTip.classList.add("errorlist", "sa-extension-policy-warning");
+        errorTip.style.scrollMarginTop = "50px";
+        errorTip.innerHTML = errorMsgHtml + " ";
+        const sendAnyway = document.createElement("a");
+        sendAnyway.onclick = () => {
+          const res = confirm(confirmMsg);
+          if (res) {
+            form.setAttribute("data-sa-send-anyway", "");
+            form.querySelector("button[type=submit]")?.click();
+          }
+        };
+        sendAnyway.textContent = sendAnywayMsg;
+        errorTip.appendChild(sendAnyway);
+
+        let errorList = form.querySelector("label > ul");
+        if (!errorList) {
+          const typeArea = postArea.querySelector("strong");
+          errorList = document.createElement("ul");
+          errorList.classList.add("errorlist");
+          postArea.insertBefore(errorList, typeArea);
+        }
+
+        errorList.appendChild(errorTip);
+        errorTip.scrollIntoView({ behavior: "smooth" });
+
+        // Hide error after typing
+        textarea.addEventListener(
+          "input",
+          () => {
+            errorTip.remove();
+          },
+          { once: true }
+        );
+      }
+    });
   }
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -895,10 +895,9 @@ if (isProfile || isStudio || isProject || isForums) {
         existingWarning.scrollIntoView({ behavior: "smooth" });
         return;
       }
-      const textarea = form.querySelector("textarea .markItUpEditor");
+      const textarea = form.querySelector("textarea.markItUpEditor");
       if (!textarea) return;
       if (shouldCaptureComment(textarea.value)) {
-        e.preventDefault();
         const errorTip = document.createElement("li");
         errorTip.classList.add("errorlist", "sa-extension-policy-warning");
         errorTip.style.scrollMarginTop = "50px";
@@ -914,6 +913,8 @@ if (isProfile || isStudio || isProject || isForums) {
         sendAnyway.textContent = sendAnywayMsg;
         errorTip.appendChild(sendAnyway);
 
+        const postArea = form.querySelector("label");
+        if (!postArea) return;
         let errorList = form.querySelector("label > ul");
         if (!errorList) {
           const typeArea = postArea.querySelector("strong");
@@ -924,6 +925,7 @@ if (isProfile || isStudio || isProject || isForums) {
 
         errorList.appendChild(errorTip);
         errorTip.scrollIntoView({ behavior: "smooth" });
+        e.preventDefault();
 
         // Hide error after typing
         textarea.addEventListener(

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -932,6 +932,9 @@ if (isProfile || isStudio || isProject || isForums) {
           "input",
           () => {
             errorTip.remove();
+            if (errorList.querySelector("li") === null) {
+              errorList.remove();
+            }
           },
           { once: true }
         );


### PR DESCRIPTION
Resolves #4746

### Changes

Extended the "scratch addons" warning to new forum posts, new forum topics, editing existing topics and (probably, haven't tested) the signature changing screen.

![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/47ba8e58-2e53-4730-b3e3-9757b7335406)

### Tests

Appears to work in Chromium. See comment: https://github.com/ScratchAddons/ScratchAddons/pull/6232#issuecomment-1599656292