### PR TITLE
editor-dark-mode: blue paint editor

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -440,7 +440,7 @@
               "type": "makeHsv",
               "h": {
                 "type": "settingValue",
-                "settingId": "primary"
+                "settingId": "page"
               },
               "s": 1,
               "v": 0.67
@@ -449,7 +449,7 @@
               "type": "makeHsv",
               "h": {
                 "type": "settingValue",
-                "settingId": "primary"
+                "settingId": "page"
               },
               "s": 0.5,
               "v": 1
@@ -968,7 +968,7 @@
       "default": false
     },
     {
-      "name": "Change the costume editor background and selection borders",
+      "name": "Change the costume editor background",
       "id": "affectPaper",
       "type": "boolean",
       "default": true


### PR DESCRIPTION
Resolves #6301

### Changes

* Uses the page background instead of the highlight color to generate the background pattern of the costume editor canvas
* Makes the selection borders always blue

### Reason for changes

Consistency with Scratch.

### Tests

Tested all presets on Edge and Firefox.