### PR TITLE
Fix unstyled button on permissions page

### DIFF
--- a/webpages/settings/permissions.html
+++ b/webpages/settings/permissions.html
@@ -15,6 +15,7 @@
        * Imports are here to attempt to speed up load. Also, it means licenses.html loads fewer unused styles, and this file doesn't get licenses.html's styles! In order of when it will be noticed/needed on the page
       */
       @import url("../styles/colors.css");
+      @import url("../styles/components/buttons.css");
     </style>
   </head>
   <body class="permissions">


### PR DESCRIPTION
### Changes

Fixes the styling of the Enable button on the permissions page. I think it was broken by #4516.

### Tests

Tested on Edge and Firefox. v1.33.1:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/5ff01902-0c10-44de-8b74-f11962f5660e)

After this change:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/94596253-b49e-4013-8543-1e66d5e8f39b)