### PR TITLE
Reconsider usage of timestamps in URLs to bypass cache

### DIFF
--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -32,11 +32,14 @@ export default async function ({ addon, console, msg }) {
     if (addon.tab.redux.state?.preview?.projectInfo?.public === false) {
       let projectToken = (
         await (
-          await fetch(`https://api.scratch.mit.edu/projects/${projectId}?current_time_to_get_updated_project_token=${Date.now()}`, {
-            headers: {
-              "x-token": await addon.auth.fetchXToken(),
-            },
-          })
+          await fetch(
+            `https://api.scratch.mit.edu/projects/${projectId}?current_time_to_get_updated_project_token=${Date.now()}`,
+            {
+              headers: {
+                "x-token": await addon.auth.fetchXToken(),
+              },
+            }
+          )
         ).json()
       ).project_token;
       search = `#?token=${projectToken}`;

--- a/addons/turbowarp-player/userscript.js
+++ b/addons/turbowarp-player/userscript.js
@@ -32,7 +32,7 @@ export default async function ({ addon, console, msg }) {
     if (addon.tab.redux.state?.preview?.projectInfo?.public === false) {
       let projectToken = (
         await (
-          await fetch(`https://api.scratch.mit.edu/projects/${projectId}?nocache=${Date.now()}`, {
+          await fetch(`https://api.scratch.mit.edu/projects/${projectId}?current_time_to_get_updated_project_token=${Date.now()}`, {
             headers: {
               "x-token": await addon.auth.fetchXToken(),
             },

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -74,7 +74,7 @@ const incognitoDatabase = new IncognitoDatabase();
  * @returns {number} the message count, or 0 if it errors
  */
 export async function fetchMessageCount(username) {
-  const resp = await fetch(`https://api.scratch.mit.edu/users/${username}/messages/count?timestamp=${Date.now()}`);
+  const resp = await fetch(`https://api.scratch.mit.edu/users/${username}/messages/count`);
   const json = await resp.json();
   return json.count || 0;
 }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -73,8 +73,12 @@ const incognitoDatabase = new IncognitoDatabase();
  * @param {string} username the username
  * @returns {number} the message count, or 0 if it errors
  */
-export async function fetchMessageCount(username) {
-  const resp = await fetch(`https://api.scratch.mit.edu/users/${username}/messages/count`);
+export async function fetchMessageCount(username, options) {
+  const bypassCache = options ? Boolean(options.bypassCache) : false;
+  const url = `https://api.scratch.mit.edu/users/${username}/messages/count${
+    !bypassCache ? "" : `?addons_bypass_cache_after_marking_read=${Date.now()}`
+  }`;
+  const resp = await fetch(url);
   const json = await resp.json();
   return json.count || 0;
 }

--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -265,10 +265,9 @@ export async function fetchMigratedComments(
 }
 
 export async function fetchLegacyComments(addon, { resourceType, resourceId, commentIds, page = 1, commentsObj = {} }) {
-  const res = await fetch(
-    `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/?page=${page}`,
-    { credentials: "omit" }
-  );
+  const res = await fetch(`https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/?page=${page}`, {
+    credentials: "omit",
+  });
   if (!res.ok) {
     console.warn(`Ignoring comments ${resourceType}/${resourceId} page ${page}, status ${res.status}`);
     return commentsObj;

--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -154,8 +154,8 @@ export async function fetchMigratedComments(
       : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}`;
   const getRepliesUrl = (commId, offset) =>
     resourceType === "project"
-      ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}`
-      : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40&nocache=${Date.now()}`;
+      ? `https://api.scratch.mit.edu/users/${projectAuthor}/projects/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40`
+      : `https://api.scratch.mit.edu/studios/${resourceId}/comments/${commId}/replies?offset=${offset}&limit=40`;
   for (const commentId of commentIds) {
     if (commentsObj[`${resourceType[0]}_${commentId}`]) continue;
 
@@ -266,7 +266,7 @@ export async function fetchMigratedComments(
 
 export async function fetchLegacyComments(addon, { resourceType, resourceId, commentIds, page = 1, commentsObj = {} }) {
   const res = await fetch(
-    `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/?page=${page}&nocache=${Date.now()}`,
+    `https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/?page=${page}`,
     { credentials: "omit" }
   );
   if (!res.ok) {

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -418,9 +418,9 @@ export default async ({ addon, msg, safeMsg }) => {
           });
       },
 
-      async updateMessageCount() {
+      async updateMessageCount(bypassCache = false) {
         const username = await addon.auth.fetchUsername();
-        const count = await MessageCache.fetchMessageCount(username);
+        const count = await MessageCache.fetchMessageCount(username, { bypassCache });
         const db = await MessageCache.openDatabase();
         try {
           await db.put("count", count, scratchAddons.cookieStoreId);
@@ -435,7 +435,7 @@ export default async ({ addon, msg, safeMsg }) => {
       // For UI
       markAsRead() {
         MessageCache.markAsRead(addon.auth.csrfToken)
-          .then(() => this.updateMessageCount())
+          .then(() => this.updateMessageCount(true))
           .then(() => {
             this.markedAsRead = true;
           })
@@ -450,7 +450,7 @@ export default async ({ addon, msg, safeMsg }) => {
               this.stMessages.findIndex((alert) => alert.id === id),
               1
             );
-            this.updateMessageCount();
+            this.updateMessageCount(true);
           })
           .catch((e) => console.error("Dismissing alert failed:", e));
       },


### PR DESCRIPTION
Resolves #6717

### Changes

- Removes `nocache=${Date.now()}` and `timestamp=${Date.now()}` from Scratch Messaging code. These requests may now get cached by the browser (disk cache) or by the Scratch API.
- When an uncached version of the request is really needed, rename the URL paramater to be descriptive.

### Reason for changes

The "nocache" keyword is filtered by the Scratch API and is intentionally throttled.