### PR TITLE
dark-www: compatibility with Scratch color changes

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -208,32 +208,13 @@
       }
     },
     {
-      "name": "navbar-scratchr2",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "navbar"
-        },
-        "r": 0.5,
-        "g": 0.92,
-        "b": 0.75
-      }
-    },
-    {
       "name": "navbar-scratchr2Text",
       "value": {
         "type": "textColor",
         "black": "#322f31",
         "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "navbar"
-          },
-          "r": 0.5,
-          "g": 0.92,
-          "b": 0.75
+          "type": "settingValue",
+          "settingId": "navbar"
         }
       }
     },
@@ -244,14 +225,8 @@
         "black": "drop-shadow(0 0 1px rgba(0, 0, 0, 0.2))",
         "white": "none",
         "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "navbar"
-          },
-          "r": 0.5,
-          "g": 0.92,
-          "b": 0.75
+          "type": "settingValue",
+          "settingId": "navbar"
         }
       }
     },
@@ -263,21 +238,9 @@
           "type": "settingValue",
           "settingId": "navbar"
         },
-        "r": 0.58,
-        "b": 0.8
-      }
-    },
-    {
-      "name": "navbar-scratchr2ItemHover",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "navbar"
-        },
-        "r": 0.48,
-        "g": 0.64,
-        "b": 0.52
+        "r": 0.9,
+        "g": 0.9,
+        "b": 0.9
       }
     },
     {
@@ -437,7 +400,7 @@
       }
     },
     {
-      "name": "box-tabSelected",
+      "name": "box-greenText",
       "value": {
         "type": "textColor",
         "black": "#328554",
@@ -531,6 +494,21 @@
           "settingId": "box"
         },
         "transparentSource": "#ff8c1a23"
+      }
+    },
+    {
+      "name": "box-embedLoader",
+      "value": {
+        "type": "textColor",
+        "black": "#4d97ff",
+        "white": {
+          "type": "settingValue",
+          "settingId": "box"
+        },
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
       }
     },
     {
@@ -789,17 +767,6 @@
       }
     },
     {
-      "name": "gray-darkText",
-      "value": {
-        "type": "textColor",
-        "black": "#3b3b3b",
-        "source": {
-          "type": "settingValue",
-          "settingId": "gray"
-        }
-      }
-    },
-    {
       "name": "gray-boxHighlight",
       "value": {
         "type": "textColor",
@@ -839,18 +806,6 @@
         "type": "textColor",
         "black": "rgba(0, 0, 0, 0.1)",
         "white": "rgba(255, 255, 255, 0.1)",
-        "source": {
-          "type": "settingValue",
-          "settingId": "gray"
-        }
-      }
-    },
-    {
-      "name": "gray-tabHover",
-      "value": {
-        "type": "textColor",
-        "black": "rgba(0, 0, 0, 0.2)",
-        "white": "rgba(255, 255, 255, 0.2)",
         "source": {
           "type": "settingValue",
           "settingId": "gray"
@@ -1295,6 +1250,29 @@
       }
     },
     {
+      "name": "blue-25",
+      "value": {
+        "type": "textColor",
+        "black": {
+          "type": "multiply",
+          "source": {
+            "type": "settingValue",
+            "settingId": "blue"
+          },
+          "r": 0.89,
+          "g": 0.94
+        },
+        "white": {
+          "type": "settingValue",
+          "settingId": "blue"
+        },
+        "source": {
+          "type": "settingValue",
+          "settingId": "blue"
+        }
+      }
+    },
+    {
       "name": "blue-opacity0",
       "value": {
         "type": "multiply",
@@ -1408,17 +1386,6 @@
       }
     },
     {
-      "name": "button-transparent15",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "button"
-        },
-        "a": 0.15
-      }
-    },
-    {
       "name": "button-transparent25",
       "value": {
         "type": "multiply",
@@ -1427,6 +1394,17 @@
           "settingId": "button"
         },
         "a": 0.25
+      }
+    },
+    {
+      "name": "button-transparent35",
+      "value": {
+        "type": "multiply",
+        "source": {
+          "type": "settingValue",
+          "settingId": "button"
+        },
+        "a": 0.35
       }
     },
     {
@@ -1459,9 +1437,9 @@
           "type": "settingValue",
           "settingId": "button"
         },
-        "r": 0.86,
-        "g": 0.85,
-        "b": 0.84
+        "r": 0.9,
+        "g": 0.9,
+        "b": 0.9
       }
     },
     {
@@ -1479,9 +1457,9 @@
             "settingId": "darkBanners"
           },
           "options": {
-            "off": 0.7,
-            "darker": 1,
-            "desaturated": 0.5
+            "off": 0.57,
+            "darker": 0.57,
+            "desaturated": 0.3
           }
         },
         "v": {
@@ -1491,9 +1469,9 @@
             "settingId": "darkBanners"
           },
           "options": {
-            "off": 1,
-            "darker": 0.6,
-            "desaturated": 0.4
+            "off": 0.84,
+            "darker": 0.4,
+            "desaturated": 0.35
           }
         }
       }
@@ -1513,9 +1491,9 @@
             "settingId": "darkBanners"
           },
           "options": {
-            "off": 0.7,
-            "darker": 1,
-            "desaturated": 0.51
+            "off": 0.56,
+            "darker": 0.56,
+            "desaturated": 0.3
           }
         },
         "v": {
@@ -1525,8 +1503,8 @@
             "settingId": "darkBanners"
           },
           "options": {
-            "off": 0.84,
-            "darker": 0.54,
+            "off": 0.75,
+            "darker": 0.35,
             "desaturated": 0.3
           }
         }
@@ -1538,17 +1516,8 @@
         "type": "textColor",
         "black": "#666666",
         "source": {
-          "type": "brighten",
-          "source": {
-            "type": "multiply",
-            "source": {
-              "type": "settingValue",
-              "settingId": "button"
-            },
-            "r": 0.61,
-            "b": 0.86
-          },
-          "g": 0.92
+          "type": "settingValue",
+          "settingId": "button"
         }
       }
     },
@@ -1558,109 +1527,20 @@
         "type": "textColor",
         "black": "#322f31",
         "source": {
-          "type": "brighten",
-          "source": {
-            "type": "multiply",
-            "source": {
-              "type": "settingValue",
-              "settingId": "button"
-            },
-            "r": 0.52,
-            "b": 0.85
-          },
-          "g": 0.85
+          "type": "settingValue",
+          "settingId": "button"
         }
-      }
-    },
-    {
-      "name": "button-scratchr2ButtonGradientTop",
-      "value": {
-        "type": "brighten",
-        "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "button"
-          },
-          "r": 0.65,
-          "b": 0.98
-        },
-        "g": 0.7
-      }
-    },
-    {
-      "name": "button-scratchr2ButtonGradientBottom",
-      "value": {
-        "type": "brighten",
-        "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "button"
-          },
-          "r": 0.61,
-          "b": 0.86
-        },
-        "g": 0.92
-      }
-    },
-    {
-      "name": "button-scratchr2ButtonBorderTop",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "button"
-        },
-        "r": 0.62,
-        "b": 0.77
-      }
-    },
-    {
-      "name": "button-scratchr2ButtonBorderBottom",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "button"
-        },
-        "r": 0.58,
-        "g": 0.89,
-        "b": 0.68
-      }
-    },
-    {
-      "name": "button-scratchr2InputFocusBorder",
-      "value": {
-        "type": "brighten",
-        "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "button"
-          },
-          "b": 0.93,
-          "a": 0.8
-        },
-        "r": 0.97,
-        "g": 0.84
       }
     },
     {
       "name": "button-scratchr2InputFocusShadow",
       "value": {
-        "type": "brighten",
+        "type": "multiply",
         "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "button"
-          },
-          "b": 0.93,
-          "a": 0.6
+          "type": "settingValue",
+          "settingId": "button"
         },
-        "r": 0.97,
-        "g": 0.84
+        "a": 0.6
       }
     },
     {
@@ -1677,22 +1557,6 @@
           "b": 0.85
         },
         "g": 0.85
-      }
-    },
-    {
-      "name": "button-scratchr2PostBorder",
-      "value": {
-        "type": "brighten",
-        "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "button"
-          },
-          "b": 0.85
-        },
-        "r": 0.9,
-        "g": 0.71
       }
     },
     {
@@ -1714,22 +1578,9 @@
           "type": "settingValue",
           "settingId": "link"
         },
-        "r": 0.86,
-        "g": 0.85,
-        "b": 0.84
-      }
-    },
-    {
-      "name": "link-variant",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "link"
-        },
-        "r": 0.66,
-        "g": 0.76,
-        "b": 0.8
+        "r": 0.9,
+        "g": 0.9,
+        "b": 0.9
       }
     },
     {
@@ -1755,33 +1606,6 @@
           "r": 0.86,
           "g": 0.85,
           "b": 0.84
-        }
-      }
-    },
-    {
-      "name": "link-scratchr2",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "link"
-        },
-        "r": 0.66,
-        "b": 0.85
-      }
-    },
-    {
-      "name": "link-scratchr2IconFilter",
-      "value": {
-        "type": "recolorFilter",
-        "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "link"
-          },
-          "r": 0.66,
-          "b": 0.85
         }
       }
     },
@@ -2177,6 +2001,17 @@
       "matches": ["https://scratch.mit.edu/become-a-scratcher"]
     },
     {
+      "url": "join.css",
+      "matches": ["https://scratch.mit.edu/join"]
+    },
+    {
+      "url": "banners/darker_explore.css",
+      "matches": ["https://scratch.mit.edu/explore/*"],
+      "if": {
+        "settings": { "darkBanners": "darker" }
+      }
+    },
+    {
       "url": "banners/desaturated_explore.css",
       "matches": ["https://scratch.mit.edu/explore/*"],
       "if": {
@@ -2184,8 +2019,29 @@
       }
     },
     {
+      "url": "banners/darker_search.css",
+      "matches": ["https://scratch.mit.edu/search/*"],
+      "if": {
+        "settings": { "darkBanners": "darker" }
+      }
+    },
+    {
       "url": "banners/desaturated_search.css",
       "matches": ["https://scratch.mit.edu/search/*"],
+      "if": {
+        "settings": { "darkBanners": "desaturated" }
+      }
+    },
+    {
+      "url": "banners/darker_join.css",
+      "matches": ["https://scratch.mit.edu/join"],
+      "if": {
+        "settings": { "darkBanners": "darker" }
+      }
+    },
+    {
+      "url": "banners/desaturated_join.css",
+      "matches": ["https://scratch.mit.edu/join"],
       "if": {
         "settings": { "darkBanners": "desaturated" }
       }

--- a/addons/dark-www/banners/darker.css
+++ b/addons/dark-www/banners/darker.css
@@ -1,3 +1,38 @@
+.unsupported-browser,
+.wedo .top-banner,
+.sa-annual-report-2019 .message-section,
+.sa-annual-report-2019 .initiatives-section .initiatives-subsection-header.community,
+.sa-annual-report-2019 .initiatives-section .initiatives-community .community-quotes .community-quote .comment-text,
+.title-banner.mod-conference,
+.conf2019-title-band {
+  background-color: #004099;
+}
+.sa-annual-report-2019 .initiatives-section .initiatives-community .community-quotes .community-quote .comment-text,
+.sa-annual-report-2019
+  .initiatives-section
+  .initiatives-community
+  .community-quotes
+  .community-quote
+  .comment-text::before,
+.sa-annual-report-2019
+  .initiatives-section
+  .initiatives-community
+  .community-quotes
+  .community-quote
+  .comment-text::after {
+  border-color: #004099;
+}
+.parents .title-banner.masthead,
+.download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,
+.gdxfor .extension-header,
+.blue-background,
+.privacy-banner,
+.sa-annual-report-2019 .subnavigation,
+.sa-annual-report-2020 .initiatives-section .initiatives-subsection-header.community,
+.sa-annual-report-2021 .initiatives-section .initiatives-subsection-header.SEC,
+.conf2017-title-band {
+  background-color: #003a8a;
+}
 .parents .title-banner.masthead .ted-talk {
   border-color: black;
 }
@@ -10,18 +45,21 @@
 .initiatives-section .initiatives-subsection-header.community,
 .teacher-registration,
 .teacher-waitingroom {
-  background-color: #220066;
+  background-color: #3d2966;
 }
 .initiatives-section .initiatives-subsection-content .teacher-quote .comment-text,
 .initiatives-section .initiatives-subsection-content .teacher-quote .comment-text::before,
 .initiatives-section .initiatives-subsection-content .teacher-quote .comment-text::after {
-  border-color: #220066;
+  border-color: #3d2966;
 }
+.boost .extension-header,
+.ev3 .extension-header,
 .wedo2 .extension-header {
-  background-color: #99004d;
+  background-color: #752475;
 }
 .hoc-banner,
 .feature-banner,
+.banner-wrapper /* Ideas */,
 .developers .title-banner.masthead,
 .sa-annual-report-2019 .reach-section,
 .initiatives-section .initiatives-subsection-header.tools,
@@ -33,8 +71,7 @@
 .sa-annual-report-2021 .reach-section,
 .sa-annual-report-2021 .reach-scratch-jr,
 .card .card-button,
-.microbit .extension-header,
-.link .extension-header /* Scratch Link download */ {
+.microbit .extension-header {
   background-color: #064734;
 }
 .hoc-banner .hoc-banner-image,

--- a/addons/dark-www/banners/darker_explore.css
+++ b/addons/dark-www/banners/darker_explore.css
@@ -1,3 +1,3 @@
 .outer .title-banner.masthead {
-  background-color: #27473e;
+  background-color: #064734;
 }

--- a/addons/dark-www/banners/darker_join.css
+++ b/addons/dark-www/banners/darker_join.css
@@ -1,0 +1,3 @@
+.modal-overlay {
+  background-color: #004099;
+}

--- a/addons/dark-www/banners/darker_search.css
+++ b/addons/dark-www/banners/darker_search.css
@@ -1,3 +1,3 @@
 .outer .title-banner.masthead {
-  background-color: #27473e;
+  background-color: #003a8a;
 }

--- a/addons/dark-www/banners/desaturated.css
+++ b/addons/dark-www/banners/desaturated.css
@@ -1,3 +1,38 @@
+.unsupported-browser,
+.wedo .top-banner,
+.sa-annual-report-2019 .message-section,
+.sa-annual-report-2019 .initiatives-section .initiatives-subsection-header.community,
+.sa-annual-report-2019 .initiatives-section .initiatives-community .community-quotes .community-quote .comment-text,
+.title-banner.mod-conference,
+.conf2019-title-band {
+  background-color: #334766;
+}
+.sa-annual-report-2019 .initiatives-section .initiatives-community .community-quotes .community-quote .comment-text,
+.sa-annual-report-2019
+  .initiatives-section
+  .initiatives-community
+  .community-quotes
+  .community-quote
+  .comment-text::before,
+.sa-annual-report-2019
+  .initiatives-section
+  .initiatives-community
+  .community-quotes
+  .community-quote
+  .comment-text::after {
+  border-color: #334766;
+}
+.parents .title-banner.masthead,
+.download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,
+.gdxfor .extension-header,
+.blue-background,
+.privacy-banner,
+.sa-annual-report-2019 .subnavigation,
+.sa-annual-report-2020 .initiatives-section .initiatives-subsection-header.community,
+.sa-annual-report-2021 .initiatives-section .initiatives-subsection-header.SEC,
+.conf2017-title-band {
+  background-color: #26364d;
+}
 .parents .title-banner.masthead .ted-talk {
   border-color: black;
 }
@@ -17,14 +52,14 @@
 .initiatives-section .initiatives-subsection-content .teacher-quote .comment-text::after {
   border-color: #473e59;
 }
-.banner-wrapper /* Ideas */ {
-  background-color: #99864d;
-}
+.boost .extension-header,
+.ev3 .extension-header,
 .wedo2 .extension-header {
-  background-color: #4d2e33;
+  background-color: #673267;
 }
 .hoc-banner,
 .feature-banner,
+.banner-wrapper /* Ideas */,
 .developers .title-banner.masthead,
 .sa-annual-report-2019 .reach-section,
 .initiatives-section .initiatives-subsection-header.tools,
@@ -36,8 +71,7 @@
 .sa-annual-report-2021 .reach-section,
 .sa-annual-report-2021 .reach-scratch-jr,
 .card .card-button,
-.microbit .extension-header,
-.link .extension-header /* Scratch Link download */ {
+.microbit .extension-header {
   background-color: #27473e;
 }
 .hoc-banner .hoc-banner-image,
@@ -62,12 +96,6 @@
 .sa-annual-report-2020 .reach-scratch-jr {
   background-color: #265064;
 }
-.banner.warning /* confirm email */,
-.modal-flush-bottom-button,
-.ev3 .extension-header,
-.boost .extension-header,
-.validation-error,
-.validation-error::before,
 .error-text,
 .report-modal-content .validation-message,
 .report-modal-content .validation-message::before,

--- a/addons/dark-www/banners/desaturated_join.css
+++ b/addons/dark-www/banners/desaturated_join.css
@@ -1,0 +1,3 @@
+.modal-overlay {
+  background-color: #334766;
+}

--- a/addons/dark-www/experimental_forums_preview.js
+++ b/addons/dark-www/experimental_forums_preview.js
@@ -14,7 +14,7 @@ function updateCssVariables(node, addon) {
     node.style.setProperty("--darkWww-page", "#ffffff");
     node.style.setProperty("--darkWww-page-scratchr2Text", "#322f31");
     node.style.setProperty("--darkWww-page-colorScheme", "light");
-    node.style.setProperty("--darkWww-link-scratchr2", "#1aa0d8");
+    node.style.setProperty("--darkWww-link", "#855cd6");
     node.style.setProperty("--darkWww-gray-scratchr2", "#f7f7f7");
     node.style.setProperty("--darkWww-gray-scratchr2Text", "#322f31");
     node.style.setProperty("--darkWww-border-15", "#cccccc");
@@ -25,7 +25,7 @@ function updateCssVariables(node, addon) {
   node.style.setProperty("--darkWww-page", addon.settings.get("box"));
   node.style.setProperty("--darkWww-page-scratchr2Text", textColor(addon.settings.get("box"), "#322f31"));
   node.style.setProperty("--darkWww-page-colorScheme", textColor(addon.settings.get("box"), "light", "dark"));
-  node.style.setProperty("--darkWww-link-scratchr2", multiply(addon.settings.get("link"), { r: 0.66, b: 0.85 }));
+  node.style.setProperty("--darkWww-link", addon.settings.get("link"));
   node.style.setProperty(
     "--darkWww-gray-scratchr2",
     textColor(

--- a/addons/dark-www/experimental_project_embed.css
+++ b/addons/dark-www/experimental_project_embed.css
@@ -1,9 +1,5 @@
 [class*="loader_background_"] {
-  background-color: var(--darkWww-navbar);
-  color: var(--darkWww-navbar-text);
-}
-[class*="loader_background_"] img {
-  filter: var(--darkWww-navbar-filter);
+  background-color: var(--darkWww-box-embedLoader);
 }
 [class*="stage-wrapper_stage-wrapper_"][class*="stage-wrapper_full-screen_"],
 [class*="stage-header_stage-header-wrapper-overlay_"] {

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -24,10 +24,10 @@ label,
 #topnav ul.account-nav .logged-in-user .dropdown-menu,
 #topnav li.logout.divider input,
 #topnav ul.account-nav .sign-in .popover {
-  background-color: var(--darkWww-navbar-scratchr2);
+  background-color: var(--darkWww-navbar);
 }
 #topnav ul.account-nav .sign-in .popover .arrow:after {
-  border-bottom-color: var(--darkWww-navbar-scratchr2);
+  border-bottom-color: var(--darkWww-navbar);
 }
 #topnav ul.site-nav li a,
 #topnav ul.account-nav > li > span,
@@ -76,10 +76,10 @@ label,
 #topnav ul.account-nav > li.sign-in.open,
 #topnav ul.account-nav.logged-in li:hover,
 #topnav li.logout.divider input:hover {
-  background-color: var(--darkWww-navbar-scratchr2ItemHover);
+  background-color: var(--darkWww-navbar-scratchr2Border);
 }
 #topnav ul.account-nav .logged-in-user.dropdown.open {
-  background-color: var(--darkWww-navbar-scratchr2ItemHover) !important;
+  background-color: var(--darkWww-navbar-scratchr2Border) !important;
 }
 
 /* Content background */
@@ -384,12 +384,9 @@ ul.pagination span /* mobile forums */ {
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button {
-  background-image: linear-gradient(
-    var(--darkWww-button-scratchr2ButtonGradientTop),
-    var(--darkWww-button-scratchr2ButtonGradientBottom)
-  );
-  border-color: var(--darkWww-button-scratchr2ButtonBorderTop);
-  border-bottom-color: var(--darkWww-button-scratchr2ButtonBorderBottom);
+  background-image: linear-gradient(var(--darkWww-button), var(--darkWww-button-variant));
+  border-color: rgba(0, 0, 0, 0.2);
+  border-bottom-color: rgba(0, 0, 0, 0.3);
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button a,
@@ -401,10 +398,7 @@ ul.pagination span /* mobile forums */ {
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button:hover {
-  background-image: linear-gradient(
-    var(--darkWww-button-scratchr2ButtonGradientBottom),
-    var(--darkWww-button-scratchr2ButtonGradientBottom)
-  );
+  background-image: linear-gradient(var(--darkWww-button-variant), var(--darkWww-button-variant));
 }
 input:focus,
 textarea:focus,
@@ -412,7 +406,7 @@ textarea:focus,
 .registration .modal-body input:focus,
 .registration .modal-body textarea:focus,
 .registration .modal-body select:focus {
-  border-color: var(--darkWww-button-scratchr2InputFocusBorder);
+  border-color: var(--darkWww-button);
   box-shadow: 0 1px 1px inset rgba(0, 0, 0, 0.08), 0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
 }
 .editable textarea:focus,
@@ -421,18 +415,18 @@ textarea:focus,
   box-shadow: none;
 }
 .blockpost div.box {
-  background-color: var(--darkWww-button-scratchr2PostHeader);
-  border-top-color: var(--darkWww-button-scratchr2PostHeader);
+  background-color: var(--darkWww-button);
+  border-top-color: var(--darkWww-button);
 }
 .my-ocular-reaction-button {
-  box-shadow: 0 0 2px var(--darkWww-button-scratchr2PostHeader);
+  box-shadow: 0 0 2px var(--darkWww-button);
 }
 .my-ocular-reaction-button.selected {
-  background-color: var(--darkWww-button-scratchr2PostHeader);
+  background-color: var(--darkWww-button);
   color: var(--darkWww-button-scratchr2PostHeaderText);
 }
 .blockpost .box-head {
-  border-top-color: var(--darkWww-button-scratchr2PostBorder);
+  border-top-color: rgba(255, 255, 255, 0.15);
 }
 .blockpost .box-head span.conr,
 .blockpost .box-head a,
@@ -456,11 +450,11 @@ input.link.black:hover,
 input.link.black:active,
 #comments .more-replies .pulldown,
 #email-resend-box a {
-  color: var(--darkWww-link-scratchr2);
+  color: var(--darkWww-link);
 }
 .inew,
 .isticky:not(.iclosed) {
-  filter: var(--darkWww-link-scratchr2IconFilter);
+  filter: var(--darkWww-link-iconFilter);
 }
 
 /* Footer background */

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -47,11 +47,7 @@ body {
 #navigation,
 .dropdown,
 .dropdown.with-arrow::before,
-.addToStudio-modal-header,
-.social-modal-header,
 .user-projects-modal .user-projects-modal-title,
-.promote-modal .promote-title,
-.manager-limit-modal .manager-limit-title,
 .transfer-host-modal .transfer-host-title {
   background-color: var(--darkWww-navbar);
   color: var(--darkWww-navbar-text);
@@ -64,14 +60,8 @@ body {
 .dropdown a:link,
 .dropdown a:visited,
 .dropdown a:active,
-.modal-title,
 .overflow-menu-container .overflow-menu-dropdown li button {
   color: var(--darkWww-navbar-text);
-}
-.report-modal-header .modal-title,
-.studio-report-modal .studio-report-title,
-.next-step-title {
-  color: white;
 }
 #navigation .inner > ul > li.search .input[type="text"]::placeholder {
   color: var(--darkWww-navbar-transparentText);
@@ -79,13 +69,8 @@ body {
 #navigation .inner > ul > li.search .btn-search,
 #navigation .mystuff > a,
 .account-nav .user-info::after,
-.modal-content-close-img,
 .overflow-menu-container .overflow-menu-dropdown li button > img {
   filter: var(--darkWww-navbar-filter);
-}
-.mod-report .modal-content-close-img,
-.studio-report-modal .modal-content-close-img {
-  filter: none;
 }
 #navigation .messages > a {
   background-image: none;
@@ -118,11 +103,6 @@ body {
 }
 #navigation .inner > ul > li.search .input[type="text"]:focus {
   background-color: var(--darkWww-navbar-inputFocus);
-}
-.addToStudio-modal-header,
-.social-modal-header,
-.user-projects-modal .user-projects-modal-title {
-  box-shadow: 0 -1px 0 inset var(--darkWww-navbar-variant);
 }
 
 /* Content background */
@@ -159,6 +139,7 @@ body:not(.sa-body-editor) .formik-input,
 .extension-landing .project-card,
 .extension-landing .hardware-card,
 .promote-modal .cancel-button,
+body:not(.sa-body-editor) [class*="stage-header_stage-size-row_"] > *,
 body:not(.sa-body-editor) [class*="stage-header_stage-button_"],
 .studio-adder-section .studio-adder-row input,
 .studio-adder-section .studio-adder-row .studio-adder-vertical-divider,
@@ -187,6 +168,8 @@ body:not(.sa-body-editor) .button.white,
 .hoc-banner .hoc-banner-image,
 .feature-banner .feature-learn-more,
 .feature-banner .feature-banner-image,
+.outer .categories li,
+.banner-wrapper .banner-button /* Choose a tutorial */,
 .studio-selector-button,
 .onboarding button.go-back,
 .button.mod-2019-conf-maillist-button,
@@ -274,13 +257,18 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 }
 .tabs button.active,
 .tabs button.active:hover {
-  border-color: var(--darkWww-box-tabSelected);
+  border-color: var(--darkWww-box-greenText);
+}
+.donate-banner .donate-container .donate-button,
+.banner-wrapper .banner-button /* Choose a tutorial */,
+.donate-section .donate-button {
+  color: var(--darkWww-box-greenText);
 }
 .social-message-icon {
   opacity: var(--darkWww-box-messageIconOpacity);
 }
-.studio-report-modal .studio-report-tile,
-.studio-report-modal .studio-report-tile-header {
+.studio-report-modal .studio-report-tile:not(.studio-report-selected),
+.studio-report-modal .studio-report-tile-header:not(.studio-report-header-selected) {
   background-color: var(--darkWww-box-studioReportTile);
 }
 .action-button.disabled,
@@ -324,15 +312,6 @@ body:not(.sa-body-editor) .outer .sort-mode .select select:focus {
 .box .box-header {
   border-top-color: var(--darkWww-gray-boxHighlight);
 }
-.outer .categories li {
-  background-color: var(--darkWww-gray-tab);
-  border-color: var(--darkWww-gray-darkText);
-  color: var(--darkWww-gray-text);
-}
-.outer .categories li:hover {
-  background-color: var(--darkWww-gray-tabHover);
-  color: var(--darkWww-gray-darkText);
-}
 .toggle-switch .slider {
   background-color: var(--darkWww-gray-darker);
 }
@@ -344,6 +323,7 @@ body:not(.sa-body-editor) .outer .sort-mode .select select:focus {
 
 /* Blue background */
 .empty,
+.intro-banner .intro-subnav,
 .social-message.mod-unread,
 .preview .remix-credit,
 .preview .project-description,
@@ -371,7 +351,9 @@ p.callout,
 .tab-choice-selected-sa,
 .sa-annual-report-2020 .initiatives-section .year-in-review,
 .initiatives-section .initiatives-subsection-content .map,
-.sa-annual-report-2021 .leadership-section .leadership-scratch-team .avatar-item img {
+.sa-annual-report-2021 .leadership-section .leadership-scratch-team .avatar-item img,
+body:not(.sa-body-editor) .gender-radio-row:hover,
+.educators .feature {
   background-color: var(--darkWww-blue);
   color: var(--darkWww-blue-text);
   color-scheme: var(--darkWww-blue-colorScheme);
@@ -412,6 +394,15 @@ p.callout,
   background-color: var(--darkWww-blue-20);
   color-scheme: var(--darKWww-blue-colorScheme);
 }
+.join-flow-footer-message {
+  background-color: var(--darkWww-blue-25);
+}
+.extension-chip,
+body:not(.sa-body-editor) .gender-radio-row-selected,
+body:not(.sa-body-editor) .gender-radio-row-selected:hover {
+  background-color: var(--darkWww-blue-25);
+  color: var(--darkWww-blue-text);
+}
 .replies.collapsed > .comment:last-of-type::after,
 .studio-list-bottom-gradient {
   background-image: linear-gradient(var(--darkWww-blue-opacity0), var(--darkWww-blue));
@@ -443,39 +434,26 @@ body:not(.sa-body-editor) .select select:focus {
 
 /* Highlight color */
 .button,
-.validation-info,
-.validation-info::before,
+.outer .categories li.active,
 .subactions .action-buttons .action-button,
 .unsupported-browser .back-button,
 .studio-status-icon-unselected,
 .studio-info .studio-info-footer-report button,
 .studio-tab-nav .active > li,
 .user-projects-modal .user-projects-modal-nav button.active,
-.navigation .dot.active,
 .os-chooser .button.active,
 .step .step-number-row .step-number,
-.download .installation-column-number,
-#footer .inner .media li,
-.initiatives-section .initiatives-community .subsection-tag,
-body:not(.sa-body-editor) [type="checkbox"].formik-checkbox:checked,
-.info-button-message,
-.info-button-message::before,
-input[type="radio"].formik-radio-button:checked::after,
-.row .checkbox input[type="checkbox"]:checked,
-.row .col-sm-9 input[type="radio"]:checked,
-.tooltip .expand,
-.tooltip .expand::before {
+.row .col-sm-9 input[type="radio"]:checked {
   background-color: var(--darkWww-button);
   color: var(--darkWww-button-text);
 }
 .forms-close-button {
   background-color: rgba(0, 0, 0, 0.1);
 }
-.banner-button {
+.banner-outer:not(.banner-danger) .banner-button /* Share */ {
   background-color: #ffab1a;
 }
-a.ttt-try-tutorial-button > span,
-.row .checkbox input[type="checkbox"]:checked::after {
+a.ttt-try-tutorial-button > span {
   color: var(--darkWww-button-text);
 }
 .row .col-sm-9 input[type="radio"]:checked::after {
@@ -491,13 +469,11 @@ a.ttt-try-tutorial-button > span,
 .inplace-input:focus,
 .inplace-textarea:focus,
 .textarea:focus,
+.outer .categories li,
 .unsupported-browser .back-button,
 body:not(.sa-body-editor) .formik-input:focus,
-body:not(.sa-body-editor) input[type="radio"].formik-radio-button:checked,
 .input:focus,
-.registration-step.demographics-step input[type="radio"]:focus,
-.onboarding button.finish-later,
-.onboarding button.go-back {
+.react-tel-input input[type="tel"]:focus {
   border-color: var(--darkWww-button);
 }
 .studio-tile-added {
@@ -521,23 +497,6 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button:checked,
 .os-chooser .button:not(.active) img {
   filter: none;
 }
-body:not(.sa-body-editor) [type="checkbox"].formik-checkbox:checked {
-  background-image: none;
-  position: relative;
-}
-body:not(.sa-body-editor) [type="checkbox"].formik-checkbox:checked::before {
-  /* move background image into a pseudo-element
-    so that the filter doesn't affect the background color */
-  content: "";
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  background: url("/svgs/forms/checkmark.svg") center;
-  filter: var(--darkWww-button-filter);
-}
 .input_label:hover {
   background-color: var(--darkWww-button-transparent10);
 }
@@ -545,20 +504,9 @@ body:not(.sa-body-editor) [type="checkbox"].formik-checkbox:checked::before {
 .user-projects-modal .user-projects-modal-nav button.active:hover {
   border-color: var(--darkWww-button-transparent10);
 }
-.studio-report-modal .studio-report-selected {
-  background-color: var(--darkWww-button-transparent15);
-}
-::selection,
-.extension-chip,
-.studio-report-modal .studio-report-header-selected,
-.user-projects-modal .user-projects-modal-nav button:hover,
-.join-flow-footer-message {
+.outer .categories li:hover,
+.user-projects-modal .user-projects-modal-nav button:hover {
   background-color: var(--darkWww-button-transparent25);
-}
-.inplace-input,
-.inplace-textarea,
-.modal-mute .nav-divider {
-  border-color: var(--darkWww-button-transparent25);
 }
 .comment .avatar {
   box-shadow: 0 0 0 1px var(--darkWww-button-transparent25);
@@ -566,63 +514,27 @@ body:not(.sa-body-editor) [type="checkbox"].formik-checkbox:checked::before {
 .inplace-input:focus,
 .inplace-textarea:focus,
 .studio-tile-added,
-body:not(.sa-body-editor) .formik-input:focus,
-body:not(.sa-body-editor) input[type="checkbox"].formik-checkbox:focus,
-body:not(.sa-body-editor) input[type="radio"].formik-radio-button:checked {
+body:not(.sa-body-editor) .formik-input:focus {
   box-shadow: 0 0 0 4px var(--darkWww-button-transparent25);
 }
-.modal-overlay {
-  background-color: var(--darkWww-button-overlay);
+body:not(.sa-body-editor) [class*="stage-header_stage-button_"]:active {
+  background-color: var(--darkWww-button-transparent35);
 }
+.outer .categories li.active:hover,
 .studio-info .studio-info-footer-report button:hover,
 .studio-tab-nav a.active.nav_link:hover > li {
   background-color: var(--darkWww-button-variant);
   color: var(--darkWww-button-text);
 }
-.navigation .dot.active {
-  border-color: var(--darkWww-button-variant);
-}
 .intro-banner .intro-container,
-.unsupported-browser,
 .title-banner.mod-messages,
 .download .download-header,
-.title-banner.mod-conference,
-.conf2019-title-band,
-.sa-annual-report-2019 .message-section,
-.sa-annual-report-2019 .initiatives-section .initiatives-subsection-header.community,
-.sa-annual-report-2019 .initiatives-section .initiatives-community .community-quotes .community-quote .comment-text,
-.title-banner.mod-blue-bg /* camp 2017 */,
-.wedo .top-banner,
-.gdxfor .extension-header {
+.link .extension-header /* Scratch Link download */,
+.information-page .title-banner.masthead,
+.modal-flush-bottom-button {
   background-color: var(--darkWww-button-banner);
 }
-.sa-annual-report-2019 .initiatives-section .initiatives-community .community-quotes .community-quote .comment-text,
-.sa-annual-report-2019
-  .initiatives-section
-  .initiatives-community
-  .community-quotes
-  .community-quote
-  .comment-text::before,
-.sa-annual-report-2019
-  .initiatives-section
-  .initiatives-community
-  .community-quotes
-  .community-quote
-  .comment-text::after {
-  border-color: var(--darkWww-button-banner);
-}
-.gradient1 {
-  background-image: linear-gradient(var(--darkWww-button-banner), black);
-}
-.blue-background,
-.parents .title-banner.masthead,
-.information-page .title-banner.masthead,
-.download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,
-.conf2017-title-band,
-.sa-annual-report-2019 .subnavigation,
-.sa-annual-report-2020 .initiatives-section .initiatives-subsection-header.community,
-.initiatives-section .initiatives-subsection-header.SEC,
-.privacy-banner {
+.modal-flush-bottom-button:hover {
   background-color: var(--darkWww-button-bannerVariant);
 }
 
@@ -637,6 +549,7 @@ body:not(.sa-body-editor) .button.white,
 .hoc-banner .hoc-banner-image .hoc-image-text,
 .feature-banner .feature-learn-more,
 .feature-banner .feature-banner-image .feature-image-text,
+.outer .categories li,
 .unsupported-browser .faq-link,
 a.social-messages-profile-link:hover,
 a.social-messages-profile-link:active,
@@ -647,11 +560,6 @@ a.social-messages-profile-link:active,
 .studio-thumb-edit-button,
 .studio-manager-count,
 .promote-modal .cancel-button,
-.onboarding button.finish-later,
-.onboarding button.go-back,
-.index .title-banner p a button,
-.financials-section .financials-button,
-.donate-section .donate-button,
 .transfer-host-modal .cancel-button {
   color: var(--darkWww-link);
 }
@@ -661,19 +569,14 @@ a.social-messages-profile-link:active,
 .user-projects-modal .studio-projects-empty-text {
   color: var(--darkWww-link-transparent);
 }
-a:hover,
-.button.mod-2019-conf-maillist-button {
+a:hover {
   color: var(--darkWww-link-hover);
 }
 .sa-annual-report-2020 a,
 .sa-annual-report-2020 a:link,
 .sa-annual-report-2020 a:visited,
-.sa-annual-report-2020 a:active,
-.sa-annual-report-2021 a,
-.sa-annual-report-2021 a:link,
-.sa-annual-report-2021 a:visited,
-.sa-annual-report-2021 a:active {
-  color: var(--darkWww-link-variant);
+.sa-annual-report-2020 a:active {
+  color: #3373cc;
 }
 .banner a,
 .privacy-banner a,
@@ -687,12 +590,6 @@ a:hover,
 .studio-thumb-edit-img,
 .studio-activity .studio-activity-icon,
 .download .older-version .little-arrow,
-.conf2021-panel-row-icon-image,
-.conf2019-panel-row-icon-image,
-.conf2017-panel-row-icon-image,
-img[src^="/images/annual-report/milestones/timeline_"],
-.financials-section .financials-button img,
-.sa-annual-report-2020 .initiatives-section .year-in-review .connector,
 .transfer-host-modal .transfer-outcome-arrow {
   filter: var(--darkWww-link-iconFilter);
 }
@@ -807,6 +704,9 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button,
 .navigation .dot {
   background-color: var(--darkWww-border-15);
 }
+.navigation .dot.active {
+  background-color: #4d97ff;
+}
 .compose-comment .textarea-row textarea:not(:focus),
 .studio-tab-nav,
 body:not(.sa-body-editor) .formik-input,
@@ -882,8 +782,17 @@ p {
   /* Fix ugly gray shadow */
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
 }
+.wedo .banner {
+  box-shadow: none;
+}
 
 .initiatives-access > .green {
   /* Change the solid color background to a transparent one */
   background-color: rgba(0, 165, 0, 0.07);
+}
+
+.twitter-tweet iframe {
+  /* If the color scheme of an iframe element is different from that
+     of the document inside, it gets an opaque backgound. */
+  color-scheme: light;
 }

--- a/addons/dark-www/join.css
+++ b/addons/dark-www/join.css
@@ -1,0 +1,3 @@
+.modal-overlay {
+  background-color: #5e85f3;
+}

--- a/addons/horizontal-mystuff-tabs/scratchr2.css
+++ b/addons/horizontal-mystuff-tabs/scratchr2.css
@@ -57,7 +57,7 @@
 .v-tabs li.active:hover {
   background-color: transparent;
   border: none;
-  border-bottom: 3px solid var(--darkWww-box-tabSelected, #328554);
+  border-bottom: 3px solid var(--darkWww-box-greenText, #328554);
 }
 
 .button[data-control="load-more"] {

--- a/addons/old-studio-layout/scratchr2.css
+++ b/addons/old-studio-layout/scratchr2.css
@@ -54,7 +54,7 @@
 .studio-tab-nav a.active.nav_link > li,
 .studio-tab-nav a.active.nav_link:hover > li {
   background: transparent;
-  border-color: var(--darkWww-box-tabSelected, #328554);
+  border-color: var(--darkWww-box-greenText, #328554);
   color: var(--darkWww-box-text, #575e75);
 }
 .studio-tab-nav .active > li img,

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -20,7 +20,7 @@ body,
   text-shadow: none;
 }
 ::selection {
-  background-color: var(--darkWww-button-transparent25, rgba(77, 151, 255, 0.25));
+  background-color: rgba(77, 151, 255, 0.25);
 }
 .box .box-head h1,
 .box .box-head h2,


### PR DESCRIPTION
### Changes

Makes `dark-www` work better with Scratch's color contrast update. I didn't make changes to other addons in this PR unless they were referencing CSS variables I renamed or removed.

We don't know what changes, if any, will be made to scratchr2. I decided to use the same colors on scratch-www and scratchr2 (see screenshots below). If the ST does something different, we can change it in a future update.

I used the updated Experimental Dark preset proposed in #6128 in the screenshots.

![Explore page](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/aadfec6d-9fcc-4fd9-978b-810b675cdca0)
![Ideas page](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/7964fe82-7da3-4b3b-ab2f-04f66cbd9d5b)
![Profile page](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/c758a8a0-0659-482a-86a3-2685db321df2)

### Tests

Tested by running scratch-www locally.