### PR TITLE
`cloud-games`: Add character limit to `url` setting in table

### DIFF
--- a/addons/cloud-games/addon.json
+++ b/addons/cloud-games/addon.json
@@ -37,6 +37,7 @@
           "name": "Project/Studio URL",
           "id": "url",
           "type": "untranslated",
+          "max": 44,
           "default": ""
         }
       ],


### PR DESCRIPTION
### Changes

Adds a character limit of 44 characters to the URL string fields in the Cloud games addon. AFAIK, 44 characters is the most you'll ever need:
```
https://               =  8
scratch.mit.edu/  + 16 = 24
projects/         +  9 = 33
1234567890/       + 11 = 44
```

### Reason for changes

I don't know why, it just seems like a good precaution nonetheless.

### Tests

Tested.
