### PR TITLE
Add VSCode snippets for addon manifests

### DIFF
--- a/.vscode/json.code-snippets
+++ b/.vscode/json.code-snippets
@@ -1,0 +1,49 @@
+{
+    "Scratch Addons manifest": {
+      "prefix": "addon",
+      "body": [
+        "{",
+        "  \"name\": \"$1\",",
+        "  \"description\": \"$2\",",
+        "  \"tags\": [$3],",
+        "  \"credits\": [",
+        "  ],",
+        "  \"user${6:scripts}\": [",
+        "  ],",
+        "  \"dynamicEnable\": ${7:false},",
+        "  \"dynamicDisable\": ${8:false},",
+        "  \"versionAdded\": \"1.${9:0}.0\",",
+        "  \"enabledByDefault\": false",
+        "}",
+        "",
+      ],
+      "description": "addon.json"
+    },
+    "Credits": {
+        "prefix": "credits",
+        "body": [
+            "{",
+            "      \"name\": \"$1\",",
+            "      \"link\": \"https://scratch.mit.edu/users/$2/\"",
+            "}"
+        ]
+    },
+    "Userscript/style": {
+        "prefix": "userscript",
+        "body": [
+            "{",
+            "\"url\": \"${1:userscript.js}\",",
+            "\"matches\": [$2]",
+            "}"
+        ]
+    },
+    "Info": {
+        "prefix": "info",
+        "body": [
+            "{",
+            "\"type\": \"$1\"",
+            "\"text\": \"$2\"",
+            "\"id\": \"$3\""
+        ]
+    }
+}

--- a/.vscode/json.code-snippets
+++ b/.vscode/json.code-snippets
@@ -1,49 +1,34 @@
 {
-    "Scratch Addons manifest": {
-      "prefix": "addon",
-      "body": [
-        "{",
-        "  \"name\": \"$1\",",
-        "  \"description\": \"$2\",",
-        "  \"tags\": [$3],",
-        "  \"credits\": [",
-        "  ],",
-        "  \"user${6:scripts}\": [",
-        "  ],",
-        "  \"dynamicEnable\": ${7:false},",
-        "  \"dynamicDisable\": ${8:false},",
-        "  \"versionAdded\": \"1.${9:0}.0\",",
-        "  \"enabledByDefault\": false",
-        "}",
-        "",
-      ],
-      "description": "addon.json"
-    },
-    "Credits": {
-        "prefix": "credits",
-        "body": [
-            "{",
-            "      \"name\": \"$1\",",
-            "      \"link\": \"https://scratch.mit.edu/users/$2/\"",
-            "}"
-        ]
-    },
-    "Userscript/style": {
-        "prefix": "userscript",
-        "body": [
-            "{",
-            "\"url\": \"${1:userscript.js}\",",
-            "\"matches\": [$2]",
-            "}"
-        ]
-    },
-    "Info": {
-        "prefix": "info",
-        "body": [
-            "{",
-            "\"type\": \"$1\"",
-            "\"text\": \"$2\"",
-            "\"id\": \"$3\""
-        ]
-    }
+  "Scratch Addons manifest": {
+    "prefix": "addon",
+    "body": [
+      "{",
+      "  \"name\": \"$1\",",
+      "  \"description\": \"$2\",",
+      "  \"tags\": [$3],",
+      "  \"credits\": [",
+      "  ],",
+      "  \"user${6:scripts}\": [",
+      "  ],",
+      "  \"dynamicEnable\": ${7:false},",
+      "  \"dynamicDisable\": ${8:false},",
+      "  \"versionAdded\": \"1.${9:0}.0\",",
+      "  \"enabledByDefault\": false",
+      "}",
+      ""
+    ],
+    "description": "addon.json"
+  },
+  "Credits": {
+    "prefix": "credits",
+    "body": ["{", "      \"name\": \"$1\",", "      \"link\": \"https://scratch.mit.edu/users/$2/\"", "}"]
+  },
+  "Userscript/style": {
+    "prefix": "userscript",
+    "body": ["{", "\"url\": \"${1:userscript.js}\",", "\"matches\": [$2]", "}"]
+  },
+  "Info": {
+    "prefix": "info",
+    "body": ["{", "\"type\": \"$1\"", "\"text\": \"$2\"", "\"id\": \"$3\""]
+  }
 }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #6641

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
Add a `json.code-snippets` file to Scratch Addons' `.vscode` folder.

### Reason for changes

<!-- Why should these changes be made? -->
People can create addon manifests quicklier, without copy-pasting from the docs.

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->
Tried to create a manifest file and it worked.
