### PR TITLE
project-notes-tabs: don't change description width

### DIFF
--- a/addons/project-notes-tabs/style.css
+++ b/addons/project-notes-tabs/style.css
@@ -1,7 +1,7 @@
-.tabs-sa {
+.preview .project-notes .tabs-sa {
   display: flex;
   overflow: hidden;
-  margin-bottom: 0 !important;
+  margin-bottom: 0;
 }
 
 .tab-choice-sa {
@@ -30,12 +30,13 @@
   background-color: rgba(77, 151, 255, 0.1);
 }
 
-.description-block {
+.preview .description-block {
   overflow: auto;
-  margin-bottom: 0 !important;
+  margin-bottom: 0;
 }
 
-.project-description {
+.preview .project-description {
+  width: 100%;
   height: 100%;
   box-sizing: border-box;
 }


### PR DESCRIPTION
### Changes

The `project-notes-tabs` addon adds `box-sizing: border-box` to the description, which changes the width. This PR adds `width: 100%` to fix that. It also removes unnecessary uses of `!important`.

### Reason for changes

This makes the right edge of the description aligned with the See inside button (and probably the preview toggle after #6489).

### Tests

Tested on Edge.