### PR TITLE
Use new purple in website addons

### DIFF
--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -88,7 +88,7 @@
       "id": "outline-color",
       "type": "color",
       "allowTransparency": true,
-      "default": "#855cd640",
+      "default": "#4d97ff40",
       "if": {
         "settings": {
           "hide-outline": false,

--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -88,7 +88,7 @@
       "id": "outline-color",
       "type": "color",
       "allowTransparency": true,
-      "default": "#396db540",
+      "default": "#855cd640",
       "if": {
         "settings": {
           "hide-outline": false,

--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -10,7 +10,10 @@
   "userstyles": [
     {
       "url": "hide_outline.css",
-      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
+      "matches": [
+        "projects",
+        "https://scratch.mit.edu/studios/*"
+      ],
       "if": {
         "settings": {
           "hide-outline": true
@@ -19,7 +22,10 @@
     },
     {
       "url": "outline_color.css",
-      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
+      "matches": [
+        "projects",
+        "https://scratch.mit.edu/studios/*"
+      ],
       "if": {
         "settings": {
           "hide-outline": false
@@ -28,7 +34,10 @@
     },
     {
       "url": "fill_transparent.css",
-      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
+      "matches": [
+        "projects",
+        "https://scratch.mit.edu/studios/*"
+      ],
       "if": {
         "settings": {
           "fill-transparent": true
@@ -37,32 +46,47 @@
     },
     {
       "url": "scratchr2/hide_outline.css",
-      "matches": ["https://scratch.mit.edu/users/*", "https://scratch.mit.edu/discuss/*"],
+      "matches": [
+        "https://scratch.mit.edu/users/*",
+        "https://scratch.mit.edu/discuss/*"
+      ],
       "if": {
         "settings": {
           "hide-outline": true
         },
-        "addonEnabled": ["scratchr2"]
+        "addonEnabled": [
+          "scratchr2"
+        ]
       }
     },
     {
       "url": "scratchr2/outline_color.css",
-      "matches": ["https://scratch.mit.edu/users/*", "https://scratch.mit.edu/discuss/*"],
+      "matches": [
+        "https://scratch.mit.edu/users/*",
+        "https://scratch.mit.edu/discuss/*"
+      ],
       "if": {
         "settings": {
           "hide-outline": false
         },
-        "addonEnabled": ["scratchr2"]
+        "addonEnabled": [
+          "scratchr2"
+        ]
       }
     },
     {
       "url": "scratchr2/fill_transparent.css",
-      "matches": ["https://scratch.mit.edu/users/*", "https://scratch.mit.edu/discuss/*"],
+      "matches": [
+        "https://scratch.mit.edu/users/*",
+        "https://scratch.mit.edu/discuss/*"
+      ],
       "if": {
         "settings": {
           "fill-transparent": true
         },
-        "addonEnabled": ["scratchr2"]
+        "addonEnabled": [
+          "scratchr2"
+        ]
       }
     }
   ],
@@ -88,7 +112,7 @@
       "id": "outline-color",
       "type": "color",
       "allowTransparency": true,
-      "default": "#4d97ff40",
+      "default": "#396db540",
       "if": {
         "settings": {
           "hide-outline": false,
@@ -97,7 +121,10 @@
       }
     }
   ],
-  "tags": ["community", "theme"],
+  "tags": [
+    "community",
+    "theme"
+  ],
   "versionAdded": "1.18.0",
   "enabledByDefault": false
 }

--- a/addons/customize-avatar-border/addon.json
+++ b/addons/customize-avatar-border/addon.json
@@ -10,10 +10,7 @@
   "userstyles": [
     {
       "url": "hide_outline.css",
-      "matches": [
-        "projects",
-        "https://scratch.mit.edu/studios/*"
-      ],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "hide-outline": true
@@ -22,10 +19,7 @@
     },
     {
       "url": "outline_color.css",
-      "matches": [
-        "projects",
-        "https://scratch.mit.edu/studios/*"
-      ],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "hide-outline": false
@@ -34,10 +28,7 @@
     },
     {
       "url": "fill_transparent.css",
-      "matches": [
-        "projects",
-        "https://scratch.mit.edu/studios/*"
-      ],
+      "matches": ["projects", "https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "fill-transparent": true
@@ -46,47 +37,32 @@
     },
     {
       "url": "scratchr2/hide_outline.css",
-      "matches": [
-        "https://scratch.mit.edu/users/*",
-        "https://scratch.mit.edu/discuss/*"
-      ],
+      "matches": ["https://scratch.mit.edu/users/*", "https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "hide-outline": true
         },
-        "addonEnabled": [
-          "scratchr2"
-        ]
+        "addonEnabled": ["scratchr2"]
       }
     },
     {
       "url": "scratchr2/outline_color.css",
-      "matches": [
-        "https://scratch.mit.edu/users/*",
-        "https://scratch.mit.edu/discuss/*"
-      ],
+      "matches": ["https://scratch.mit.edu/users/*", "https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "hide-outline": false
         },
-        "addonEnabled": [
-          "scratchr2"
-        ]
+        "addonEnabled": ["scratchr2"]
       }
     },
     {
       "url": "scratchr2/fill_transparent.css",
-      "matches": [
-        "https://scratch.mit.edu/users/*",
-        "https://scratch.mit.edu/discuss/*"
-      ],
+      "matches": ["https://scratch.mit.edu/users/*", "https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "fill-transparent": true
         },
-        "addonEnabled": [
-          "scratchr2"
-        ]
+        "addonEnabled": ["scratchr2"]
       }
     }
   ],
@@ -121,10 +97,7 @@
       }
     }
   ],
-  "tags": [
-    "community",
-    "theme"
-  ],
+  "tags": ["community", "theme"],
   "versionAdded": "1.18.0",
   "enabledByDefault": false
 }

--- a/addons/necropost-highlighter/style.css
+++ b/addons/necropost-highlighter/style.css
@@ -1,3 +1,3 @@
 .highlighted-necropost {
-  background-color: var(--darkWww-highlight-transparent20, #855cd63);
+  background-color: var(--darkWww-highlight-transparent20, #855cd633);
 }

--- a/addons/necropost-highlighter/style.css
+++ b/addons/necropost-highlighter/style.css
@@ -1,3 +1,3 @@
 .highlighted-necropost {
-  background-color: var(--darkWww-highlight-transparent20, #4d97ff33);
+  background-color: var(--darkWww-highlight-transparent20, #396db533);
 }

--- a/addons/necropost-highlighter/style.css
+++ b/addons/necropost-highlighter/style.css
@@ -1,3 +1,3 @@
 .highlighted-necropost {
-  background-color: var(--darkWww-highlight-transparent20, #396db533);
+  background-color: var(--darkWww-highlight-transparent20, #855cd63);
 }

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -12,7 +12,12 @@
       "id": "itemsPerRow"
     }
   ],
-  "tags": ["community", "theme", "studios", "featured"],
+  "tags": [
+    "community",
+    "theme",
+    "studios",
+    "featured"
+  ],
   "credits": [
     {
       "name": "Maximouse",
@@ -24,14 +29,14 @@
       "name": "defaultLinkIconFilter",
       "value": {
         "type": "recolorFilter",
-        "source": "#4d97ff"
+        "source": "#855cd6"
       }
     },
     {
       "name": "defaultLinkHoverIconFilter",
       "value": {
         "type": "recolorFilter",
-        "source": "#4280d7"
+        "source": "#396db5"
       }
     }
   ],
@@ -43,27 +48,39 @@
   "userscripts": [
     {
       "url": "classes.js",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": [
+        "https://scratch.mit.edu/studios/*"
+      ],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/studios/*"]
+      "matches": [
+        "https://scratch.mit.edu/studios/*"
+      ]
     },
     {
       "url": "default.css",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": [
+        "https://scratch.mit.edu/studios/*"
+      ],
       "if": {
-        "settings": { "version": "default" }
+        "settings": {
+          "version": "default"
+        }
       }
     },
     {
       "url": "scratchr2.css",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": [
+        "https://scratch.mit.edu/studios/*"
+      ],
       "if": {
-        "settings": { "version": "scratchr2" }
+        "settings": {
+          "version": "scratchr2"
+        }
       }
     }
   ],

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -56,18 +56,14 @@
       "url": "default.css",
       "matches": ["https://scratch.mit.edu/studios/*"],
       "if": {
-        "settings": {
-          "version": "default"
-        }
+        "settings": { "version": "default" }
       }
     },
     {
       "url": "scratchr2.css",
       "matches": ["https://scratch.mit.edu/studios/*"],
       "if": {
-        "settings": {
-          "version": "scratchr2"
-        }
+        "settings": { "version": "scratchr2" }
       }
     }
   ],

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -12,12 +12,7 @@
       "id": "itemsPerRow"
     }
   ],
-  "tags": [
-    "community",
-    "theme",
-    "studios",
-    "featured"
-  ],
+  "tags": ["community", "theme", "studios", "featured"],
   "credits": [
     {
       "name": "Maximouse",
@@ -48,24 +43,18 @@
   "userscripts": [
     {
       "url": "classes.js",
-      "matches": [
-        "https://scratch.mit.edu/studios/*"
-      ],
+      "matches": ["https://scratch.mit.edu/studios/*"],
       "runAtComplete": false
     }
   ],
   "userstyles": [
     {
       "url": "style.css",
-      "matches": [
-        "https://scratch.mit.edu/studios/*"
-      ]
+      "matches": ["https://scratch.mit.edu/studios/*"]
     },
     {
       "url": "default.css",
-      "matches": [
-        "https://scratch.mit.edu/studios/*"
-      ],
+      "matches": ["https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "version": "default"
@@ -74,9 +63,7 @@
     },
     {
       "url": "scratchr2.css",
-      "matches": [
-        "https://scratch.mit.edu/studios/*"
-      ],
+      "matches": ["https://scratch.mit.edu/studios/*"],
       "if": {
         "settings": {
           "version": "scratchr2"

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -31,7 +31,7 @@
       "name": "defaultLinkHoverIconFilter",
       "value": {
         "type": "recolorFilter",
-        "source": "#396db5"
+        "source": "#855cd6"
       }
     }
   ],

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -31,7 +31,7 @@
       "name": "defaultLinkHoverIconFilter",
       "value": {
         "type": "recolorFilter",
-        "source": "#855cd6"
+        "source": "#7854c0"
       }
     }
   ],

--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -81,7 +81,7 @@
 }
 .studio-info .studio-info-footer-report button:hover {
   background: transparent;
-  color: var(--darkWww-link-hover, #855cd6);
+  color: var(--darkWww-link-hover, #7854c0);
 }
 .studio-info .studio-info-footer-report button img {
   filter: var(--darkWww-link-iconFilter, var(--oldStudioLayout-defaultLinkIconFilter));

--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -81,7 +81,7 @@
 }
 .studio-info .studio-info-footer-report button:hover {
   background: transparent;
-  color: var(--darkWww-link-hover, #396db5);
+  color: var(--darkWww-link-hover, #855cd6);
 }
 .studio-info .studio-info-footer-report button img {
   filter: var(--darkWww-link-iconFilter, var(--oldStudioLayout-defaultLinkIconFilter));

--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -75,13 +75,13 @@
   margin: 0.25em;
   padding: 0;
   background: transparent;
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #855cd6);
   font-size: 1em;
   font-weight: bold;
 }
 .studio-info .studio-info-footer-report button:hover {
   background: transparent;
-  color: var(--darkWww-link-hover, #4280d7);
+  color: var(--darkWww-link-hover, #396db5);
 }
 .studio-info .studio-info-footer-report button img {
   filter: var(--darkWww-link-iconFilter, var(--oldStudioLayout-defaultLinkIconFilter));

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -39,9 +39,7 @@
       "url": "forums_bubbles.css",
       "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
-        "settings": {
-          "postStyle": "bubble"
-        }
+        "settings": { "postStyle": "bubble" }
       }
     },
     {

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -1,11 +1,7 @@
 {
   "name": "Scratch 2.0 \u2192 3.0",
   "description": "Makes Scratch 2.0-styled pages look like Scratch 3.0.",
-  "tags": [
-    "community",
-    "theme",
-    "recommended"
-  ],
+  "tags": ["community", "theme", "recommended"],
   "credits": [
     {
       "name": "Maximouse",
@@ -29,27 +25,19 @@
   "userstyles": [
     {
       "url": "scratchr2.css",
-      "matches": [
-        "isNotScratchWWW"
-      ]
+      "matches": ["isNotScratchWWW"]
     },
     {
       "url": "scratchr2_errors.css",
-      "matches": [
-        "isNotScratchWWW"
-      ]
+      "matches": ["isNotScratchWWW"]
     },
     {
       "url": "forums.css",
-      "matches": [
-        "https://scratch.mit.edu/discuss/*"
-      ]
+      "matches": ["https://scratch.mit.edu/discuss/*"]
     },
     {
       "url": "forums_bubbles.css",
-      "matches": [
-        "https://scratch.mit.edu/discuss/*"
-      ],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": {
           "postStyle": "bubble"
@@ -58,9 +46,7 @@
     },
     {
       "url": "forums_topic.css",
-      "matches": [
-        "https://scratch.mit.edu/discuss/topic/*/"
-      ]
+      "matches": ["https://scratch.mit.edu/discuss/topic/*/"]
     },
     {
       "url": "forums_subpage.css",
@@ -73,28 +59,19 @@
     },
     {
       "url": "forums_yt.css",
-      "matches": [
-        "https://scratch.mit.edu/discuss/youtube/*/"
-      ]
+      "matches": ["https://scratch.mit.edu/discuss/youtube/*/"]
     },
     {
       "url": "profile.css",
-      "matches": [
-        "https://scratch.mit.edu/users/*/",
-        "https://scratch.mit.edu/classes/*/"
-      ]
+      "matches": ["https://scratch.mit.edu/users/*/", "https://scratch.mit.edu/classes/*/"]
     },
     {
       "url": "scratchr2_comments.css",
-      "matches": [
-        "https://scratch.mit.edu/users/*/"
-      ]
+      "matches": ["https://scratch.mit.edu/users/*/"]
     },
     {
       "url": "remixtree.css",
-      "matches": [
-        "https://scratch.mit.edu/projects/*/remixtree/"
-      ]
+      "matches": ["https://scratch.mit.edu/projects/*/remixtree/"]
     },
     {
       "url": "v_tabs.css",
@@ -107,9 +84,7 @@
     },
     {
       "url": "mystuff.css",
-      "matches": [
-        "https://scratch.mit.edu/mystuff/"
-      ]
+      "matches": ["https://scratch.mit.edu/mystuff/"]
     },
     {
       "url": "settings.css",

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -13,7 +13,7 @@
       "name": "defaultLinkIconFilter",
       "value": {
         "type": "recolorFilter",
-        "source": "#396db5"
+        "source": "#855cd6"
       }
     }
   ],

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -1,7 +1,11 @@
 {
   "name": "Scratch 2.0 \u2192 3.0",
   "description": "Makes Scratch 2.0-styled pages look like Scratch 3.0.",
-  "tags": ["community", "theme", "recommended"],
+  "tags": [
+    "community",
+    "theme",
+    "recommended"
+  ],
   "credits": [
     {
       "name": "Maximouse",
@@ -13,7 +17,7 @@
       "name": "defaultLinkIconFilter",
       "value": {
         "type": "recolorFilter",
-        "source": "#4d97ff"
+        "source": "#396db5"
       }
     }
   ],
@@ -25,26 +29,38 @@
   "userstyles": [
     {
       "url": "scratchr2.css",
-      "matches": ["isNotScratchWWW"]
+      "matches": [
+        "isNotScratchWWW"
+      ]
     },
     {
       "url": "scratchr2_errors.css",
-      "matches": ["isNotScratchWWW"]
+      "matches": [
+        "isNotScratchWWW"
+      ]
     },
     {
       "url": "forums.css",
-      "matches": ["https://scratch.mit.edu/discuss/*"]
+      "matches": [
+        "https://scratch.mit.edu/discuss/*"
+      ]
     },
     {
       "url": "forums_bubbles.css",
-      "matches": ["https://scratch.mit.edu/discuss/*"],
+      "matches": [
+        "https://scratch.mit.edu/discuss/*"
+      ],
       "if": {
-        "settings": { "postStyle": "bubble" }
+        "settings": {
+          "postStyle": "bubble"
+        }
       }
     },
     {
       "url": "forums_topic.css",
-      "matches": ["https://scratch.mit.edu/discuss/topic/*/"]
+      "matches": [
+        "https://scratch.mit.edu/discuss/topic/*/"
+      ]
     },
     {
       "url": "forums_subpage.css",
@@ -57,19 +73,28 @@
     },
     {
       "url": "forums_yt.css",
-      "matches": ["https://scratch.mit.edu/discuss/youtube/*/"]
+      "matches": [
+        "https://scratch.mit.edu/discuss/youtube/*/"
+      ]
     },
     {
       "url": "profile.css",
-      "matches": ["https://scratch.mit.edu/users/*/", "https://scratch.mit.edu/classes/*/"]
+      "matches": [
+        "https://scratch.mit.edu/users/*/",
+        "https://scratch.mit.edu/classes/*/"
+      ]
     },
     {
       "url": "scratchr2_comments.css",
-      "matches": ["https://scratch.mit.edu/users/*/"]
+      "matches": [
+        "https://scratch.mit.edu/users/*/"
+      ]
     },
     {
       "url": "remixtree.css",
-      "matches": ["https://scratch.mit.edu/projects/*/remixtree/"]
+      "matches": [
+        "https://scratch.mit.edu/projects/*/remixtree/"
+      ]
     },
     {
       "url": "v_tabs.css",
@@ -82,7 +107,9 @@
     },
     {
       "url": "mystuff.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"]
+      "matches": [
+        "https://scratch.mit.edu/mystuff/"
+      ]
     },
     {
       "url": "settings.css",

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -170,7 +170,7 @@ body > #pagewrapper {
   color: var(--darkWww-button-text, white);
 }
 .pagination .current:hover {
-  background-color: var(--darkWww-button-variant, #4280d7);
+  background-color: var(--darkWww-button-variant, #7854c0);
 }
 .pagination .disabled {
   opacity: 0.5;
@@ -297,7 +297,7 @@ body > #pagewrapper {
 }
 .postmsg ::selection {
   /* Don't break [color=transparent] hidden text */
-  background-color: var(--darkWww-button-variant, #4280d7);
+  background-color: var(--darkWww-button-variant, #7854c0);
   color: var(--darkWww-button-text, white);
 }
 .postfootright > ul {

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -165,7 +165,7 @@ body > #pagewrapper {
   color: var(--darkWww-page-text, #575e75);
 }
 .pagination .current {
-  background-color: var(--darkWww-button, #396db5);
+  background-color: var(--darkWww-button, #855cd6);
   border-color: rgba(0, 0, 0, 0.15);
   color: var(--darkWww-button-text, white);
 }
@@ -269,13 +269,13 @@ body > #pagewrapper {
   overflow: hidden;
   border-radius: 4px;
   background-color: var(--darkWww-gray, #f2f2f2);
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
   font-size: 16px;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 .djangobb .username:visited:not(:hover) {
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
 }
 .djangobb .username:hover {
   width: -moz-fit-content;

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -297,7 +297,7 @@ body > #pagewrapper {
 }
 .postmsg ::selection {
   /* Don't break [color=transparent] hidden text */
-  background-color: var(--darkWww-button-variant, #7854c0);
+  background-color: #3373cc;
   color: var(--darkWww-button-text, white);
 }
 .postfootright > ul {

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -165,7 +165,7 @@ body > #pagewrapper {
   color: var(--darkWww-page-text, #575e75);
 }
 .pagination .current {
-  background-color: var(--darkWww-button, #4d97ff);
+  background-color: var(--darkWww-button, #396db5);
   border-color: rgba(0, 0, 0, 0.15);
   color: var(--darkWww-button-text, white);
 }
@@ -269,13 +269,13 @@ body > #pagewrapper {
   overflow: hidden;
   border-radius: 4px;
   background-color: var(--darkWww-gray, #f2f2f2);
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
   font-size: 16px;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 .djangobb .username:visited:not(:hover) {
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
 }
 .djangobb .username:hover {
   width: -moz-fit-content;

--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -84,7 +84,7 @@
 .action-bar .inner .dropdown:focus,
 .action-bar .inner .dropdown.open {
   background-image: var(--darkWww-input-caretHover, url("%addon-self-dir%/assets/caret_hover.svg"));
-  border-color: var(--darkWww-button, #4d97ff);
+  border-color: var(--darkWww-button, #396db5);
 }
 .action-bar .inner .dropdown .dropdown-toggle {
   display: block;
@@ -108,7 +108,7 @@
   height: 48px;
   background-color: var(--darkWww-box, white);
   border-radius: 4px;
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
   font-size: 14px;
 }
 .action-bar .inner .button:not(.dropdown) > span {
@@ -119,7 +119,7 @@
 .box .box-head .buttons .button {
   background-color: var(--darkWww-box, white);
   border-radius: 4px;
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
 }
 .media-list {
   padding: 0;
@@ -160,7 +160,7 @@
   top: 9px;
 }
 .media-control .dropdown-menu {
-  background-color: var(--darkWww-navbar, #4d97ff);
+  background-color: var(--darkWww-navbar, #396db5);
   left: 0;
   border: 1px solid rgba(0, 0, 0, 0.1);
   min-width: 218px;

--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -84,7 +84,7 @@
 .action-bar .inner .dropdown:focus,
 .action-bar .inner .dropdown.open {
   background-image: var(--darkWww-input-caretHover, url("%addon-self-dir%/assets/caret_hover.svg"));
-  border-color: var(--darkWww-button, #396db5);
+  border-color: var(--darkWww-button, #855cd6);
 }
 .action-bar .inner .dropdown .dropdown-toggle {
   display: block;
@@ -108,7 +108,7 @@
   height: 48px;
   background-color: var(--darkWww-box, white);
   border-radius: 4px;
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
   font-size: 14px;
 }
 .action-bar .inner .button:not(.dropdown) > span {
@@ -119,7 +119,7 @@
 .box .box-head .buttons .button {
   background-color: var(--darkWww-box, white);
   border-radius: 4px;
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
 }
 .media-list {
   padding: 0;
@@ -160,7 +160,7 @@
   top: 9px;
 }
 .media-control .dropdown-menu {
-  background-color: var(--darkWww-navbar, #396db5);
+  background-color: var(--darkWww-navbar, #855cd6);
   left: 0;
   border: 1px solid rgba(0, 0, 0, 0.1);
   min-width: 218px;

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -1,5 +1,5 @@
 a:visited {
-  color: #855cd6;
+  color: var(--darkWww-link), #855cd6;
 }
 a:active,
 a:active:hover,

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -4,7 +4,7 @@ a:visited {
 a:active,
 a:active:hover,
 a:visited:hover {
-  color: #7854c0;
+  color: var(--darkWww-link-hover, #7854c0);
 }
 #zoomContainer {
   height: 24px;

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -1,5 +1,5 @@
 a:visited {
-  color: #4d97ff;
+  color: #396db5;
 }
 a:active,
 a:active:hover,

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -4,7 +4,7 @@ a:visited {
 a:active,
 a:active:hover,
 a:visited:hover {
-  color: #4280d7;
+  color: #7854c0;
 }
 #zoomContainer {
   height: 24px;

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -1,5 +1,5 @@
 a:visited {
-  color: #396db5;
+  color: #855cd6;
 }
 a:active,
 a:active:hover,

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -1,5 +1,5 @@
 a:visited {
-  color: var(--darkWww-link), #855cd6;
+  color: var(--darkWww-link, #855cd6);
 }
 a:active,
 a:active:hover,

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -41,7 +41,7 @@ input.link:hover,
 input.link:active,
 input.link.black:hover,
 input.link.black:active {
-  color: var(--darkWww-link-hover, #4280d7);
+  color: var(--darkWww-link-hover, #7854c0);
   text-decoration: none;
 }
 #content {
@@ -625,7 +625,7 @@ select:focus {
   background-color: var(--darkWww-navbar, #855cd6);
   border: none;
   color: var(--darkWww-navbar-text, white);
-  box-shadow: inset 0 -1px 0 0 var(--darkWww-navbar-variant, #4280d7);
+  box-shadow: inset 0 -1px 0 0 var(--darkWww-navbar-variant, #7854c0);
 }
 .modal .modal-header .close,
 .jqui-modal .ui-widget-header .ui-dialog-titlebar-close {

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -89,7 +89,7 @@ textarea:focus {
 .editable-empty.write {
   border-style: solid !important;
   border-color: var(--darkWww-button, #855cd6) !important;
-  box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
+  box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(133, 92, 214, 0.25));
 }
 .editable textarea,
 .editable-empty textarea,

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -8,7 +8,7 @@ a,
 input.link,
 .ui-widget-content a,
 #email-resend-box a {
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
   font-weight: bold;
   text-decoration: none;
 }
@@ -70,11 +70,11 @@ textarea {
 }
 input:focus {
   box-shadow: none;
-  border-color: var(--darkWww-button, #396db5);
+  border-color: var(--darkWww-button, #855cd6);
 }
 textarea:focus {
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
-  border: 2px solid var(--darkWww-button, #396db5);
+  border: 2px solid var(--darkWww-button, #855cd6);
 }
 .editable-empty,
 .editable.read,
@@ -88,7 +88,7 @@ textarea:focus {
 .editable.write,
 .editable-empty.write {
   border-style: solid !important;
-  border-color: var(--darkWww-button, #396db5) !important;
+  border-color: var(--darkWww-button, #855cd6) !important;
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
 }
 .editable textarea,
@@ -138,7 +138,7 @@ button.grey,
 #email-resend-box input[type="button"]:hover {
   border-radius: 8px;
   border: none;
-  background: var(--darkWww-button, #396db5);
+  background: var(--darkWww-button, #855cd6);
   box-shadow: none;
   font-family: inherit;
   font-weight: bold;
@@ -208,7 +208,7 @@ select:focus {
   background-image: var(--darkWww-input-caretHover, url("%addon-self-dir%/assets/caret_hover.svg"));
 }
 select:focus {
-  border-color: var(--darkWww-button, #396db5);
+  border-color: var(--darkWww-button, #855cd6);
   outline: none;
 }
 .box {
@@ -231,7 +231,7 @@ select:focus {
   font-weight: normal;
   top: 24px;
   left: -1px;
-  border: 1px solid #396db5;
+  border: 1px solid #855cd6;
   box-shadow: none;
 }
 #footer {
@@ -282,7 +282,7 @@ select:focus {
 #topnav .innerwrap {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
-  background-color: var(--darkWww-navbar, #396db5);
+  background-color: var(--darkWww-navbar, #855cd6);
   height: 50px;
 }
 #topnav .logo {
@@ -385,7 +385,7 @@ select:focus {
 }
 #topnav ul.account-nav .sign-in .popover {
   margin-top: 40px;
-  background-color: var(--darkWww-navbar, #396db5);
+  background-color: var(--darkWww-navbar, #855cd6);
   border-color: rgba(0, 0, 0, 0.1);
   cursor: auto;
 }
@@ -394,7 +394,7 @@ select:focus {
   width: 14px;
   height: 14px;
   transform: rotate(45deg);
-  background-color: var(--darkWww-navbar, #396db5);
+  background-color: var(--darkWww-navbar, #855cd6);
   border: none;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
@@ -432,7 +432,7 @@ select:focus {
   height: auto;
   background-color: var(--darkWww-box, white);
   border-radius: 8px;
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
   font-size: 12.8px;
   line-height: 24px;
 }
@@ -514,7 +514,7 @@ select:focus {
   line-height: 24px;
 }
 #topnav ul.account-nav .logged-in-user .dropdown-menu {
-  background-color: var(--darkWww-navbar, #396db5);
+  background-color: var(--darkWww-navbar, #855cd6);
   margin-top: 0;
   top: 50px;
   padding-top: 5px;
@@ -577,7 +577,7 @@ select:focus {
 }
 .alert-info {
   background-color: var(--darkWww-blue, #e9f1fc);
-  border-color: var(--darkWww-button, #396db5);
+  border-color: var(--darkWww-button, #855cd6);
 }
 .alert-success {
   background-color: var(--darkWww-box-success, #cef2e8);
@@ -622,7 +622,7 @@ select:focus {
   padding-top: 8px;
   padding-right: 8px;
   border-radius: 16px 16px 0 0;
-  background-color: var(--darkWww-navbar, #396db5);
+  background-color: var(--darkWww-navbar, #855cd6);
   border: none;
   color: var(--darkWww-navbar-text, white);
   box-shadow: inset 0 -1px 0 0 var(--darkWww-navbar-variant, #4280d7);
@@ -674,7 +674,7 @@ select:focus {
   border-radius: 8px;
 }
 #featured-project-modal .project.thumb.selected {
-  border-color: var(--darkWww-button, #396db5) !important;
+  border-color: var(--darkWww-button, #855cd6) !important;
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
 }
 #featured-project-modal .project.thumb img {
@@ -703,5 +703,5 @@ select:focus {
 .modal-footer .btn:not(.blue) {
   border: 1px solid var(--darkWww-border, rgba(0, 0, 0, 0.1));
   background: var(--darkWww-box, white);
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
 }

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -73,7 +73,7 @@ input:focus {
   border-color: var(--darkWww-button, #855cd6);
 }
 textarea:focus {
-  box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
+  box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(133, 92, 214, 0.25));
   border: 2px solid var(--darkWww-button, #855cd6);
 }
 .editable-empty,

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -8,7 +8,7 @@ a,
 input.link,
 .ui-widget-content a,
 #email-resend-box a {
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
   font-weight: bold;
   text-decoration: none;
 }
@@ -70,11 +70,11 @@ textarea {
 }
 input:focus {
   box-shadow: none;
-  border-color: var(--darkWww-button, #4d97ff);
+  border-color: var(--darkWww-button, #396db5);
 }
 textarea:focus {
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
-  border: 2px solid var(--darkWww-button, #4d97ff);
+  border: 2px solid var(--darkWww-button, #396db5);
 }
 .editable-empty,
 .editable.read,
@@ -88,7 +88,7 @@ textarea:focus {
 .editable.write,
 .editable-empty.write {
   border-style: solid !important;
-  border-color: var(--darkWww-button, #4d97ff) !important;
+  border-color: var(--darkWww-button, #396db5) !important;
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
 }
 .editable textarea,
@@ -138,7 +138,7 @@ button.grey,
 #email-resend-box input[type="button"]:hover {
   border-radius: 8px;
   border: none;
-  background: var(--darkWww-button, #4d97ff);
+  background: var(--darkWww-button, #396db5);
   box-shadow: none;
   font-family: inherit;
   font-weight: bold;
@@ -208,7 +208,7 @@ select:focus {
   background-image: var(--darkWww-input-caretHover, url("%addon-self-dir%/assets/caret_hover.svg"));
 }
 select:focus {
-  border-color: var(--darkWww-button, #4d97ff);
+  border-color: var(--darkWww-button, #396db5);
   outline: none;
 }
 .box {
@@ -231,7 +231,7 @@ select:focus {
   font-weight: normal;
   top: 24px;
   left: -1px;
-  border: 1px solid #4d97ff;
+  border: 1px solid #396db5;
   box-shadow: none;
 }
 #footer {
@@ -282,7 +282,7 @@ select:focus {
 #topnav .innerwrap {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
-  background-color: var(--darkWww-navbar, #4d97ff);
+  background-color: var(--darkWww-navbar, #396db5);
   height: 50px;
 }
 #topnav .logo {
@@ -385,7 +385,7 @@ select:focus {
 }
 #topnav ul.account-nav .sign-in .popover {
   margin-top: 40px;
-  background-color: var(--darkWww-navbar, #4d97ff);
+  background-color: var(--darkWww-navbar, #396db5);
   border-color: rgba(0, 0, 0, 0.1);
   cursor: auto;
 }
@@ -394,7 +394,7 @@ select:focus {
   width: 14px;
   height: 14px;
   transform: rotate(45deg);
-  background-color: var(--darkWww-navbar, #4d97ff);
+  background-color: var(--darkWww-navbar, #396db5);
   border: none;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-left: 1px solid rgba(0, 0, 0, 0.1);
@@ -432,7 +432,7 @@ select:focus {
   height: auto;
   background-color: var(--darkWww-box, white);
   border-radius: 8px;
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
   font-size: 12.8px;
   line-height: 24px;
 }
@@ -514,7 +514,7 @@ select:focus {
   line-height: 24px;
 }
 #topnav ul.account-nav .logged-in-user .dropdown-menu {
-  background-color: var(--darkWww-navbar, #4d97ff);
+  background-color: var(--darkWww-navbar, #396db5);
   margin-top: 0;
   top: 50px;
   padding-top: 5px;
@@ -577,7 +577,7 @@ select:focus {
 }
 .alert-info {
   background-color: var(--darkWww-blue, #e9f1fc);
-  border-color: var(--darkWww-button, #4d97ff);
+  border-color: var(--darkWww-button, #396db5);
 }
 .alert-success {
   background-color: var(--darkWww-box-success, #cef2e8);
@@ -622,7 +622,7 @@ select:focus {
   padding-top: 8px;
   padding-right: 8px;
   border-radius: 16px 16px 0 0;
-  background-color: var(--darkWww-navbar, #4d97ff);
+  background-color: var(--darkWww-navbar, #396db5);
   border: none;
   color: var(--darkWww-navbar-text, white);
   box-shadow: inset 0 -1px 0 0 var(--darkWww-navbar-variant, #4280d7);
@@ -674,7 +674,7 @@ select:focus {
   border-radius: 8px;
 }
 #featured-project-modal .project.thumb.selected {
-  border-color: var(--darkWww-button, #4d97ff) !important;
+  border-color: var(--darkWww-button, #396db5) !important;
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
 }
 #featured-project-modal .project.thumb img {
@@ -703,5 +703,5 @@ select:focus {
 .modal-footer .btn:not(.blue) {
   border: 1px solid var(--darkWww-border, rgba(0, 0, 0, 0.1));
   background: var(--darkWww-box, white);
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
 }

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -675,7 +675,7 @@ select:focus {
 }
 #featured-project-modal .project.thumb.selected {
   border-color: var(--darkWww-button, #855cd6) !important;
-  box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
+  box-shadow: 0 0 0 4px var(--darkWww-button-transparent25, rgba(133, 92, 214, 0.25));
 }
 #featured-project-modal .project.thumb img {
   border: none;

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -118,7 +118,7 @@
   border-radius: 8px;
 }
 #comments .comment .info .name a {
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
 }
 #comments .comment .info .name a:hover {
   color: var(--darkWww-link-hover, #4280d7);
@@ -170,7 +170,7 @@
   padding: 0 8px;
   background-color: var(--darkWww-blue, #eaf1fc);
   border: none;
-  color: var(--darkWww-link, #4d97ff);
+  color: var(--darkWww-link, #396db5);
   font-weight: bold;
 }
 #comments .more-replies:hover .pulldown {

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -121,7 +121,7 @@
   color: var(--darkWww-link, #855cd6);
 }
 #comments .comment .info .name a:hover {
-  color: var(--darkWww-link-hover, #4280d7);
+  color: var(--darkWww-link-hover, #7854c0);
 }
 #comments .comment .info .time {
   color: var(--darkWww-box-transparentText, #b3b3b3);
@@ -174,7 +174,7 @@
   font-weight: bold;
 }
 #comments .more-replies:hover .pulldown {
-  color: var(--darkWww-link-hover, #4280d7);
+  color: var(--darkWww-link-hover, #7854c0);
 }
 #comments .comment form > .control-group:last-child {
   /* emoji-picker compatibility */

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -118,7 +118,7 @@
   border-radius: 8px;
 }
 #comments .comment .info .name a {
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
 }
 #comments .comment .info .name a:hover {
   color: var(--darkWww-link-hover, #4280d7);
@@ -170,7 +170,7 @@
   padding: 0 8px;
   background-color: var(--darkWww-blue, #eaf1fc);
   border: none;
-  color: var(--darkWww-link, #396db5);
+  color: var(--darkWww-link, #855cd6);
   font-weight: bold;
 }
 #comments .more-replies:hover .pulldown {

--- a/addons/scratchr2/v_tabs.css
+++ b/addons/scratchr2/v_tabs.css
@@ -15,7 +15,7 @@
   padding-top: 20px;
   padding-bottom: 8px;
   border-radius: 0;
-  background: #396db5;
+  background: #855cd6;
   border: none;
 }
 #content > .cols > .col-12 > .box > .box-head h2 {
@@ -58,7 +58,7 @@
   border-color: var(--darkWww-border, rgba(0, 0, 0, 0.1));
 }
 .v-tabs li.active {
-  background-color: var(--darkWww-button, #396db5);
+  background-color: var(--darkWww-button, #855cd6);
   border: 1px solid rgba(0, 0, 0, 0.15);
 }
 .v-tabs li.active:hover {

--- a/addons/scratchr2/v_tabs.css
+++ b/addons/scratchr2/v_tabs.css
@@ -15,7 +15,7 @@
   padding-top: 20px;
   padding-bottom: 8px;
   border-radius: 0;
-  background: #4d97ff;
+  background: #396db5;
   border: none;
 }
 #content > .cols > .col-12 > .box > .box-head h2 {
@@ -58,7 +58,7 @@
   border-color: var(--darkWww-border, rgba(0, 0, 0, 0.1));
 }
 .v-tabs li.active {
-  background-color: var(--darkWww-button, #4d97ff);
+  background-color: var(--darkWww-button, #396db5);
   border: 1px solid rgba(0, 0, 0, 0.15);
 }
 .v-tabs li.active:hover {

--- a/addons/scratchr2/v_tabs.css
+++ b/addons/scratchr2/v_tabs.css
@@ -62,7 +62,7 @@
   border: 1px solid rgba(0, 0, 0, 0.15);
 }
 .v-tabs li.active:hover {
-  background-color: var(--darkWww-button-variant, #4280d7);
+  background-color: var(--darkWww-button-variant, #7854c0);
   border: 1px solid rgba(0, 0, 0, 0.15);
 }
 .v-tabs li a {

--- a/addons/scratchr2/view_all.css
+++ b/addons/scratchr2/view_all.css
@@ -107,7 +107,7 @@ body,
   color: var(--darkWww-gray-text, #575e75);
 }
 .box .box-content .pagination .active {
-  background-color: var(--darkWww-button, #396db5);
+  background-color: var(--darkWww-button, #855cd6);
   border-color: rgba(0, 0, 0, 0.15);
   color: var(--darkWww-button-text, white);
 }

--- a/addons/scratchr2/view_all.css
+++ b/addons/scratchr2/view_all.css
@@ -112,7 +112,7 @@ body,
   color: var(--darkWww-button-text, white);
 }
 .box .box-content .pagination .active:hover {
-  background-color: var(--darkWww-button-variant, #4280d7);
+  background-color: var(--darkWww-button-variant, #7854c0);
 }
 .box .box-content .pagination .disabled {
   opacity: 0.5;

--- a/addons/scratchr2/view_all.css
+++ b/addons/scratchr2/view_all.css
@@ -107,7 +107,7 @@ body,
   color: var(--darkWww-gray-text, #575e75);
 }
 .box .box-content .pagination .active {
-  background-color: var(--darkWww-button, #4d97ff);
+  background-color: var(--darkWww-button, #396db5);
   border-color: rgba(0, 0, 0, 0.15);
   color: var(--darkWww-button-text, white);
 }

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -175,7 +175,7 @@ export default async function ({ addon, msg, console }) {
               }),
               fill: false,
               showLine: true,
-              borderColor: "#396db5",
+              borderColor: "#855cd6",
               lineTension: 0,
             },
           ],

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -175,7 +175,7 @@ export default async function ({ addon, msg, console }) {
               }),
               fill: false,
               showLine: true,
-              borderColor: "#4d97ff",
+              borderColor: "#396db5",
               lineTension: 0,
             },
           ],


### PR DESCRIPTION
Progress on #6091

### Changes

Switches to the new purple in website addons, except for `dark-www` which is handled in #6128 and #6268.

### Reason for changes

Scratch is changing it's blue colour (`#4d97ff`) to purple (`#855cd6`) and addons should stay consistent with Scratch. Scratch also changed some other colours, but those aren't handheld in this PR yet.

### Tests

Untested. I'm probably missing something. I'm submitting this now because we're getting very close to the deadline and my local `scratch-www` instance isn't quite working.