### PR TITLE
Fix stage header addons not showing in full screen

### DIFF
--- a/addons/clones/style.css
+++ b/addons/clones/style.css
@@ -37,6 +37,6 @@
   content: attr(data-str);
 }
 
-.sa-clones-small .clone-container-container {
+.sa-small-stage .clone-container-container {
   display: none !important;
 }

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -1,27 +1,12 @@
+import addSmallStageClass from "../../libraries/common/cs/small-stage.js";
+
 export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
 
   let showOnProjectPage = addon.settings.get("projectpage");
   let showIconOnly = addon.settings.get("showicononly");
 
-  const updateStageSize = () => {
-    if (!addon.tab.redux.state) return;
-    const isSmallStage = addon.tab.redux.state.scratchGui.stageSize.stageSize === "small";
-    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
-    const isPlayerOnly = addon.tab.redux.state.scratchGui.mode.isPlayerOnly;
-    document.body.classList.toggle("sa-clones-small", isSmallStage && !isFullScreen && !isPlayerOnly);
-  };
-  updateStageSize();
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (
-      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
-      e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN" ||
-      e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
-    ) {
-      updateStageSize();
-    }
-  });
+  addSmallStageClass();
 
   let countContainerContainer = document.createElement("div");
 

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -4,17 +4,22 @@ export default async function ({ addon, console, msg }) {
   let showOnProjectPage = addon.settings.get("projectpage");
   let showIconOnly = addon.settings.get("showicononly");
 
-  if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
-    document.body.classList.add("sa-clones-small");
-  }
+  const updateStageSize = () => {
+    if (!addon.tab.redux.state) return;
+    const isSmallStage = addon.tab.redux.state.scratchGui.stageSize.stageSize === "small";
+    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
+    const isPlayerOnly = addon.tab.redux.state.scratchGui.mode.isPlayerOnly;
+    document.body.classList.toggle("sa-clones-small", isSmallStage && !isFullScreen && !isPlayerOnly);
+  };
+  updateStageSize();
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE") {
-      if (e.detail.action.stageSize === "small") {
-        document.body.classList.add("sa-clones-small");
-      } else {
-        document.body.classList.remove("sa-clones-small");
-      }
+    if (
+      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE"
+      || e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
+      || e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
+    ) {
+      updateStageSize();
     }
   });
 

--- a/addons/clones/userscript.js
+++ b/addons/clones/userscript.js
@@ -15,9 +15,9 @@ export default async function ({ addon, console, msg }) {
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
     if (
-      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE"
-      || e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
-      || e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
+      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
+      e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN" ||
+      e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
     ) {
       updateStageSize();
     }

--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -8,7 +8,7 @@
   margin-left: 0.2rem;
 }
 
-.sa-debugger-small [class*="gui_body-wrapper_"]:not(.sa-stage-hidden) .sa-debugger-container {
+.sa-small-stage [class*="gui_body-wrapper_"]:not(.sa-stage-hidden) .sa-debugger-container {
   display: none !important;
 }
 

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -3,6 +3,7 @@ import createLogsTab from "./logs.js";
 import createThreadsTab from "./threads.js";
 import createPerformanceTab from "./performance.js";
 import Utils from "../find-bar/blockly/Utils.js";
+import addSmallStageClass from "../../libraries/common/cs/small-stage.js";
 
 const removeAllChildren = (element) => {
   while (element.firstChild) {
@@ -529,19 +530,7 @@ export default async function ({ addon, console, msg }) {
   }
   setActiveTab(allTabs[0]);
 
-  if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
-    document.body.classList.add("sa-debugger-small");
-  }
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE") {
-      if (e.detail.action.stageSize === "small") {
-        document.body.classList.add("sa-debugger-small");
-      } else {
-        document.body.classList.remove("sa-debugger-small");
-      }
-    }
-  });
+  addSmallStageClass();
 
   const ogGreenFlag = vm.runtime.greenFlag;
   vm.runtime.greenFlag = function (...args) {

--- a/addons/gamepad/style.css
+++ b/addons/gamepad/style.css
@@ -47,7 +47,7 @@
   filter: invert(100%);
 }
 
-.sa-gamepad-small [class*="gui_body-wrapper_"]:not(.sa-stage-hidden) .sa-gamepad-container[data-editor-mode="editor"] {
+.sa-small-stage [class*="gui_body-wrapper_"]:not(.sa-stage-hidden) .sa-gamepad-container {
   display: none !important;
 }
 

--- a/addons/gamepad/userscript.js
+++ b/addons/gamepad/userscript.js
@@ -1,4 +1,5 @@
 import GamepadLib from "./gamepadlib.js";
+import addSmallStageClass from "../../libraries/common/cs/small-stage.js";
 
 export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
@@ -286,19 +287,7 @@ export default async function ({ addon, console, msg }) {
     editor.focus();
   });
 
-  if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
-    document.body.classList.add("sa-gamepad-small");
-  }
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE") {
-      if (e.detail.action.stageSize === "small") {
-        document.body.classList.add("sa-gamepad-small");
-      } else {
-        document.body.classList.remove("sa-gamepad-small");
-      }
-    }
-  });
+  addSmallStageClass();
 
   const virtualCursorElement = document.createElement("img");
   virtualCursorElement.hidden = true;

--- a/addons/mouse-pos/style.css
+++ b/addons/mouse-pos/style.css
@@ -20,6 +20,6 @@
   content: attr(data-content);
 }
 
-.sa-mouse-pos-small .pos-container-container {
+.sa-small-stage .pos-container-container {
   display: none !important;
 }

--- a/addons/mouse-pos/userscript.js
+++ b/addons/mouse-pos/userscript.js
@@ -43,17 +43,20 @@ export default async function ({ addon, console }) {
     },
   });
 
-  if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
-    document.body.classList.add("sa-mouse-pos-small");
-  }
+  const updateStageSize = () => {
+    if (!addon.tab.redux.state) return;
+    const size = addon.tab.redux.state.scratchGui.stageSize.stageSize;
+    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
+    document.body.classList.toggle("sa-mouse-pos-small", size === "small" && !isFullScreen);
+  };
+  updateStageSize();
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE") {
-      if (e.detail.action.stageSize === "small") {
-        document.body.classList.add("sa-mouse-pos-small");
-      } else {
-        document.body.classList.remove("sa-mouse-pos-small");
-      }
+    if (
+      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE"
+      || e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
+    ) {
+      updateStageSize();
     }
   });
 

--- a/addons/mouse-pos/userscript.js
+++ b/addons/mouse-pos/userscript.js
@@ -1,3 +1,5 @@
+import addSmallStageClass from "../../libraries/common/cs/small-stage.js";
+
 export default async function ({ addon, console }) {
   var posContainerContainer = document.createElement("div");
   addon.tab.displayNoneWhileDisabled(posContainerContainer, { display: "flex" });
@@ -43,22 +45,7 @@ export default async function ({ addon, console }) {
     },
   });
 
-  const updateStageSize = () => {
-    if (!addon.tab.redux.state) return;
-    const size = addon.tab.redux.state.scratchGui.stageSize.stageSize;
-    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
-    document.body.classList.toggle("sa-mouse-pos-small", size === "small" && !isFullScreen);
-  };
-  updateStageSize();
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (
-      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
-      e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
-    ) {
-      updateStageSize();
-    }
-  });
+  addSmallStageClass();
 
   while (true) {
     await addon.tab.waitForElement('[class*="controls_controls-container"]', {

--- a/addons/mouse-pos/userscript.js
+++ b/addons/mouse-pos/userscript.js
@@ -53,8 +53,8 @@ export default async function ({ addon, console }) {
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
     if (
-      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE"
-      || e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
+      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
+      e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
     ) {
       updateStageSize();
     }

--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -69,9 +69,9 @@ export default async function ({ addon, console }) {
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
     if (
-      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE"
-      || e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
-      || e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
+      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
+      e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN" ||
+      e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
     ) {
       updateStageSize();
     }

--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -1,4 +1,5 @@
 import { setup, setVolume, onVolumeChanged, getVolume, setMuted, setUnmutedVolume, isMuted } from "./module.js";
+import addSmallStageClass from "../../libraries/common/cs/small-stage.js";
 
 export default async function ({ addon, console }) {
   const vm = addon.tab.traps.vm;
@@ -58,24 +59,7 @@ export default async function ({ addon, console }) {
     display: "flex",
   });
 
-  const updateStageSize = () => {
-    if (!addon.tab.redux.state) return;
-    const isSmallStage = addon.tab.redux.state.scratchGui.stageSize.stageSize === "small";
-    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
-    const isPlayerOnly = addon.tab.redux.state.scratchGui.mode.isPlayerOnly;
-    document.body.classList.toggle("sa-vol-slider-small", isSmallStage && !isFullScreen && !isPlayerOnly);
-  };
-  updateStageSize();
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (
-      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
-      e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN" ||
-      e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
-    ) {
-      updateStageSize();
-    }
-  });
+  addSmallStageClass();
 
   addon.self.addEventListener("disabled", () => {
     setVolume(1);

--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -58,17 +58,22 @@ export default async function ({ addon, console }) {
     display: "flex",
   });
 
-  if (addon.tab.redux.state && addon.tab.redux.state.scratchGui.stageSize.stageSize === "small") {
-    document.body.classList.add("sa-vol-slider-small");
-  }
+  const updateStageSize = () => {
+    if (!addon.tab.redux.state) return;
+    const isSmallStage = addon.tab.redux.state.scratchGui.stageSize.stageSize === "small";
+    const isFullScreen = addon.tab.redux.state.scratchGui.mode.isFullScreen;
+    const isPlayerOnly = addon.tab.redux.state.scratchGui.mode.isPlayerOnly;
+    document.body.classList.toggle("sa-vol-slider-small", isSmallStage && !isFullScreen && !isPlayerOnly);
+  };
+  updateStageSize();
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", (e) => {
-    if (e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE") {
-      if (e.detail.action.stageSize === "small") {
-        document.body.classList.add("sa-vol-slider-small");
-      } else {
-        document.body.classList.remove("sa-vol-slider-small");
-      }
+    if (
+      e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE"
+      || e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN"
+      || e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
+    ) {
+      updateStageSize();
     }
   });
 

--- a/addons/vol-slider/userstyle.css
+++ b/addons/vol-slider/userstyle.css
@@ -28,8 +28,8 @@
   cursor: pointer;
 }
 
-.sa-vol-slider-small .sa-vol-slider-input,
-.sa-vol-slider-small .sa-vol-slider-icon:not([data-icon="mute"]) {
+.sa-small-stage .sa-vol-slider-input,
+.sa-small-stage .sa-vol-slider-icon:not([data-icon="mute"]) {
   display: none;
 }
 

--- a/libraries/common/cs/small-stage.js
+++ b/libraries/common/cs/small-stage.js
@@ -1,0 +1,26 @@
+function updateClass() {
+  const state = __scratchAddonsRedux.state;
+  if (!state) return;
+  const isSmallStage = state.scratchGui.stageSize.stageSize === "small";
+  const isFullScreen = state.scratchGui.mode.isFullScreen;
+  const isPlayerOnly = state.scratchGui.mode.isPlayerOnly;
+  document.body.classList.toggle("sa-small-stage", isSmallStage && !isFullScreen && !isPlayerOnly);
+}
+
+function handleStateChange(e) {
+  if (
+    e.detail.action.type === "scratch-gui/StageSize/SET_STAGE_SIZE" ||
+    e.detail.action.type === "scratch-gui/mode/SET_FULL_SCREEN" ||
+    e.detail.action.type === "scratch-gui/mode/SET_PLAYER"
+  ) {
+    updateClass();
+  }
+}
+
+export default function addSmallStageClass() {
+  if (!__scratchAddonsRedux.target) return;
+  updateClass();
+  /* The listener isn't an anonymous function to make sure that only one listener is added
+     if multiple addons on the same tab use this module. */
+  __scratchAddonsRedux.target.addEventListener("statechanged", handleStateChange);
+}


### PR DESCRIPTION
Resolves #6275

### Changes

Fixes a bug in `clones`, `mouse-pos` and `vol-slider`: switching to full screen or the project page while small stage mode was selected didn't show the addon's UI. `gamepad` doesn't seem to be affected.

### Tests

Tested on Edge and Firefox.