### PR TITLE
dark-www: fix duplicate preset IDs

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2261,7 +2261,7 @@
     },
     {
       "name": "\"Experimental\" Dark (blue)",
-      "id": "experimentalDark",
+      "id": "experimentalDark-blue",
       "description": "\"Experimental\" Dark with a blue accent color",
       "values": {
         "page": "#202020",
@@ -2318,7 +2318,7 @@
     },
     {
       "name": "Scratch's default colors (blue)",
-      "id": "scratch",
+      "id": "scratch-blue",
       "description": "The colors originally used by Scratch",
       "values": {
         "page": "#fcfcfc",


### PR DESCRIPTION
### Changes

Changes the IDs of the two "blue" website dark mode presets. They currently (in v1.33.2) have the same IDs as the purple versions.

### Reason for changes

If two presets have the same ID, only one string is uploaded to Transifex and their names and descriptions are the same in languages other than English.

### Tests

The presets are still displayed correctly on the settings page.