### PR TITLE
Update remaining uses of blue accent color

### DIFF
--- a/addon-api/content-script/modal.js
+++ b/addon-api/content-script/modal.js
@@ -89,8 +89,8 @@ export const createScratchWwwModal = (title, { isOpen = false, useSizesClass = t
       height: 3rem;
       box-sizing: border-box;
       padding-top: 0.75rem;
-      background-color: var(--darkWww-navbar, #4d97ff);
-      box-shadow: 0 -1px 0 0 inset var(--darkWww-navbar-variant, #4280d7);
+      background-color: var(--darkWww-navbar, #855cd6);
+      box-shadow: 0 -1px 0 0 inset var(--darkWww-navbar-variant, #7854c0);
       color: var(--darkWww-navbar-text, white);
       text-align: center;
       font-weight: bold;

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -497,10 +497,10 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 /* Don't affect ask prompt: */
 [class*="question_question-input_"] [class*="input_input-form_"]:hover,
 [class*="question_question-container_"] /* <-- specificity */ [class*="question_question-input_"] [class*="input_input-form_"]:focus {
-  border-color: #4d97ff;
+  border-color: #855cd6;
 }
 [class*="question_question-container_"] /* <-- specificity */ [class*="question_question-input_"] [class*="input_input-form_"]:focus {
-  box-shadow: 0 0 0 4px rgba(77, 151, 255, 0.35);
+  box-shadow: 0 0 0 4px rgba(133, 92, 214, 0.35);
 }
 
 /* Text and icon highlight color */

--- a/addons/op-badge/forums.css
+++ b/addons/op-badge/forums.css
@@ -1,6 +1,6 @@
 .sa-original-poster {
   display: inline-block;
-  background-color: var(--darkWww-button-scratchr2PostHeader, #28a5da);
+  background-color: var(--darkWww-button, #855cd6);
   color: var(--darkWww-button-text, white);
   border-radius: 16px;
   text-shadow: none;

--- a/addons/op-badge/projectpage.css
+++ b/addons/op-badge/projectpage.css
@@ -1,5 +1,5 @@
 .sa-original-poster {
-  background-color: var(--darkWww-button, #4d97ff);
+  background-color: var(--darkWww-button, #855cd6);
   color: var(--darkWww-button-text, white);
   border-radius: 16px;
   padding: 4px;

--- a/webpages/settings/components/previews/editor-dark-mode.html
+++ b/webpages/settings/components/previews/editor-dark-mode.html
@@ -1085,7 +1085,7 @@
     color: var(--highlightText);
   }
   .edm-tool-button-icons-not-affected .edm-tool-button .edm-icon-placeholder {
-    color: #4c97ff;
+    color: #855cd6;
   }
   .edm-tool-button > .edm-text-placeholder {
     margin: 0;


### PR DESCRIPTION
Part of #6091

### Changes

Updates the `op-badge` addon, `addon.tab.createModal`, and the editor dark mode preview to use the new purple color.

### Tests

Tested on Edge.