### PR TITLE
`copy-message-link`: fix incompatibility, remove unnecessary css

### DIFF
--- a/addons/copy-message-link/addon.json
+++ b/addons/copy-message-link/addon.json
@@ -21,10 +21,6 @@
   ],
   "userstyles": [
     {
-      "url": "profile.css",
-      "matches": ["https://scratch.mit.edu/users/*/"]
-    },
-    {
       "url": "project.css",
       "matches": ["projects", "https://scratch.mit.edu/studios/*"]
     }

--- a/addons/copy-message-link/profile.css
+++ b/addons/copy-message-link/profile.css
@@ -1,7 +1,0 @@
-#comments .comment .report {
-  display: block;
-  opacity: 0;
-}
-#comments .comment:hover .report {
-  opacity: 1;
-}

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -2,40 +2,47 @@ export default async function ({ addon, console, msg }) {
   addon.self.addEventListener("disabled", () => {
     document.querySelectorAll(".sa-copy-link-btn").forEach(element => element.remove());
   })
-  
-  let amtOfComments = 0;
-  let pass = 0;
-  while (true) {
-    const newAmtOfComments = document.querySelectorAll("div.comment").length;
-    if (amtOfComments !== newAmtOfComments) {
-      pass++;
-      amtOfComments = newAmtOfComments;
+  addon.self.addEventListener("reenabled", () => {
+    createButtons;
+  })
+
+  createButtons();
+
+  function createButtons() {
+    let amtOfComments = 0;
+    let pass = 0;
+    while (true) {
+      const newAmtOfComments = document.querySelectorAll("div.comment").length;
+      if (amtOfComments !== newAmtOfComments) {
+        pass++;
+        amtOfComments = newAmtOfComments;
+      }
+      const comment = await addon.tab.waitForElement(`div.comment:not([data-sa-copy-link-pass='${pass}'])`);
+      comment.dataset.saCopyLinkPass = pass;
+      if (comment.querySelector(".sa-copy-link-btn")) {
+        // This will to all comments after posting a new one,
+        // and to the first comment on every loaded page.
+        // Do not readd button if we already added it
+        continue;
+      }
+      const newElem = document.createElement("span");
+      newElem.className = "actions report sa-copy-link-btn";
+      newElem.textContent = msg("copyLink");
+      newElem.onclick = () => {
+        // For profiles, respect correct username casing in URL
+        let url =
+          location.pathname.split("/")[1] === "users"
+            ? `${location.origin}/users/${Scratch.INIT_DATA.PROFILE.model.id}/`
+            : `${location.origin}${location.pathname}`;
+        navigator.clipboard.writeText(`${url}#${comment.id}`);
+        newElem.textContent = msg("copied");
+        newElem.style.fontWeight = "bold";
+        setTimeout(() => {
+          newElem.textContent = msg("copyLink");
+          newElem.style.fontWeight = "";
+        }, 5000);
+      };
+      comment.querySelector("div.actions-wrap").appendChild(newElem);
     }
-    const comment = await addon.tab.waitForElement(`div.comment:not([data-sa-copy-link-pass='${pass}'])`);
-    comment.dataset.saCopyLinkPass = pass;
-    if (comment.querySelector(".sa-copy-link-btn")) {
-      // This will to all comments after posting a new one,
-      // and to the first comment on every loaded page.
-      // Do not readd button if we already added it
-      continue;
-    }
-    const newElem = document.createElement("span");
-    newElem.className = "actions report sa-copy-link-btn";
-    newElem.textContent = msg("copyLink");
-    newElem.onclick = () => {
-      // For profiles, respect correct username casing in URL
-      let url =
-        location.pathname.split("/")[1] === "users"
-          ? `${location.origin}/users/${Scratch.INIT_DATA.PROFILE.model.id}/`
-          : `${location.origin}${location.pathname}`;
-      navigator.clipboard.writeText(`${url}#${comment.id}`);
-      newElem.textContent = msg("copied");
-      newElem.style.fontWeight = "bold";
-      setTimeout(() => {
-        newElem.textContent = msg("copyLink");
-        newElem.style.fontWeight = "";
-      }, 5000);
-    };
-    comment.querySelector("div.actions-wrap").appendChild(newElem);
   }
 }

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -16,7 +16,6 @@ export default async function ({ addon, console, msg }) {
       continue;
     }
     const newElem = document.createElement("span");
-    addon.tab.displayNoneWhileDisabled(newElem);
     newElem.className = "actions report sa-copy-link-btn";
     newElem.textContent = msg("copyLink");
     newElem.onclick = () => {

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -1,4 +1,8 @@
 export default async function ({ addon, console, msg }) {
+  addon.self.addEventListener("disabled", () => {
+    document.querySelectorAll(".sa-copy-link-btn").forEach(element => element.remove());
+  })
+  
   let amtOfComments = 0;
   let pass = 0;
   while (true) {


### PR DESCRIPTION
### Changes

Removes unnecessary stylesheet, and removes the displayNoneWhileDisabled thing.
Also has the unfortunate side effect of no longer removing the _copy link_ button when the addon is disabled. I can't imagine why.

- [x] Fix displayNoneWhileDisabled thing

### Reason for changes

The stylesheet is completely useless - the only reason it's needed is because of the displayNoneWhileDisabled thing. Since that modifies the display property, it means that you can't do display:none while the mouse isn't hovered over the buttons. So you need to make them transparent instead, which makes them retain their dimensions. This causes conflict with `emoji-picker` (and possibly something else too) by being visible on top of the emoji picker dialogs.

<sub>I can't test now, and I won't be able to check github until tuesday</sub>