### PR TITLE
Migrate new dark-www settings in presets

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -6,7 +6,7 @@ import minifySettings from "../libraries/common/minify-settings.js";
 
  - editor-dark-mode 10 (bumped 4 times in v1.33.2)
  - editor-theme3 3 (last bumped in v1.32)
- - dark-www 5 (bumped five times in v1.33.2)
+ - dark-www 7 (bumped twice in v1.34.0)
  */
 
 const areColorsEqual = (currentColor, oldPresetColor) => {
@@ -294,6 +294,45 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
             },
             () => {
               settings.link = "#855cd6";
+              madeAnyChanges = madeChangesToAddon = true;
+            }
+          );
+
+          updatePresetIfMatching(
+            settings,
+            6,
+            // "Scratch default colors (blue)" preset
+            {
+              page: "#fcfcfc",
+              box: "#ffffff",
+              gray: "#f2f2f2",
+              blue: "#e9f1fc",
+              input: "#fafafa",
+              link: "#4d97ff",
+              footer: "#f2f2f2",
+              border: "#0000001a",
+            },
+            () => {
+              settings.messageIndicatorOnMessagesPage = "#ffab1a";
+              madeAnyChanges = madeChangesToAddon = true;
+            }
+          );
+          updatePresetIfMatching(
+            settings,
+            7,
+            // "Experimental Dark (blue)" preset
+            {
+              page: "#202020",
+              box: "#282828",
+              gray: "#333333",
+              blue: "#252c37",
+              input: "#202020",
+              link: "#4d97ff",
+              footer: "#333333",
+              border: "#606060",
+            },
+            () => {
+              settings.messageIndicatorOnMessagesPage = "#ffab1a";
               madeAnyChanges = madeChangesToAddon = true;
             }
           );


### PR DESCRIPTION
Resolves #6366

### Changes

If at the time of the update, the user settings appear to be one of the "blue" themed presets (`"Experimental" Dark (blue)` or `Scratch default colors (blue)`), then the new "messages count in messages page" will be set to orange, instead of the default shade of red.

We assume the users that selected one of the blue presets prefer to restore the old orange and stay in sync with the preset they chose. Still, it's easy for users to go back.

### Tests

Tested setting migration from v1.33.3 to master branch, with the `"Experimental" Dark (blue)` preset.