### PR TITLE
Fix addon userscripts using wrong language for localized strings

### DIFF
--- a/addon-api/common/FetchableAuth.js
+++ b/addon-api/common/FetchableAuth.js
@@ -96,6 +96,6 @@ export default class FetchableAuth extends AuthCommon {
    * @type {string}
    */
   get scratchLang() {
-    return this._getCookie("scratchlanguage");
+    return this._getCookie("scratchlanguage") || navigator.language;
   }
 }

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -350,7 +350,7 @@ function waitForDocumentHead() {
 }
 
 function getL10NURLs() {
-  const langCode = /scratchlanguage=([\w-]+)/.exec(document.cookie)?.[1] || "en";
+  const langCode = /scratchlanguage=([\w-]+)/.exec(document.cookie)?.[1] || navigator.language;
   const urls = [chrome.runtime.getURL(`addons-l10n/${langCode}`)];
   if (langCode === "pt") {
     urls.push(chrome.runtime.getURL(`addons-l10n/pt-br`));


### PR DESCRIPTION
### Changes

When there's no `scratchlanguage` cookie, Scratch uses `navigator.language` as the language, and we want to match the language used by Scratch.

Remember that in modern browsers, `navigator.language = navigator.languages[0]` which doesn't necessarily match with the browser UI language, which is used for the popup and settings page through `chrome.i18n`.

### Tests

Tested in Chromium