### PR TITLE
Fix two lint errors

### DIFF
--- a/addons/necropost-highlighter/userscript.js
+++ b/addons/necropost-highlighter/userscript.js
@@ -214,7 +214,7 @@ export default async function ({ addon, global, console, msg }) {
       return searchResultsPageName;
     }
     // check each forum we explicitly know about, so might be highlighting
-    for (let setting in customForumSettingToForum) {
+    for (let setting of Object.keys(customForumSettingToForum)) {
       let forum = customForumSettingToForum[setting];
       if (titleText.includes(forum)) {
         return forum;

--- a/addons/vol-slider/userscript.js
+++ b/addons/vol-slider/userscript.js
@@ -13,7 +13,7 @@ export default async function ({ addon, console }) {
 
   const updateIcon = () => {
     const newVolume = getVolume();
-    if (newVolume == 0) {
+    if (newVolume === 0) {
       icon.dataset.icon = "mute";
     } else if (newVolume < 0.5) {
       icon.dataset.icon = "quiet";


### PR DESCRIPTION
The other two stems from use of ES2022 feature. While static fields are supported by the lowest supported browsers (Chrome 80/Firefox 86) it is not in ES2020 (which eslint is configured to). Eslint config would be modified when we revisit supported version policy.