### PR TITLE
Style non link links with `colorblind`

### DIFF
--- a/addons/colorblind/bold-links.css
+++ b/addons/colorblind/bold-links.css
@@ -1,6 +1,7 @@
 /* Include */
 a,
 a:link,
+a:not([href]),
 a:hover,
 a:active,
 a.black:hover,

--- a/addons/colorblind/underline-links.css
+++ b/addons/colorblind/underline-links.css
@@ -1,6 +1,7 @@
 /* Include */
 a,
 a:link,
+a:not([href]),
 a:hover,
 a:active,
 a.black:hover,


### PR DESCRIPTION
Resolves #6536

### Changes

Explicitly also style anchor tags without an `href` for specificity reasons.

![All links being styled.](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/60939b98-c280-44f2-afc8-12305ca1794d)

### Reason for changes

Some links were unstyled.

### Tests

Tested on Edge.
