### PR TITLE
Do not show update notification on iframes

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -727,6 +727,7 @@ const showBanner = () => {
 };
 
 const handleBanner = async () => {
+  if (window.frameElement) return;
   const currentVersion = chrome.runtime.getManifest().version;
   const [major, minor, _patch] = currentVersion.split(".");
   let currentVersionMajorMinor = `${major}.${minor}`;


### PR DESCRIPTION
Resolves #6304

### Changes

Do not show update notification banner if running on an iframe.

### Tests

This is quite difficult to test. But in non-iframes, the update notification works normally after this change.