### PR TITLE
Add code snippets for addon manifest

### DIFF
--- a/.vscode/addon-manifest.code-snippets
+++ b/.vscode/addon-manifest.code-snippets
@@ -1,0 +1,80 @@
+{
+  "Scratch Addons addon manifest": {
+    "scope": "json",
+    "prefix": "addon.json",
+    "body": [
+      "{",
+      "\t\"name\": \"$1\",",
+      "\t\"description\": \"$2\",",
+      "\t\"credits\": [",
+      "\t\t{",
+      "\t\t\t\"name\": \"$3\",",
+      "\t\t\t\"link\": \"https://scratch.mit.edu/users/$4/\"",
+      "\t\t}",
+      "\t],"
+      "\t\"user${7:scripts}\": [",
+      "\t\t{"
+      "\t\t\t\"url\": \"${8:userscript.js}\","
+      "\t\t\t\"matches\": [$9]"
+      "\t\t}",
+      "\t],",
+      "\t\"settings\": [$0],",
+      "\t\"dynamicEnable\": false,",
+      "\t\"dynamicDisable\": false,",
+      "\t\"tags\": [$5],",
+      "\t\"versionAdded\": \"1.${6:0}.0\","
+      "\t\"enabledByDefault\": false"
+      "}",
+      ""
+    ],
+    "description": "addon.json",
+  },
+
+  "Boolean setting": {
+    "scope": "json",
+    "prefix": "settingBoolean",
+    "body": [
+      "{",
+      "\t\"name\": \"$1\",",
+      "\t\"id\": \"$2\",",
+      "\t\"type\": \"boolean\",",
+      "\t\"default\": ${3:false}",
+      "}$0"
+    ],
+    "description": "boolean setting"
+  },
+
+  "Integer setting": {
+    "scope": "json",
+    "prefix": "settingInteger",
+    "body": [
+      "{",
+      "\t\"name\": \"$1\",",
+      "\t\"id\": \"$2\",",
+      "\t\"type\": \"integer\",",
+      "\t\"min\": ${3:0},",
+      "\t\"max\": ${4:100},",
+      "\t\"default\": ${5:0}",
+      "}$0"
+    ],
+    "description": "integer setting"
+  },
+
+  "Radio setting": {
+    "scope": "json",
+    "prefix": "settingSelect",
+    "body": [
+      "{",
+      "\t\"name\": \"$1\",",
+      "\t\"id\": \"$2\",",
+      "\t\"type\": \"select\",",
+      "\t\"potentialValues\": [",
+      "\t\t{\n\t\t\t\"id\": \"$3\",\n\t\t\t\"name\": \"$4\"\n\t\t},",
+      "\t\t${0:{\n\t\t\t\"id\": \"$5\",\n\t\t\t\"name\": \"$6\"\n\t\t\\}}",
+      "\t],",
+      "\t\"default\": \"$3\"",
+      "}"
+    ],
+    "description": "select setting"
+  }
+}


### PR DESCRIPTION
Resolves #6641

### Changes

Adds a code snippets file containing various frequently used components of addon.json (addon manifest) files, and there's even one acting as a template for an entire addon manifest!

### Reason for changes

The one thing I don't like about making addon manifests is the repetition and having to look at documentation/other addon manifests for guidance. This is great news for me as now Visual Studio Code can do all that for me, thanks to the code snippets file, making that process much faster.

### Try it out

1. Download the branch.
2. Open the root directory in Visual Studio Code (File > Open Folder...).
3. Make sure IntelliSense is turned on and provides code snippets suggestions.
4. Add a new file named "addon.json".
5. Start typing "addon.json", "settingBoolean", "settingInteger", or "settingSelect" for any one of the four proposed code snippets. Press <kbd>Enter</kbd> to accept the suggestion.
6. Fill in the blanks. Press <kbd>Tab</kbd> to advance to the next cursor placement to continue filling in the blanks.

### Tests

Tested in Visual Studio Code 1.82.0.

### Next steps

Document the code snippets and how to use them.