### PR TITLE
Better forum-post-countdown name and description

### DIFF
--- a/addons/forum-post-countdown/addon.json
+++ b/addons/forum-post-countdown/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Cooldown display for posting in the forums",
-  "description": "After submitting a forum post, displays a countdown showing when you can post again.",
+  "name": "Forum post cooldown display",
+  "description": "After submitting a forum post, displays a countdown on the submit button showing how long you have to wait before posting again.",
   "tags": ["community", "forums"],
   "versionAdded": "1.34.0",
   "userscripts": [


### PR DESCRIPTION
### Changes

Shortens the  `forum-post-countdown` name and adds a bit more to the description.

### Reason for changes

Because shorter addon names are better in most cases and the location feels like it should be part of the description.

### Tests

Tested on Chromium 115