### PR TITLE
Re-add decimal settings + Remove key incremention select settings

### DIFF
--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -50,6 +50,7 @@
       "type": "decimal",
       "default": 1,
       "min": 0,
+      "max": 100,
       "step": 0.1,
       "if": { "settings": { "useCustom": true } }
     },
@@ -89,6 +90,7 @@
       "type": "decimal",
       "default": 10,
       "min": 0,
+      "max": 100,
       "step": 0.1,
       "if": { "settings": { "useCustom": true } }
     },
@@ -128,6 +130,7 @@
       "type": "decimal",
       "default": 0.1,
       "min": 0,
+      "max": 100,
       "step": 0.01,
       "if": { "settings": { "useCustom": true } }
     },

--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -17,73 +17,13 @@
   "settings": [
     {
       "name": "Change on regular key press",
-      "id": "regular",
-      "type": "select",
-      "default": "one",
-      "potentialValues": [
-        {
-          "id": "none",
-          "name": "None"
-        },
-        {
-          "id": "hundredth",
-          "name": "0.01"
-        },
-        {
-          "id": "tenth",
-          "name": "0.1"
-        },
-        {
-          "id": "one",
-          "name": "1"
-        },
-        {
-          "id": "ten",
-          "name": "10"
-        }
-      ],
-      "if": { "settings": { "useCustom": false } }
-    },
-    {
-      "name": "Change on regular key press",
       "id": "regularCustom",
       "type": "decimal",
       "default": 1,
       "min": 0,
       "max": 100,
-      "step": 0.1,
-      "if": { "settings": { "useCustom": true } }
+      "step": "any"
     },
-    {
-      "name": "Change on Shift+Key",
-      "id": "shift",
-      "type": "select",
-      "default": "ten",
-      "potentialValues": [
-        {
-          "id": "none",
-          "name": "None"
-        },
-        {
-          "id": "hundredth",
-          "name": "0.01"
-        },
-        {
-          "id": "tenth",
-          "name": "0.1"
-        },
-        {
-          "id": "one",
-          "name": "1"
-        },
-        {
-          "id": "ten",
-          "name": "10"
-        }
-      ],
-      "if": { "settings": { "useCustom": false } }
-    },
-
     {
       "name": "Change on Shift+Key",
       "id": "shiftCustom",
@@ -91,39 +31,8 @@
       "default": 10,
       "min": 0,
       "max": 100,
-      "step": 0.1,
-      "if": { "settings": { "useCustom": true } }
+      "step": "any"
     },
-    {
-      "name": "Change on Alt+Key",
-      "id": "alt",
-      "type": "select",
-      "default": "tenth",
-      "potentialValues": [
-        {
-          "id": "none",
-          "name": "None"
-        },
-        {
-          "id": "hundredth",
-          "name": "0.01"
-        },
-        {
-          "id": "tenth",
-          "name": "0.1"
-        },
-        {
-          "id": "one",
-          "name": "1"
-        },
-        {
-          "id": "ten",
-          "name": "10"
-        }
-      ],
-      "if": { "settings": { "useCustom": false } }
-    },
-
     {
       "name": "Change on Alt+Key",
       "id": "altCustom",
@@ -131,15 +40,7 @@
       "default": 0.1,
       "min": 0,
       "max": 100,
-      "step": 0.01,
-      "if": { "settings": { "useCustom": true } }
-    },
-
-    {
-      "name": "Use custom values",
-      "id": "useCustom",
-      "type": "boolean",
-      "default": false
+      "step": "any"
     }
   ],
   "credits": [

--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -47,9 +47,10 @@
     {
       "name": "Change on regular key press",
       "id": "regularCustom",
-      "type": "string",
-      "default": "1",
-      "max": 8,
+      "type": "decimal",
+      "default": 1,
+      "min": 0,
+      "step": 0.1,
       "if": { "settings": { "useCustom": true } }
     },
     {
@@ -85,9 +86,10 @@
     {
       "name": "Change on Shift+Key",
       "id": "shiftCustom",
-      "type": "string",
-      "default": "10",
-      "max": 8,
+      "type": "decimal",
+      "default": 10,
+      "min": 0,
+      "step": 0.1,
       "if": { "settings": { "useCustom": true } }
     },
     {
@@ -123,9 +125,10 @@
     {
       "name": "Change on Alt+Key",
       "id": "altCustom",
-      "type": "string",
-      "default": "0.1",
-      "max": 8,
+      "type": "decimal",
+      "default": 0.1,
+      "min": 0,
+      "step": 0.01,
       "if": { "settings": { "useCustom": true } }
     },
 

--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -17,7 +17,7 @@
   "settings": [
     {
       "name": "Change on regular key press",
-      "id": "regularCustom",
+      "id": "regular",
       "type": "decimal",
       "default": 1,
       "min": 0,
@@ -26,7 +26,7 @@
     },
     {
       "name": "Change on Shift+Key",
-      "id": "shiftCustom",
+      "id": "shift",
       "type": "decimal",
       "default": 10,
       "min": 0,
@@ -35,7 +35,7 @@
     },
     {
       "name": "Change on Alt+Key",
-      "id": "altCustom",
+      "id": "alt",
       "type": "decimal",
       "default": 0.1,
       "min": 0,

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -122,14 +122,9 @@ export default async function ({ addon }) {
         : e.altKey
         ? addon.settings.get("altCustom")
         : addon.settings.get("regularCustom");
-      if (settingValue === "") settingValue = 0;
-      let valueAsFloat = parseFloat(settingValue);
-      if (valueAsFloat < 0) valueAsFloat *= -1; // If user typed a negative number, we make it positive
-      if (Number.isNaN(valueAsFloat)) {
-        return;
-      } else if (valueAsFloat === 0 || (valueAsFloat < 100000000 && valueAsFloat > 0.00000099)) {
+      if (settingValue === 0 || (settingValue < 100000000 && settingValue > 0.00000099)) {
         // This will exclude valid floats such as `1e20` that are less than 9 characters
-        changeBy *= valueAsFloat;
+        changeBy *= settingValue;
       } else {
         return;
       }

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -110,10 +110,10 @@ export default async function ({ addon }) {
 
     let changeBy = e.code === "ArrowUp" ? 1 : -1;
     changeBy *= e.shiftKey
-      ? addon.settings.get("shiftCustom")
+      ? addon.settings.get("shift")
       : e.altKey
-      ? addon.settings.get("altCustom")
-      : addon.settings.get("regularCustom");
+      ? addon.settings.get("alt")
+      : addon.settings.get("regular");
 
     const newValueAsInt =
       shiftDecimalPointToRight(e.target.value, 5) + shiftDecimalPointToRight(changeBy.toString(), 5);

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -1,11 +1,4 @@
 export default async function ({ addon }) {
-  const settings = {
-    none: 0,
-    hundredth: 0.01,
-    tenth: 0.1,
-    one: 1,
-    ten: 10,
-  };
   const inputMap = new WeakMap();
 
   const amountOfDecimals = (numStr) => {
@@ -116,25 +109,11 @@ export default async function ({ addon }) {
     // number input (increase or decrease by 1). If we didn't prevent, the user would be increasing twice.
 
     let changeBy = e.code === "ArrowUp" ? 1 : -1;
-    if (addon.settings.get("useCustom")) {
-      let settingValue = e.shiftKey
-        ? addon.settings.get("shiftCustom")
-        : e.altKey
-        ? addon.settings.get("altCustom")
-        : addon.settings.get("regularCustom");
-      if (settingValue === 0 || (settingValue < 100000000 && settingValue > 0.00000099)) {
-        // This will exclude valid floats such as `1e20` that are less than 9 characters
-        changeBy *= settingValue;
-      } else {
-        return;
-      }
-    } else {
-      changeBy *= e.shiftKey
-        ? settings[addon.settings.get("shift")]
-        : e.altKey
-        ? settings[addon.settings.get("alt")]
-        : settings[addon.settings.get("regular")];
-    }
+    changeBy *= e.shiftKey
+      ? addon.settings.get("shiftCustom")
+      : e.altKey
+      ? addon.settings.get("altCustom")
+      : addon.settings.get("regularCustom");
 
     const newValueAsInt =
       shiftDecimalPointToRight(e.target.value, 5) + shiftDecimalPointToRight(changeBy.toString(), 5);

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -162,7 +162,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
             // cloning required for tables
             settings[option.id] = JSON.parse(JSON.stringify(option.default));
-          } else if (option.type === "positive_integer" || option.type === "integer") {
+          } else if (option.type === "positive_integer" || option.type === "integer" || option.type === "decimal") {
             // ^ else means typeof can't be "undefined", so it must be number
             if (typeof settings[option.id] !== "number") {
               // This setting was stringified, see #2142

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -639,6 +639,33 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
             settings.bordercolor = "#855cd6";
           });
         }
+        if (addonId === "editor-number-arrow-keys" && settings.useCustom != null) {
+          // Transition v1.35 to v1.36
+          // Remove select settings
+          console.log(settings.useCustom);
+          if (settings.useCustom) {
+            settings.regular = Number(settings.regularCustom);
+            settings.shift = Number(settings.shiftCustom);
+            settings.alt = Number(settings.altCustom);
+          } else {
+            // This part isn't working
+            const conversions = {
+              none: 0,
+              hundredth: 0.01,
+              tenth: 0.1,
+              one: 1,
+              ten: 10,
+            };
+            settings.regular = conversions[settings.regular];
+            settings.shift = conversions[settings.shift];
+            settings.alt = conversions[settings.alt];
+          }
+          delete settings.regularCustom;
+          delete settings.shiftCustom;
+          delete settings.altCustom;
+          delete settings.useCustom;
+          madeAnyChanges = madeChangesToAddon = true;
+        }
       }
 
       if (addonsEnabled[addonId] === undefined) addonsEnabled[addonId] = !!manifest.enabledByDefault;

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -4,7 +4,7 @@
     class="addon-setting"
     :class="{
     'boolean-setting': setting.type === 'boolean',
-    'number-setting': setting.type === 'integer' || setting.type === 'positive_integer',
+    'number-setting': setting.type === 'integer' || setting.type === 'positive_integer' || setting.type === 'decimal',
   }"
   >
     <div class="setting-label-container">
@@ -72,18 +72,7 @@
       </div>
     </template>
     <div v-else class="setting-input-container" :class="{ 'full-radius': tableChild }">
-      <template v-if="setting.type === 'positive_integer'">
-        <input
-          type="number"
-          class="setting-input number"
-          v-model="addonSettings[setting.id]"
-          @change="checkValidity() || updateSettings()"
-          :disabled="!addon._enabled"
-          min="0"
-          number
-        />
-      </template>
-      <template v-if="setting.type === 'integer'">
+      <template v-if="setting.type === 'decimal'">
         <input
           type="number"
           class="setting-input number"
@@ -91,6 +80,19 @@
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           :min="setting.min"
+          :max="setting.max"
+          :step="setting.step || 0.1"
+          number
+        />
+      </template>
+      <template v-if="setting.type === 'integer' || setting.type === 'positive_integer'">
+        <input
+          type="number"
+          class="setting-input number"
+          v-model="addonSettings[setting.id]"
+          @change="checkValidity() || updateSettings()"
+          :disabled="!addon._enabled"
+          :min="setting.type === 'positive_integer' ? 0 : setting.min"
           :max="setting.max"
           number
         />


### PR DESCRIPTION
Resolves #6769

### Changes

- Re-adds decimal settings (#6744)
- Sets the setting steps to `any` as suggested in https://github.com/ScratchAddons/ScratchAddons/pull/6744#issuecomment-1751738617
- Removes the select settings

### Reason for changes

It allows full value customization while still being validated by the settings page and simplifies the addon's code.

### Tests

The addon works but transitioning from the select settings to decimal ones doesn't right now.