### PR TITLE
project-notes-tabs: More accurately get the name for each section

### DIFF
--- a/addons/project-notes-tabs/userscript.js
+++ b/addons/project-notes-tabs/userscript.js
@@ -38,7 +38,7 @@ export default async function ({ addon, console }) {
       const tab = document.createElement("div");
       tab.classList.add("tab-choice-sa");
       const inner = document.createElement("span");
-      inner.innerText = labels[i].innerText;
+      inner.innerText = labels[i].querySelector("span").innerText;
       tab.appendChild(inner);
       tab.addEventListener("click", () => selectTab(i));
       tabButtons.push(tab);


### PR DESCRIPTION
Resolves #6606 and resolves a pending compatibility task from unmerged PR #6258

### Changes

We previously assumed `section.querySelector(".project-textlabel").innerText` to be the correct name for each section (either Instructions or Notes&Credits). It is also true in vanilla Scratch that the textContent of the first span child of that same element is the name of the section. So let's shrink the assumption as much as possible.

### Tests

Tested in Chromium