### PR TITLE
Fix ghost messages after marking as read (scratch-messaging)

### DIFF
--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -112,20 +112,9 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     }
     case BADGE_ALARM_NAME: {
       if (scratchAddons.globalState.auth.isLoggedIn) {
-        const { count, resId } = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
-        const db = await MessageCache.openDatabase();
-        try {
-          const lastResId = await db.get("countResId", scratchAddons.cookieStoreId);
-          if (lastResId && lastResId === resId) {
-            // No need to replace the count cache. We've already seen this request.
-            // We don't want to override the count as it might potentially be more up-to-date, if cache was recently bypassed by other code.
-            console.log("Ignored cached request for message count endpoint (in alarm).");
-          } else {
-            await db.put("count", count, scratchAddons.cookieStoreId);
-          }
-        } finally {
-          await db.close();
-        }
+        const msgCountData = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
+        const count = MessageCache.getUpToDateMsgCount(scratchAddons.cookieStoreId, msgCountData);
+        await db.put("count", count, scratchAddons.cookieStoreId);
       }
       await updateBadge(scratchAddons.cookieStoreId);
     }

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -113,7 +113,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     case BADGE_ALARM_NAME: {
       if (scratchAddons.globalState.auth.isLoggedIn) {
         const msgCountData = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
-        const count = MessageCache.getUpToDateMsgCount(scratchAddons.cookieStoreId, msgCountData);
+        const count = await MessageCache.getUpToDateMsgCount(scratchAddons.cookieStoreId, msgCountData);
         const db = await MessageCache.openDatabase();
         try {
           await db.put("count", count, scratchAddons.cookieStoreId);

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -112,7 +112,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     }
     case BADGE_ALARM_NAME: {
       if (scratchAddons.globalState.auth.isLoggedIn) {
-        const count = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
+        const { messageCount: count } = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
         const db = await MessageCache.openDatabase();
         try {
           await db.put("count", count, scratchAddons.cookieStoreId);

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -112,9 +112,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     }
     case BADGE_ALARM_NAME: {
       if (scratchAddons.globalState.auth.isLoggedIn) {
-        const { messageCount: count, resId } = await MessageCache.fetchMessageCount(
-          scratchAddons.globalState.auth.username
-        );
+        const { count, resId } = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
         const db = await MessageCache.openDatabase();
         try {
           const lastResId = await db.get("countResId", scratchAddons.cookieStoreId);

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -112,10 +112,19 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     }
     case BADGE_ALARM_NAME: {
       if (scratchAddons.globalState.auth.isLoggedIn) {
-        const { messageCount: count } = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
+        const { messageCount: count, resId } = await MessageCache.fetchMessageCount(
+          scratchAddons.globalState.auth.username
+        );
         const db = await MessageCache.openDatabase();
         try {
-          await db.put("count", count, scratchAddons.cookieStoreId);
+          const lastResId = await db.get("countResId", scratchAddons.cookieStoreId);
+          if (lastResId && lastResId === resId) {
+            // No need to replace the count cache. We've already seen this request.
+            // We don't want to override the count as it might potentially be more up-to-date, if cache was recently bypassed by other code.
+            console.log("Ignored cached request for message count endpoint (in alarm).")
+          } else {
+            await db.put("count", count, scratchAddons.cookieStoreId);
+          }
         } finally {
           await db.close();
         }

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -118,7 +118,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
         try {
           await db.put("count", count, scratchAddons.cookieStoreId);
         } finally {
-          db.close();
+          await db.close();
         }
       }
       await updateBadge(scratchAddons.cookieStoreId);

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -119,7 +119,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
           // We obtained the up-to-date message count, so we can safely override the cached count in IDB.
           await db.put("count", count, scratchAddons.cookieStoreId);
           if (msgCountData.resId && !(db instanceof MessageCache.IncognitoDatabase)) {
-            await tx.objectStore("count").put(msgCountData.resId, `${cookieStoreId}_resId`);
+            await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
           }
         } finally {
           await db.close();

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -116,7 +116,11 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
         const count = await MessageCache.getUpToDateMsgCount(scratchAddons.cookieStoreId, msgCountData);
         const db = await MessageCache.openDatabase();
         try {
+          // We obtained the up-to-date message count, so we can safely override the cached count in IDB.
           await db.put("count", count, scratchAddons.cookieStoreId);
+          if (msgCountData.resId && !(db instanceof MessageCache.IncognitoDatabase)) {
+            await tx.objectStore("count").put(msgCountData.resId, `${cookieStoreId}_resId`);
+          }
         } finally {
           await db.close();
         }

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -121,7 +121,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
           if (lastResId && lastResId === resId) {
             // No need to replace the count cache. We've already seen this request.
             // We don't want to override the count as it might potentially be more up-to-date, if cache was recently bypassed by other code.
-            console.log("Ignored cached request for message count endpoint (in alarm).")
+            console.log("Ignored cached request for message count endpoint (in alarm).");
           } else {
             await db.put("count", count, scratchAddons.cookieStoreId);
           }

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -114,7 +114,12 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
       if (scratchAddons.globalState.auth.isLoggedIn) {
         const msgCountData = await MessageCache.fetchMessageCount(scratchAddons.globalState.auth.username);
         const count = MessageCache.getUpToDateMsgCount(scratchAddons.cookieStoreId, msgCountData);
-        await db.put("count", count, scratchAddons.cookieStoreId);
+        const db = await MessageCache.openDatabase();
+        try {
+          await db.put("count", count, scratchAddons.cookieStoreId);
+        } finally {
+          db.close();
+        }
       }
       await updateBadge(scratchAddons.cookieStoreId);
     }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -78,6 +78,7 @@ export async function fetchMessageCount(username, options) {
   const url = `https://api.scratch.mit.edu/users/${username}/messages/count`;
   const fetchOptions = {
     cache: bypassCache ? "reload" : "default",
+    credentials: "omit",
   };
   const resp = await fetch(url, fetchOptions);
   const json = await resp.json();

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -37,6 +37,8 @@ class IncognitoDatabase {
         return this.messages.slice();
       case "count":
         return this.msgCount;
+      case "countResId":
+        return null;
     }
   }
 
@@ -48,6 +50,9 @@ class IncognitoDatabase {
       }
       case "count": {
         this.msgCount = value;
+        return;
+      }
+      case "countResId": {
         return;
       }
     }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -206,7 +206,9 @@ export async function updateMessages(cookieStoreId, forceClear, username, xToken
     await tx.objectStore("cache").put(messages, cookieStoreId);
     await tx.objectStore("lastUpdated").put(Date.now(), cookieStoreId);
     await tx.objectStore("count").put(messageCount, cookieStoreId);
-    if (msgCountData.resId) await tx.objectStore("count").put(msgCountData.resId, `${cookieStoreId}_resId`);
+    if (msgCountData.resId && !(db instanceof IncognitoDatabase)) {
+      await tx.objectStore("count").put(msgCountData.resId, `${cookieStoreId}_resId`);
+    }
     await tx.done;
     return newlyAdded;
   } finally {
@@ -222,6 +224,7 @@ export async function updateMessages(cookieStoreId, forceClear, username, xToken
  */
 export async function getUpToDateMsgCount(cookieStoreId, { count: responseMsgCount, resId }) {
   const db = await openDatabase();
+  if (db instanceof IncognitoDatabase) return responseMsgCount;
   try {
     const lastResId = await db.get("count", `${cookieStoreId}_resId`);
     if (lastResId && lastResId === resId) {

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -92,7 +92,7 @@ export async function fetchMessageCount(username, options) {
 
   const resId = bypassCache ? null : resp.headers.get("X-Amz-Cf-Id");
 
-  return { messageCount: json.count || 0, resId };
+  return { count: json.count || 0, resId };
 }
 
 /**
@@ -188,7 +188,7 @@ export async function openMessageCache(cookieStoreId, forceClear) {
 export async function updateMessages(cookieStoreId, forceClear, username, xToken) {
   await openMessageCache(cookieStoreId, forceClear);
   if (username === null) return [];
-  let { messageCount, resId } = await fetchMessageCount(username);
+  let { count: messageCount, resId } = await fetchMessageCount(username);
   const db = await openDatabase();
   try {
     const lastResId = await db.get("countResId", cookieStoreId);

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -234,9 +234,11 @@ export async function getUpToDateMsgCount(cookieStoreId, { count: responseMsgCou
     } else {
       return responseMsgCount;
     }
+  } catch (err) {
+    console.error(err);
+    return responseMsgCount;
   } finally {
     await db.close();
-    return responseMsgCount;
   }
 }
 

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -118,7 +118,7 @@ export async function fetchMessages(username, xToken, offset) {
 export async function openDatabase() {
   if (IncognitoDatabase.isIncognito()) return incognitoDatabase;
 
-  const DB_VERSION = 1; // It's preferred to keep it as 1 and migrate through other means
+  const DB_VERSION = 1; // It's preferred to keep it as 1 when possible
 
   return idb.openDB("messaging", DB_VERSION, {
     upgrade(d) {

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -147,7 +147,7 @@ export async function openMessageCache(cookieStoreId, forceClear) {
   if (db instanceof IncognitoDatabase) return;
 
   try {
-    const tx = await db.transaction(["cache", "lastUpdated", "count"], "readwrite");
+    const tx = await db.transaction(["cache", "lastUpdated", "count", "countResId"], "readwrite");
     const lastUpdated = await tx.objectStore("lastUpdated").get(cookieStoreId);
     if (lastUpdated === undefined || forceClear || lastUpdated + 12 * 60 * 60 * 1000 < Date.now()) {
       // Clear items last updated more than 1 hour ago

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -117,12 +117,19 @@ export async function fetchMessages(username, xToken, offset) {
  */
 export async function openDatabase() {
   if (IncognitoDatabase.isIncognito()) return incognitoDatabase;
-  return idb.openDB("messaging", 1, {
-    upgrade(d) {
-      d.createObjectStore("cache");
-      d.createObjectStore("lastUpdated");
-      d.createObjectStore("count");
-      d.createObjectStore("countResId");
+
+  const DB_VERSION = 2;
+
+  return idb.openDB("messaging", DB_VERSION, {
+    upgrade(d, oldVersion, newVersion, tx) {
+      if (!oldVersion) {
+        d.createObjectStore("cache");
+        d.createObjectStore("lastUpdated");
+        d.createObjectStore("count");
+      }
+      if (!tx.objectStoreNames.contains("countResId")) {
+        d.createObjectStore("countResId");
+      }
     },
   });
 }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -219,7 +219,7 @@ export async function updateMessages(cookieStoreId, forceClear, username, xToken
 /**
  * Returns either the received message count or the one in IDB, based on which one is more recent
  * @param {string} cookieStoreId the cookie store ID for the IDB cache
- * @param {string} resId the value of the `X-Amz-Cf-Id` response header
+ * @param {object} msgCountData the return value from fetchMessageCount()
  * @returns {number} the most up-to-date message count, possibly identical to the received parameter
  */
 export async function getUpToDateMsgCount(cookieStoreId, { count: responseMsgCount, resId }) {
@@ -231,9 +231,9 @@ export async function getUpToDateMsgCount(cookieStoreId, { count: responseMsgCou
       // Since `lastResId` is not null, we know we have a message count in IDB we can use.
       // In some cases, the message count in IDB will be more up-to-date. In other cases,
       // it will simply match the message count of this response, leading to the same result.
-      console.log("Ignored cached request for message count endpoint.");
-      const cachedCount = await db.get("count", cookieStoreId);
-      return cachedCount;
+      console.log("Ignored network-cached response for message count endpoint.");
+      const idbCount = await db.get("count", cookieStoreId);
+      return idbCount;
     } else {
       return responseMsgCount;
     }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -218,7 +218,7 @@ export async function updateMessages(cookieStoreId, forceClear, username, xToken
  * Returns either the received message count or the one in IDB, based on which one is more recent
  * @param {string} cookieStoreId the cookie store ID for the IDB cache
  * @param {string} resId the value of the `X-Amz-Cf-Id` response header
- * @returns {number} the most up-to-date message count, possibly identicalto the received parameter
+ * @returns {number} the most up-to-date message count, possibly identical to the received parameter
  */
 export async function getUpToDateMsgCount(cookieStoreId, { count: responseMsgCount, resId }) {
   const db = await openDatabase();

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -75,10 +75,11 @@ const incognitoDatabase = new IncognitoDatabase();
  */
 export async function fetchMessageCount(username, options) {
   const bypassCache = options ? Boolean(options.bypassCache) : false;
-  const url = `https://api.scratch.mit.edu/users/${username}/messages/count${
-    !bypassCache ? "" : `?addons_bypass_cache_after_marking_read=${Date.now()}`
-  }`;
-  const resp = await fetch(url);
+  const url = `https://api.scratch.mit.edu/users/${username}/messages/count`;
+  const fetchOptions = {
+    cache: bypassCache ? "reload" : "default"
+  };
+  const resp = await fetch(url, fetchOptions);
   const json = await resp.json();
   return json.count || 0;
 }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -181,12 +181,11 @@ export async function updateMessages(cookieStoreId, forceClear, username, xToken
   try {
     const lastResId = await db.get("countResId", cookieStoreId);
     if (lastResId && lastResId === resId) {
-      // We should ignore the message count request we just did, if possible.
+      // We should ignore the message count request we just did.
+      // Since we know `db.get("countResId")` isn't null, we can use the cached count.
       const cachedCount = await db.get("count", cookieStoreId);
-      if (cachedCount || cachedCount === 0) {
-        messageCount = cachedCount;
-        console.log("Ignored cached request for message count endpoint.");
-      }
+      messageCount = cachedCount;
+      console.log("Ignored cached request for message count endpoint.");
     }
     const maxPages = Math.min(Math.ceil(messageCount / 40) + 1, 25);
 

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -235,7 +235,7 @@ export async function getUpToDateMsgCount(cookieStoreId, { count: responseMsgCou
       return responseMsgCount;
     }
   } finally {
-    db.close();
+    await db.close();
     return responseMsgCount;
   }
 }

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -26,7 +26,7 @@ class IncognitoTransaction {
   }
 }
 
-class IncognitoDatabase {
+export class IncognitoDatabase {
   constructor() {
     this.messages = [];
     this.msgCount = 0;

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -77,7 +77,7 @@ export async function fetchMessageCount(username, options) {
   const bypassCache = options ? Boolean(options.bypassCache) : false;
   const url = `https://api.scratch.mit.edu/users/${username}/messages/count`;
   const fetchOptions = {
-    cache: bypassCache ? "reload" : "default"
+    cache: bypassCache ? "reload" : "default",
   };
   const resp = await fetch(url, fetchOptions);
   const json = await resp.json();

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -84,8 +84,8 @@ export async function fetchMessageCount(username, options) {
     !bypassCache ? "" : `?addons_bypass_cache_after_marking_read=1`
   }`;
   const fetchOptions = {
+    credentials: "omit", // No need to send cookies, this is a public endpoint
     cache: bypassCache ? "reload" : "default",
-    credentials: "omit",
   };
   const resp = await fetch(url, fetchOptions);
   const json = await resp.json();

--- a/libraries/common/message-cache.js
+++ b/libraries/common/message-cache.js
@@ -146,6 +146,7 @@ export async function openMessageCache(cookieStoreId, forceClear) {
       // Clear items last updated more than 1 hour ago
       await tx.objectStore("cache").put([], cookieStoreId);
       await tx.objectStore("count").put(0, cookieStoreId);
+      await tx.objectStore("countResId").put(null, cookieStoreId);
       // lastUpdated is only set when actually fetching
     }
     await tx.done;

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -424,7 +424,9 @@ export default async ({ addon, msg, safeMsg }) => {
         const { messageCount: count } = await MessageCache.fetchMessageCount(username, { bypassCache });
         const db = await MessageCache.openDatabase();
         try {
+          // Always override cache count, as we just bypassed cache, so it's guaranteed to be up-to-date.
           await db.put("count", count, scratchAddons.cookieStoreId);
+          // We intentionally avoid storing the resId for requets that bypassed the cache through URL params.
         } finally {
           await db.close();
         }

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -429,6 +429,7 @@ export default async ({ addon, msg, safeMsg }) => {
           await db.put("count", count, scratchAddons.cookieStoreId);
 
           if (!bypassCache && !chrome.extension.inIncognitoContext) {
+            // Note: as of Oct 2023, this method is never called with bypassCache:false, so this never happens
             await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
           }
         } finally {

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -428,7 +428,7 @@ export default async ({ addon, msg, safeMsg }) => {
           // We obtained the up-to-date message count, so we can safely override the cached count in IDB.
           await db.put("count", count, scratchAddons.cookieStoreId);
 
-          if (!bypassCache && !(db instanceof MessageCache.IncognitoDatabase)) {
+          if (!bypassCache && msgCountData.resId && !(db instanceof MessageCache.IncognitoDatabase)) {
             // Note: as of Oct 2023, this method is never called with bypassCache:false, so this never happens
             await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
           }

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -419,8 +419,9 @@ export default async ({ addon, msg, safeMsg }) => {
       },
 
       async updateMessageCount(bypassCache = false) {
+        // As of October 2023, all calls to this method use bypassCache:true
         const username = await addon.auth.fetchUsername();
-        const count = await MessageCache.fetchMessageCount(username, { bypassCache });
+        const { messageCount: count } = await MessageCache.fetchMessageCount(username, { bypassCache });
         const db = await MessageCache.openDatabase();
         try {
           await db.put("count", count, scratchAddons.cookieStoreId);

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -428,7 +428,7 @@ export default async ({ addon, msg, safeMsg }) => {
           // We obtained the up-to-date message count, so we can safely override the cached count in IDB.
           await db.put("count", count, scratchAddons.cookieStoreId);
 
-          if (!bypassCache && !chrome.extension.inIncognitoContext) {
+          if (!bypassCache && !(db instanceof MessageCache.IncognitoDatabase)) {
             // Note: as of Oct 2023, this method is never called with bypassCache:false, so this never happens
             await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
           }

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -421,7 +421,7 @@ export default async ({ addon, msg, safeMsg }) => {
       async updateMessageCount(bypassCache = false) {
         // As of October 2023, all calls to this method use bypassCache:true
         const username = await addon.auth.fetchUsername();
-        const { messageCount: count } = await MessageCache.fetchMessageCount(username, { bypassCache });
+        const { count } = await MessageCache.fetchMessageCount(username, { bypassCache });
         const db = await MessageCache.openDatabase();
         try {
           // Always override cache count, as we just bypassed cache, so it's guaranteed to be up-to-date.

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -428,7 +428,9 @@ export default async ({ addon, msg, safeMsg }) => {
           // We obtained the up-to-date message count, so we can safely override the cached count in IDB.
           await db.put("count", count, scratchAddons.cookieStoreId);
 
-          if (!bypassCache) await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
+          if (!bypassCache && !chrome.extension.inIncognitoContext) {
+            await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
+          }
         } finally {
           await db.close();
         }

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -428,7 +428,7 @@ export default async ({ addon, msg, safeMsg }) => {
           // We obtained the up-to-date message count, so we can safely override the cached count in IDB.
           await db.put("count", count, scratchAddons.cookieStoreId);
 
-          if (!bypassCache) await db.put("countResId", msgCountData.resId, scratchAddons.cookieStoreId);
+          if (!bypassCache) await db.put("count", msgCountData.resId, `${scratchAddons.cookieStoreId}_resId`);
         } finally {
           await db.close();
         }


### PR DESCRIPTION
Resolves #6777

### Changes

- Continues to add URL parameters to the URL when bypassing the cache (after marking messages as read)
- Store last seen `X-Amz-Cf-Id` header in IDB, as an attempt to ignore server-side cached responses to the message count endpoint
- Do not send cookies to the message count endpoint, as it's not necessary

### Tests

Tested in Chromium