### PR TITLE
Apply "Ctrl+Enter to post" when reporting in the forums 

### DIFF
--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -46,11 +46,7 @@
     },
     {
       "url": "comments.js",
-      "matches": [
-        "https://scratch.mit.edu/studios/*",
-        "https://scratch.mit.edu/users/*",
-        "projects"
-      ],
+      "matches": ["https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/users/*", "projects"],
       "if": {
         "settings": {
           "comments": true
@@ -59,8 +55,6 @@
     }
   ],
   "versionAdded": "1.18.0",
-  "tags": [
-    "community"
-  ],
+  "tags": ["community"],
   "enabledByDefault": false
 }

--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -35,21 +35,32 @@
       "matches": [
         "https://scratch.mit.edu/discuss/topic/*",
         "https://scratch.mit.edu/discuss/post/*",
-        "https://scratch.mit.edu/discuss/settings/*"
+        "https://scratch.mit.edu/discuss/settings/*",
+        "https://scratch.mit.edu/discuss/misc/*"
       ],
       "if": {
-        "settings": { "forums": true }
+        "settings": {
+          "forums": true
+        }
       }
     },
     {
       "url": "comments.js",
-      "matches": ["https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/users/*", "projects"],
+      "matches": [
+        "https://scratch.mit.edu/studios/*",
+        "https://scratch.mit.edu/users/*",
+        "projects"
+      ],
       "if": {
-        "settings": { "comments": true }
+        "settings": {
+          "comments": true
+        }
       }
     }
   ],
   "versionAdded": "1.18.0",
-  "tags": ["community"],
+  "tags": [
+    "community"
+  ],
   "enabledByDefault": false
 }

--- a/addons/ctrl-enter-post/forums.js
+++ b/addons/ctrl-enter-post/forums.js
@@ -4,6 +4,10 @@ export default async function ({ addon }) {
   let textarea = document.querySelector(type === "settings" ? "#id_signature" : "#id_body");
   let postButton = document.querySelector(type === "topic" ? ".button.grey:nth-child(1)" : "button");
 
+  if (type === "misc") {
+    textarea = document.querySelector("#id_reason");
+  }
+
   if (!textarea) return;
   textarea.addEventListener("keydown", (e) => {
     if (!addon.self.disabled && (e.ctrlKey || e.metaKey) && (e.code === "Enter" || e.code === "NumpadEnter")) {


### PR DESCRIPTION
Resolves #6262

### Changes

Adds an `if` check to handle the different textbox on forum post report pages under `/discuss/misc/*

### Tests

Reported a post and it seems to work, tested on Firefox, macOS (cmd+enter and ctrl+enter)
