### PR TITLE
"Show profile pictures next to usernames" addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -149,6 +149,7 @@
   "forum-post-countdown",
   "paint-skew",
   "preview-project-description",
+  "more-pfps",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/more-pfps/addon.json
+++ b/addons/more-pfps/addon.json
@@ -1,0 +1,42 @@
+{
+  "name": "Show profile pictures next to usernames",
+  "description": "Shows the user's profile picture next to their username in several places on the website.",
+  "tags": ["community"],
+  "userscripts": [
+    {
+      "matches": "*",
+      "url": "userscript.js"
+    }
+  ],
+  "userstyles": [
+    {
+      "matches": "*",
+      "url": "userstyle.css"
+    },
+    {
+      "matches": "*",
+      "url": "in-href.css",
+      "if": {
+        "settings": { "in-href": false }
+      }
+    }
+  ],
+  "settings": [
+    {
+      "id": "in-href",
+      "name": "Show profile pictures even if the user is only linked",
+      "type": "boolean",
+      "default": false
+    }
+  ],
+  "versionAdded": "1.35.0",
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ],
+  "dynamicDisable": true,
+  "dynamicEnable": true,
+  "updateUserstylesOnSettingsChange": true
+}

--- a/addons/more-pfps/in-href.css
+++ b/addons/more-pfps/in-href.css
@@ -1,0 +1,4 @@
+.sa-more-pfps-in-href {
+  /* Important required to override displayNoneWhileDisabled */
+  display: none !important;
+}

--- a/addons/more-pfps/userscript.js
+++ b/addons/more-pfps/userscript.js
@@ -1,0 +1,52 @@
+export default async function ({ addon, console }) {
+  const linkRegex = /(?:https?:\/\/scratch.mit.edu)?\/users\/([a-zA-Z0-9_-]{3,})\/?/;
+  const noPfpQueries = [
+    ".social-message-content", // What's Happening?
+    ".studio-project-info", // Studio projects
+    ".thumbnail-title", // Explore projects
+    ".actor", // What I've been doing
+    ".user.thumb.item", // Following / Followers
+    ".comment .info .name", // scratchr2 comment usernames
+    ".postleft", // forum post authors
+  ];
+
+  const getPfp = async (username) => {
+    const response = await (await fetch(`https://api.scratch.mit.edu/users/${username}`)).json();
+    if (!("profile" in response)) {
+      console.log(`Unexpected response from ${username}:`, response);
+      return null;
+    }
+    return response.profile.images["32x32"];
+  };
+
+  console.log(document.querySelectorAll("a"));
+  const addPfp = async (element) => {
+    const match = element.href.match(linkRegex);
+    if (!match) {
+      return;
+    }
+    if (element.children.length !== 0) {
+      return;
+    }
+    const username = match[1];
+    if (noPfpQueries.some((query) => element.closest(query))) {
+      return;
+    }
+    const pfp = await getPfp(username);
+    if (pfp === null) {
+      return;
+    }
+    const pfpElement = document.createElement("img");
+    pfpElement.src = pfp;
+    pfpElement.classList.add("sa-more-pfps-pfp");
+    const trimmedContent = element.textContent.trim();
+    if (trimmedContent !== username && trimmedContent !== `@${username}`) {
+      pfpElement.classList.add("sa-more-pfps-in-href");
+    }
+    addon.tab.displayNoneWhileDisabled(pfpElement);
+    element.prepend(pfpElement);
+    element.classList.add("sa-more-pfps-link");
+  };
+
+  document.querySelectorAll("a").forEach(addPfp);
+}

--- a/addons/more-pfps/userstyle.css
+++ b/addons/more-pfps/userstyle.css
@@ -1,0 +1,11 @@
+img.sa-more-pfps-pfp {
+  width: 1.5em !important;
+  height: 1.5em !important;
+  display: inline;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+}
+
+a.sa-more-pfps-link {
+  vertical-align: middle;
+}


### PR DESCRIPTION
Resolves #6270
Supersedes #6693 <small>(which I closed and deleted for... some reason)</small>

### Changes

Create a "Show profile pictures next to usernames" addon that does what it says.

### Reason for changes

PFPs are in most parts of the website.

### Tests

Tested in Edge.

### To Do

**Make it respond to changes in the DOM.** Currently, it doesn't work with most scratch-www things and also not for any new comments. I have tried doing this with `MutationObserver` and crashed my browser every time.
Also, I have probably missed some selectors, which means profile pictures there appear twice.