### PR TITLE
editor-dark-mode: use blue color for some elements

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -736,6 +736,18 @@
       }
     },
     {
+      "name": "categoryMenu-hoverText",
+      "value": {
+        "type": "textColor",
+        "black": "#3373cc",
+        "white": "#80b5ff",
+        "source": {
+          "type": "settingValue",
+          "settingId": "categoryMenu"
+        }
+      }
+    },
+    {
       "name": "palette-text",
       "value": {
         "type": "textColor",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -123,17 +123,6 @@
       }
     },
     {
-      "name": "primary-transparent25",
-      "value": {
-        "type": "multiply",
-        "source": {
-          "type": "settingValue",
-          "settingId": "primary"
-        },
-        "a": 0.25
-      }
-    },
-    {
       "name": "primary-transparent20",
       "value": {
         "type": "multiply",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -63,6 +63,21 @@
       }
     },
     {
+      "name": "page-loader",
+      "value": {
+        "type": "textColor",
+        "black": "#4d97ff",
+        "white": {
+          "type": "settingValue",
+          "settingId": "page"
+        },
+        "source": {
+          "type": "settingValue",
+          "settingId": "page"
+        }
+      }
+    },
+    {
       "name": "primary-text",
       "value": {
         "type": "textColor",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -15,12 +15,14 @@
 [class*="gui_tab_"]:not([class*="gui_is-selected_"]):hover img {
   filter: var(--editorDarkMode-page-tabHoverFilter);
 }
+[class*="loader_background_"] {
+  background-color: var(--editorDarkMode-page-loader);
+}
 
 /* Menu bar background */
 [class*="menu-bar_menu-bar_"],
 [class*="menu_menu_"],
 [class*="menu_submenu_"] > [class*="menu_menu_"]::-webkit-scrollbar-track,
-[class*="loader_background_"],
 [class*="modal_header_"] {
   background-color: var(--editorDarkMode-menuBar);
   color: var(--editorDarkMode-menuBar-text);
@@ -63,8 +65,7 @@
 .sa-editormessages::before,
 [class*="account-nav_user-info_"] [class*="account-nav_dropdown-caret-position_"] img,
 [class*="modal_back-button_"] [class*="button_icon_"],
-[class*="modal_header-item-close_"] [class*="close-button_close-icon_"],
-[class*="loader_background_"] img {
+[class*="modal_header-item-close_"] [class*="close-button_close-icon_"] {
   filter: var(--editorDarkMode-menuBar-filter);
 }
 [class*="menu-bar_divider_"],

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -425,10 +425,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 [class*="button_mod-disabled_"]:active {
   background-color: transparent;
 }
-.sa-body-editor::selection,
-.sa-body-editor ::selection {
-  background-color: var(--editorDarkMode-primary-transparent25);
-}
 [class*="library_filter-bar_"],
 .sa-body-editor [class*="stage-header_stage-button_"]:active,
 [class*="toggle-buttons_button_"]:active,

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -469,12 +469,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 [class*="record-modal_button-row_"] button[class*="record-modal_ok-button_"] {
   color: var(--editorDarkMode-primary-text);
 }
-.checked > .blocklyFlyoutCheckbox {
-  fill: var(--editorDarkMode-primary);
-}
-.checked .blocklyFlyoutCheckboxPath {
-  stroke: var(--editorDarkMode-primary-text);
-}
 [class*="gui_extension-button-icon_"],
 [class*="delete-button_delete-icon_"],
 [class*="action-menu_main-button_"]:not(:hover) [class*="action-menu_main-icon_"],
@@ -495,9 +489,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 [class*="audio-trimmer_selector_"] [class*="audio-trimmer_trim-line_"] {
   border-color: var(--editorDarkMode-primary-variant);
 }
-.checked > .blocklyFlyoutCheckbox {
-  stroke: var(--editorDarkMode-primary-variant);
-}
 /* Don't affect ask prompt: */
 [class*="question_question-input_"] [class*="input_input-form_"]:hover,
 [class*="question_question-container_"] /* <-- specificity */ [class*="question_question-input_"] [class*="input_input-form_"]:focus {
@@ -515,9 +506,6 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 [class*="record-modal_button-row_"] button,
 .sa-debugger-tabs li.sa-debugger-tab-selected {
   color: var(--editorDarkMode-highlightText);
-}
-.scratchCategoryMenuItem:hover {
-  color: var(--editorDarkMode-highlightText) !important;
 }
 [class*="gui_tab_"][class*="gui_is-selected_"] img,
 .sa-body-editor

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -343,6 +343,9 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
   background-color: var(--editorDarkMode-categoryMenu-selection);
   color: var(--editorDarkMode-categoryMenu-text);
 }
+.scratchCategoryMenuItem:hover {
+  color: var(--editorDarkMode-categoryMenu-hoverText) !important;
+}
 
 /* Block palette background */
 .blocklyFlyoutBackground {


### PR DESCRIPTION
### Changes

Makes selected text, hovered block category names, and checkboxes in the block palette blue even if a different highlight color is chosen.

A blue loading screen would look very bright in a dark theme, so the page background is used in dark themes instead.

### Reason for changes

In Scratch, these things are still blue and not purple.

### Tests

Tested by running scratch-www locally.