### PR TITLE
Fix share confirm modal appearing on ideas button

### DIFF
--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -13,7 +13,7 @@ export default async function ({ addon, console, msg }) {
       let cancelMessage = null;
       if (
         addon.settings.get("projectsharing") &&
-        e.target.closest("[class*='share-button_share-button']:not([class*='is-shared']), .banner-button")
+        e.target.closest("[class*='share-button_share-button']:not([class*='is-shared']), .banner-text + .banner-button")
       ) {
         title = addon.tab.scratchMessage("project.share.shareButton"); // "Share"
         cancelMessage = msg("share");

--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -13,7 +13,9 @@ export default async function ({ addon, console, msg }) {
       let cancelMessage = null;
       if (
         addon.settings.get("projectsharing") &&
-        e.target.closest("[class*='share-button_share-button']:not([class*='is-shared']), .banner-text + .banner-button")
+        e.target.closest(
+          "[class*='share-button_share-button']:not([class*='is-shared']), .banner-text + .banner-button"
+        )
       ) {
         title = addon.tab.scratchMessage("project.share.shareButton"); // "Share"
         cancelMessage = msg("share");


### PR DESCRIPTION
Resolves #6683

### Changes

Make the `.banner-button` selector more specific by also requiring a `.banner-text` next to it, which the ideas button doesn't have.

### Reason for changes

To fix the share modal appearing on the ideas button.

### Tests

Tested on Edge 116.
