### PR TITLE
Store setting migrations that were applied

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -58,6 +58,8 @@ const updatePresetIfMatching = (settings, version, oldPreset = null, presetOrFn 
       if (typeof presetOrFn === "object") map[key] = presetOrFn.values[key];
     }
 
+    if (settings._appliedVersions) settings._appliedVersions.push(version);
+    else settings._appliedVersions = [version];
     if (typeof presetOrFn === "function") return presetOrFn(); // Custom migration logic if preset matches
 
     const preset = presetOrFn;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -58,7 +58,7 @@ const updatePresetIfMatching = (settings, version, oldPreset = null, presetOrFn 
       if (typeof presetOrFn === "object") map[key] = presetOrFn.values[key];
     }
 
-    if (settings._appliedVersions) settings._appliedVersions.push(version);
+    if (Array.isArray(settings._appliedVersions)) settings._appliedVersions.push(version);
     else settings._appliedVersions = [version];
     if (typeof presetOrFn === "function") return presetOrFn(); // Custom migration logic if preset matches
 


### PR DESCRIPTION
### Changes

Store the list of setting migrations that were applied. Might be useful in the future, in case we want to distinguish users that have some settings because of the migration vs. they already had those settings before then. It's also possible that we'll never use this. It won't take a lot of space to store a few integer numbers.

### Tests

To be tested