### PR TITLE
Fix "expanding search bar" regression (with scratchr2 addon enabled)

### DIFF
--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -84,12 +84,12 @@ export default async function ({ addon, console }) {
         //Clicking into the search bar
         if (addon.self.disabled) return; //Don't expand if addon disabled
         exsearch_siteNav.style.width = "0px"; //Hide the site navigation (make them invisible but maintain keyboard-focusablility)
-        exsearch_siteNav.style.opacity = "0";
+        exsearch_siteNav.style.overflow = "hidden";
       }
       function exsearch_clickOut() {
         //Clicking out of  the search bar
         exsearch_siteNav.style.removeProperty("width"); //Show the site nav
-        exsearch_siteNav.style.removeProperty("opacity");
+        exsearch_siteNav.style.removeProperty("overflow");
       }
       //Events
       exsearch_searchBarInput.addEventListener("focusin", exsearch_clickIn);

--- a/addons/expanding-search-bar/expanding-search-bar.js
+++ b/addons/expanding-search-bar/expanding-search-bar.js
@@ -84,10 +84,12 @@ export default async function ({ addon, console }) {
         //Clicking into the search bar
         if (addon.self.disabled) return; //Don't expand if addon disabled
         exsearch_siteNav.style.width = "0px"; //Hide the site navigation (make them invisible but maintain keyboard-focusablility)
+        exsearch_siteNav.style.opacity = "0";
       }
       function exsearch_clickOut() {
         //Clicking out of  the search bar
         exsearch_siteNav.style.removeProperty("width"); //Show the site nav
+        exsearch_siteNav.style.removeProperty("opacity");
       }
       //Events
       exsearch_searchBarInput.addEventListener("focusin", exsearch_clickIn);


### PR DESCRIPTION
### Changes

Sets the overflow property of the navigation bar links to hidden to avoid them showing up on top of (technically, under) the search bar while the `scratchr2` addon is enabled.

### Reason for changes

To fix #6567

### Tests

Tested in Edge 115.
