### PR TITLE
Use setAttribute to set ARIA attributes

### DIFF
--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -14,9 +14,9 @@ export default async function ({ addon, console, msg }) {
     // Temporary code to support both current and future Scratch version
     if (addon.tab.scratchClass("stage-header_stage-button-toggled-off"))
       hideStageButton.classList.remove(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
-    hideStageButton.ariaPressed = true;
-    smallStageButton.ariaPressed = false;
-    largeStageButton.ariaPressed = false;
+    hideStageButton.setAttribute("aria-pressed", true);
+    smallStageButton.setAttribute("aria-pressed", false);
+    largeStageButton.setAttribute("aria-pressed", false);
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
   }
 
@@ -28,13 +28,14 @@ export default async function ({ addon, console, msg }) {
     // Temporary code to support both current and future Scratch version
     if (addon.tab.scratchClass("stage-header_stage-button-toggled-off"))
       hideStageButton.classList.add(addon.tab.scratchClass("stage-header_stage-button-toggled-off"));
-    hideStageButton.ariaPressed = false;
+    hideStageButton.setAttribute("aria-pressed", false);
     if (e) {
       const clickedButton = e.target.closest("button");
-      if (clickedButton) clickedButton.ariaPressed = true;
+      if (clickedButton) clickedButton.setAttribute("aria-pressed", true);
     } else if (addon.tab.redux.state) {
-      if (addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") smallStageButton.ariaPressed = true;
-      else largeStageButton.ariaPressed = true;
+      if (addon.tab.redux.state.scratchGui.stageSize.stageSize === "small")
+        smallStageButton.setAttribute("aria-pressed", true);
+      else largeStageButton.setAttribute("aria-pressed", true);
     }
     window.dispatchEvent(new Event("resize")); // resizes the code area and paint editor canvas
   }
@@ -64,19 +65,18 @@ export default async function ({ addon, console, msg }) {
           )
         : addon.tab.scratchClass("toggle-buttons_button", { others: "sa-hide-stage-button" }),
       title: msg("hide-stage"),
-      ariaLabel: msg("hide-stage"),
-      ariaPressed: false,
     });
+    hideStageButton.setAttribute("aria-label", msg("hide-stage"));
+    hideStageButton.setAttribute("aria-pressed", false);
     addon.tab.displayNoneWhileDisabled(hideStageButton);
     stageControls.insertBefore(hideStageButton, smallStageButton);
-    hideStageButton.appendChild(
-      Object.assign(document.createElement("img"), {
-        className: addon.tab.scratchClass("stage-header_stage-button-icon"),
-        src: addon.self.dir + "/icon.svg",
-        draggable: false,
-        ariaHidden: true,
-      })
-    );
+    const icon = Object.assign(document.createElement("img"), {
+      className: addon.tab.scratchClass("stage-header_stage-button-icon"),
+      src: addon.self.dir + "/icon.svg",
+      draggable: false,
+    });
+    icon.setAttribute("aria-hidden", true);
+    hideStageButton.appendChild(icon);
     if (stageHidden) hideStage();
     else unhideStage();
     hideStageButton.addEventListener("click", hideStage);

--- a/addons/search-profile/userscript.js
+++ b/addons/search-profile/userscript.js
@@ -7,9 +7,9 @@ export default async function ({ addon, console, msg }) {
     user = document.querySelector('[name="q"]').value.trim(),
     valid = /^[\w-]{3,20}$/g.test(user);
   tab.type = "button";
-  tab.role = "tab";
+  tab.setAttribute("role", "tab");
+  tab.setAttribute("aria-selected", false);
   tab.tabIndex = -1; // unselected tabs should only be focusable using arrow keys
-  tab.ariaSelected = false;
   img.src = addon.self.dir + "/user.svg";
   img.className = "tab-icon";
   span.innerText = msg("profile");


### PR DESCRIPTION
### Changes

Changes code that sets `role` and `aria-*` attributes to use `setAttribute()` because `.role` and `.aria*` don't work on Firefox.

### Reason for changes

Some things didn't work correctly on Firefox:
* The tab added by `search-profile` was read as "button" instead of "tab, not selected" by screen readers.
* In the beta version of scratch-gui, the hide stage button didn't appear selected when the stage was hidden.

### Tests

Tested on Edge and Firefox. The `hide-stage` change was tested by running scratch-www locally.