### PR TITLE
Don't feature `longer-wiwo`

### DIFF
--- a/addons/longer-wiwo/addon.json
+++ b/addons/longer-wiwo/addon.json
@@ -16,6 +16,6 @@
     }
   ],
   "versionAdded": "1.11.0",
-  "tags": ["community", "profiles", "featured"],
+  "tags": ["community", "profiles"],
   "enabledByDefault": false
 }


### PR DESCRIPTION
### Changes

Moves the 'Higher Character Limit in "What I'm Working on"' addon down from Featured to Others.

### Reason for changes

I don't like the sound of putting exploits higher up - advertising the method to extend the WIWO by 55 characters won't make the Scratch Team happy. Then again, we're an unofficial extension...

### Tests

Not tested.
