### PR TITLE
Fix workspace undo bugs after workspace reload

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -335,10 +335,12 @@ export default async function ({ addon, console }) {
     }
     const flyout = workspace.getFlyout();
     if (flyout) {
+      Blockly.Events.disable();
       const flyoutWorkspace = flyout.getWorkspace();
       Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);
       workspace.getToolbox().refreshSelection();
       workspace.toolboxRefreshEnabled_ = true;
+      Blockly.Events.enable();
     }
   }
 }

--- a/addons/custom-block-shape/update-all-blocks.js
+++ b/addons/custom-block-shape/update-all-blocks.js
@@ -1,4 +1,7 @@
-export function updateAllBlocks(vm, workspace) {
+export function updateAllBlocks(vm, workspace, blockly) {
+  const eventsOriginallyEnabled = blockly.Events.isEnabled();
+  blockly.Events.disable(); // Clears workspace right-click→undo (see SA/SA#6691)
+
   if (workspace) {
     if (vm.editingTarget) {
       vm.emitWorkspaceUpdate();
@@ -14,4 +17,8 @@ export function updateAllBlocks(vm, workspace) {
       workspace.toolboxRefreshEnabled_ = true;
     }
   }
+
+  // There's no particular reason for checking whether events were originally enabled.
+  // Unconditionally enabling events at this point could, in theory, cause bugs in the future,
+  if (eventsOriginallyEnabled) blockly.Events.enable(); // Re-enable events
 }

--- a/addons/custom-block-shape/update-all-blocks.js
+++ b/addons/custom-block-shape/update-all-blocks.js
@@ -19,6 +19,6 @@ export function updateAllBlocks(vm, workspace, blockly) {
   }
 
   // There's no particular reason for checking whether events were originally enabled.
-  // Unconditionally enabling events at this point could, in theory, cause bugs in the future,
+  // Unconditionally enabling events at this point could, in theory, cause bugs in the future.
   if (eventsOriginallyEnabled) blockly.Events.enable(); // Re-enable events
 }

--- a/addons/custom-block-shape/userscript.js
+++ b/addons/custom-block-shape/userscript.js
@@ -238,7 +238,7 @@ export default async function ({ addon, console }) {
 
     function applyAndUpdate(...args) {
       applyChanges(...args);
-      updateAllBlocks(vm, addon.tab.traps.getWorkspace());
+      updateAllBlocks(vm, addon.tab.traps.getWorkspace(), BlocklyInstance);
     }
 
     addon.settings.addEventListener("change", () => applyAndUpdate());

--- a/addons/custom-block-text/userscript.js
+++ b/addons/custom-block-text/userscript.js
@@ -49,7 +49,7 @@ export default async function ({ addon, console }) {
     // If font size has changed, middle click popup needs to clear it's cache too
     clearTextWidthCache();
 
-    updateAllBlocks(vm, addon.tab.traps.getWorkspace());
+    updateAllBlocks(vm, addon.tab.traps.getWorkspace(), blocklyInstance);
   };
 
   const setFontSize = (wantedSize) => {

--- a/addons/editor-dark-mode/extension_icons.js
+++ b/addons/editor-dark-mode/extension_icons.js
@@ -24,12 +24,14 @@ export default async function ({ addon, console }) {
   };
 
   const reloadToolbox = () => {
+    Blockly.Events.disable();
     const workspace = Blockly.getMainWorkspace();
     const flyout = workspace.getFlyout();
     const toolbox = workspace.getToolbox();
     const flyoutWorkspace = flyout.getWorkspace();
     Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);
     toolbox.populate_(workspace.options.languageTree);
+    Blockly.Events.enable();
   };
   reloadToolbox();
   addon.settings.addEventListener("change", reloadToolbox);

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -427,10 +427,12 @@ export default async function ({ addon, console, msg }) {
       vm.emitWorkspaceUpdate();
     }
     if (!flyout || !toolbox) return;
+    Blockly.Events.disable();
     const flyoutWorkspace = flyout.getWorkspace();
     Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);
     toolbox.populate_(workspace.options.languageTree);
     workspace.toolboxRefreshEnabled_ = true;
+    Blockly.Events.enable();
   };
 
   updateColors();


### PR DESCRIPTION
Resolves #6691

### Changes

Disables workspace undo after reloading the workspace. The whole undo stack gets cleared.
There might be a way to keep the old "undo" actions available, but I'm not aware of them.

### Tests

Fixes the bug in Chromium, addons custom-block-shape and custom-block-text
cc @DNin01 We probably need to check other addons that use `clearWorkspaceAndLoadFromXml`