### PR TITLE
dark-www: old scratchr2 blue and other changes

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -231,7 +231,7 @@
       }
     },
     {
-      "name": "navbar-scratchr2Border",
+      "name": "navbar-scratchr2ItemHover",
       "value": {
         "type": "multiply",
         "source": {

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -208,6 +208,24 @@
       }
     },
     {
+      "name": "navbar-scratchr2",
+      "value": {
+        "type": "map",
+        "source": {
+          "type": "settingValue",
+          "settingId": "navbar"
+        },
+        "options": {
+          "#4d97ff": "#0f8bc0",
+          "#4d97ffff": "#0f8bc0"
+        },
+        "default": {
+          "type": "settingValue",
+          "settingId": "navbar"
+        }
+      }
+    },
+    {
       "name": "navbar-scratchr2Text",
       "value": {
         "type": "textColor",
@@ -233,14 +251,25 @@
     {
       "name": "navbar-scratchr2ItemHover",
       "value": {
-        "type": "multiply",
+        "type": "map",
         "source": {
           "type": "settingValue",
           "settingId": "navbar"
         },
-        "r": 0.9,
-        "g": 0.9,
-        "b": 0.9
+        "options": {
+          "#4d97ff": "#0c6185",
+          "#4d97ffff": "#0c6185"
+        },
+        "default": {
+          "type": "multiply",
+          "source": {
+            "type": "settingValue",
+            "settingId": "navbar"
+          },
+          "r": 0.9,
+          "g": 0.9,
+          "b": 0.9
+        }
       }
     },
     {
@@ -1511,6 +1540,48 @@
       }
     },
     {
+      "name": "button-scratchr2",
+      "value": {
+        "type": "map",
+        "source": {
+          "type": "settingValue",
+          "settingId": "button"
+        },
+        "options": {
+          "#4d97ff": "#18abeb",
+          "#4d97ffff": "#18abeb"
+        },
+        "default": {
+          "type": "settingValue",
+          "settingId": "button"
+        }
+      }
+    },
+    {
+      "name": "button-scratchr2Hover",
+      "value": {
+        "type": "map",
+        "source": {
+          "type": "settingValue",
+          "settingId": "button"
+        },
+        "options": {
+          "#4d97ff": "#169fdb",
+          "#4d97ffff": "#169fdb"
+        },
+        "default": {
+          "type": "multiply",
+          "source": {
+            "type": "settingValue",
+            "settingId": "button"
+          },
+          "r": 0.9,
+          "g": 0.9,
+          "b": 0.9
+        }
+      }
+    },
+    {
       "name": "button-scratchr2ButtonText",
       "value": {
         "type": "textColor",
@@ -1546,17 +1617,19 @@
     {
       "name": "button-scratchr2PostHeader",
       "value": {
-        "type": "brighten",
+        "type": "map",
         "source": {
-          "type": "multiply",
-          "source": {
-            "type": "settingValue",
-            "settingId": "button"
-          },
-          "r": 0.52,
-          "b": 0.85
+          "type": "settingValue",
+          "settingId": "button"
         },
-        "g": 0.85
+        "options": {
+          "#4d97ff": "#28a5da",
+          "#4d97ffff": "#28a5da"
+        },
+        "default": {
+          "type": "settingValue",
+          "settingId": "button"
+        }
       }
     },
     {
@@ -1606,6 +1679,24 @@
           "r": 0.86,
           "g": 0.85,
           "b": 0.84
+        }
+      }
+    },
+    {
+      "name": "link-scratchr2",
+      "value": {
+        "type": "map",
+        "source": {
+          "type": "settingValue",
+          "settingId": "link"
+        },
+        "options": {
+          "#4d97ff": "#1aa0d8",
+          "#4d97ffff": "#1aa0d8"
+        },
+        "default": {
+          "type": "settingValue",
+          "settingId": "link"
         }
       }
     },

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -261,14 +261,14 @@
           "#4d97ffff": "#0c6185"
         },
         "default": {
-          "type": "multiply",
+          "type": "textColor",
+          "black": "rgba(0, 0, 0, 0.1)",
+          "white": "rgba(255, 255, 255, 0.1)",
           "source": {
             "type": "settingValue",
             "settingId": "navbar"
           },
-          "r": 0.9,
-          "g": 0.9,
-          "b": 0.9
+          "threshold": 60
         }
       }
     },

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -448,6 +448,7 @@ input.link:hover,
 input.link:active,
 input.link.black:hover,
 input.link.black:active,
+#comments .comment .info .name a:hover,
 #comments .more-replies .pulldown,
 #email-resend-box a {
   color: var(--darkWww-link);

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -24,7 +24,7 @@ label,
 #topnav ul.account-nav .logged-in-user .dropdown-menu,
 #topnav li.logout.divider input,
 #topnav ul.account-nav .sign-in .popover {
-  background-color: var(--darkWww-navbar);
+  background-color: var(--darkWww-navbar-scratchr2);
 }
 #topnav ul.site-nav li,
 #topnav ul.site-nav li.last,
@@ -33,11 +33,11 @@ label,
 #topnav ul.account-nav.logged-in > li,
 #topnav ul.account-nav ul.user-nav li.logout.divider,
 #topnav ul.account-nav .sign-in .popover {
-  border-color: var(--darkWww-navbar);
+  border-color: var(--darkWww-navbar-scratchr2);
 }
 #topnav ul.account-nav .sign-in .popover .arrow,
 #topnav ul.account-nav .sign-in .popover .arrow::after {
-  border-bottom-color: var(--darkWww-navbar);
+  border-bottom-color: var(--darkWww-navbar-scratchr2);
 }
 #topnav ul.site-nav li a,
 #topnav ul.account-nav > li > span,
@@ -382,9 +382,9 @@ ul.pagination span /* mobile forums */ {
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button {
-  background-color: var(--darkWww-button);
+  background-color: var(--darkWww-button-scratchr2);
   background-image: none; /* Fixes Scratch bug: https://scratch.mit.edu/discuss/topic/694218/ */
-  border-color: var(--darkWww-button);
+  border-color: var(--darkWww-button-scratchr2);
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button a,
@@ -396,7 +396,7 @@ ul.pagination span /* mobile forums */ {
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button:hover {
-  background-color: var(--darkWww-button-variant);
+  background-color: var(--darkWww-button-scratchr2Hover);
   background-image: none; /* Fixes Scratch bug: https://scratch.mit.edu/discuss/topic/694218/ */
 }
 input:focus,
@@ -414,14 +414,14 @@ textarea:focus,
   box-shadow: none;
 }
 .blockpost div.box {
-  background-color: var(--darkWww-button);
-  border-top-color: var(--darkWww-button);
+  background-color: var(--darkWww-button-scratchr2PostHeader);
+  border-top-color: var(--darkWww-button-scratchr2PostHeader);
 }
 .my-ocular-reaction-button {
-  box-shadow: 0 0 2px var(--darkWww-button);
+  box-shadow: 0 0 2px var(--darkWww-button-scratchr2PostHeader);
 }
 .my-ocular-reaction-button.selected {
-  background-color: var(--darkWww-button);
+  background-color: var(--darkWww-button-scratchr2PostHeader);
   color: var(--darkWww-button-scratchr2PostHeaderText);
 }
 .blockpost .box-head {
@@ -450,7 +450,7 @@ input.link.black:active,
 #comments .comment .info .name a:hover,
 #comments .more-replies .pulldown,
 #email-resend-box a {
-  color: var(--darkWww-link);
+  color: var(--darkWww-link-scratchr2);
 }
 .inew,
 .isticky:not(.iclosed) {

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -22,9 +22,12 @@ label,
 /* Navigation bar background */
 #topnav .innerwrap,
 #topnav ul.account-nav .logged-in-user .dropdown-menu,
-#topnav li.logout.divider input,
 #topnav ul.account-nav .sign-in .popover {
   background-color: var(--darkWww-navbar-scratchr2);
+}
+#topnav li.logout.divider input,
+#topnav li.logout.divider input:hover {
+  background-color: transparent;
 }
 #topnav ul.site-nav li,
 #topnav ul.site-nav li.last,
@@ -33,11 +36,13 @@ label,
 #topnav ul.account-nav.logged-in > li,
 #topnav ul.account-nav ul.user-nav li.logout.divider,
 #topnav ul.account-nav .sign-in .popover {
-  border-color: var(--darkWww-navbar-scratchr2);
+  border-color: transparent;
 }
-#topnav ul.account-nav .sign-in .popover .arrow,
-#topnav ul.account-nav .sign-in .popover .arrow::after {
+#topnav ul.account-nav .sign-in .popover .arrow {
   border-bottom-color: var(--darkWww-navbar-scratchr2);
+}
+#topnav ul.account-nav .sign-in .popover .arrow::after {
+  border-bottom-color: transparent;
 }
 #topnav ul.site-nav li a,
 #topnav ul.account-nav > li > span,
@@ -72,8 +77,7 @@ label,
 #topnav ul.site-nav li:hover,
 #topnav ul.account-nav > li.sign-in:hover,
 #topnav ul.account-nav > li.sign-in.open,
-#topnav ul.account-nav.logged-in li:hover,
-#topnav li.logout.divider input:hover {
+#topnav ul.account-nav.logged-in li:hover {
   background-color: var(--darkWww-navbar-scratchr2ItemHover);
 }
 #topnav ul.account-nav .logged-in-user.dropdown.open {

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -26,7 +26,17 @@ label,
 #topnav ul.account-nav .sign-in .popover {
   background-color: var(--darkWww-navbar);
 }
-#topnav ul.account-nav .sign-in .popover .arrow:after {
+#topnav ul.site-nav li,
+#topnav ul.site-nav li.last,
+#topnav ul.account-nav > li,
+#topnav ul.account-nav > li.join-scratch,
+#topnav ul.account-nav.logged-in > li,
+#topnav ul.account-nav ul.user-nav li.logout.divider,
+#topnav ul.account-nav .sign-in .popover {
+  border-color: var(--darkWww-navbar);
+}
+#topnav ul.account-nav .sign-in .popover .arrow,
+#topnav ul.account-nav .sign-in .popover .arrow::after {
   border-bottom-color: var(--darkWww-navbar);
 }
 #topnav ul.site-nav li a,
@@ -59,27 +69,15 @@ label,
   background: url("https://cdn.scratch.mit.edu/scratchr2/static/images/nav-notifications.png") no-repeat center center;
   filter: var(--darkWww-navbar-scratchr2ShadowFilter);
 }
-#topnav ul.site-nav li,
-#topnav ul.site-nav li.last,
-#topnav ul.account-nav > li,
-#topnav ul.account-nav > li.join-scratch,
-#topnav ul.account-nav.logged-in > li,
-#topnav ul.account-nav ul.user-nav li.logout.divider,
-#topnav ul.account-nav .sign-in .popover {
-  border-color: var(--darkWww-navbar-scratchr2Border);
-}
-#topnav ul.account-nav .sign-in .popover .arrow {
-  border-bottom-color: var(--darkWww-navbar-scratchr2Border);
-}
 #topnav ul.site-nav li:hover,
 #topnav ul.account-nav > li.sign-in:hover,
 #topnav ul.account-nav > li.sign-in.open,
 #topnav ul.account-nav.logged-in li:hover,
 #topnav li.logout.divider input:hover {
-  background-color: var(--darkWww-navbar-scratchr2Border);
+  background-color: var(--darkWww-navbar-scratchr2ItemHover);
 }
 #topnav ul.account-nav .logged-in-user.dropdown.open {
-  background-color: var(--darkWww-navbar-scratchr2Border) !important;
+  background-color: var(--darkWww-navbar-scratchr2ItemHover) !important;
 }
 
 /* Content background */
@@ -384,9 +382,9 @@ ul.pagination span /* mobile forums */ {
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button {
-  background-image: linear-gradient(var(--darkWww-button), var(--darkWww-button-variant));
-  border-color: rgba(0, 0, 0, 0.2);
-  border-bottom-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--darkWww-button);
+  background-image: none; /* Fixes Scratch bug: https://scratch.mit.edu/discuss/topic/694218/ */
+  border-color: var(--darkWww-button);
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button a,
@@ -398,7 +396,8 @@ ul.pagination span /* mobile forums */ {
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button:hover {
-  background-image: linear-gradient(var(--darkWww-button-variant), var(--darkWww-button-variant));
+  background-color: var(--darkWww-button-variant);
+  background-image: none; /* Fixes Scratch bug: https://scratch.mit.edu/discuss/topic/694218/ */
 }
 input:focus,
 textarea:focus,

--- a/addons/op-badge/forums.css
+++ b/addons/op-badge/forums.css
@@ -1,6 +1,6 @@
 .sa-original-poster {
   display: inline-block;
-  background-color: var(--darkWww-button, #855cd6);
+  background-color: var(--darkWww-button-scratchr2PostHeader, #28a5da);
   color: var(--darkWww-button-text, white);
   border-radius: 16px;
   text-shadow: none;

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -279,7 +279,7 @@ function setCssVariables(addonSettings, addonsWithUserstyles) {
         // this is not even a color lol
         return getColor(addonId, obj.source) ? getColor(addonId, obj.true) : getColor(addonId, obj.false);
       case "map":
-        return obj.options[getColor(addonId, obj.source)];
+        return getColor(addonId, obj.options[getColor(addonId, obj.source)]) || getColor(addonId, obj.default);
       case "textColor": {
         hex = getColor(addonId, obj.source);
         let black = getColor(addonId, obj.black);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -279,7 +279,7 @@ function setCssVariables(addonSettings, addonsWithUserstyles) {
         // this is not even a color lol
         return getColor(addonId, obj.source) ? getColor(addonId, obj.true) : getColor(addonId, obj.false);
       case "map":
-        return getColor(addonId, obj.options[getColor(addonId, obj.source)]) || getColor(addonId, obj.default);
+        return getColor(addonId, obj.options[getColor(addonId, obj.source)] ?? obj.default);
       case "textColor": {
         hex = getColor(addonId, obj.source);
         let black = getColor(addonId, obj.black);


### PR DESCRIPTION
Resolves #6314

### Changes

* Fixes the color of hovered usernames in profile comments (https://github.com/ScratchAddons/ScratchAddons/issues/6296#issuecomment-1612304865)
* Removes separators between menu bar items (#6314)
* Changes the blue color on scratchr2 pages if a blue preset is selected (https://github.com/ScratchAddons/ScratchAddons/pull/6268#issuecomment-1613487815)
* `customCssVariables` changes:
  * New `default` property for `"type": "map"` value providers. It's a value provider that's used as a fallback if none of the options match.
  * The `options` of a `"type": "map"` value provider can now also be value providers.

### Reason for changes

To make the "Scratch's default colors" preset more similar to Scratch's new design and the blue presets to the old one.

### Tests

Tested on Edge and Firefox.