### PR TITLE
New addon: "pop-out stage" (draft)

### DIFF
--- a/addons/60fps/vm-stepping-interval-module.js
+++ b/addons/60fps/vm-stepping-interval-module.js
@@ -1,0 +1,27 @@
+const DEFAULT_FPS = 30;
+let interval = 1000 / DEFAULT_FPS;
+
+let polluted = false;
+export function polluteRuntimeStart(vm) {
+  if (polluted) return;
+  polluted = true;
+
+  vm.runtime.start = function () {
+    if (this._steppingInterval) return;
+    this.currentStepTime = interval;
+    this._steppingInterval = setInterval(() => {
+      this._step();
+    }, interval);
+    this.emit("RUNTIME_STARTED");
+  };
+}
+
+export function setVmIntervalDelay(newInterval) {
+  interval = newInterval;
+}
+
+export function restartStepInterval(vm) {
+  clearInterval(vm.runtime._steppingInterval);
+  vm.runtime._steppingInterval = null;
+  vm.runtime.start();
+}

--- a/addons/60fps/vm-stepping-interval-module.js
+++ b/addons/60fps/vm-stepping-interval-module.js
@@ -1,5 +1,7 @@
 const DEFAULT_FPS = 30;
 let interval = 1000 / DEFAULT_FPS;
+let intervalOwner = window; // Defaults to main window object
+let lastInterval = { owner: null, intervalId: null };
 
 let polluted = false;
 export function polluteRuntimeStart(vm) {
@@ -9,11 +11,20 @@ export function polluteRuntimeStart(vm) {
   vm.runtime.start = function () {
     if (this._steppingInterval) return;
     this.currentStepTime = interval;
-    this._steppingInterval = setInterval(() => {
+    this._steppingInterval = intervalOwner.setInterval(() => {
       this._step();
     }, interval);
     this.emit("RUNTIME_STARTED");
+
+    lastInterval = { owner: intervalOwner, intervalId: this._steppingInterval};
   };
+}
+
+export function getIntervalOwner() {
+  return intervalOwner;
+}
+export function setIntervalOwner(windowObj) {
+  intervalOwner = windowObj;
 }
 
 export function setVmIntervalDelay(newInterval) {
@@ -21,7 +32,7 @@ export function setVmIntervalDelay(newInterval) {
 }
 
 export function restartStepInterval(vm) {
-  clearInterval(vm.runtime._steppingInterval);
+  lastInterval.owner.clearInterval(lastInterval.intervalId);
   vm.runtime._steppingInterval = null;
   vm.runtime.start();
 }

--- a/addons/60fps/vm-stepping-interval-module.js
+++ b/addons/60fps/vm-stepping-interval-module.js
@@ -16,7 +16,7 @@ export function polluteRuntimeStart(vm) {
     }, interval);
     this.emit("RUNTIME_STARTED");
 
-    lastInterval = { owner: intervalOwner, intervalId: this._steppingInterval};
+    lastInterval = { owner: intervalOwner, intervalId: this._steppingInterval };
   };
 }
 

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -150,6 +150,7 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "popout-stage",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/popout-stage/addon.json
+++ b/addons/popout-stage/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Pop-out stage to a new tab",
+  "description": "Adds a button to make the stage into a separate browser tab. (TODO)",
+  "credits": [
+    {
+      "name": "World_Languages"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "tags": ["editor", "projectPlayer", "featured", "beta"],
+  "versionAdded": "1.36.0",
+  "enabledByDefault": false
+}

--- a/addons/popout-stage/userscript.js
+++ b/addons/popout-stage/userscript.js
@@ -1,0 +1,44 @@
+export default async function ({ addon, console, msg }) {
+  function getNewTab() {
+    const newWindow = window.open("");
+
+    // The <canvas> is streamed into a <video> element
+    const video = Object.assign(document.createElement("video"), {
+      playsInline: true,
+      autoplay: true,
+      muted: true,
+    });
+
+    // TODO: style new tab similarly to the fullscreen view? How to handle resolution?
+    video.style.height = "360px";
+    video.style.width = "480px";
+
+    newWindow.document.body.appendChild(video);
+
+    const title = document.createElement("title");
+    title.textContent = "Project player"; // TODO
+    // Favicon TODO
+    newWindow.document.head.appendChild(title);
+
+    return { newWindow, video };
+  }
+
+  // Type `p()` into the console to use
+  window.p = () => {
+    const { newWindow: $window, video: $videoElem } = getNewTab();
+
+    const canvas = document.querySelector("canvas"); // The project stage canvas
+    const stream = canvas.captureStream(30);
+    $videoElem.srcObject = stream;
+
+    // Mouse, touch, and wheel events
+    // https://github.com/scratchfoundation/scratch-gui/blob/9198878ad3f1ce31e0fdaa819b9951a3469614a7/src/containers/stage.jsx#L121-L138
+    $videoElem.addEventListener("mousedown", (e) => {
+      canvas.dispatchEvent(new MouseEvent("mousedown", e));
+    });
+    $videoElem.addEventListener("mouseup", (e) => {
+      canvas.dispatchEvent(new MouseEvent("mouseup", e));
+    });
+    // (TODO other events)
+  };
+}


### PR DESCRIPTION
Resolves #1993

### Changes

- [ ] Stream the project stage canvas into a different tab
- [ ] The project FPS is not throttled when the main editor window is backgrounded
- [ ] General compatibility with `60fps` addon
- [ ] `<mouse down?>` block works properly in the pop-out tab
- [ ] Other mouse events
- [ ] Keyboard events
- [ ] Mouse coordinates
- [ ] Green flag, pause button and stop button from the popout tab
- [ ] Variable and list monitors
- [ ] "Ask-and-wait" prompts

### Tests

Not until it's ready.