### PR TITLE
Use non-deprecated API on share-through-mystuff

### DIFF
--- a/addons/share-through-mystuff/userscript.js
+++ b/addons/share-through-mystuff/userscript.js
@@ -20,7 +20,31 @@ export default async function ({ addon, console, msg }) {
     event.preventDefault();
     const confirmation = await addon.tab.confirm(msg("confirmation-title"), msg("confirmation"));
     if (confirmation) {
-      event.target.parentElement.querySelector(".media-share").click();
+      const xToken = await addon.auth.fetchXToken();
+      const projectId = event.target
+        .closest(".media-item-content")
+        .querySelector(".media-thumb > a")
+        .href.match(/\d+/)[0];
+
+      const xhrOpen = XMLHttpRequest.prototype.open;
+      const xhrSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function (method, path, ...args) {
+        const newPath = `https://api.scratch.mit.edu/proxy/projects/${projectId}/share`;
+        xhrOpen.call(this, "PUT", newPath, ...args);
+        // CSRF token header is added by Scratch
+        this.setRequestHeader("x-token", xToken);
+        this.withCredentials = true;
+        this.send = () => {
+          this.setRequestHeader("X-Requested-With", ""); // Do not send this header
+          xhrSend.call(this); // Send empty body
+        };
+        return undefined;
+      };
+
+      event.target.parentElement.querySelector(".media-share").click(); // .click() is synchronous
+      // By this point, the request has already been sent. Remove traps.
+      XMLHttpRequest.prototype.open = xhrOpen;
+      XMLHttpRequest.prototype.send = xhrSend;
     }
   }
 

--- a/addons/share-through-mystuff/userscript.js
+++ b/addons/share-through-mystuff/userscript.js
@@ -27,7 +27,6 @@ export default async function ({ addon, console, msg }) {
         .href.match(/\d+/)[0];
 
       const xhrOpen = XMLHttpRequest.prototype.open;
-      const xhrSend = XMLHttpRequest.prototype.send;
       XMLHttpRequest.prototype.open = function (method, path, ...args) {
         const newPath = `https://api.scratch.mit.edu/proxy/projects/${projectId}/share`;
         xhrOpen.call(this, "PUT", newPath, ...args);
@@ -36,7 +35,7 @@ export default async function ({ addon, console, msg }) {
         this.withCredentials = true;
         this.send = () => {
           this.setRequestHeader("X-Requested-With", ""); // Do not send this header
-          xhrSend.call(this); // Send empty body
+          XMLHttpRequest.prototype.send.call(this); // Send empty body
         };
         return undefined;
       };
@@ -44,7 +43,6 @@ export default async function ({ addon, console, msg }) {
       event.target.parentElement.querySelector(".media-share").click(); // .click() is synchronous
       // By this point, the request has already been sent. Remove traps.
       XMLHttpRequest.prototype.open = xhrOpen;
-      XMLHttpRequest.prototype.send = xhrSend;
     }
   }
 


### PR DESCRIPTION
Resolves #6280

### Changes

Adds traps so that Scratch sends a request to the REST API instead of the deprecated one, which is never used by vanilla Scratch to share projects.
This means the addon continues to work exactly like before, but the request is going to the intended URL. Checking whether the request succeeded or failed is still handled by Scratch, just like before.

### Tests

Tested in Chromium