### PR TITLE
Feature color-related addons at the top of settings (1.32.2)

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2098,7 +2098,7 @@
   "versionAdded": "1.4.0",
   "latestUpdate": {
     "version": "1.33.2",
-    "temporaryNotice": "TODO.",
+    "temporaryNotice": "The presets for this addon have been updated to use Scratch's new purple accent color. Presets that use blue are still available as well.",
     "isMajor": true
   },
   "updateUserstylesOnSettingsChange": true,

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2097,9 +2097,9 @@
   "injectAsStyleElt": true,
   "versionAdded": "1.4.0",
   "latestUpdate": {
-    "version": "1.23.0",
-    "isMajor": true,
-    "temporaryNotice": "You can now completely customize the appearance of the Scratch website."
+    "version": "1.33.2",
+    "temporaryNotice": "TODO.",
+    "isMajor": true
   },
   "updateUserstylesOnSettingsChange": true,
   "userscripts": [

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1206,7 +1206,7 @@
   },
   "latestUpdate": {
     "version": "1.33.2",
-    "temporaryNotice": "TODO.",
+    "temporaryNotice": "The presets for this addon have been updated to use Scratch's new purple accent color. Presets that use blue are still available as well.",
     "isMajor": true
   },
   "tags": ["editor", "theme", "featured"],

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1205,9 +1205,9 @@
     "colors": ["primary", "menuBar", "page", "accent", "workspace", "selector"]
   },
   "latestUpdate": {
-    "version": "1.32.0",
-    "newSettings": ["popup"],
-    "temporaryNotice": "You can now customize the color of popup backdrops (the solid-color background behind prompts for actions like naming a new variable) separately."
+    "version": "1.33.2",
+    "temporaryNotice": "TODO.",
+    "isMajor": true
   },
   "tags": ["editor", "theme", "featured"],
   "enabledByDefault": false

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -28,7 +28,6 @@
   ],
   "latestUpdate": {
     "version": "1.33.2",
-    "temporaryNotice": "TODO.",
     "isMajor": true
   },
   "customCssVariables": [

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -27,8 +27,9 @@
     }
   ],
   "latestUpdate": {
-    "version": "1.31.0",
-    "temporaryNotice": "Two new presets have been added, including a preset for the new high-contrast block colors coming to Scratch soon."
+    "version": "1.33.2",
+    "temporaryNotice": "TODO.",
+    "isMajor": true
   },
   "customCssVariables": [
     {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -562,11 +562,17 @@ let fuse;
       if (manifest.versionAdded) {
         const [extMajor, extMinor, _] = vue.version.split(".");
         const [addonMajor, addonMinor, __] = manifest.versionAdded.split(".");
-        if (extMajor === addonMajor && extMinor === addonMinor) {
+        const excluded_1_33_0 = manifest.versionAdded === "1.33.0";
+        if (!excluded_1_33_0 && extMajor === addonMajor && extMinor === addonMinor) {
           manifest.tags.push("new");
           manifest._groups.push(
             manifest.tags.includes("recommended") || manifest.tags.includes("featured") ? "featuredNew" : "new"
           );
+        } else if (excluded_1_33_0) {
+          // Addon: op-badge
+          // TODO: remove this for v1.34.0 release.
+          manifest.tags.push("new");
+          manifest._groups.push("new");
         }
       }
 


### PR DESCRIPTION
I don't see any reason not to do this (see screenshot).
Also, `op-badge` has been moved to the "other new addons and updates" group,

![brave_PEs9wSk3Ap](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/cf54c001-e0b5-460a-b650-016068e64e1f)
