### PR TITLE
`copy-message-link`: fix `emoji-picker` incompatibility

### DIFF
--- a/addons/copy-message-link/profile.css
+++ b/addons/copy-message-link/profile.css
@@ -1,7 +1,6 @@
 #comments .comment .report {
-  display: block;
-  opacity: 0;
+  display: none !important;
 }
 #comments .comment:hover .report {
-  opacity: 1;
+  display: block !important;
 }


### PR DESCRIPTION
Continuation of #6799, I messed that one up and couldn't revert the commits so here we are.

### Changes

Fixes incompatibility with `emoji-picker`.

### Reason for changes

Since the displayNoneWhileDisabled thing modifies the display property of the button, you can't do display:none while the mouse isn't hovered over the buttons. So you need to make them transparent instead, which makes them retain their dimensions. This causes conflict with `emoji-picker` (and possibly something else too) by being visible on top of the emoji picker dialogs.
![screenshot of the bug](https://github.com/ScratchAddons/ScratchAddons/assets/73294041/09c70ae5-86ad-4c51-9e8f-9ff6e2dc2ab4)

---

Works on Edge 118.