### PR TITLE
Revert "Bump version to 1.35.0 stable"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "1.35.0",
-  "version_name": "1.35.0",
+  "version_name": "1.35.0-prerelease",
   "default_locale": "en",
   "background": {
     "page": "background/background.html"


### PR DESCRIPTION
Reverts ScratchAddons/ScratchAddons#6763

What was the point of merging #6744 as part of this release?