### PR TITLE
Don't snap to costume mask

### DIFF
--- a/addons/paint-snap/genScalePoints.js
+++ b/addons/paint-snap/genScalePoints.js
@@ -97,7 +97,7 @@ export default function createScalePoints(paper, lib, objects, sx, sy) {
     ...(snapTo.objectEdges
       ? Object.fromEntries(
           objects
-            .filter((item) => !(item.selected || item.data.isHelperItem))
+            .filter((item) => !(item.selected || item.data.isHelperItem || item.locked || item.guide))
             .map((item) =>
               [
                 sx && [
@@ -158,7 +158,7 @@ export default function createScalePoints(paper, lib, objects, sx, sy) {
     ...(snapTo.objectMidlines
       ? Object.fromEntries(
           objects
-            .filter((item) => !(item.selected || item.data.isHelperItem))
+            .filter((item) => !(item.selected || item.data.isHelperItem || item.locked || item.guide))
             .map((item) =>
               [
                 sx && [

--- a/addons/paint-snap/genSnapPoints.js
+++ b/addons/paint-snap/genSnapPoints.js
@@ -124,7 +124,7 @@ export default function createSnapPoints(paper, selectionBounds, lib, objects) {
     ...(snapTo.objectEdges
       ? Object.fromEntries(
           objects
-            .filter((item) => !(item.selected || item.data.isHelperItem))
+            .filter((item) => !(item.selected || item.data.isHelperItem || item.locked || item.guide))
             .map((item) => [
               [
                 `item_${item.id}_r`,
@@ -177,7 +177,7 @@ export default function createSnapPoints(paper, selectionBounds, lib, objects) {
     ...(snapTo.objectCenters
       ? Object.fromEntries(
           objects
-            .filter((item) => !item.selected)
+            .filter((item) => !(item.selected || item.data.isHelperItem || item.locked || item.guide))
             .map((item) => [
               [
                 `item_${item.id}_c`,
@@ -193,7 +193,7 @@ export default function createSnapPoints(paper, selectionBounds, lib, objects) {
     ...(snapTo.objectMidlines
       ? Object.fromEntries(
           objects
-            .filter((item) => !item.selected)
+            .filter((item) => !(item.selected || item.data.isHelperItem || item.locked || item.guide))
             .map((item) => [
               [
                 `item_${item.id}_cx`,
@@ -216,7 +216,7 @@ export default function createSnapPoints(paper, selectionBounds, lib, objects) {
     ...(snapTo.objectCorners
       ? Object.fromEntries(
           objects
-            .filter((item) => !(item.selected || item.data.isHelperItem))
+            .filter((item) => !(item.selected || item.data.isHelperItem || item.locked || item.guide))
             .map((item) => [
               [
                 `item_${item.id}_tl`,


### PR DESCRIPTION
### Changes
Added an extra filter to the snapping algorithm that was using the costume mask, resulting in snapping to center even when snap to page center was disabled

### Tests

(Below images run with only snap from selection center and snap to object center enabled)
Before:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/70162741/cb337803-a279-4bc0-85b6-c412866ca290)
After:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/70162741/93650b1e-28b1-44f0-85bd-a6b4f4096778)

