### PR TITLE
Rename speed options

### DIFF
--- a/addons/collapse-footer/addon.json
+++ b/addons/collapse-footer/addon.json
@@ -34,16 +34,16 @@
       "type": "select",
       "potentialValues": [
         {
-          "id": "short",
-          "name": "Quick"
+          "id": "long",
+          "name": "Slow"
         },
         {
           "id": "default",
-          "name": "Default"
+          "name": "Normal"
         },
         {
-          "id": "long",
-          "name": "Slow"
+          "id": "short",
+          "name": "Fast"
         }
       ],
       "default": "default"

--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -62,25 +62,25 @@
       "default": false
     },
     {
-      "name": "Autohide Animation Speed",
+      "name": "Autohide Animation",
       "id": "speed",
       "type": "select",
       "potentialValues": [
         {
           "id": "none",
-          "name": "Instant"
-        },
-        {
-          "id": "short",
-          "name": "Quick"
-        },
-        {
-          "id": "default",
-          "name": "Default"
+          "name": "Off"
         },
         {
           "id": "long",
           "name": "Slow"
+        },
+        {
+          "id": "default",
+          "name": "Normal"
+        },
+        {
+          "id": "short",
+          "name": "Fast"
         }
       ],
       "default": "default",

--- a/addons/forum-live-preview/addon.json
+++ b/addons/forum-live-preview/addon.json
@@ -24,21 +24,21 @@
   ],
   "settings": [
     {
-      "name": "Refresh rate",
+      "name": "Refresh delay",
       "id": "rate",
       "type": "select",
       "potentialValues": [
         {
-          "id": "slow",
-          "name": "Slow"
+          "id": "fast",
+          "name": "Short"
         },
         {
           "id": "default",
           "name": "Default"
         },
         {
-          "id": "fast",
-          "name": "Fast"
+          "id": "slow",
+          "name": "Long"
         }
       ],
       "default": "default"

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -86,25 +86,25 @@
       "default": "cathover"
     },
     {
-      "name": "Animation speed",
+      "name": "Animation",
       "id": "speed",
       "type": "select",
       "potentialValues": [
         {
           "id": "none",
-          "name": "Instant"
-        },
-        {
-          "id": "short",
-          "name": "Quick"
-        },
-        {
-          "id": "default",
-          "name": "Default"
+          "name": "Off"
         },
         {
           "id": "long",
           "name": "Slow"
+        },
+        {
+          "id": "default",
+          "name": "Normal"
+        },
+        {
+          "id": "short",
+          "name": "Fast"
         }
       ],
       "default": "default"

--- a/addons/sprite-properties/addon.json
+++ b/addons/sprite-properties/addon.json
@@ -57,25 +57,25 @@
       }
     },
     {
-      "name": "Animation speed",
+      "name": "Animation",
       "id": "transitionDuration",
       "type": "select",
       "potentialValues": [
         {
           "id": "none",
-          "name": "Instant"
-        },
-        {
-          "id": "short",
-          "name": "Quick"
-        },
-        {
-          "id": "default",
-          "name": "Default"
+          "name": "Off"
         },
         {
           "id": "long",
           "name": "Slow"
+        },
+        {
+          "id": "default",
+          "name": "Normal"
+        },
+        {
+          "id": "short",
+          "name": "Fast"
         }
       ],
       "default": "default"


### PR DESCRIPTION
Resolves #6352?

### Changes

Changes animation speed settings' names as follows:

- "Instant", "Quick", "Default", "Slow" to "Off", "Slow", "Normal", "Fast" (which is also swapped from before)
- "Animation speed" to "Animation" wherever "Off" is an option
- `forum-live-preview`:
  - "Refresh rate" to "Refresh delay"
  - "Slow", "Default", "Fast" to "Short", "Default", "Long" (which is also swapped from before)

(Isn't it something that for all of these, whether they are durations or speeds are now the opposite from what they were originally?)

### Reason for changes

To make them sound more natural.

### Tests

Tested on Edge 118.
