### PR TITLE
Create "Costume numbers in block dropdowns" addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -150,6 +150,7 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "dropdown-costume-numbers",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/dropdown-costume-numbers/addon.json
+++ b/addons/dropdown-costume-numbers/addon.json
@@ -1,0 +1,24 @@
+{
+  "name": "Costume numbers in block dropdowns",
+  "description": "Shows the costume numbers when costumes are used in a dropdown.",
+  "userstyles": [
+    {
+      "matches": ["projects"],
+      "url": "userstyle.css"
+    }
+  ],
+  "userscripts": [
+    {
+      "matches": ["projects"],
+      "url": "userscript.js"
+    }
+  ],
+  "tags": ["editor", "codeEditor"],
+  "versionAdded": "1.35.0",
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ]
+}

--- a/addons/dropdown-costume-numbers/userscript.js
+++ b/addons/dropdown-costume-numbers/userscript.js
@@ -29,7 +29,7 @@ export default async function ({ addon, console }) {
       const cutThree = COSTUME_BLOCKS[block.type];
       allItems.forEach((el, i) => {
         if (cutThree && i >= allItems.length - 3) return;
-        el.lastChild.dataset.index = i;
+        el.lastChild.dataset.index = i + 1;
       });
     } else {
       dropDownDiv.classList.remove("sa-dropdown-costume-numbers");

--- a/addons/dropdown-costume-numbers/userscript.js
+++ b/addons/dropdown-costume-numbers/userscript.js
@@ -7,7 +7,7 @@ export default async function ({ addon, console }) {
   };
 
   const dropDownDiv = await addon.tab.waitForElement(".blocklyDropDownDiv");
-  const workspace = (await addon.tab.traps.getBlockly()).getMainWorkspace();
+  const workspace = await addon.tab.traps.getWorkspace();
 
   // This will show the original text without the numbers for a bit.
   // I'm not aware of any better way to detect dropdown close, though

--- a/addons/dropdown-costume-numbers/userscript.js
+++ b/addons/dropdown-costume-numbers/userscript.js
@@ -1,0 +1,39 @@
+export default async function ({ addon, console }) {
+  // The boolean value is for whether the last three items should not have a number - e.g. for the "next background", "previous background" etc
+  const COSTUME_BLOCKS = {
+    looks_switchcostumeto: false,
+    looks_switchbackdropto: true,
+    looks_switchbackdroptoandwait: true,
+  };
+
+  const dropDownDiv = await addon.tab.waitForElement(".blocklyDropDownDiv");
+  const workspace = (await addon.tab.traps.getBlockly()).getMainWorkspace();
+
+  // This will show the original text without the numbers for a bit.
+  // I'm not aware of any better way to detect dropdown close, though
+  const waitForDropdownClose = () => {
+    const currentStyle = dropDownDiv.getAttribute("style");
+    return new Promise((resolve) =>
+      setInterval(() => {
+        if (currentStyle !== dropDownDiv.getAttribute("style")) resolve();
+      }, 100)
+    );
+  };
+
+  while (true) {
+    const element = await addon.tab.waitForElement(".blocklySelected");
+    const block = workspace.getBlockById(element.dataset.id);
+    if (block.type in COSTUME_BLOCKS) {
+      dropDownDiv.classList.add("sa-dropdown-costume-numbers");
+      const allItems = [...dropDownDiv.querySelectorAll(".goog-menuitem")];
+      const cutThree = COSTUME_BLOCKS[block.type];
+      allItems.forEach((el, i) => {
+        if (cutThree && i >= allItems.length - 3) return;
+        el.lastChild.dataset.index = i;
+      });
+    } else {
+      dropDownDiv.classList.remove("sa-dropdown-costume-numbers");
+    }
+    await waitForDropdownClose();
+  }
+}

--- a/addons/dropdown-costume-numbers/userstyle.css
+++ b/addons/dropdown-costume-numbers/userstyle.css
@@ -1,0 +1,3 @@
+.sa-dropdown-costume-numbers:not(.sa-dropdown-costume-numbers-cut-three) .goog-menuitem-content[data-index]::before {
+  content: attr(data-index) ". ";
+}


### PR DESCRIPTION
Resolves #4992

### Changes

Create a new "Costume numbers in block dropdowns" addon that shows costume numbers in block dropdowns.

![A screenshot of a backdrop dropdown with costume numbers.](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/a77479ae-a698-40ca-9f7d-fc1cf740cf22)

### Reason for changes

It can be helpful sometimes.

### Tests

Tested in Edge. It's compatible with `editor-searchable-dropdowns`.
