### PR TITLE
Default popup to "addons" tab (instead of "messaging")

### DIFF
--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -94,12 +94,12 @@ chrome.runtime.sendMessage("getSettingsInfo", (res) => {
   });
   vue.popups = popupObjects;
   chrome.storage.local.get("lastSelectedPopup", ({ lastSelectedPopup }) => {
-    let id = 0;
+    let id = -1;
     if (typeof lastSelectedPopup === "string") {
       id = vue.popups.findIndex((popup) => popup._addonId === lastSelectedPopup);
-      if (id === -1) id = 0;
     }
-    vue.setPopup(vue.popups[id]);
+    if (id !== -1) vue.setPopup(vue.popups[id]);
+    else vue.setPopup(vue.popups.find((p) => p._addonId === "__settings__"));
   });
 });
 


### PR DESCRIPTION
Resolves none (I think)

### Changes

If there is no "lastSelectedPopup", for example when the extension was recently installed, default to the "Addons" tab instead of the "Messaging" tab.

### Reason for changes

The "Addons" tab is more useful for new users.

### Tests

Tested in Chromium