### PR TITLE
old-studio-layout: preserve thumbnail aspect ratio

### DIFF
--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -40,7 +40,7 @@
 }
 .studio-info .studio-image {
   width: 250px;
-  height: 147px;
+  height: 162.5px;
 }
 .studio-thumb-edit-img {
   padding: 0 0.25em;


### PR DESCRIPTION
From feedback:
> this has been a problem for a while but i didnt really realize how bad it actually was until now
i design my studio icons with the addon in mind, but for regular users it looks stretched

This PR preserves the aspect ratio of `1.53846153846` (😂) even when `old-studio-layout` is enabled. Technically this goes against the spirit of the addon, as studios previously used this aspect ratio, but it's still a weird decision to change it.

cc @mxmou