### PR TITLE
chrome.cookies.onChanged: avoid infinite loops

### DIFF
--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -32,7 +32,8 @@ function getDefaultStoreId() {
 })();
 
 const onCookiesChanged = ({ cookie, cause, removed }) => {
-  if (cookie.name === "scratchsessionsid" || cookie.name === "scratchlanguage" || cookie.name === "scratchcsrftoken") {
+  // We already know that this is true:
+  // `cookie.name === "scratchsessionsid" || cookie.name === "scratchlanguage" || cookie.name === "scratchcsrftoken"`
     if (cookie.name === "scratchlanguage") {
       setLanguage();
     } else if (!scratchAddons.cookieStoreId) {
@@ -54,7 +55,6 @@ const onCookiesChanged = ({ cookie, cause, removed }) => {
       openMessageCache(cookie.storeId, true);
     }
     notify(cookie);
-  }
 };
 
 const COOKIE_CHANGE_RATE_LIMIT = 1500; // (ms) First events get processed immediately, then rate-limit is used.
@@ -75,6 +75,12 @@ const process = ({ clearIntervalIfQueueEmpty }) => {
   }
 };
 const addToQueue = (item) => {
+  const { cookie } = item;
+  if (cookie.name !== "scratchsessionsid" && cookie.name !== "scratchlanguage" && cookie.name !== "scratchcsrftoken") {
+    // Ignore this event
+    return;
+  }
+
   queue.push(item);
   n++;
   if (timer === null) {

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -31,7 +31,7 @@ function getDefaultStoreId() {
   startCache(defaultStoreId);
 })();
 
-chrome.cookies.onChanged.addListener(({ cookie, cause, removed }) => {
+const onCookiesChanged = ({ cookie, cause, removed }) => {
   if (cookie.name === "scratchsessionsid" || cookie.name === "scratchlanguage" || cookie.name === "scratchcsrftoken") {
     if (cookie.name === "scratchlanguage") {
       setLanguage();
@@ -55,7 +55,43 @@ chrome.cookies.onChanged.addListener(({ cookie, cause, removed }) => {
     }
     notify(cookie);
   }
-});
+};
+
+const COOKIE_CHANGE_RATE_LIMIT = 1500; // (ms) First events get processed immediately, then rate-limit is used.
+const queue = []; // We store cookies.onChanged events here. We'll try to process them all, but there's no guarantee.
+let timer = null; // The integer ID returned by setInterval.
+let n = 0; // Resets to 0 after each "burst" ends. If number is low, the event is processed with no delay.
+
+const process = ({ clearIntervalIfQueueEmpty }) => {
+  if (queue.length > 0) {
+    const item = queue.shift();
+    onCookiesChanged(item);
+    if (clearIntervalIfQueueEmpty) console.log("Processed cookies.onChanged event from queue.");
+  }
+  if (clearIntervalIfQueueEmpty && queue.length === 0) {
+    clearInterval(timer);
+    timer = null;
+    n = 0;
+  }
+};
+const addToQueue = (item) => {
+  queue.push(item);
+  n++;
+  if (timer === null) {
+    timer = setInterval(() => process({ clearIntervalIfQueueEmpty: true }), COOKIE_CHANGE_RATE_LIMIT);
+    // setInterval may not work as expected in the extension background context, but worst
+    // that can happen is that we discard events instead of processing them later.
+  }
+  if (n <= 5) {
+    // Process first 5 events immediately (gets reset after receiving 0 events for `COOKIE_CHANGE_RATE_LIMIT` milliseconds)
+    process({ clearIntervalIfQueueEmpty: false });
+  }
+  if (queue.length > 15) {
+    // If queue has more than 15 items, remove the oldest one.
+    queue.shift();
+  }
+};
+chrome.cookies.onChanged.addListener((e) => addToQueue(e));
 
 function getCookieValue(name) {
   return new Promise((resolve) => {

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -34,27 +34,27 @@ function getDefaultStoreId() {
 const onCookiesChanged = ({ cookie, cause, removed }) => {
   // We already know that this is true:
   // `cookie.name === "scratchsessionsid" || cookie.name === "scratchlanguage" || cookie.name === "scratchcsrftoken"`
-    if (cookie.name === "scratchlanguage") {
-      setLanguage();
-    } else if (!scratchAddons.cookieStoreId) {
-      getDefaultStoreId().then(() => checkSession());
-    } else if (
-      // do not refetch for csrf token expiration date change
-      cookie.storeId === scratchAddons.cookieStoreId &&
-      !(cookie.name === "scratchcsrftoken" && cookie.value === scratchAddons.globalState.auth.csrfToken)
-    ) {
-      checkSession().then(() => {
-        if (cookie.name === "scratchsessionsid") {
-          startCache(scratchAddons.cookieStoreId, true);
-          purgeDatabase();
-        }
-      });
-    } else if (cookie.name === "scratchsessionsid") {
-      // Clear message cache for the store
-      // This is not the main one, so we don't refetch here
-      openMessageCache(cookie.storeId, true);
-    }
-    notify(cookie);
+  if (cookie.name === "scratchlanguage") {
+    setLanguage();
+  } else if (!scratchAddons.cookieStoreId) {
+    getDefaultStoreId().then(() => checkSession());
+  } else if (
+    // do not refetch for csrf token expiration date change
+    cookie.storeId === scratchAddons.cookieStoreId &&
+    !(cookie.name === "scratchcsrftoken" && cookie.value === scratchAddons.globalState.auth.csrfToken)
+  ) {
+    checkSession().then(() => {
+      if (cookie.name === "scratchsessionsid") {
+        startCache(scratchAddons.cookieStoreId, true);
+        purgeDatabase();
+      }
+    });
+  } else if (cookie.name === "scratchsessionsid") {
+    // Clear message cache for the store
+    // This is not the main one, so we don't refetch here
+    openMessageCache(cookie.storeId, true);
+  }
+  notify(cookie);
 };
 
 const COOKIE_CHANGE_RATE_LIMIT = 1500; // (ms) First events get processed immediately, then rate-limit is used.


### PR DESCRIPTION
Resolves (mitigates?) #6460

### Changes

After 5 received events "in a row" (during 1500ms), `chrome.cookies.onChanged` events are added to a queue and only one is processed every 1500ms.

### Tests

To emulate #6460 (requesting `/session/` itself setting cookies unexpectedly), add this to the top of handle-fetch.js:

```js
const extraInfoSpec = ["blocking", "responseHeaders"];
if (Object.prototype.hasOwnProperty.call(chrome.webRequest.OnBeforeSendHeadersOptions, "EXTRA_HEADERS"))
  extraInfoSpec.push("extraHeaders");

chrome.webRequest.onHeadersReceived.addListener(
  function (details) {
    details.responseHeaders.push({
      name: "Set-Cookie",
      value: "scratchcsrftoken=abc; Domain=.scratch.mit.edu; expires=Fri, 30-Aug-2024 12:00:00 GMT; Max-Age=31449600; Path=/; secure",
    });
    return {
      responseHeaders: details.responseHeaders,
    };
  },
  {
    urls: ["https://scratch.mit.edu/session/"],
    types: ["xmlhttprequest"],
  },
  extraInfoSpec
);
```