### PR TITLE
`better-quoter`: Automatically add `/get_image/.%2E` to assets.scratch.mit.edu images

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -90,6 +90,13 @@ function getSelectionBBCode(selection) {
           img
         );
       } else img.parentNode.insertBefore(document.createTextNode(`[img${img.src}[/img]`), img);
+    } else if (/assets.scratch.mit.edu\/[0-9a-f]+/.test(img.src)) {
+      img.parentNode.insertBefore(
+        document.createTextNode(
+          `[img]${img.src.replace("assets.scratch.mit.edu", "assets.scratch.mit.edu/get_image/.%2E")}[/img]`
+        ),
+        img
+      );
     } else img.parentNode.insertBefore(document.createTextNode(`[img]${img.src}[/img]`), img);
   }
 

--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -90,14 +90,7 @@ function getSelectionBBCode(selection) {
           img
         );
       } else img.parentNode.insertBefore(document.createTextNode(`[img${img.src}[/img]`), img);
-    } else if (/assets.scratch.mit.edu\/[0-9a-f]+/.test(img.src)) {
-      img.parentNode.insertBefore(
-        document.createTextNode(
-          `[img]${img.src.replace("assets.scratch.mit.edu", "assets.scratch.mit.edu/get_image/.%2E")}[/img]`
-        ),
-        img
-      );
-    } else img.parentNode.insertBefore(document.createTextNode(`[img]${img.src}[/img]`), img);
+    } else img.parentNode.insertBefore(document.createTextNode(`[img]${img.getAttribute("src")}[/img]`), img);
   }
 
   // bold, italic, underline, strikethrough, big, small and color


### PR DESCRIPTION
Resolves #6754

### Changes

Automatically add `/get_image/.%2E` to assets.scratch.mit.edu links when quoting them with `better-quoter` to make quoted assets.scratch.mit.edu links work correctly.

~If there's any weird commits, it's probably new line encoding problems - currently trying to figure out how to set these up correctly with Git~ I've found the correct option lol

### Reason for changes

Better UX

### Tests

Tested in Edge
