### PR TITLE
editor-dark-mode: fix scrollbar hover color

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -323,7 +323,9 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 [id^="blocklyGridPattern"] line {
   stroke: var(--editorDarkMode-workspace-dots);
 }
-.blocklyMainWorkspaceScrollbar .blocklyScrollbarHandle {
+.blocklyMainWorkspaceScrollbar .blocklyScrollbarHandle,
+.blocklyMainWorkspaceScrollbar .blocklyScrollbarBackground:hover + .blocklyScrollbarHandle,
+.blocklyMainWorkspaceScrollbar .blocklyScrollbarHandle:hover {
   fill: var(--editorDarkMode-workspace-scrollbar);
 }
 .blocklyInsertionMarker > .blocklyPath {
@@ -350,7 +352,9 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 .blocklyFlyoutButton .blocklyText {
   fill: var(--editorDarkMode-palette-text);
 }
-.blocklyFlyoutScrollbar .blocklyScrollbarHandle {
+.blocklyFlyoutScrollbar .blocklyScrollbarHandle,
+.blocklyFlyoutScrollbar .blocklyScrollbarBackground:hover + .blocklyScrollbarHandle,
+.blocklyFlyoutScrollbar .blocklyScrollbarHandle:hover {
   fill: var(--editorDarkMode-palette-scrollbar);
 }
 


### PR DESCRIPTION
### Changes

Fixes a bug in the beta version of scratch-gui: when the mouse is moved over the code area scrollbar but not over the thumb, the scrollbar reverts to the default color.

The Scratch change that caused this is explained here: https://github.com/scratchfoundation/scratch-blocks/pull/2962#discussion_r1108574249

### Reason for changes

The bug is annoying.

### Tests

Tested locally and on scratch.mit.edu.