### PR TITLE
editor-compact: fix "wide" layout of sprite info

### DIFF
--- a/addons/editor-compact/sprite-properties.css
+++ b/addons/editor-compact/sprite-properties.css
@@ -1,10 +1,8 @@
 /* These styles are in a separate file with "if" to make sure that they aren't applied
    when sprite-properties is dynamically disabled. */
-.sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
-  height: calc(5.25rem + 1px);
-}
+.sa-show-sprite-properties [class^="sprite-info_sprite-info_"],
 .sa-sprite-properties-wide-locale.sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
-  height: calc(5.25rem + 1px + 2rem);
+  height: calc(5.25rem + 1px);
 }
 .sa-sprite-properties-close-btn {
   height: 1rem;

--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -100,6 +100,19 @@
 [class*="sprite-info_column_"] {
   margin-inline-end: 1rem;
 }
+[class*="sprite-info_group"]:last-child,
+[class*="sprite-info_column_"]:last-child {
+  margin-inline-end: 0;
+}
+[class*="sprite-info_column_"],
+[class*="label_input-group-column_"] {
+  flex-direction: row;
+  align-items: center;
+}
+[class*="sprite-info_column_"] span,
+[class*="label_input-group-column_"] span {
+  margin-bottom: 0;
+}
 [class*="sprite-info_icon-wrapper"] {
   width: 1.5rem;
   height: 1.5rem;


### PR DESCRIPTION
Resolves #6545
Resolves #6551

### Changes

Places labels next to inputs in all languages. There's enough space for them with the compact layout.
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/1735a2fa-e191-4489-b98e-c6f8f42437ce)

### Reason for changes

To fix the bug described in #6551 and use space more efficiently.

### Tests

Tested on Edge and Firefox. Works as expected in all languages that normally use the wide layout ([list](https://github.com/scratchfoundation/scratch-gui/blob/953c39d85d7436bb43e894abdfbfe772e1fc86f7/src/lib/locale-utils.js)).