### PR TITLE
Add a math extension

### DIFF
--- a/addons/3d-extension/addon.json
+++ b/addons/3d-extension/addon.json
@@ -1,6 +1,12 @@
 {
     "name": "3D Addon",
     "description": "Loads a 3D extension.",
+    "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects", "https://scratch.mit.edu/",]
+    }
+  ],
     "tags": ["editor"],
     "enabledByDefault": true
   }

--- a/addons/3d-extension/addon.json
+++ b/addons/3d-extension/addon.json
@@ -1,0 +1,6 @@
+{
+    "name": "3D Addon",
+    "description": "Loads a 3D extension.",
+    "tags": ["editor"],
+    "enabledByDefault": true
+  }

--- a/addons/3d-extension/addon.json
+++ b/addons/3d-extension/addon.json
@@ -4,7 +4,7 @@
     "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects", "https://scratch.mit.edu/",]
+      "matches": ["projects", "https://scratch.mit.edu/"]
     }
   ],
     "tags": ["editor"],

--- a/addons/3d-extension/addon.json
+++ b/addons/3d-extension/addon.json
@@ -1,12 +1,19 @@
 {
-    "name": "3D Addon",
-    "description": "Loads a 3D extension.",
-    "userscripts": [
+  "name": "Math Extension",
+  "description": "Adds a math extension to scratch",
+  "credits": [
     {
-      "url": "userscript.js",
-      "matches": ["projects", "https://scratch.mit.edu/"]
+      "name": ["kokofixcomputers", "lolucky"]
     }
   ],
-    "tags": ["editor"],
-    "enabledByDefault": true
-  }
+  "dynamicEnable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "versionAdded": "1.0.0",
+  "tags": ["editor", "codeEditor", "recommended"],
+  "enabledByDefault": true
+}

--- a/addons/3d-extension/userscript.js
+++ b/addons/3d-extension/userscript.js
@@ -1,0 +1,4 @@
+export default async function ({ addon, console }) {
+  console.log("Attempting to add an extension to Scratch");
+  window.location.href = 'javascript:fetch("https://raw.githubusercontent.com/LoganAbel/ScratchMath/main/Math.js").then(r=>r.text()).then(t=>eval(t))';
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -1,4 +1,5 @@
 [
+  "3d-extension"
   "editor-searchable-dropdowns",
   "editor-devtools",
   "forum-search",


### PR DESCRIPTION
### Changes

I've added a addon named Math Extension it adds a extension to scratch named Math

### Reason for changes

I added these changes so that I could do more math on scratch. Warning: other people without this math extension cannot run this project please add this warning. Other people could also add a bookmark on this url: javascript:fetch('https://raw.githubusercontent.com/LoganAbel/ScratchMath/main/Math.js').then(r=>r.text()).then(t=>eval(t))

### Tests

Tested on Brave (Chrome)
