### PR TITLE
Infinite scrolling: support Explore and Search pages

### DIFF
--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -63,6 +63,12 @@
       "id": "messageScroll",
       "type": "boolean",
       "default": true
+    },
+    {
+      "name": "Search and Explore",
+      "id": "searchExploreScroll",
+      "type": "boolean",
+      "default": true
     }
   ],
   "userscripts": [
@@ -79,7 +85,9 @@
         "projects",
         "https://scratch.mit.edu/studios/*",
         "https://scratch.mit.edu/users/*",
-        "https://scratch.mit.edu/messages"
+        "https://scratch.mit.edu/messages",
+        "https://scratch.mit.edu/search/*",
+        "https://scratch.mit.edu/explore/*"
       ]
     }
   ],
@@ -93,6 +101,10 @@
     }
   ],
   "tags": ["community", "featured"],
+  "latestUpdate": {
+    "newSettings": ["searchExploreScroll"],
+    "version": "1.36.0"
+  },
   "versionAdded": "1.2.0",
   "enabledByDefault": false
 }

--- a/addons/infinite-scroll/buttonScroll.js
+++ b/addons/infinite-scroll/buttonScroll.js
@@ -1,4 +1,10 @@
-async function commentLoader(addon, heightControl, selector, pathname, { yProvider = undefined } = {}) {
+async function commentLoader(
+  addon,
+  heightControl,
+  selector,
+  pathname,
+  { yProvider = undefined, canClick = () => true } = {}
+) {
   let func;
   let prevScrollDetector;
   const yProviderValue = yProvider;
@@ -21,7 +27,7 @@ async function commentLoader(addon, heightControl, selector, pathname, { yProvid
       if (typeof pathname === "string" && (window.location.pathname.split("/")[3] || "") !== pathname) return;
       if (threshold >= el.closest(heightControl).offsetHeight - 500) {
         if (el) {
-          el.click();
+          if (canClick()) el.click();
         }
       }
     };
@@ -36,6 +42,7 @@ export default async function ({ addon, console }) {
   const isStudioComments = isStudio && addon.settings.get("studioScroll");
   const isProjectComments =
     window.location.pathname.split("/")[1] === "projects" && addon.settings.get("projectScroll");
+  const isSearchOrExplore = ["search", "explore"].includes(window.location.pathname.split("/")[1]);
   if (isProjectComments || isStudioComments) {
     const buttonSelector = isStudioComments
       ? ".studio-compose-container .load-more-button"
@@ -69,6 +76,12 @@ export default async function ({ addon, console }) {
     commentLoader(addon, "#view", "div > .studio-members:last-child .studio-grid-load-more > button", "curators"); // Only scrolling curators for now
   if (isStudio && addon.settings.get("studioActivityScroll"))
     commentLoader(addon, "#view", ".studio-activity .studio-grid-load-more > button", "activity");
+  if (isSearchOrExplore && addon.settings.get("searchExploreScroll")) {
+    import("./search-explore-module.js").then((m) => {
+      const canClick = () => !m.currentlyFetchingProjects();
+      commentLoader(addon, "#view", "#projectBox > button.button", undefined, { canClick });
+    });
+  }
 
   // Enable scrolling for studio-followers
   // Disabled, see #3238

--- a/addons/infinite-scroll/search-explore-module.js
+++ b/addons/infinite-scroll/search-explore-module.js
@@ -1,0 +1,29 @@
+let currentRequests = 0;
+
+const xhrOpen = XMLHttpRequest.prototype.open;
+XMLHttpRequest.prototype.open = function (method, path, ...args) {
+  const request = xhrOpen.call(this, method, path, ...args);
+
+  try {
+    const url = new URL(path);
+    if ((url.pathname.startsWith("/search/") || url.pathname.startsWith("/explore/")) && method === "GET") {
+      currentRequests++;
+      this.addEventListener(
+        "load",
+        () => {
+          // We intentionally do not decrease if request failed with non-2xx
+          currentRequests--;
+        },
+        { once: true }
+      );
+    }
+    return request;
+  } catch(err) {
+    console.error(err);
+    return request;
+  }
+};
+
+export function currentlyFetchingProjects() {
+  return currentRequests != 0;
+}

--- a/addons/infinite-scroll/search-explore-module.js
+++ b/addons/infinite-scroll/search-explore-module.js
@@ -18,7 +18,7 @@ XMLHttpRequest.prototype.open = function (method, path, ...args) {
       );
     }
     return request;
-  } catch(err) {
+  } catch (err) {
     console.error(err);
     return request;
   }


### PR DESCRIPTION
Superseeds #5629
Resolves #2520
Included at #5419

### Changes

Adds infinite scrolling support to project/studio search and project/studio explore.

PR #5629 also attempted this, but it sent too many requests. Scratch's "load more" button sends one request each time it's clicked, and we don't want to be sending more than one request concurrently. This is not the case in other infinite scrolling areas where the button is disabled/hidden while a new page of content is loading.

### Tests

Tested in Chromium