### PR TITLE
`pause`: Set title to "resume" for resume button

### DIFF
--- a/addons-l10n/en/pause.json
+++ b/addons-l10n/en/pause.json
@@ -1,3 +1,4 @@
 {
-  "pause/pause": "Pause"
+  "pause/pause": "Pause",
+  "pause/play": "Resume"
 }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -8,7 +8,10 @@ export default async function ({ addon, console, msg }) {
   img.draggable = false;
   img.title = msg("pause");
 
-  const setSrc = () => (img.src = addon.self.dir + (isPaused() ? "/play.svg" : "/pause.svg"));
+  const setSrc = () => {
+    img.src = addon.self.dir + (isPaused() ? "/play.svg" : "/pause.svg");
+    img.title = (isPaused() ? msg("play") : msg("pause"))
+  };
   img.addEventListener("click", () => setPaused(!isPaused()));
   addon.tab.displayNoneWhileDisabled(img);
   addon.self.addEventListener("disabled", () => setPaused(false));

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -10,7 +10,7 @@ export default async function ({ addon, console, msg }) {
 
   const setSrc = () => {
     img.src = addon.self.dir + (isPaused() ? "/play.svg" : "/pause.svg");
-    img.title = (isPaused() ? msg("play") : msg("pause"))
+    img.title = isPaused() ? msg("play") : msg("pause");
   };
   img.addEventListener("click", () => setPaused(!isPaused()));
   addon.tab.displayNoneWhileDisabled(img);


### PR DESCRIPTION
### Changes

Currently, when hovering over the pause button, it shows a tooltip reading "Pause", but it also says "Pause" when hovering over the _resume_ button. Now, the resume button has its own tooltip - "Resume".

### Reason for changes

You know.

### Tests

Tested in Edge 115.
Tested Dynamic Disable and in combination with `debugger`.