### PR TITLE
Don't collapse search bar on icon click

### DIFF
--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -51,7 +51,7 @@ export default async function ({ addon, console }) {
             ahref.style.setProperty("padding", "0px", "important");
             let span = exsearch_links[i].querySelector("span");
             span.style.display = "none";
-          } //Hide them. (Make them invisible but still keyboard-focusable)
+          } //Hide them (make them invisible but maintain keyboard-focusablility)
         }
       }
       function exsearch_clickOut() {
@@ -89,7 +89,7 @@ export default async function ({ addon, console }) {
       function exsearch_clickIn() {
         //Clicking into the search bar
         if (addon.self.disabled) return; //Don't expand if addon disabled
-        exsearch_siteNav.style.width = "0px"; //Hide the site navigation
+        exsearch_siteNav.style.width = "0px"; //Hide the site navigation (make them invisible but maintain keyboard-focusablility)
       }
       function exsearch_clickOut() {
         //Clicking out of  the search bar

--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -2,11 +2,19 @@ export default async function ({ addon, console }) {
   if (addon.tab.clientVersion === null) return; //if neither www or r2, exit
 
   var exsearch_searchBar; //The search bar element
+  var exsearch_searchBarInput; //The input portion of the search bar element
 
   //Wait for the search bar to load (we get the header links as we hide/show them, no need to worry about that)
   //Also we set the search bar value here too
   while (true) {
-    exsearch_searchBar = await addon.tab.waitForElement(
+    exsearch_searchBar = await addon.tab.waitForElement(".search", {
+      markAsSeen: true,
+      reduxCondition: (state) => {
+        if (!state.scratchGui) return true;
+        return state.scratchGui.mode.isPlayerOnly;
+      },
+    });
+    exsearch_searchBarInput = await addon.tab.waitForElement(
       addon.tab.clientVersion === "scratch-www" ? "#frc-q-1088" : "#search-input",
       {
         markAsSeen: true,
@@ -38,8 +46,12 @@ export default async function ({ addon, console }) {
         for (i = 0; i < exsearch_links.length; i++) {
           //Iterate the links
           if (exsearch_links[i]) {
-            exsearch_links[i].style.display = "none";
-          } //Hide them
+            exsearch_links[i].style.width = "0px";
+            let ahref = exsearch_links[i].querySelector("a");
+            ahref.style.setProperty("padding", "0px", "important");
+            let span = exsearch_links[i].querySelector("span");
+            span.style.display = "none";
+          } //Hide them. (Make them invisible but still keyboard-focusable)
         }
       }
       function exsearch_clickOut() {
@@ -49,13 +61,21 @@ export default async function ({ addon, console }) {
         for (i = 0; i < exsearch_links.length; i++) {
           //Iterate the links
           if (exsearch_links[i]) {
-            exsearch_links[i].style.removeProperty("display");
+            exsearch_links[i].style.removeProperty("width");
+            let ahref = exsearch_links[i].querySelector("a");
+            ahref.style.removeProperty("padding");
+            let span = exsearch_links[i].querySelector("span");
+            span.style.removeProperty("display");
           } //Show them
         }
       }
       //Events
-      exsearch_searchBar.addEventListener("focusin", exsearch_clickIn);
-      exsearch_searchBar.addEventListener("focusout", exsearch_clickOut);
+      exsearch_searchBarInput.addEventListener("focusin", exsearch_clickIn);
+      exsearch_searchBar.addEventListener("focusout", (e) => {
+        if (!exsearch_searchBar.contains(e.relatedTarget)) {
+          exsearch_clickOut();
+        }
+      });
 
       addon.self.addEventListener("disabled", () => exsearch_clickOut());
     } else {
@@ -69,15 +89,19 @@ export default async function ({ addon, console }) {
       function exsearch_clickIn() {
         //Clicking into the search bar
         if (addon.self.disabled) return; //Don't expand if addon disabled
-        exsearch_siteNav.style.display = "none"; //Hide the site navigation
+        exsearch_siteNav.style.width = "0px"; //Hide the site navigation
       }
       function exsearch_clickOut() {
         //Clicking out of  the search bar
-        exsearch_siteNav.style.removeProperty("display"); //Show the site nav
+        exsearch_siteNav.style.removeProperty("width"); //Show the site nav
       }
       //Events
-      exsearch_searchBar.addEventListener("focusin", exsearch_clickIn);
-      exsearch_searchBar.addEventListener("focusout", exsearch_clickOut);
+      exsearch_searchBarInput.addEventListener("focusin", exsearch_clickIn);
+      exsearch_searchBar.addEventListener("focusout", (e) => {
+        if (!exsearch_searchBar.contains(e.relatedTarget)) {
+          exsearch_clickOut();
+        }
+      });
 
       addon.self.addEventListener("disabled", () => exsearch_clickOut());
     }

--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -7,13 +7,6 @@ export default async function ({ addon, console }) {
   //Wait for the search bar to load (we get the header links as we hide/show them, no need to worry about that)
   //Also we set the search bar value here too
   while (true) {
-    exsearch_searchBar = await addon.tab.waitForElement(".search", {
-      markAsSeen: true,
-      reduxCondition: (state) => {
-        if (!state.scratchGui) return true;
-        return state.scratchGui.mode.isPlayerOnly;
-      },
-    });
     exsearch_searchBarInput = await addon.tab.waitForElement(
       addon.tab.clientVersion === "scratch-www" ? "#frc-q-1088" : "#search-input",
       {
@@ -24,6 +17,7 @@ export default async function ({ addon, console }) {
         },
       }
     );
+    exsearch_searchBar = exsearch_searchBarInput.closest(".search");
 
     ///Events
     if (addon.tab.clientVersion === "scratch-www") {


### PR DESCRIPTION
### Changes

- When clicking the magnifying glass icon, which is actually a button to search, the search bar now stays expanded if it was expanded already. You still need to focus the search bar input for it to expand, to let you know when you can type into the search bar.
- A side effect of this change is that pressing Shift+Tab now moves to the Scratch logo instead of "About" on the navbar, so the way the links are hidden has been changed so pressing Shift+Tab (to move to the previous element) when navigating with a keyboard still moves focus to "About". Keyboard usability is useful not only for accessibility but also efficiency (I could imagine people Tabbing to the search bar all the time).

### Reason for changes

- Prevents accidents if someone decides to click the magnifying glass.

### Try it out

#### Without this change

1. Click the search bar. Optionally type in a search query.
2. Try to click the magnifying glass icon. The search bar will collapse before you can activate it.

#### With this change

1. Click the search bar and type in a search query.
2. Click the magnifying glass icon. The search bar will stay expanded and you will be sent to the search results page.
3. Press Tab until focus moves onto the search bar. The search bar will expand once the search input is focused.
4. Press Shift+Tab until focus moves onto the "About" button. The search bar will collapse once focus moves out of the _entire_ search bar element.

### Tests

Tested on Edge 114 in combination with `discuss-button`.
