### PR TITLE
dark-www: fix text color in About me & WIWO

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -619,11 +619,29 @@
       }
     },
     {
-      "name": "box-scratchr2TransparentText",
+      "name": "box-scratchr2GrayText",
       "value": {
         "type": "textColor",
-        "black": "rgba(0, 0, 0, 0.47)",
-        "white": "rgba(255, 255, 255, 0.75)",
+        "black": {
+          "type": "multiply",
+          "source": {
+            "type": "settingValue",
+            "settingId": "box"
+          },
+          "r": 0.53,
+          "g": 0.53,
+          "b": 0.53
+        },
+        "white": {
+          "type": "brighten",
+          "source": {
+            "type": "settingValue",
+            "settingId": "box"
+          },
+          "r": 0.25,
+          "g": 0.25,
+          "b": 0.25
+        },
         "source": {
           "type": "settingValue",
           "settingId": "box"
@@ -979,11 +997,29 @@
       }
     },
     {
-      "name": "gray-scratchr2TransparentText",
+      "name": "gray-scratchr2GrayText",
       "value": {
         "type": "textColor",
-        "black": "rgba(0, 0, 0, 0.45)",
-        "white": "rgba(255, 255, 255, 0.75)",
+        "black": {
+          "type": "multiply",
+          "source": {
+            "type": "settingValue",
+            "settingId": "gray"
+          },
+          "r": 0.55,
+          "g": 0.55,
+          "b": 0.55
+        },
+        "white": {
+          "type": "brighten",
+          "source": {
+            "type": "settingValue",
+            "settingId": "gray"
+          },
+          "r": 0.25,
+          "g": 0.25,
+          "b": 0.25
+        },
         "source": {
           "type": "settingValue",
           "settingId": "gray"

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -191,7 +191,7 @@ span.small-text,
 #comments .comment .delete,
 .box .box-content .pagination .disabled,
 .registration a.why-we-ask {
-  color: var(--darkWww-box-scratchr2TransparentText);
+  color: var(--darkWww-box-scratchr2GrayText);
 }
 .dropdown span.dropdown-toggle.black span.caret {
   border-top-color: var(--darkWww-box-scratchr2Caret);
@@ -304,7 +304,7 @@ button:hover,
 .activity-stream .time,
 #profile-data .footer #report-this,
 .profile-box-footer-module textarea::placeholder {
-  color: var(--darkWww-gray-scratchr2TransparentText);
+  color: var(--darkWww-gray-scratchr2GrayText);
 }
 #comments .highlighted .info .name a {
   color: var(--darkWww-gray-scratchr2LabelText);

--- a/addons/user-id/userstyle.css
+++ b/addons/user-id/userstyle.css
@@ -1,5 +1,5 @@
 .sa-user-id {
-  color: var(--darkWww-gray-scratchr2TransparentText, rgba(0, 0, 0, 0.45));
+  color: var(--darkWww-gray-scratchr2GrayText, #888);
   font-size: 16px;
   line-height: normal;
   margin-left: 4px;


### PR DESCRIPTION
Resolves #6306

### Changes

Changes the text color of About me and WIWO sections on profile pages to an opaque one.

### Reason for changes

The transparent color wasn't dark enough on Chromium-based browsers. It also made emojis transparent.

### Tests

Tested on Edge and Firefox.