### PR TITLE
Fix duplicate latestUpdate key in addon manifest

### DIFF
--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -6,7 +6,7 @@
   "latestUpdate": {
     "version": "1.35.0",
     "newSettings": ["useCustom"],
-    "temporaryNotice": "You can now increment input fields that are not in blocks, like the sprite properties and fully customize the values."
+    "temporaryNotice": "You can now increment input fields that are not in blocks, like the sprite properties, and fully customize the values."
   },
   "userscripts": [
     {

--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -4,9 +4,9 @@
   "tags": ["editor", "codeEditor", "recommended"],
   "versionAdded": "1.34.0",
   "latestUpdate": {
-    "version": "1.35",
+    "version": "1.35.0",
     "newSettings": ["useCustom"],
-    "temporaryNotice": "There is now the option to fully customize the values."
+    "temporaryNotice": "You can now increment input fields that are not in blocks, like the sprite properties and fully customize the values."
   },
   "userscripts": [
     {
@@ -145,10 +145,6 @@
       "name": "World_Languages"
     }
   ],
-  "latestUpdate": {
-    "version": "1.35.0",
-    "temporaryNotice": "You can now also increment input fields that are not in blocks, like the sprite properties."
-  },
   "dynamicDisable": true,
   "dynamicEnable": true
 }


### PR DESCRIPTION
### Changes

Merges a duplicate `latestUpdate` key in `editor-number-arrow-keys`.

### Tests

Tested on Chromium.