### PR TITLE
Fix references to Scratch asset URLs

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -329,8 +329,8 @@
       "name": "selectorSelection-filter",
       "value": {
         "type": "textColor",
-        "black": "none",
-        "white": "brightness(0) invert(1)",
+        "black": "drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.15)",
+        "white": "brightness(0) invert(1) drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.15)",
         "source": {
           "type": "settingValue",
           "settingId": "selectorSelection"

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -142,9 +142,11 @@
   [class*="sprite-selector-item_sprite-info_"] {
   color: var(--editorDarkMode-selectorSelection-text);
 }
-[class*="gui_tab-panel_"]:nth-child(4) [class*="sprite-selector-item_is-selected_"]
+[class*="gui_tab-panel_"]:nth-child(4)
+  [class*="sprite-selector-item_is-selected_"]
   [class*="sprite-selector-item_sprite-image_"],
-[class*="gui_tab-panel_"]:nth-child(4) [class*="sprite-selector-item_sprite-selector-item_"]:hover
+[class*="gui_tab-panel_"]:nth-child(4)
+  [class*="sprite-selector-item_sprite-selector-item_"]:hover
   [class*="sprite-selector-item_sprite-image_"] {
   filter: var(--editorDarkMode-selectorSelection-filter);
 }

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -128,8 +128,8 @@
 [class*="selector_list-item_"] [class*="sprite-selector-item_sprite-info_"] {
   color: var(--editorDarkMode-selector2-text);
 }
-img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
-  filter: var(--editorDarkMode-selector2-filter) drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.15)) !important;
+[class*="gui_tab-panel_"]:nth-child(4) [class*="sprite-selector-item_sprite-image_"] {
+  filter: var(--editorDarkMode-selector2-filter);
 }
 
 /* Selected list item background */
@@ -142,10 +142,11 @@ img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
   [class*="sprite-selector-item_sprite-info_"] {
   color: var(--editorDarkMode-selectorSelection-text);
 }
-[class*="sprite-selector-item_is-selected_"] img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"],
-[class*="sprite-selector-item_sprite-selector-item_"]:hover
-  img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
-  filter: var(--editorDarkMode-selectorSelection-filter) drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.15)) !important;
+[class*="gui_tab-panel_"]:nth-child(4) [class*="sprite-selector-item_is-selected_"]
+  [class*="sprite-selector-item_sprite-image_"],
+[class*="gui_tab-panel_"]:nth-child(4) [class*="sprite-selector-item_sprite-selector-item_"]:hover
+  [class*="sprite-selector-item_sprite-image_"] {
+  filter: var(--editorDarkMode-selectorSelection-filter);
 }
 
 /* Accent background */
@@ -212,7 +213,7 @@ img[src="/static/assets/63e5827c1506216bd7c9927a4e5eb558.svg"] {
 img[class*="tool-select-base_tool-select-icon_"],
 [class*="paint-editor_button-group-button-icon_"],
 [class*="mode-tools_mode-tools-icon_"],
-img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
+[class*="library-item_library-item-image_"][src*="static/assets"] /* sound icon */,
 [class*="library-item_featured-extension-metadata-detail_"] img {
   filter: var(--editorDarkMode-accent-filter);
 }
@@ -499,8 +500,8 @@ img[src="/static/assets/7bd7487b704797cb5ab3cb441486ea70.svg"],
 [class*="sound-editor_tool-button_"] img,
 [class*="audio-trimmer_trim-handle_"] img,
 [class*="filter_filter-icon_"],
-img[src="/static/assets/d889a872f3b0985b28fa872764172ef1.svg"] /* record modal play */,
-img[src="/static/assets/26255153f92ea41df149a58d3c3fe2cf.svg"] /* record modal stop */,
+img[src="/static/assets/7911235b3ccae7b7452ba3da6b5e9c7f.svg"] /* record modal play */,
+img[src*="c3RvcC1wbGF5YmFjayI+CiAgICAgICAgICAgICAgICAgICAgICAgIDx1c2UgZmlsbD0iYmxhY2siIGZpbGwtb3BhY2l0eT0iMSIgZmlsdGVyPSJ1cmwoI2ZpbHRlci0yKSIgeGxpbms6aHJlZj0iI3BhdGgtMSI+PC91c2U+CiAgICAgICAgICAgICAgICAgICAgICAgIDx1c2UgZmlsbD0iIzg1NUNENiIg"] /* record modal stop */,
 [class*="record-modal_rerecord-button_"] img,
 .sa-debugger-tabs li.sa-debugger-tab-selected img {
   filter: var(--editorDarkMode-highlightText-iconFilter);

--- a/addons/scratchr2/assets/zoom_in.svg
+++ b/addons/scratchr2/assets/zoom_in.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="6 6 24 24"><defs><style>.cls-4{fill:none;stroke:#575e75;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px}</style></defs><g class="cls-3"><circle class="cls-4" cx="18" cy="18" r="7"/><path class="cls-4" d="m23 23 3 3M16 18h4M18 16v4"/></g></svg>

--- a/addons/scratchr2/assets/zoom_out.svg
+++ b/addons/scratchr2/assets/zoom_out.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="6 6 24 24"><defs><style>.cls-4{fill:none;stroke:#575e75;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px}</style></defs><g class="cls-3"><circle class="cls-4" cx="18" cy="18" r="7"/><path class="cls-4" d="m23 23 3 3M16 18h4"/></g></svg>

--- a/addons/scratchr2/assets/zoom_reset.svg
+++ b/addons/scratchr2/assets/zoom_reset.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="6 6 24 24"><defs><style>.cls-4{fill:#575e75}</style></defs><g class="cls-3"><rect class="cls-4" x="13" y="14" width="10" height="2" rx="1" ry="1"/><rect class="cls-4" x="13" y="20" width="10" height="2" rx="1" ry="1"/></g></svg>

--- a/addons/scratchr2/remixtree.css
+++ b/addons/scratchr2/remixtree.css
@@ -26,17 +26,17 @@ a:visited:hover {
   border-bottom-left-radius: 4px;
 }
 #zoomOut img {
-  content: url("https://scratch.mit.edu/static/assets/1fa6345d57ffc67eccd9f44cf6a383dd.svg");
+  content: url("%addon-self-dir%/assets/zoom_out.svg");
 }
 #zoomEqual img {
-  content: url("https://scratch.mit.edu/static/assets/dba629c24296756d68a135988fe96011.svg");
+  content: url("%addon-self-dir%/assets/zoom_reset.svg");
 }
 #zoomIn {
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
 }
 #zoomIn img {
-  content: url("https://scratch.mit.edu/static/assets/3cfc9b39a0d002246119d47f6756d77e.svg");
+  content: url("%addon-self-dir%/assets/zoom_in.svg");
 }
 .box .box-head {
   padding: 8px 20px;


### PR DESCRIPTION
scratchfoundation/scratch-gui#8843 changed the way Scratch serves static files, which broke existing URLs and caused a few issues in SA (#6292 is already fixed). This PR fixes the following bugs:

* Zoom icons in remix tree were broken if 2.0 → 3.0 was enabled:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/97f13e5a-3e8a-47a3-b50e-dfa2ef1ffe42)
* Icons in the Sounds tab and library weren't white in dark mode:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/a32d93b3-78c7-47b5-9b79-9b1eea973ff0)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/92e9f2e6-8376-4a74-95a6-a553472125d1)
* Play and Stop icons in the record modal weren't affected by the highlight color setting.