### PR TITLE
Extension popup settings: support reduced motion for enablepopup component

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -379,7 +379,9 @@ let fuse;
         setTimeout(() => window.parent.close(), 100);
       },
       hidePopup() {
-        document.querySelector(".popup").style.animation = "closePopup 0.6s 1";
+        document.querySelector(".popup").style.animation = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+          ? "closePopup 0.35s 1"
+          : "closePopup 0.6s 1";
         document.querySelector(".popup").addEventListener(
           "animationend",
           () => {

--- a/webpages/styles/components/enablepopup.css
+++ b/webpages/styles/components/enablepopup.css
@@ -34,6 +34,26 @@
   }
 }
 
+@media (prefers-reduced-motion) {
+  @keyframes dropDown {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes closePopup {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+}
+
 .popup img {
   height: 50px;
   width: 50px;


### PR DESCRIPTION
A step towards #6705

### Changes

The `enablepopup` component now uses an opacity-fade animation if the user prefers reduced motion.

https://github.com/ScratchAddons/ScratchAddons/assets/106490990/4e4200eb-a624-45a4-ab88-16ea27c429b4

### Reason for changes

To prevent vestibular motion triggers from the unexpected fly-in animation.

### Tests

Tested in Edge 117.
