### PR TITLE
Fix sprite pane not using all height (`editor-compact` & `sprite-properties`)

### DIFF
--- a/addons/sprite-properties/userstyle.css
+++ b/addons/sprite-properties/userstyle.css
@@ -10,7 +10,9 @@
   border: none;
 }
 
-[class^="sprite-selector_scroll-wrapper_"] {
+[class^="sprite-selector_scroll-wrapper_"],
+/* Also take full height if `sprite-properties` is hiding the properties (specificity) */
+.sa-hide-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
   height: 100%;
   transition-property: height;
   transition-duration: var(--spriteProperties-transitionDuration);


### PR DESCRIPTION
Resolves #6602
Sprite pane not using all available space when both `editor-compact` and (collapsing)`sprite-properties` enabled

### Changes

Increases the specificity of the selector with `height: 100%` inside so that it wins when the sprite properties are collapsed through the addon.

### Tests

I will test this more thoroughly before merging. Send a review if you find a bug.
I will try to check all addons that target this element