### PR TITLE
More robust solution for editor-compact/columns compat

### DIFF
--- a/addons/columns/userscript.js
+++ b/addons/columns/userscript.js
@@ -148,21 +148,21 @@ export default async function ({ addon, msg, console }) {
     toolbox.populate_(workspace.options.languageTree);
     // Reposition the toolbox, since it's likely our addon moved it.
     toolbox.position();
-
-    addClass();
   }
 
-  function addClass() {
+  function updateClass() {
     // Add class to allow editor-compact to handle this addon
-    if (addon.tab.editorMode === "editor") {
-      if (addon.self.disabled) document.querySelector("[class*='gui_tab-panel']").classList.toggle("sa-columns", false);
-      else document.querySelector("[class*='gui_tab-panel']").classList.toggle("sa-columns", true);
-    }
+    if (addon.self.disabled) document.body.classList.remove("sa-columns-enabled");
+    else document.body.classList.add("sa-columns-enabled");
   }
 
   updateToolbox();
   addon.self.addEventListener("disabled", updateToolbox);
   addon.self.addEventListener("reenabled", updateToolbox);
+
+  updateClass();
+  addon.self.addEventListener("disabled", updateClass);
+  addon.self.addEventListener("reenabled", updateClass);
 
   while (true) {
     const addExtensionButton = await addon.tab.waitForElement("[class*='gui_extension-button_']", {
@@ -170,7 +170,6 @@ export default async function ({ addon, msg, console }) {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       condition: () => !addon.tab.redux.state.scratchGui.mode.isPlayerOnly,
     });
-    addClass();
     const addExtensionLabel = Object.assign(document.createElement("span"), {
       className: "sa-add-extension-label",
       innerText: addon.tab.scratchMessage("gui.gui.addExtension"),

--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -255,7 +255,7 @@ button[class*="action-menu_more-button"] {
 }
 
 /* Code tab */
-[class*="gui_tab-panel"]:not(.sa-columns) .scratchCategoryMenuItem {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .scratchCategoryMenuItem {
   padding: 0.25rem 0;
 }
 .scratchCategoryItemBubble,
@@ -264,14 +264,14 @@ button[class*="action-menu_more-button"] {
   height: 1rem;
   background-size: 1rem 1rem;
 }
-[class*="gui_tab-panel"]:not(.sa-columns) .blocklyToolboxDiv {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxDiv {
   height: calc(100% - 2rem) !important;
   scrollbar-width: none;
 }
-[class*="gui_tab-panel"]:not(.sa-columns) .blocklyToolboxDiv::-webkit-scrollbar {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxDiv::-webkit-scrollbar {
   display: none;
 }
-[class*="gui_tab-panel"]:not(.sa-columns) [class*="gui_extension-button-container_"] {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] [class*="gui_extension-button-container_"] {
   height: 2rem;
 }
 


### PR DESCRIPTION
Resolves #6444

### Changes

Adds a class to the `<body>` element instead of adding it to the `gui_tab-panel`

### Reason for changes

Easiest way to make sure we're not missing any edge cases where the panel is re-created. The body element is always the same.

### Tests

Tested in Chromium