### PR TITLE
Increase mediarecorder (project recorder) limit from 5 min to 10

### DIFF
--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -35,7 +35,7 @@ export default async ({ addon, console, msg }) => {
       const recordOptionSecondsInput = Object.assign(document.createElement("input"), {
         type: "number",
         min: 1,
-        max: 300,
+        max: 600,
         defaultValue: 30,
         id: "recordOptionSecondsInput",
         className: addon.tab.scratchClass("prompt_variable-name-text-input"),
@@ -53,7 +53,7 @@ export default async ({ addon, console, msg }) => {
       const recordOptionDelayInput = Object.assign(document.createElement("input"), {
         type: "number",
         min: 0,
-        max: 300,
+        max: 600,
         defaultValue: 0,
         id: "recordOptionDelayInput",
         className: addon.tab.scratchClass("prompt_variable-name-text-input"),
@@ -224,7 +224,7 @@ export default async ({ addon, console, msg }) => {
     };
     const startRecording = async (opts) => {
       // Timer
-      const secs = Math.min(300, Math.max(1, opts.secs));
+      const secs = Math.min(600, Math.max(1, opts.secs));
 
       // Initialize MediaRecorder
       recordBuffer = [];


### PR DESCRIPTION
Resolves part of #5101

### Changes

- This does not let you record as long as you want.
- This, still, does not warn you that the recording will stop after 10 minutes, even if you entered more than 600 seconds in the input. That will still be tracked as part of #5101
- I think we capped at 5 minutes because of potential RAM limitations or accidentally wasting hard drive space (for example see comment https://github.com/ScratchAddons/ScratchAddons/issues/5101#issuecomment-1247550130) but I think we can all agree 10 minutes, while being double, is still not a lot, and reasonable. We can always try to increase the limit later. This is a very simple change.

### Tests

Is testing necessary?