### PR TITLE
`editor-theme3`: Style define blocks correctly

### DIFF
--- a/addons/editor-theme3/forums/base.css
+++ b/addons/editor-theme3/forums/base.css
@@ -13,6 +13,10 @@
 .sb-pen {
   fill: var(--sa-block-color);
 }
+.sb-define-hat-cap {
+  fill: var(--sa-block-color);
+  stroke: var(--sa-block-color);
+}
 .sb3-motion,
 .sb3-looks,
 .sb3-sound,
@@ -137,7 +141,8 @@
 .sb-custom-arg ~ .sb-label,
 .sb3-custom-arg,
 .sb3-custom-arg-dark,
-.sb3-custom-arg ~ .sb3-label {
+.sb3-custom-arg ~ .sb3-label,
+.sb-define-hat-cap {
   --sa-block-color: var(--editorTheme3-customColor);
 }
 .sb-extension,


### PR DESCRIPTION
Resolves #6686

### Changes

Style the `.sb-define-hat-cap` class.

![A define scratch block properly styled with `editor-theme3`.](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/896fe6de-567a-4683-afb6-6dd3a3451507)

### Reason for changes

To make `editor-theme3` affect define blocks.

### Tests

Tested in Edge 116.
