### PR TITLE
`better-quoter`: Escape square brackets

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -57,10 +57,8 @@ function getSelectionBBCode(selection) {
     return "";
   }
 
-  console.log({ html });
   const textNodes = getTextNodes(html, ["code", "sa-copyCodeDiv"]);
   for (const textNode of textNodes) {
-    console.log({ textNode }, "in", { textNodes });
     textNode.textContent = textNode.textContent.replaceAll("[", "[[]");
   }
 
@@ -198,14 +196,12 @@ function getSelectionBBCode(selection) {
 function getTextNodes(element, excludeClasses) {
   let textNodes = [];
   for (const child of element.childNodes) {
-    console.log("going through", { child }, "of", { element }, "with", { textNodes });
     if (child.nodeType === 3) {
       textNodes.push(child);
     } else if (!excludeClasses.some((className) => child.classList.contains(className))) {
       textNodes = textNodes.concat(getTextNodes(child, excludeClasses));
     }
   }
-  console.log({ element }, "returns", { textNodes });
   return textNodes;
 }
 

--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -57,6 +57,13 @@ function getSelectionBBCode(selection) {
     return "";
   }
 
+  console.log({ html });
+  const textNodes = getTextNodes(html, ["code", "sa-copyCodeDiv"]);
+  for (const textNode of textNodes) {
+    console.log({ textNode }, "in", { textNodes });
+    textNode.textContent = textNode.textContent.replaceAll("[", "[[]");
+  }
+
   // new lines
   const lineBreaks = html.querySelectorAll("br");
   for (const br of lineBreaks) br.insertAdjacentText("afterend", "\n");
@@ -186,6 +193,20 @@ function getSelectionBBCode(selection) {
   }
 
   return html.textContent;
+}
+
+function getTextNodes(element, excludeClasses) {
+  let textNodes = [];
+  for (const child of element.childNodes) {
+    console.log("going through", { child }, "of", { element }, "with", { textNodes });
+    if (child.nodeType === 3) {
+      textNodes.push(child);
+    } else if (!excludeClasses.some((className) => child.classList.contains(className))) {
+      textNodes = textNodes.concat(getTextNodes(child, excludeClasses));
+    }
+  }
+  console.log({ element }, "returns", { textNodes });
+  return textNodes;
 }
 
 function setup() {


### PR DESCRIPTION
Resolves #6815

### Changes

Automatically escape open brackets `[` to `[[]` in forum posts.

This does escape more than necessary - for example, to make the text `[[]scratchblocks]` appear in a post, you only need to do `[[[]]scratchblocks]`, while this change would escape it to `[[][[]]scratchblocks]` - but it will still result in the same visual output, so it's fine.

### Reason for changes

To fix the bug.

### Tests

Tested in Edge.
