### PR TITLE
Fix projects can be paused with Alt+X after disabling

### DIFF
--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -16,7 +16,7 @@ export default async function ({ addon, console, msg }) {
   onPauseChanged(setSrc);
 
   document.addEventListener("keydown", function (e) {
-    if (e.altKey && e.code === "KeyX") {
+    if (e.altKey && e.code === "KeyX" && !addon.self.disabled) {
       e.preventDefault();
       setPaused(!isPaused());
     }


### PR DESCRIPTION
Resolves #6369

### Changes

Fixes

>Usually, you aren't able to pause a project after dynamically disabling the Pause button addon because the button disappears. However, it is still possible to pause the project with the recently added Alt+X keyboard shortcut even after the addon is disabled.

### Tests

No