### PR TITLE
Style usernames in `studio-followers` with `colorblind`

### DIFF
--- a/addons/colorblind/bold-links.css
+++ b/addons/colorblind/bold-links.css
@@ -12,6 +12,7 @@ input.link.black:hover,
 input.link.black:active,
 .button > span,
 button,
+.studio-project-title,
 #comments .more-replies .pulldown,
 #email-resend-box a {
   font-weight: bold;

--- a/addons/colorblind/underline-links.css
+++ b/addons/colorblind/underline-links.css
@@ -11,6 +11,7 @@ input.link:active,
 input.link.black:hover,
 input.link.black:active,
 .news li h4,
+.studio-project-title,
 #footer .lists dd a,
 #comments .more-replies .pulldown,
 #email-resend-box a {


### PR DESCRIPTION
Resolves #6538

### Changes

Styles `.studio-project-title` in `colorblind`.

![Demo](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/fdc924f5-0de4-423d-99b5-ec78b8efc5cf)

### Reason for changes

Consistency

### Tests

Tested in Edge
