### PR TITLE
Custom nicknames addon

### DIFF
--- a/addons-l10n/en/nicknames.json
+++ b/addons-l10n/en/nicknames.json
@@ -1,0 +1,5 @@
+{
+  "nicknames/change-nickname": "Change nickname",
+  "nicknames/set-nickname": "Set nickname",
+  "nicknames/which-nickname": "What should {username}'s nickname be?"
+}

--- a/addons-l10n/en/nicknames.json
+++ b/addons-l10n/en/nicknames.json
@@ -1,5 +1,5 @@
 {
   "nicknames/change-nickname": "Change nickname",
   "nicknames/set-nickname": "Set nickname",
-  "nicknames/which-nickname": "What should {username}'s nickname be?"
+  "nicknames/which-nickname": "What should {username}'s nickname be? Leave this blank to remove the nickname."
 }

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -150,6 +150,7 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "nicknames",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/nicknames/addon.json
+++ b/addons/nicknames/addon.json
@@ -1,0 +1,30 @@
+{
+  "name": "Custom nicknames",
+  "description": "Allows you to give users custom nicknames so you can recognize them better.",
+  "tags": ["community", "profiles"],
+  "userscripts": [
+    {
+      "matches": "*",
+      "url": "userscript.js"
+    },
+    {
+      "matches": ["profiles"],
+      "url": "profiles.js"
+    }
+  ],
+  "info": [
+    {
+      "id": "personal",
+      "text": "These nicknames will only be seen by you."
+    }
+  ],
+  "versionAdded": "1.35.0",
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/nicknames/lib.js
+++ b/addons/nicknames/lib.js
@@ -1,0 +1,79 @@
+export const getNicknames = () => {
+  const storageItem = localStorage.getItem("sa-nicknames");
+  if (storageItem === null) {
+    localStorage.setItem("sa-nicknames", "{}");
+    return {};
+  }
+  return JSON.parse(storageItem);
+};
+
+let addon = null;
+
+export const registerAddon = (toRegister) => {
+  addon = toRegister;
+};
+
+/**
+ * @callback ReplaceEl
+ * @param {HTMLElement} el The element that `waitForElement` returned.
+ * @returns {HTMLElement} The new element.
+ *
+ * @callback ToMatch
+ * @param {HTMLElement} el The element that has the username in it.
+ * @returns {string} The string to match for a username.
+ *
+ * @callback Condition
+ * @param {string} username The username matched via the `usernameRegex`.
+ * @param {HTMLElement} el The element that has the username in it.
+ * @returns {boolean} Whether to replace the text.
+ *
+ * @callback NewText
+ * @param {string} nickname The nickname of the user matched via the `usernameRegex`.
+ * @param {HTMLElement} el The element that has the username in it.
+ * @returns {string} The text to replace the current text with.
+ */
+
+/**
+ * Register an occurence of a username.
+ * @param {object} addon The `addon` object.
+ * @param {object} options The options.
+ * @param {string} options.selector The selector to pass to `waitForElement`.
+ * @param {ReplaceEl} [options.replaceEl] Returns a different element where the element actually is. Useful for text nodes or other things a selector can't easily do. Gets in the found element.
+ * @param {ToMatch} [options.toMatch] Returns the string to match for a username. Gets in the found element. Defaults to the text content.
+ * @param {RegExp} [options.usernameRegex] The regular expression to match the username in `toMatch`. If it doesn't match, the element will be discared. The username should be in the 1st capture group. Defaults to `/(.*)/`.
+ * @param {Condition} [options.condition] Returns whether to replace the text. Gets in the username and the found element. Defaults to true.
+ * @param {NewText} [options.newText] Returns the string to replace the text with. Gets in the nickname and the found element. Defaults to just the nickname.
+ */
+export const occurence = async (
+  addon,
+  {
+    selector,
+    replaceEl = (el) => el,
+    toMatch = (el) => el.textContent,
+    usernameRegex = /(.*)/,
+    condition = () => true,
+    newText = (nickname) => nickname,
+  }
+) => {
+  while (true) {
+    const el = replaceEl(
+      await addon.tab.waitForElement(selector, { markAsSeen: true, condition: () => !addon.tab.disabled })
+    );
+
+    const match = toMatch(el).match(usernameRegex);
+    if (!match) {
+      continue;
+    }
+    const username = match[1];
+    if (condition(username, el) && username in nicknames) {
+      if ("dataset" in el) {
+        el.dataset.saNicknamesUsername = username;
+      } else {
+        el.parentElement.dataset.saNicknamesUsername = username;
+      }
+      el.textContent = newText(nicknames[username], el);
+    }
+  }
+};
+
+const nicknames = getNicknames();

--- a/addons/nicknames/profiles.js
+++ b/addons/nicknames/profiles.js
@@ -1,0 +1,42 @@
+import { getNicknames } from "./lib.js";
+
+export default async function ({ addon, console, msg }) {
+  const locationElement = document.querySelector(".location");
+  const userElement = document.querySelector("h2");
+  const nicknames = getNicknames();
+
+  const username = userElement.textContent;
+  const hasNickname = username in nicknames;
+  if (hasNickname) {
+    userElement.textContent = nicknames[username];
+  }
+
+  const group = document.createElement("span");
+  group.classList.add("group");
+  const changeNickname = document.createElement("span");
+  const changeNicknameLink = document.createElement("a");
+  if (hasNickname) {
+    changeNickname.append(`${username} `);
+    changeNicknameLink.textContent = `(${msg("change-nickname")})`;
+  } else {
+    changeNicknameLink.textContent = msg("set-nickname");
+  }
+  changeNickname.append(changeNicknameLink);
+  locationElement.insertAdjacentElement("beforebegin", group);
+  locationElement.insertAdjacentElement("beforebegin", changeNickname);
+
+  changeNicknameLink.addEventListener("click", async () => {
+    const nickname = await addon.tab.prompt(msg("change-nickname"), msg("which-nickname", { username }), username);
+    if (nickname === null) {
+      return;
+    }
+    if (nickname === username) {
+      const newNicknames = { ...nicknames };
+      delete newNicknames[username];
+      localStorage.setItem("sa-nicknames", JSON.stringify(newNicknames));
+    } else {
+      localStorage.setItem("sa-nicknames", JSON.stringify({ ...nicknames, [username]: nickname }));
+    }
+    location.reload();
+  });
+}

--- a/addons/nicknames/profiles.js
+++ b/addons/nicknames/profiles.js
@@ -26,11 +26,15 @@ export default async function ({ addon, console, msg }) {
   locationElement.insertAdjacentElement("beforebegin", changeNickname);
 
   changeNicknameLink.addEventListener("click", async () => {
-    const nickname = await addon.tab.prompt(msg("change-nickname"), msg("which-nickname", { username }), username);
+    const nickname = await addon.tab.prompt(
+      msg("change-nickname"),
+      msg("which-nickname", { username }),
+      nicknames[username] ?? username
+    );
     if (nickname === null) {
       return;
     }
-    if (nickname === username) {
+    if (nickname === "") {
       const newNicknames = { ...nicknames };
       delete newNicknames[username];
       localStorage.setItem("sa-nicknames", JSON.stringify(newNicknames));

--- a/addons/nicknames/userscript.js
+++ b/addons/nicknames/userscript.js
@@ -1,0 +1,65 @@
+import { getNicknames, occurence } from "./lib.js";
+
+export default async function ({ addon, console }) {
+  // Regular links
+  occurence(addon, {
+    selector: 'a[href^="/users/"]',
+    toMatch: (el) => el.href,
+    usernameRegex: /^https:\/\/scratch.mit.edu\/users\/(.+?)\/?$/,
+    condition: (username, el) => el.textContent === username || el.textContent === `@${username}`,
+    newText: (nickname, el) => (el.textContent.startsWith("@") ? "@" : "") + nickname,
+  });
+
+  // "user's profile" in messages
+  occurence(addon, {
+    selector: '.comment-message-info a[href^="/users"] span',
+    toMatch: (el) => el.parentElement.href,
+    usernameRegex: /^https:\/\/scratch.mit.edu\/users\/(.+?)\//,
+    newText: (nickname) => `${nickname}'s profile`,
+  });
+
+  // Forum quotes
+  occurence(addon, {
+    selector: ".bb-quote-author",
+    usernameRegex: /^(.*?) wrote:$/,
+    newText: (nickname) => nickname + " wrote:",
+  });
+
+  // Account dropdown
+  occurence(addon, {
+    selector: ".profile-name, .sa-profile-name",
+  });
+
+  // scratchr2 account dropdown
+  occurence(addon, {
+    selector: ".user-name",
+    replaceEl: (el) => el.childNodes[1],
+  });
+
+  if (window.copy_paste) {
+    const originalCopyPaste = window.copy_paste;
+    window.copy_paste = (postId) => {
+      const usernameText = document.querySelector(`#${postId} .black.username`);
+      const username = usernameText.dataset.saNicknamesUsername;
+      if (username) {
+        const nickname = usernameText.textContent;
+        usernameText.textContent = username;
+        originalCopyPaste(postId);
+        usernameText.textContent = nickname;
+      }
+    };
+  }
+
+  addon.self.addEventListener("disabled", () => {
+    document.querySelectorAll("[data-sa-nicknames-username]").forEach((el) => {
+      el.dataset.saNicknamesNickname = el.textContent;
+      el.textContent = el.dataset.saNicknamesUsername;
+    });
+  });
+  addon.self.addEventListener("reenabled", () => {
+    document.querySelectorAll("[data-sa-nicknames-nickname]").forEach((el) => {
+      el.textContent = el.dataset.saNicknamesNickname;
+      delete el.dataset.saNicknamesNickname;
+    });
+  });
+}


### PR DESCRIPTION
Resolves #5317

### Changes

Create a "Custom Nicknames" addon that allows you to set custom nicknames for anyone.

![The header of JLdude33's profile with a "Set nickname" button](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/e0491843-1595-413e-b633-92343bdc69b5)

![The header of JLdude33's profile with the nickname set as JLnickname33 - the "Set nickname" button is now a "Change nickname" button](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/1801b1f0-a1bd-4b82-b85b-49ee1daff66b)

![A comment chain involving JLdude33, where every link to JLdude33 mentions "JLnickname33"](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/8b7da194-58e1-454b-b27e-e49baf930a9f)


### Reason for changes

Easier recognition of users

### Tests

Tested in Edge.
