### PR TITLE
studio-tools: remove unused string

### DIFF
--- a/addons-l10n/en/studio-tools.json
+++ b/addons-l10n/en/studio-tools.json
@@ -5,7 +5,6 @@
   "studio-tools/leave-new": "Leave Studio",
   "studio-tools/promote-btn": "Promote",
   "studio-tools/remove-btn": "Remove",
-  "studio-tools/owner-error": "You are the owner of the studio.",
   "studio-tools/leave-confirm": "Are you sure you want to leave this studio?",
   "studio-tools/added-by": "Button added by Scratch Addons browser extension",
   "studio-tools/invalid-username": "The username is not valid.",


### PR DESCRIPTION
### Changes

Removes the string `studio-tools/owner-error`.

### Reason for changes

Before the studio update, this error appeared if the owner of a studio tried to use the "Leave Studio" button. In the current version of the addon, the button doesn't appear if you're the owner, so this string isn't used anywhere.

### Tests

Tested on Edge.