### PR TITLE
`collapse-footer`: Fix footer appearing expanded at first on scratchr2 pages

### DIFF
--- a/addons/collapse-footer/userscript.js
+++ b/addons/collapse-footer/userscript.js
@@ -30,7 +30,7 @@ export default async function ({ addon, console }) {
   let collapseTimeout;
 
   footer.addEventListener("mouseover", () => {
-    footer.classList.add("expanded");
+    footer.classList.add("transition", "expanded");
     if (collapseTimeout) {
       clearTimeout(collapseTimeout);
     }

--- a/addons/collapse-footer/userstyle.css
+++ b/addons/collapse-footer/userstyle.css
@@ -13,6 +13,9 @@
   border-top: 1px solid #d9d9d9;
   box-sizing: border-box;
   z-index: 20;
+  transition-duration: 0;
+}
+.sa-collapse-footer #footer.transition {
   transition-duration: var(--collapseFooter-expandSpeed);
 }
 .sa-collapse-footer #footer .lists dl {

--- a/addons/collapse-footer/userstyle.css
+++ b/addons/collapse-footer/userstyle.css
@@ -13,7 +13,6 @@
   border-top: 1px solid #d9d9d9;
   box-sizing: border-box;
   z-index: 20;
-  transition-duration: 0;
 }
 .sa-collapse-footer #footer.transition {
   transition-duration: var(--collapseFooter-expandSpeed);


### PR DESCRIPTION
Resolves #6720

### Changes

Fix footer appearing expanded at first on scratchr2 pages by lazily applying the transition on expand.

### Reason for changes

To make the experience feel less buggy.

### Tests

Tested in Edge.
