### PR TITLE
Fix editor-compact bug: stage header imgs overflow vertically

### DIFF
--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -209,6 +209,12 @@ button[class*="action-menu_more-button"] {
   width: 1.5rem;
   height: 1.5rem;
 }
+.sa-body-editor [class*="turbo-mode_turbo-icon_"]:not([class*="stage-wrapper_full-screen"] *),
+.sa-body-editor .clone-icon:not([class*="stage-wrapper_full-screen"] *) {
+  /* Remove vertical margin from images that appear on the stage header */
+  margin-top: 0;
+  margin-bottom: 0;
+}
 .sa-body-editor [class*="stage-header_stage-button_"]:not([class*="stage-wrapper_full-screen"] *) {
   padding: calc(0.25rem - 1px);
 }


### PR DESCRIPTION
Resolves #6435

### Changes

Now `editor-compact` removes the margin-top and margin-bottom of the images that may appear on the stage header (at the moment, the turbo mode indicator and the clone counter).
The volume slider / muted indicator wasn't causing any style issues so they aren't affected.

### Tests

Tested in editor mode and project fullscreen in Chromium