### PR TITLE
Make forum breadcrumbs and page numbers styled by `scratchr2` not affected by `colorblind`

### DIFF
--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -156,6 +156,7 @@ body > #pagewrapper {
   line-height: 18px;
   font-weight: bold;
   text-align: center;
+  text-decoration: none;
 }
 .linkst li:not(:last-child) a:hover,
 .linksb li:not(:last-child) a:hover,


### PR DESCRIPTION
Resolves #6534

### Changes

Add `text-decoration: none` to the CSS in `scratchr2` responsible for styling the breadcrumbs. This is enough for `scratchr2` to override `colorblind`.

### Reason for changes

To make `colorblind` make more sense and only style links that are visible as such (rather than buttons).

### Tests

Tested in Edge.
