### PR TITLE
Fix long preset names not looking correct

### DIFF
--- a/webpages/styles/components/buttons.css
+++ b/webpages/styles/components/buttons.css
@@ -2,10 +2,9 @@
   color: var(--content-text);
   background: var(--button-background);
   border: 1px solid var(--control-border);
-  padding: 0 12px;
+  padding: 7px 12px;
   border-radius: 4px;
   transition: 0.2s ease;
-  height: 32px;
   box-sizing: border-box;
   font-family: inherit;
   font-size: 12px;

--- a/webpages/styles/components/buttons.css
+++ b/webpages/styles/components/buttons.css
@@ -2,6 +2,7 @@
   color: var(--content-text);
   background: var(--button-background);
   border: 1px solid var(--control-border);
+  display: flex;
   padding: 7px 12px;
   border-radius: 4px;
   transition: 0.2s ease;

--- a/webpages/styles/components/buttons.css
+++ b/webpages/styles/components/buttons.css
@@ -3,6 +3,7 @@
   background: var(--button-background);
   border: 1px solid var(--control-border);
   display: flex;
+  align-items: center;
   padding: 7px 12px;
   border-radius: 4px;
   transition: 0.2s ease;


### PR DESCRIPTION
Resolves #6468

(Don't mind the branch name, I originally solved this using a different strategy which didn't actually work)

### Changes

Change the way padding works on a .large-button to use actual padding.

### Reason for changes

So that buttons with more than one line look correct

### Tests

Tested in Edge, it would surprise me if it didn't work everywhere

![the button looking correct](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/26949592-20d1-416e-9f95-555e35803f66)