### PR TITLE
Fix debugger and gamepad buttons in full screen

### DIFF
--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -625,18 +625,22 @@ export default async function ({ addon, console, msg }) {
   };
 
   while (true) {
-    await addon.tab.waitForElement('[class*="stage-header_stage-size-row"]', {
-      markAsSeen: true,
-      reduxEvents: [
-        "scratch-gui/mode/SET_PLAYER",
-        "scratch-gui/mode/SET_FULL_SCREEN",
-        "fontsLoaded/SET_FONTS_LOADED",
-        "scratch-gui/locales/SELECT_LOCALE",
-      ],
-    });
+    await addon.tab.waitForElement(
+      '[class^="stage-header_stage-size-row"] [class^="button_outlined-button"], [class^="stage-header_stage-menu-wrapper"] > [class^="button_outlined-button"], [class*="stage-header_unselect-wrapper_"] > [class^="button_outlined-button"]',
+      {
+        markAsSeen: true,
+        reduxEvents: [
+          "scratch-gui/mode/SET_PLAYER",
+          "scratch-gui/mode/SET_FULL_SCREEN",
+          "fontsLoaded/SET_FONTS_LOADED",
+          "scratch-gui/locales/SELECT_LOCALE",
+        ],
+      }
+    );
     if (addon.tab.editorMode === "editor") {
       addon.tab.appendToSharedSpace({ space: "stageHeader", element: debuggerButtonOuter, order: 0 });
     } else {
+      debuggerButtonOuter.remove();
       setInterfaceVisible(false);
     }
   }

--- a/addons/gamepad/userscript.js
+++ b/addons/gamepad/userscript.js
@@ -418,7 +418,7 @@ export default async function ({ addon, console, msg }) {
 
   while (true) {
     const target = await addon.tab.waitForElement(
-      '[class^="stage-header_stage-size-row"], [class^="stage-header_stage-menu-wrapper"] > [class^="button_outlined-button"]',
+      '[class^="stage-header_stage-size-row"] [class^="button_outlined-button"], [class^="stage-header_stage-menu-wrapper"] > [class^="button_outlined-button"], [class*="stage-header_unselect-wrapper_"] > [class^="button_outlined-button"]',
       {
         markAsSeen: true,
         reduxEvents: [
@@ -430,7 +430,7 @@ export default async function ({ addon, console, msg }) {
       }
     );
     container.dataset.editorMode = addon.tab.editorMode;
-    if (target.className.includes("stage-size-row")) {
+    if (target.closest('[class^="stage-header_stage-size-row"]')) {
       addon.tab.appendToSharedSpace({ space: "stageHeader", element: container, order: 1 });
     } else {
       addon.tab.appendToSharedSpace({ space: "fullscreenStageHeader", element: container, order: 0 });


### PR DESCRIPTION
### Changes

Fixes a bug that happens in the beta version of scratch-gui. When debugger and gamepad are enabled, full screen mode looks like this:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/f3aa964d-b517-472c-bb71-d7b77fb620d9)

This happens because React reuses the `stage-header_stage-size-row` when entering full screen mode and changes its class name instead of removing it from the DOM and inserting a new element.

### Reason for changes

To make addons work correctly when the update is released.

### Tests

Tested in both browsers, locally and on scratch.mit.edu.