### PR TITLE
Rename hide-signatures

### DIFF
--- a/addons/hide-signatures/addon.json
+++ b/addons/hide-signatures/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hide signatures on forums",
+  "name": "Hide forum signatures",
   "description": "Hides signatures in forum posts and adds a \"Show signature\" button.",
   "credits": [
     {


### PR DESCRIPTION
I'm not totally sure why it had to be "Hide signatures _on_ forums".