### PR TITLE
Make `forum-live-preview` affected by toolbar buttons

### DIFF
--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -40,7 +40,11 @@ export default async function ({ addon, console }) {
 
   textarea.addEventListener("input", delayedPreview);
   markItUpButtons.forEach((el) => {
-    el.addEventListener("click", delayedPreview);
+    el.addEventListener("click", () => {
+      if (textarea.value) {
+        delayedPreview();
+      }
+    });
   });
   addon.self.addEventListener("disabled", () => {
     showPreview();

--- a/addons/forum-live-preview/userscript.js
+++ b/addons/forum-live-preview/userscript.js
@@ -1,6 +1,7 @@
 export default async function ({ addon, console }) {
   const textarea = await addon.tab.waitForElement(".markItUpEditor");
   const previewButton = await addon.tab.waitForElement(".markItUpButton.preview");
+  const markItUpButtons = document.querySelectorAll(".markItUpButton:not(.markItUpDropMenu)");
   let previewIframe;
   let delay;
   switch (addon.settings.get("rate")) {
@@ -32,9 +33,14 @@ export default async function ({ addon, console }) {
   };
 
   let timeout;
-  textarea.addEventListener("input", () => {
+  const delayedPreview = () => {
     if (timeout !== undefined) clearTimeout(timeout);
     timeout = setTimeout(updatePreview, delay);
+  };
+
+  textarea.addEventListener("input", delayedPreview);
+  markItUpButtons.forEach((el) => {
+    el.addEventListener("click", delayedPreview);
   });
   addon.self.addEventListener("disabled", () => {
     showPreview();


### PR DESCRIPTION
Resolves #6685

### Changes

Add a click to a toolbar button to the actions that trigger the event to show the preview.

### Reason for changes

To make the experience make more sense.

### Tests

Tested in Edge 116.
