### PR TITLE
better-img-uploads (HD image uploads) bug fixes

### DIFF
--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -110,7 +110,7 @@ export default async function ({ addon, console, msg }) {
     let processed = new Array();
 
     for (let file of files) {
-      if (file.type.endsWith("/svg") || file.name.endsWith(".sprite3")) {
+      if (file.type.endsWith("/svg+xml") || file.name.endsWith(".sprite3")) {
         // The file is either an SVG or a sprite3 file, we should not change it...
         processed.push(file);
         continue;

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -25,7 +25,7 @@ export default async function ({ addon, console, msg }) {
     });
     button.append(img);
     const input = Object.assign(document.createElement("input"), {
-      accept: ".svg, .png, .bmp, .jpg, .jpeg, .sprite3",
+      accept: ".svg, .png, .bmp, .jpg, .jpeg, .sprite2, .sprite3",
       className: `${addon.tab.scratchClass(
         "action-menu_file-input" /* TODO: when adding dynamicDisable, ensure compat with drag-drop */
       )} sa-better-img-uploads-input`,
@@ -110,8 +110,15 @@ export default async function ({ addon, console, msg }) {
     let processed = new Array();
 
     for (let file of files) {
-      if (file.type.endsWith("/svg+xml") || file.name.endsWith(".sprite3")) {
-        // The file is either an SVG or a sprite3 file, we should not change it...
+      if (
+        !(
+          file.name.endsWith(".png") ||
+          file.name.endsWith(".bmp") ||
+          file.name.endsWith(".jpg") ||
+          file.name.endsWith(".jpeg")
+        )
+      ) {
+        // The file is not in the whitelist, so we should ignore it, and let scratch deal with it..
         processed.push(file);
         continue;
       }

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -25,7 +25,7 @@ export default async function ({ addon, console, msg }) {
     });
     button.append(img);
     const input = Object.assign(document.createElement("input"), {
-      accept: ".svg, .png, .bmp, .jpg, .jpeg",
+      accept: ".svg, .png, .bmp, .jpg, .jpeg, .sprite3",
       className: `${addon.tab.scratchClass(
         "action-menu_file-input" /* TODO: when adding dynamicDisable, ensure compat with drag-drop */
       )} sa-better-img-uploads-input`,
@@ -110,8 +110,8 @@ export default async function ({ addon, console, msg }) {
     let processed = new Array();
 
     for (let file of files) {
-      if (file.type.includes("svg")) {
-        //The file is already a svg, we should not change it...
+      if (file.type.includes("svg") || (file.name.includes(".sprite3") && file.type === "")) {
+        // The file is either an SVG or a sprite3 file, we should not change it...
         processed.push(file);
         continue;
       }
@@ -150,7 +150,7 @@ export default async function ({ addon, console, msg }) {
       } //Otherwise just leave the image the same size
 
       function getResizedWidthHeight(oldWidth, oldHeight) {
-        const STAGE_WIDTH = 479;
+        const STAGE_WIDTH = 480;
         const STAGE_HEIGHT = 360;
         const STAGE_RATIO = STAGE_WIDTH / STAGE_HEIGHT;
 

--- a/addons/better-img-uploads/userscript.js
+++ b/addons/better-img-uploads/userscript.js
@@ -110,7 +110,7 @@ export default async function ({ addon, console, msg }) {
     let processed = new Array();
 
     for (let file of files) {
-      if (file.type.includes("svg") || (file.name.includes(".sprite3") && file.type === "")) {
+      if (file.type.endsWith("/svg") || file.name.endsWith(".sprite3")) {
         // The file is either an SVG or a sprite3 file, we should not change it...
         processed.push(file);
         continue;


### PR DESCRIPTION
Resolves  #6238 

### Changes

Added support for importing .sprite3 files (they are accepted but passed through with no changes), and changed 1 number in the logic for image sizing from 479 to 480 to stop it resizing certain things incorrectly.

### Reason for changes

Cuz they were annoying me and mxmou and WL said they were good 👍

### Tests

Tested in Brave Version 1.52.126, Chromium version 114.0.5735.133
