### PR TITLE
Style forum error messages in dark-www

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2115,6 +2115,18 @@
           "settingId": "page"
         }
       }
+    },
+    {
+      "name": "page-forumErrorColor",
+      "value": {
+        "type": "textColor",
+        "black": "red",
+        "white": "lightcoral",
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
     }
   ],
   "dynamicEnable": true,

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -410,7 +410,9 @@ textarea:focus,
 .registration .modal-body textarea:focus,
 .registration .modal-body select:focus {
   border-color: var(--darkWww-button);
-  box-shadow: 0 1px 1px inset rgba(0, 0, 0, 0.08), 0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
+  box-shadow:
+    0 1px 1px inset rgba(0, 0, 0, 0.08),
+    0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
 }
 .editable textarea:focus,
 .editable-empty textarea:focus {

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -410,9 +410,7 @@ textarea:focus,
 .registration .modal-body textarea:focus,
 .registration .modal-body select:focus {
   border-color: var(--darkWww-button);
-  box-shadow:
-    0 1px 1px inset rgba(0, 0, 0, 0.08),
-    0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
+  box-shadow: 0 1px 1px inset rgba(0, 0, 0, 0.08), 0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
 }
 .editable textarea:focus,
 .editable-empty textarea:focus {
@@ -703,4 +701,12 @@ input.link.black {
    is meant to be entirely transparent. */
 .iframeshim {
   color-scheme: light;
+}
+
+/* Forum errors */
+
+.errorlist {
+  background-color: var(--darkWww-box) !important;
+  border-color: var(--darkWww-page-forumErrorColor) !important;
+  color: var(--darkWww-page-forumErrorColor) !important;
 }

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -410,9 +410,7 @@ textarea:focus,
 .registration .modal-body textarea:focus,
 .registration .modal-body select:focus {
   border-color: var(--darkWww-button);
-  box-shadow:
-    0 1px 1px inset rgba(0, 0, 0, 0.08),
-    0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
+  box-shadow: 0 1px 1px inset rgba(0, 0, 0, 0.08), 0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
 }
 .editable textarea:focus,
 .editable-empty textarea:focus {
@@ -707,8 +705,8 @@ input.link.black {
 
 /* Forum errors */
 
-.errorlist {
-  background-color: var(--darkWww-box) !important;
-  border-color: var(--darkWww-page-forumErrorColor) !important;
-  color: var(--darkWww-page-forumErrorColor) !important;
+.djangobb ul.errorlist {
+  background-color: var(--darkWww-box);
+  border-color: var(--darkWww-page-forumErrorColor);
+  color: var(--darkWww-page-forumErrorColor);
 }


### PR DESCRIPTION
Resolves #6475

### Changes

Style forum error messages with the box color. Note that this changes the error message color with the default settings from `#f5f5f5` to `#f7f7f7`, but it's not that noticable.

![demo](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/8c9f9b9f-4552-4f4b-82bd-08fa8787dfdb)

### Reason for changes

So error messages aren't as bright in dark mode.

### Tests

Tested in Edge.
