### PR TITLE
Fix Scratch Messaging popup "forEach of undefined"

### DIFF
--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -197,7 +197,7 @@ export async function fetchMigratedComments(
     const getReplies = async (offset) => {
       const repliesRes = await fetch(getRepliesUrl(parentId, offset));
       if (!repliesRes.ok) {
-        if (repliesRes.status === 404 || repliesRes.status === 403) return;
+        if (repliesRes.status === 404 || repliesRes.status === 403) return null;
         throw HTTPError.fromResponse(`Ignoring comment ${resourceType}/${commentId}`, repliesRes);
       }
       const repliesJson = await repliesRes.json();
@@ -213,6 +213,7 @@ export async function fetchMigratedComments(
     if (parentComment.reply_count > 0) {
       while (lastRepliesLength === 40) {
         const newReplies = await getReplies(offset);
+        if (!Array.isArray(newReplies)) break;
         newReplies.forEach((c) => replies.push(c));
         lastRepliesLength = newReplies.length;
         offset += 40;


### PR DESCRIPTION
### Changes

- Fixes bug: handle case where `getReplies` doesn't return an array and instead it returns an object or `null` (both are valid JSON)
- Small fix for consistency: `getReplies` now returns on 404 errors `null` instead of `undefined`, which is not valid JSON

### Reason for changes

Feedback:

> ''TypeError: Cannot read properties of undefined (reading 'forEach')'' Please fix it :'(

This appears to be the only place where forEach is used in scratch-messaging

### Tests

Not really worth it to try to emulate the bug, as we can never be 100% certain this is what the user reported, but Scratch Messaging continues to work fine for me.