### PR TITLE
Fix editor-theme3 browser support (array.prototype.at)

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -271,7 +271,7 @@ export default async function ({ addon, console, msg }) {
       }
     } else {
       const iconsToReplace = ["repeat.svg", "rotate-left.svg", "rotate-right.svg"];
-      const iconName = src.split("/").at(-1);
+      const iconName = src.split("/")[src.split("/").length - 1];
       if (iconsToReplace.includes(iconName)) {
         src = `${iconPath()}/${iconName}`;
       }


### PR DESCRIPTION
### Changes

Avoid `array.at(-1)`, specially inside a Blockly trap.
`Array.prototype.at` is only available in Chromium 92+ (released June 2021)

### Reason for changes

This was the root issue from a feedback report (Chromium 87).
![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/54408e22-3c6c-4c48-9e27-1d325a89ea2c)
