### PR TITLE
dark-www: support admin messages

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -350,7 +350,7 @@ p.callout,
 .transfer-host-modal .transfer-outcome,
 .filter-container,
 .tab-choice-selected-sa,
-.admin-message /* username change */,
+#bad-username-splash .admin-message /* username change */,
 .sa-annual-report-2020 .initiatives-section .year-in-review,
 .initiatives-section .initiatives-subsection-content .map,
 .sa-annual-report-2021 .leadership-section .leadership-scratch-team .avatar-item img,
@@ -363,7 +363,7 @@ body:not(.sa-body-editor) .gender-radio-row:hover,
 .empty h4,
 .thumbnail-column .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .studio-page #view,
-.admin-message .admin-message-date /* username change */,
+#bad-username-splash .admin-message .admin-message-date /* username change */,
 .milestones-section h2 {
   color: var(--darkWww-blue-text);
 }
@@ -508,7 +508,8 @@ body:not(.sa-body-editor) .formik-input:focus,
   border-color: var(--darkWww-button-transparent10);
 }
 .outer .categories li:hover,
-.user-projects-modal .user-projects-modal-nav button:hover {
+.user-projects-modal .user-projects-modal-nav button:hover,
+.messages-admin-list .admin-message {
   background-color: var(--darkWww-button-transparent25);
 }
 .comment .avatar {
@@ -712,6 +713,7 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button,
 }
 .compose-comment .textarea-row textarea:not(:focus),
 .studio-tab-nav,
+.messages-admin-list .admin-message,
 body:not(.sa-body-editor) .formik-input,
 body:not(.sa-body-editor) input[type="checkbox"].formik-checkbox:not(:checked),
 .row .checkbox input[type="checkbox"]:not(:checked) {


### PR DESCRIPTION
Resolves #6383

### Changes

Makes messages from the Scratch Team affected by the highlight color setting in dark-www.

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/c24d5291-9949-4e3b-9aee-058286607d13)

### Reason for changes

Before #6395, the addon didn't change the background color of admin messages at all. In #6395, I accidentally made them use the "blue background" setting.

### Tests

Tested by running scratch-www locally and modifying the code to show a test alert.