### PR TITLE
editor-messages: use fetch instead of `addon.account.getMsgCount()`

### DIFF
--- a/addon-api/content-script/Account.js
+++ b/addon-api/content-script/Account.js
@@ -15,6 +15,7 @@ export default class Account extends Listenable {
    * @returns {Promise<?number>} - current message count.
    */
   getMsgCount() {
+    throw new Error("Unimplemented; use fetch");
     return this._addon.auth.fetchIsLoggedIn().then((isLoggedIn) => {
       if (!isLoggedIn) return null;
       return scratchAddons.methods.getMsgCount();

--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -9,9 +9,9 @@ export default async function ({ addon, console, msg }) {
   messageCount.classList.add("sa-editormessages-count");
   messages.appendChild(messageCount);
   const setMessages = async () => {
-    const msgCount = Number(await addon.account.getMsgCount());
-    messageCount.innerText = msgCount;
-    if (msgCount === 0) {
+    const { count } = await (await fetch("https://api.scratch.mit.edu/users/World_Languages/messages/count")).json();
+    messageCount.innerText = count;
+    if (count === 0) {
       messageCount.setAttribute("style", `display: none;`);
     } else {
       messageCount.setAttribute("style", "");
@@ -22,12 +22,12 @@ export default async function ({ addon, console, msg }) {
   function createInterval() {
     if (addon.tab.editorMode === "editor") {
       setMessages();
-      interval = setInterval(setMessages, 5000);
+      interval = setInterval(setMessages, 30_000);
     } else {
       addon.tab.addEventListener("urlChange", function thisFunction() {
         if (addon.tab.editorMode === "editor") {
           setMessages();
-          interval = setInterval(setMessages, 5000);
+          interval = setInterval(setMessages, 30_000);
           addon.tab.removeEventListener("urlChange", thisFunction);
         }
       });

--- a/addons/editor-messages/userscript.js
+++ b/addons/editor-messages/userscript.js
@@ -9,7 +9,9 @@ export default async function ({ addon, console, msg }) {
   messageCount.classList.add("sa-editormessages-count");
   messages.appendChild(messageCount);
   const setMessages = async () => {
-    const { count } = await (await fetch("https://api.scratch.mit.edu/users/World_Languages/messages/count")).json();
+    const username = await addon.auth.fetchUsername();
+    if (!username) return;
+    const { count } = await (await fetch(`https://api.scratch.mit.edu/users/${username}/messages/count`)).json();
     messageCount.innerText = count;
     if (count === 0) {
       messageCount.setAttribute("style", `display: none;`);


### PR DESCRIPTION
Resolves #5991

### Changes

- The only userscript that used this API now uses fetch every 30 seconds (instead of using addon.account.getMsgCount every 5 seconds)
- Old addon.account.getMsgCount code was not removed but it was made inaccesible.

### Reason for changes

See #5991

### Tests

Addon still works