### PR TITLE
Fix global translation string IDs not prefixed with `_general`

### DIFF
--- a/addons-l10n/en/_general.json
+++ b/addons-l10n/en/_general.json
@@ -2,9 +2,9 @@
   "_locale": "en",
   "_locale_name": "English",
 
-  "global/blocks/green-flag": "flag",
-  "global/blocks/clockwise": "clockwise",
-  "global/blocks/anticlockwise": "anti-clockwise",
-  "global/meta/managedBySa": "Managed by Scratch Addons",
-  "global/meta/addonSettings": "Addon Settings"
+  "_general/blocks/green-flag": "flag",
+  "_general/blocks/clockwise": "clockwise",
+  "_general/blocks/anticlockwise": "anti-clockwise",
+  "_general/meta/managedBySa": "Managed by Scratch Addons",
+  "_general/meta/addonSettings": "Addon Settings"
 }

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -347,11 +347,11 @@ export default async function ({ addon, console, msg }) {
           } else if (type === "field_image") {
             const src = argInfo.src;
             if (src.endsWith("rotate-left.svg")) {
-              formattedMessage += msg("/global/blocks/anticlockwise");
+              formattedMessage += msg("/_general/blocks/anticlockwise");
             } else if (src.endsWith("rotate-right.svg")) {
-              formattedMessage += msg("/global/blocks/clockwise");
+              formattedMessage += msg("/_general/blocks/clockwise");
             } else if (src.endsWith("green-flag.svg")) {
-              formattedMessage += msg("/global/blocks/green-flag");
+              formattedMessage += msg("/_general/blocks/green-flag");
             }
           } else {
             formattedMessage += "()";

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -492,14 +492,14 @@ export default async function ({ addon, console, msg }) {
     const managedBySa = elementToClone.cloneNode(true);
     addon.tab.displayNoneWhileDisabled(managedBySa, { display: "block" });
     managedBySa.classList.add("sa-theme3-managed");
-    managedBySa.querySelector("div span").textContent = msg("/global/meta/managedBySa");
+    managedBySa.querySelector("div span").textContent = msg("/_general/meta/managedBySa");
     managedBySa.querySelector("img[class*=settings-menu_icon_]").src = SA_ICON_URL;
 
     const addonSettingsLink = elementToClone.cloneNode(true);
     addon.tab.displayNoneWhileDisabled(addonSettingsLink, { display: "block" });
     addonSettingsLink.classList.add("sa-theme3-link");
     addonSettingsLink.classList.add(addon.tab.scratchClass("menu_menu-section") || "_");
-    addonSettingsLink.querySelector("div span").textContent = msg("/global/meta/addonSettings");
+    addonSettingsLink.querySelector("div span").textContent = msg("/_general/meta/addonSettings");
     addonSettingsLink.querySelector("img[class*=settings-menu_icon_]").src = SA_ICON_URL;
     const addonSettingsImg = document.createElement("img");
     addonSettingsImg.classList.add("sa-theme3-new-tab");

--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -406,13 +406,13 @@ export class BlockTypeInfo {
       } else if (field instanceof Blockly.FieldImage) {
         switch (field.src_) {
           case "/static/blocks-media/green-flag.svg":
-            parts.push(locale("/global/blocks/green-flag"));
+            parts.push(locale("/_general/blocks/green-flag"));
             break;
           case "/static/blocks-media/rotate-right.svg":
-            parts.push(locale("/global/blocks/clockwise"));
+            parts.push(locale("/_general/blocks/clockwise"));
             break;
           case "/static/blocks-media/rotate-left.svg":
-            parts.push(locale("/global/blocks/anticlockwise"));
+            parts.push(locale("/_general/blocks/anticlockwise"));
             break;
         }
       } else {


### PR DESCRIPTION
Resolves #6579

### Changes

Changes the `global/` string prefixes to `_general/`

### Reason for changes

To fix a bug where some tribulations were located in the wrong file.

### Tests

Tested by moving another language's translations to the _general file locally. The find bar's flag label is still not translated and #6599 should be fixed with #6600