### PR TITLE
Fix modal API "X" close icon not loading

### DIFF
--- a/addon-api/content-script/modal.js
+++ b/addon-api/content-script/modal.js
@@ -31,7 +31,7 @@ export const createEditorModal = (tab, title, { isOpen = false } = {}) => {
   closeButton.appendChild(
     Object.assign(document.createElement("img"), {
       className: tab.scratchClass("close-button_close-icon"),
-      src: "/static/assets/cb666b99d3528f91b52f985dfb102afa.svg",
+      src: import.meta.url + "/../../../images/cs/close-s3.svg",
     })
   );
   const content = Object.assign(document.createElement("div"), {

--- a/images/cs/close-s3.svg
+++ b/images/cs/close-s3.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.48 7.48"><defs><style>.cls-1{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:2px;}</style></defs><title>icon--add</title><line class="cls-1" x1="3.74" y1="6.48" x2="3.74" y2="1"/><line class="cls-1" x1="1" y1="3.74" x2="6.48" y2="3.74"/></svg>


### PR DESCRIPTION
Resolves #6292

### Changes

Looks like Scratch currently uses a data URL for its "X" icon. There may be a new URL that works now, but anyways I think it's better to include the close icon as part of the source.