### PR TITLE
Commit 2ac31c6ac7809690333ec57671fc2efe743ffda1

### DIFF
--- a/addon-api/content-script/Trap.js
+++ b/addon-api/content-script/Trap.js
@@ -31,15 +31,31 @@ export default class Trap extends Listenable {
     return "__reactInternalInstance$";
   }
 
-  /**
-   * Gets Blockly instance actually used by Scratch.
-   * This is different from window.Blockly.
-   * @async
-   * @throws when on non-project page.
-   * @returns {Promise<object>}
-   */
-  async getBlockly() {
-    if (this._cache.Blockly) return this._cache.Blockly;
+  _getBlocksComponent(wrapper) {
+    if (!this._react_internal_key) {
+      this._react_internal_key = Object.keys(wrapper).find((key) => key.startsWith(this.REACT_INTERNAL_PREFIX));
+    }
+    const internal = wrapper[this._react_internal_key];
+    let childable = internal;
+    /* eslint-disable no-empty */
+    while (((childable = childable.child), !childable || !childable.stateNode || !childable.stateNode.ScratchBlocks)) {}
+    /* eslint-enable no-empty */
+    return childable;
+  }
+
+  _getBlocksWrapperComponentSync() {
+    const editorMode = this._getEditorMode();
+    if (!editorMode || editorMode === "embed")
+      throw new Error(`Cannot access Blockly on ${editorMode} page (${location.pathname})`);
+    const BLOCKS_CLASS = '[class^="gui_blocks-wrapper"]';
+    let elem = document.querySelector(BLOCKS_CLASS);
+    if (!elem) {
+      throw new Error("Could not find workspace element, is the page in editor mode?");
+    }
+    return this._getBlocksComponent(elem);
+  }
+
+  async _getBlocksWrapperComponent() {
     const editorMode = this._getEditorMode();
     if (!editorMode || editorMode === "embed")
       throw new Error(`Cannot access Blockly on ${editorMode} page (${location.pathname})`);
@@ -50,15 +66,33 @@ export default class Trap extends Listenable {
         reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
       });
     }
-    if (!this._react_internal_key) {
-      this._react_internal_key = Object.keys(elem).find((key) => key.startsWith(this.REACT_INTERNAL_PREFIX));
-    }
-    const internal = elem[this._react_internal_key];
-    let childable = internal;
-    /* eslint-disable no-empty */
-    while (((childable = childable.child), !childable || !childable.stateNode || !childable.stateNode.ScratchBlocks)) {}
-    /* eslint-enable no-empty */
+    return this._getBlocksComponent(elem);
+  }
+
+  /**
+   * Gets Blockly instance actually used by Scratch.
+   * This is different from window.Blockly.
+   * @async
+   * @throws when on non-project page.
+   * @returns {Promise<object>}
+   */
+  async getBlockly() {
+    if (this._cache.Blockly) return this._cache.Blockly;
+    const childable = await this._getBlocksComponent();
     return (this._cache.Blockly = childable.stateNode.ScratchBlocks);
+  }
+
+  /**
+   * Gets the Blockly workspace synchronously.
+   * This must be called while the workspace is visible (i.e. in editor).
+   * Unlike Blockly#getMainWorkspace, this always returns the editor workspace
+   * (and not the custom block prompt workspace).
+   * The result is not cached and should be queried every time workspace access is needed.
+   * @throws when the workspace is not available
+   * @returns {object}
+   */
+  getWorkspace() {
+    return this._getBlocksComponent().stateNode.workspace;
   }
 
   /**
@@ -84,7 +118,7 @@ export default class Trap extends Listenable {
     const editorMode = this._getEditorMode();
     if (!editorMode || editorMode === "embed") throw new Error("Cannot access paper on this page");
     // We can access paper through .tool on tools, for example:
-    // https://github.com/scratchfoundation/scratch-paint/blob/develop/src/containers/bit-brush-mode.jsx#L60-L62
+    // https://github.com/LLK/scratch-paint/blob/develop/src/containers/bit-brush-mode.jsx#L60-L62
     // It happens that paper's Tool objects contain a reference to the entirety of paper's scope.
     const modeSelector = await this._waitForElement("[class*='paint-editor_mode-selector']", {
       reduxCondition: (state) => state.scratchGui.editorTab.activeTabIndex === 1 && !state.scratchGui.mode.isPlayerOnly,


### PR DESCRIPTION
Replaces closed draft PR #6227

Resolves #6212

### Changes

- [ ] Do not store objects one per each addon, we can store them globally for each tab
- [ ] Handle case where queried outside editor
- [ ] Use this API in a few addons, such as `hide-flyout` (should fix #3906 & #6224)
- [ ] Test in both browsers