### PR TITLE
Minor `emoji-picker` bugfix

### DIFF
--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -9,7 +9,6 @@
   box-shadow: 0px 0px 5px #00000022;
   z-index: 1;
   padding: 5px;
-  padding-bottom: 0;
   overflow: hidden;
   line-height: 0px;
   font-size: 15px;
@@ -88,12 +87,11 @@
 .compose-comment .compose-bottom-row .sa-emoji-picker-see-more {
   width: 100%;
   margin-top: 5px;
-  margin-bottom: 5px;
 }
 #comments #comment-form .sa-emoji-button-r2 .sa-emoji-picker-see-more,
 #comments .comment form .sa-emoji-button-r2 .sa-emoji-picker-see-more {
   width: calc(100% - 2px);
-  margin-bottom: 7px;
+  margin-bottom: 2px;
   margin-top: 4px;
 }
 

--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -85,15 +85,16 @@
   width: 20px;
   height: 20px;
 }
-.sa-emoji-picker-see-more {
+.compose-comment .compose-bottom-row .sa-emoji-picker-see-more {
   width: 100%;
-  margin-top: 5px !important;
-  margin-bottom: 5px !important;
+  margin-top: 5px;
+  margin-bottom: 5px;
 }
-.sa-emoji-button-r2 .sa-emoji-picker-see-more {
+#comments #comment-form .sa-emoji-button-r2 .sa-emoji-picker-see-more,
+#comments .comment form .sa-emoji-button-r2 .sa-emoji-picker-see-more {
   width: calc(100% - 2px);
   margin-bottom: 7px;
-  margin-top: 4px !important;
+  margin-top: 4px;
 }
 
 form > .control-group:not(.tooltip) {

--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -87,12 +87,13 @@
 }
 .sa-emoji-picker-see-more {
   width: 100%;
-  margin-top: 5px;
+  margin-top: 5px !important;
+  margin-bottom: 5px !important;
 }
 .sa-emoji-button-r2 .sa-emoji-picker-see-more {
   width: calc(100% - 2px);
   margin-bottom: 7px;
-  margin-top: 4px;
+  margin-top: 4px !important;
 }
 
 form > .control-group:not(.tooltip) {


### PR DESCRIPTION
### Changes

Just adds a few `!important`s in the stylesheet to fix the margins below the show more emojis button on profile pages.

### Reason for changes

![image](https://github.com/ScratchAddons/ScratchAddons/assets/73294041/3e934d5e-7f0a-44ae-8466-e80c292db5ca)
<sup>Weird margins</sup>

### Tests

Tested in Edge 118.

---

<strike>Also since I've opened a PR for emoji-picker anyways, do you guys think it would be a good idea to replace the emoji on the button with one of the cat emojis?</strike> This is way too much work, I'm sure someone will get to it later.