### PR TITLE
Note that you can undo a sprite deletion

### DIFF
--- a/addons/hide-delete-button/addon.json
+++ b/addons/hide-delete-button/addon.json
@@ -4,7 +4,7 @@
   "tags": ["editor", "featured"],
   "info": [
     {
-      "text": "Bonus tip: Accidentally deleted a sprite, costume, or sound? You can bring it back with Edit \u2192 Restore <item> in the menu bar.",
+      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore <item>.",
       "id": "restoretip"
     }
   ],

--- a/addons/hide-delete-button/addon.json
+++ b/addons/hide-delete-button/addon.json
@@ -4,7 +4,7 @@
   "tags": ["editor", "featured"],
   "info": [
     {
-      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore <item>.",
+      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore.",
       "id": "restoretip"
     }
   ],

--- a/addons/hide-delete-button/addon.json
+++ b/addons/hide-delete-button/addon.json
@@ -2,6 +2,12 @@
   "name": "Hide delete button",
   "description": "Hides delete button (trash can icon) from sprites, costumes and sounds. They can still be deleted using the right click context menu.",
   "tags": ["editor", "featured"],
+  "info": [
+    {
+      "text": "Bonus tip: Accidentally deleted a sprite, costume, or sound? You can bring it back with Edit \u2192 Restore <item> in the menu bar.",
+      "id": "restoretip"
+    }
+  ],
   "versionAdded": "1.19.0",
   "dynamicEnable": true,
   "dynamicDisable": true,

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -1,6 +1,12 @@
 {
   "name": "Sprite deletion confirmation",
   "description": "Asks if you're sure when deleting a sprite inside a project.",
+  "info": [
+    {
+      "text": "Bonus tip: Accidentally deleted a sprite, costume, or sound? You can bring it back with Edit \u2192 Restore <item> in the menu bar.",
+      "id": "restoretip"
+    }
+  ],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -3,7 +3,7 @@
   "description": "Asks if you're sure when deleting a sprite inside a project.",
   "info": [
     {
-      "text": "Bonus tip: Accidentally deleted a sprite, costume, or sound? You can bring it back with Edit \u2192 Restore <item> in the menu bar.",
+      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore <item>.",
       "id": "restoretip"
     }
   ],

--- a/addons/remove-sprite-confirm/addon.json
+++ b/addons/remove-sprite-confirm/addon.json
@@ -3,7 +3,7 @@
   "description": "Asks if you're sure when deleting a sprite inside a project.",
   "info": [
     {
-      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore <item>.",
+      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore.",
       "id": "restoretip"
     }
   ],


### PR DESCRIPTION
### Changes

Considering `disable-paste-offset` has a bonus tip ("This behavior can also be achieved without this addon by Alt+Clicking the item."), I thought it'd be alright to add a bonus tip to the sprite deletion-related addons:

> Bonus tip: Accidentally deleted a sprite, costume, or sound? You can bring it back with Edit → Restore \<item> in the menu bar.

### Tests and Issues

Tested.

- [x] ~~The string currently uses the characters `<` and `>` which confuse Transifex.~~ We've now removed it from the description completely.
