### PR TITLE
Mention new website dark mode presets

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2124,7 +2124,7 @@
   "latestUpdate": {
     "version": "1.34.0",
     "newSettings": ["messageIndicatorColor", "messageIndicatorOnMessagesPage"],
-    "temporaryNotice": "There are now presets for Scratch 2.0 and the colors used on the front page between 2015 and 2018. The message badge colors are also customizable now."
+    "temporaryNotice": "There are two new presets - one resembling Scratch 2.0 and one with a light blue accent color, which was used on the front page between 2015 and 2018. The message badge color is also customizable now."
   },
   "updateUserstylesOnSettingsChange": true,
   "userscripts": [

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2124,7 +2124,7 @@
   "latestUpdate": {
     "version": "1.34.0",
     "newSettings": ["messageIndicatorColor", "messageIndicatorOnMessagesPage"],
-    "temporaryNotice": "There are now presets for Scratch 2.0 and the colors used on the front page between 2015 and 2018. The message bagde colors are also customizable now."
+    "temporaryNotice": "There are now presets for Scratch 2.0 and the colors used on the front page between 2015 and 2018. The message badge colors are also customizable now."
   },
   "updateUserstylesOnSettingsChange": true,
   "userscripts": [

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2124,7 +2124,7 @@
   "latestUpdate": {
     "version": "1.34.0",
     "newSettings": ["messageIndicatorColor", "messageIndicatorOnMessagesPage"],
-    "isMajor": false
+    "temporaryNotice": "There are now presets for Scratch 2.0 and the colors used on the front page between 2015 and 2018. The message bagde colors are also customizable now."
   },
   "updateUserstylesOnSettingsChange": true,
   "userscripts": [


### PR DESCRIPTION
Resolves #6463

### Changes

Adds a temporary notice to website dark mode mentioning the new presets.

### Reason for changes

Users might not notice them or not realize they're new.

### Tests

Tested on Firefox 116.
