### PR TITLE
Align 'My Stuff' Buttons

### DIFF
--- a/addons/scratchr2/mystuff.css
+++ b/addons/scratchr2/mystuff.css
@@ -216,3 +216,6 @@
   box-shadow: 0 0 0 4px hsla(163, 85%, 40%, 0.25);
   border-color: hsl(163, 85%, 40%);
 }
+#sidebar li.sub-list {
+    margin-left: 0 !important;
+}


### PR DESCRIPTION
Aligns the buttons in the my stuff page (all projects, shared projects, etc.)

Resolves #6584

### Changes

Used css to tidy up the two stray buttons

### Reason for changes

It doesn't look right otherwise and also it should be aligned to begin with.

### Tests

Tested on chrome
