### PR TITLE
Fix editor-compact/echo-effect compatibility

### DIFF
--- a/addons/echo-effect/userscript.js
+++ b/addons/echo-effect/userscript.js
@@ -1,3 +1,5 @@
+import { updateTooltips } from "../editor-compact/force-tooltip-update.js";
+
 export default async ({ addon }) => {
   while (true) {
     const soundEditorRobot = await addon.tab.waitForElement('[class*="sound-editor_row-reverse_"] > :nth-child(10)', {
@@ -28,5 +30,6 @@ export default async ({ addon }) => {
     echoTitleWrapper.append(echoTitle);
     echoButton.append(echoIcon, echoTitleWrapper);
     soundEditorRobot.after(echoButton);
+    updateTooltips();
   }
 };

--- a/addons/editor-compact/force-tooltip-update.js
+++ b/addons/editor-compact/force-tooltip-update.js
@@ -1,0 +1,5 @@
+export const eventTarget = new EventTarget();
+
+export function updateTooltips() {
+  eventTarget.dispatchEvent(new CustomEvent("update"));
+}

--- a/addons/editor-compact/userscript.js
+++ b/addons/editor-compact/userscript.js
@@ -1,3 +1,5 @@
+import { eventTarget as tooltipUpdateEventTarget } from "./force-tooltip-update.js";
+
 export default async function ({ addon, global, console }) {
   // The workspace needs to be manually resized via a window resize event
   // whenever the addon modifies or stops modifying UI elements
@@ -37,6 +39,8 @@ export default async function ({ addon, global, console }) {
   addon.settings.addEventListener("change", updateTooltips);
   addon.self.addEventListener("disabled", updateTooltips);
   addon.self.addEventListener("reenabled", updateTooltips);
+  tooltipUpdateEventTarget.addEventListener("update", updateTooltips);
+
   while (true) {
     await addon.tab.waitForElement("[class*='sound-editor_editor-container_']", {
       markAsSeen: true,


### PR DESCRIPTION
Resolves #6445

### Changes

Addon `echo-effect` now calls `updateTooltips()` when adding the echo button

### Tests

Bug fixed in Chromium