### PR TITLE
Debugger addon description: clarify Threads tab

### DIFF
--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Debugger",
-  "description": "Adds a new \"debugger\" window to the editor. Allows for logging into the \"Logs\" tab of the debugger window using the \"log\", \"warn\" and \"error\" blocks. The \"breakpoint\" block will pause the project when executed. All running threads can be viewed in the \"Threads\" tab of the debugger, and when paused the \"Step\" button can be used to execute the next block. A graph of frames per second and number of clones can be viewed in the \"Performance\" tab.",
+  "description": "Adds a new \"debugger\" window to the editor. Allows for logging into the \"Logs\" tab of the debugger window using the \"log\", \"warn\" and \"error\" blocks. The \"breakpoint\" block will pause the project when executed. All running stacks of blocks can be viewed in the \"Threads\" tab of the debugger window, and when paused the \"Step\" button can be used to execute the next block. A graph of frames per second and number of clones can be viewed in the \"Performance\" tab.",
   "credits": [
     {
       "name": "Tacodiva",


### PR DESCRIPTION
We've been asked this question: #4412

### Changes

Makes the meaning of the Threads tab in the Debugger window clearer by referring to a thread as a stack of blocks in the addon description.
