### PR TITLE
Specify end of line sequence in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "files.eol": "\n",
-  
+
   "search.exclude": {
     "libraries/thirdparty/**": true,
     "libraries/licenses/**": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "files.eol": "\n",
+  
   "search.exclude": {
     "libraries/thirdparty/**": true,
     "libraries/licenses/**": true,


### PR DESCRIPTION
### Changes

Sets `files.eol` in `.vscode/settings.json` to "\n", which makes newly created files in Visual Studio Code use LF as the default end of line sequence in the Scratch Addons directory.

### Reason for changes

To try to reduce the number of times the Prettier status check fails because the files were not using the end of line sequence we were asking for. Not sure how much it will help, but hey, anything that helps still helps.

### Tests

Tested in Visual Studio Code.
