### PR TITLE
Create error page, redirect to it on typical settings page crashes

### DIFF
--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -54,7 +54,7 @@ const localizeSettings = (addonId, setting, tableId) => {
     } catch (ex) {
       console.error(`Failed to load addon manifest for ${addonId}, crashing:`, ex);
       chrome.tabs.create({
-        url: `data:text/plain,Scratch Addons crashed: invalid addon.json for addon with id ${addonId}. Click the "Errors" button on the extension tile for more details.`,
+        url: chrome.runtime.getURL(`/webpages/error/index.html?problem=invalidManifest&addon=${addonId}`),
       });
       throw ex;
     }

--- a/webpages/error/check-chrome-storage.js
+++ b/webpages/error/check-chrome-storage.js
@@ -1,0 +1,37 @@
+const testStorage = () => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject("Reached setTimeout while testing storage"), 8000);
+
+    chrome.storage.sync.get("addonsEnabled", (c) => {
+      if (chrome.runtime.lastError) {
+        console.error(chrome.runtime.lastError); // Will be lost if console clears logs after navigation
+        if (typeof chrome.runtime.lastError.toString === "function") reject(chrome.runtime.lastError.toString());
+        else reject("Unknown lastError");
+      } else if (c === null) reject("c is null");
+      else if (typeof c !== "object") reject("c is not of type object");
+      else if (c.addonsEnabled === null) reject("c.addonsEnabled is null");
+      else if (typeof c.addonsEnabled !== "object") reject("c.addonsEnabled is not of type object");
+      else if (Object.keys(c.addonsEnabled).length === 0) reject("c.addonsEnabled is an empty object");
+      else {
+        // Storage looks OK
+        resolve();
+      }
+    });
+  });
+};
+
+const redirectToErrorPage = (errorInfo) => {
+  const url = new URL(chrome.runtime.getURL("/webpages/error/index.html"));
+  url.searchParams.set("problem", "storage");
+  url.searchParams.set("info", errorInfo);
+  location.href = url.href;
+};
+
+// Wait a few seconds and check storage
+setTimeout(() => {
+  testStorage()
+    .then(() => console.log("Storage test succeeded"))
+    .catch((error) => {
+      redirectToErrorPage(error);
+    });
+}, 1500);

--- a/webpages/error/export.js
+++ b/webpages/error/export.js
@@ -1,4 +1,0 @@
-document.querySelector("#export-settings-btn").onclick = () => {
-  // TODO
-  window.exportedSettings = true;
-};

--- a/webpages/error/export.js
+++ b/webpages/error/export.js
@@ -1,0 +1,4 @@
+document.querySelector("#export-settings-btn").onclick = () => {
+  // TODO
+  window.exportedSettings = true;
+};

--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -16,6 +16,7 @@
 
     <br />
 
+    <!--
     <p>
       <b>Before trying to solve the problem, we recommend backing up your Scratch Addons settings.</b>
       <br />
@@ -27,6 +28,9 @@
     <br /><br />
 
     <p>After downloading your settings, try the following steps:</p>
+  -->
+
+    <p>Try the following steps:</p>
     <ul>
       <li>
         Fully restart your browser. You can achieve this by typing

--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- <script src="../set-lang.js" type="module"></script> -->
+    <script src="./index.js" type="module"></script>
+    <script src="./export.js" type="module"></script>
+    <script src="./reset-settings.js" type="module"></script>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+
+  <body>
+    <h2 id="problem-title">Scratch Addons encountered a problem:</h2>
+
+    <h1 id="problem-type">(unknown error)</h1>
+
+    <br />
+
+    <p>
+      <b>Before trying to solve the problem, we recommend backing up your Scratch Addons settings.</b>
+      <br />
+      You can import them later in the Scratch Addons settings page, in the "More Settings" section.
+    </p>
+
+    <button type="button" id="export-settings-btn">Export settings as a .json file</button>
+
+    <br /><br />
+
+    <p>After downloading your settings, try the following steps:</p>
+    <ul>
+      <li>
+        Fully restart your browser. You can achieve this by typing
+        <span id="restart-url">chrome://restart</span>
+        into your address bar and pressing Enter.
+      </li>
+      <li>
+        Update your browser to its latest version. You are currently using:
+        <span id="browser-info">(unknown browser)</span>
+      </li>
+      <li><a id="reset-settings-btn" href="#">Reset Scratch Addons to default settings</a>. Make sure to back up your settings first.</li>
+    </ul>
+  </body>
+</html>

--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -37,7 +37,10 @@
         Update your browser to its latest version. You are currently using:
         <span id="browser-info">(unknown browser)</span>
       </li>
-      <li><a id="reset-settings-btn" href="#">Reset Scratch Addons to default settings</a>. Make sure to back up your settings first.</li>
+      <li>
+        <a id="reset-settings-btn" href="#">Reset Scratch Addons to default settings</a>. Make sure to back up your
+        settings first.
+      </li>
     </ul>
   </body>
 </html>

--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -14,6 +14,8 @@
 
     <h1 id="problem-type">(unknown error)</h1>
 
+    <p id="problem-details"></p>
+
     <br />
 
     <!--
@@ -33,7 +35,7 @@
     <p>Try the following steps:</p>
     <ul>
       <li>
-        Fully restart your browser. You can achieve this by typing
+        <b>Fully restart your browser.</b> You can achieve this by typing
         <span id="restart-url">chrome://restart</span>
         into your address bar and pressing Enter.
       </li>
@@ -42,8 +44,9 @@
         <span id="browser-info">(unknown browser)</span>
       </li>
       <li>
-        <a id="reset-settings-btn" href="#">Reset Scratch Addons to default settings</a>. Make sure to back up your
-        settings first.
+        <a id="reset-settings-btn" href="#">Reset Scratch Addons to default settings</a>.
+        <!--Make sure to back up your
+        settings first.-->
       </li>
     </ul>
   </body>

--- a/webpages/error/index.js
+++ b/webpages/error/index.js
@@ -16,4 +16,7 @@ const getVersion = () => {
 
 const info = getVersion();
 if (info.browser === "Chrome") info.browser = "Chrome/Edge/Brave/Chromium";
+else if (info.browser === "Firefox") {
+  $("#restart-url").textContent = "about:restartrequired";
+}
 $("#browser-info").textContent = `${info.browser} ${info.version}`;

--- a/webpages/error/index.js
+++ b/webpages/error/index.js
@@ -3,9 +3,13 @@ const problem = url.searchParams.get("problem");
 const $ = document.querySelector.bind(document);
 
 if (problem === "unsupportedBrowser") {
+  // Currently unused
   $("#problem-type").textContent = "Unsupported browser";
 } else if (problem === "invalidManifest") {
   $("#problem-type").textContent = `Invalid JSON file: addons/${url.searchParams.get("addon")}/addon.json`;
+} else if (problem === "storage") {
+  $("#problem-type").textContent = "Extension settings are corrupted or temporarily unavailable";
+  $("#problem-details").textContent = "Error: " + (url.searchParams.get("info") || "No info");
 }
 
 const getVersion = () => {

--- a/webpages/error/index.js
+++ b/webpages/error/index.js
@@ -1,0 +1,19 @@
+const url = new URL(location.href);
+const problem = url.searchParams.get("problem");
+const $ = document.querySelector.bind(document);
+
+if (problem === "unsupportedBrowser") {
+  $("#problem-type").textContent = "Unsupported browser";
+} else if (problem === "invalidManifest") {
+  $("#problem-type").textContent = `Invalid JSON file: addons/${url.searchParams.get("addon")}/addon.json`;
+}
+
+const getVersion = () => {
+  let userAgent = /(Firefox|Chrome)\/([0-9.]+)/.exec(navigator.userAgent);
+  if (!userAgent) return { browser: null, version: null };
+  return { browser: userAgent[1], version: userAgent[2].split(".")[0] };
+};
+
+const info = getVersion();
+if (info.browser === "Chrome") info.browser = "Chrome/Edge/Brave/Chromium";
+$("#browser-info").textContent = `${info.browser} ${info.version}`;

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -33,7 +33,7 @@ document.querySelector("#reset-settings-btn").onclick = () => {
 
     (async () => {
       const dbs = window.indexedDB.databases ? await window.indexedDB.databases() : null;
-      const dbNames = dbs ? IDB_DATABASES : dbs.map((db) => db.name);
+      const dbNames = !dbs ? IDB_DATABASES : dbs.map((db) => db.name);
       dbNames.forEach((name) => {
         window.indexedDB.deleteDatabase(name);
       });

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -13,21 +13,34 @@ document.querySelector("#reset-settings-btn").onclick = () => {
 
   try {
     chrome.storage.local.clear();
-  } catch (err) {}
+  } catch (err) {
+    console.error(err);
+  }
   try {
     chrome.storage.sync.clear();
-  } catch (err) {}
+  } catch (err) {
+    console.error(err);
+  }
   try {
     localStorage.clear();
-  } catch (err) {}
+  } catch (err) {
+    console.error(err);
+  }
   try {
+    // We should try to list all IndexedDB databases here so that
+    // we can actually clear them all in Firefox.
+    const IDB_DATABASES = ["notifier", "messaging"];
+
     (async () => {
-      const dbs = await window.indexedDB.databases();
-      dbs.forEach((db) => {
-        window.indexedDB.deleteDatabase(db.name);
+      const dbs = window.indexedDB.databases ? await window.indexedDB.databases() : null;
+      const dbNames = dbs ? IDB_DATABASES : dbs.map((db) => db.name);
+      dbNames.forEach((name) => {
+        window.indexedDB.deleteDatabase(name);
       });
     })();
-  } catch (err) {}
+  } catch (err) {
+    console.error(err);
+  }
 
   setTimeout(() => {
     alert("All settings were reset. The extension will reload.");

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -32,5 +32,5 @@ document.querySelector("#reset-settings-btn").onclick = () => {
   setTimeout(() => {
     alert("All settings were reset. The extension will reload.");
     chrome.runtime.reload();
-  }, 1500)
+  }, 1500);
 };

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -1,0 +1,36 @@
+document.querySelector("#reset-settings-btn").onclick = () => {
+  if (!window.exportedSettings) {
+    const res = confirm(
+      "Are you sure you want to CLEAR ALL SETTINGS? If you haven't exported your settings first, click Cancel."
+    );
+    if (!res) return;
+    const res2 = prompt("Type 123 to confirm. You will lose all your Scratch Addons settings.");
+    if (res2 !== "123") {
+      alert("You did not type 123. Did not reset settings.");
+      return;
+    }
+  }
+
+  try {
+    chrome.storage.local.clear();
+  } catch (err) {}
+  try {
+    chrome.storage.sync.clear();
+  } catch (err) {}
+  try {
+    localStorage.clear();
+  } catch (err) {}
+  try {
+    (async () => {
+      const dbs = await window.indexedDB.databases();
+      dbs.forEach((db) => {
+        window.indexedDB.deleteDatabase(db.name);
+      });
+    })();
+  } catch (err) {}
+
+  setTimeout(() => {
+    alert("All settings were reset. The extension will reload.");
+    chrome.runtime.reload();
+  }, 1500)
+};

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -6,7 +6,7 @@ document.querySelector("#reset-settings-btn").onclick = () => {
     if (!res) return;
     const res2 = prompt("Type 123 to confirm. You will lose all your Scratch Addons settings.");
     if (res2 !== "123") {
-      alert("You did not type 123. Did not reset settings.");
+      alert("Settings were NOT reset.");
       return;
     }
   }

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -1,5 +1,6 @@
 document.querySelector("#reset-settings-btn").onclick = () => {
-  if (!window.exportedSettings) {
+  // TODO: if (!window.exportedSettings) after error page gets an "export settings" button.
+  if (true) {
     const res = confirm(
       "Are you sure you want to CLEAR ALL SETTINGS? If you haven't exported your settings first, click Cancel."
     );

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -1,9 +1,14 @@
 html {
   font-size: 20px;
+  background-color: white;
 }
 
 #browser-info {
-  font-weight: bold;
+  font-style: italic;
+}
+
+#problem-details {
+  font-family: monospace;
 }
 
 #restart-url {

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -5,3 +5,9 @@ html {
 #browser-info {
   font-weight: bold;
 }
+
+#restart-url {
+  display: inline-block;
+  margin: 0 6px 0 6px;
+  font-family: monospace;
+}

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -1,0 +1,7 @@
+html {
+  font-size: 20px;
+}
+
+#browser-info {
+  font-weight: bold;
+}

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -90,6 +90,7 @@
 
     <script src="../set-lang.js" type="module"></script>
     <script src="../check-unsupported.js" defer></script>
+    <script src="../error/check-chrome-storage.js" defer></script>
 
     <style>
       /*


### PR DESCRIPTION
Related to / mitigates #5306
Related to #6048
Related to #4949

### Changes

I posted this idea a while ago: https://github.com/ScratchAddons/ScratchAddons/issues/5306#issuecomment-1299223233

This PR creates an error page and displays it in the following situations:
- Invalid addon.json file during development (already existed since #4949, now also supports Firefox)
- The settings page crashed or doesn't work because `chrome.storage` is unavailable/broken (#6048) which happens quite often in Chrome

This page also provides a link/button to reset all extension settings. It also recommends restarting the browser.

This page won't be localized for now. I'm open to adding more CSS, but it's not very important. Also, this page won't support dark mode.

### Before: blank settings page

![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/faae97a0-60e5-4bf0-8fe4-8ddd6c6e0b4c)

### After: redirect to error page

![brave_dQHnZRIZ3X](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/00b1dcee-86df-4df5-9fe3-43114eb58bd0)