### PR TITLE
editor-compact: fix narrow number inputs

### DIFF
--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -123,12 +123,12 @@
 [class*="gui_body-wrapper_"] [class*="stage-selector_is-selected_"] {
   box-shadow: 0px 0px 0px 2px var(--editorDarkMode-primary-transparent35, hsl(260deg 60% 60% / 35%));
 }
-[class*="input_input-small"][type=text],
-[class*="sprite-info_larger-input"] input[type=text] {
+[class*="input_input-small"][type="text"],
+[class*="sprite-info_larger-input"] input[type="text"] {
   /* Vanilla is width:4rem */
   width: 2.5rem;
 }
-[class*="input_input-small"][type=number] {
+[class*="input_input-small"][type="number"] {
   /* Vanilla is width:4rem but browsers take part of it for the up/down arrows */
   width: 3.5rem;
 }

--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -123,9 +123,14 @@
 [class*="gui_body-wrapper_"] [class*="stage-selector_is-selected_"] {
   box-shadow: 0px 0px 0px 2px var(--editorDarkMode-primary-transparent35, hsl(260deg 60% 60% / 35%));
 }
-[class*="input_input-small"],
-[class*="sprite-info_larger-input"] input {
+[class*="input_input-small"][type=text],
+[class*="sprite-info_larger-input"] input[type=text] {
+  /* Vanilla is width:4rem */
   width: 2.5rem;
+}
+[class*="input_input-small"][type=number] {
+  /* Vanilla is width:4rem but browsers take part of it for the up/down arrows */
+  width: 3.5rem;
 }
 
 [class*="sprite-selector_scroll-wrapper"] {


### PR DESCRIPTION
Resolves #6563

### Changes

The old CSS is left intact but it only affects inputs with type=text
Inputs with type=number get more room and only get reduced by `0.5rem` vs vanilla width,


### Tests

Now, three digit numbers fit in Chromium and Firefox

![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/b666b094-99ca-49be-aa48-40df1375286e)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/354686b7-0fe3-4de9-be0b-efb4199606a1)

