### PR TITLE
Allow stage header to overflow to a side

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -632,6 +632,13 @@ export default class Tab extends Listenable {
       },
     };
 
+    if (space === "stageHeader") {
+      // Load stageHeader space CSS
+      import("./stage-header-styles.js").then((m) => {
+        m.applyStyles();
+      });
+    }
+
     const spaceInfo = sharedSpaces[space];
     const spaceElement = spaceInfo.element();
     if (!spaceElement) return false;

--- a/addon-api/content-script/stage-header-styles.js
+++ b/addon-api/content-script/stage-header-styles.js
@@ -1,0 +1,20 @@
+let injected = false;
+
+export function applyStyles() {
+  if (injected) return;
+  injected = true;
+
+  const css = `
+/* appendToSharedSpace CSS for stageHeader space - see SA/SA#3030 */
+[class*="stage-header_stage-header-wrapper_"] {
+    height: 2.75rem;
+}
+  
+[class*="stage-header_stage-menu-wrapper_"] {
+    position: absolute;
+    right: 0;
+    min-width: 100%;
+}
+`.trim();
+  document.head.appendChild(Object.assign(document.createElement("style"), { textContent: css }));
+}


### PR DESCRIPTION
Resolves #3030

### Changes

Adds the CSS styles suggested by mxmou (in comment https://github.com/ScratchAddons/ScratchAddons/issues/3030#issuecomment-1657084455) when using appendToSharedSpace with the stageHeader space.

![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/6be93e16-674b-4566-b030-943a3bda1c0a)

Having `appendToSharedSpace` inject styles on its own is not ideal, but the overflow bug is bad enough on its own. We can find better ways to handle shared CSS between addons in the future.

Also worth discussing: now that's space, the debugger and gamepad buttons can stay visible even if the stage is in small-mode. We currently hide them to save space, but there's enough space now.

### Tests

- [ ] Test in RTL
- [ ] Test with addons enabled such as `editor-stage-left` and `editor-buttons-reverse-order` (in LTR)
- [ ] Item above but RTL