### PR TITLE
dark-www: better support for scratch.mit.edu/statistics

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2127,6 +2127,18 @@
           "settingId": "box"
         }
       }
+    },
+    {
+      "name": "page-statsTextColor",
+      "value": {
+        "type": "textColor",
+        "black": "#554747",
+        "white": "#eae6e6",
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
     }
   ],
   "dynamicEnable": true,

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2127,18 +2127,6 @@
           "settingId": "box"
         }
       }
-    },
-    {
-      "name": "page-statsTextColor",
-      "value": {
-        "type": "textColor",
-        "black": "#554747",
-        "white": "#eae6e6",
-        "source": {
-          "type": "settingValue",
-          "settingId": "box"
-        }
-      }
     }
   ],
   "dynamicEnable": true,

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -150,7 +150,8 @@ select {
 .modal h2,
 .modal h3,
 .modal h4,
-.profile-box-footer-module h4 {
+.profile-box-footer-module h4,
+.stats li {
   color: var(--darkWww-box-scratchr2HeaderText);
 }
 .box-content label,
@@ -696,9 +697,6 @@ input.link.black {
 .stats li.data {
   background-image: url("%addon-self-dir%/assets/meow.png");
   background-size: 20px 15px;
-}
-.stats li {
-  color: var(--darkWww-box-scratchr2HeaderText);
 }
 
 /* If the color scheme of an iframe element is different from that

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -410,9 +410,7 @@ textarea:focus,
 .registration .modal-body textarea:focus,
 .registration .modal-body select:focus {
   border-color: var(--darkWww-button);
-  box-shadow:
-    0 1px 1px inset rgba(0, 0, 0, 0.08),
-    0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
+  box-shadow: 0 1px 1px inset rgba(0, 0, 0, 0.08), 0 0 8px var(--darkWww-button-scratchr2InputFocusShadow);
 }
 .editable textarea:focus,
 .editable-empty textarea:focus {
@@ -696,6 +694,9 @@ input.link.black {
 .stats li.data {
   background-image: url("%addon-self-dir%/assets/meow.png");
   background-size: 20px 15px;
+}
+.stats li {
+  color: var(--darkWww-page-statsTextColor);
 }
 
 /* If the color scheme of an iframe element is different from that


### PR DESCRIPTION
Resolves #6710

### Changes

Change the text color of the statistics items when on a dark background.

![The statistics page in a dark mode with better contrast between the background and text](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/b466f633-e8e8-4e41-a88c-a8373bf264a2)
### Reason for changes

Contrast.

### Tests

Tested in Edge.
