### PR TITLE
Create "Text-to-speech subtitles" addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -150,6 +150,7 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "tts-subtitles",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/tts-subtitles/addon.json
+++ b/addons/tts-subtitles/addon.json
@@ -1,0 +1,31 @@
+{
+  "name": "Text-to-speech subtitles",
+  "description": "Adds subtitles to every project that uses text-to-speech.",
+  "tags": ["community", "projectPage"],
+  "userscripts": [
+    {
+      "matches": ["projects"],
+      "url": "userscript.js"
+    }
+  ],
+  "userstyles": [
+    {
+      "matches": ["projects"],
+      "url": "userstyle.css"
+    }
+  ],
+  "versionAdded": "1.36.0",
+  "info": [
+    {
+      "id": "add-subtitles",
+      "text": "Only people that have this addon enabled will be able to see these subtitles. In your projects, make sure to add subtitles yourself, so that anyone can use these subtitles.",
+      "type": "notice"
+    }
+  ],
+  "credits": [
+    {
+      "link": "https://scratch.mit.edu/users/mybearworld",
+      "name": "mybearworld"
+    }
+  ]
+}

--- a/addons/tts-subtitles/addon.json
+++ b/addons/tts-subtitles/addon.json
@@ -14,6 +14,14 @@
       "url": "userstyle.css"
     }
   ],
+  "settings": [
+    {
+      "id": "show-in-editor",
+      "name": "Show subtitles in editor",
+      "type": "boolean",
+      "default": false
+    }
+  ],
   "versionAdded": "1.36.0",
   "info": [
     {

--- a/addons/tts-subtitles/addon.json
+++ b/addons/tts-subtitles/addon.json
@@ -35,5 +35,7 @@
       "link": "https://scratch.mit.edu/users/mybearworld",
       "name": "mybearworld"
     }
-  ]
+  ],
+  "dynamicDisable": true,
+  "dynamicEnable": true
 }

--- a/addons/tts-subtitles/userscript.js
+++ b/addons/tts-subtitles/userscript.js
@@ -3,6 +3,7 @@ export default async function ({ addon, console }) {
   const createSubtitleBox = async () => {
     subtitleBox?.remove?.();
     if (
+      addon.self.disabled ||
       (addon.tab.editorMode !== "projectpage" && addon.tab.editorMode !== "editor") ||
       (addon.tab.editorMode === "editor" && !addon.settings.get("show-in-editor"))
     ) {
@@ -17,6 +18,8 @@ export default async function ({ addon, console }) {
     player.insertAdjacentElement("afterend", box);
     subtitleBox = box;
   };
+  addon.self.addEventListener("disabled", createSubtitleBox);
+  addon.self.addEventListener("reenabled", createSubtitleBox);
   addon.settings.addEventListener("change", createSubtitleBox);
   addon.tab.addEventListener("urlChange", createSubtitleBox);
   createSubtitleBox();

--- a/addons/tts-subtitles/userscript.js
+++ b/addons/tts-subtitles/userscript.js
@@ -1,7 +1,11 @@
 export default async function ({ addon, console }) {
   let subtitleBox;
   const createSubtitleBox = async () => {
-    if (addon.tab.editorMode !== "projectpage" && addon.tab.editorMode !== "editor") {
+    subtitleBox?.remove?.();
+    if (
+      (addon.tab.editorMode !== "projectpage" && addon.tab.editorMode !== "editor") ||
+      (addon.tab.editorMode === "editor" && !addon.settings.get("show-in-editor"))
+    ) {
       return null;
     }
     const player =
@@ -11,12 +15,11 @@ export default async function ({ addon, console }) {
     const box = document.createElement("div");
     box.classList.add("sa-tts-subtitles-box");
     player.insertAdjacentElement("afterend", box);
-    return box;
+    subtitleBox = box;
   };
-  addon.tab.addEventListener("urlChange", async () => {
-    subtitleBox = await createSubtitleBox();
-  });
-  subtitleBox = await createSubtitleBox();
+  addon.settings.addEventListener("change", createSubtitleBox);
+  addon.tab.addEventListener("urlChange", createSubtitleBox);
+  createSubtitleBox();
 
   const addToSubtitlesBox = (text) => {
     if (!subtitleBox) {

--- a/addons/tts-subtitles/userscript.js
+++ b/addons/tts-subtitles/userscript.js
@@ -1,0 +1,41 @@
+export default async function ({ addon, console }) {
+  let subtitleBox;
+  const createSubtitleBox = async () => {
+    if (addon.tab.editorMode !== "projectpage" && addon.tab.editorMode !== "editor") {
+      return null;
+    }
+    const player =
+      addon.tab.editorMode === "projectpage"
+        ? (await addon.tab.waitForElement(".guiPlayer")).parentElement
+        : await addon.tab.waitForElement("[class^='stage-wrapper_stage-wrapper']");
+    const box = document.createElement("div");
+    box.classList.add("sa-tts-subtitles-box");
+    player.insertAdjacentElement("afterend", box);
+    return box;
+  };
+  addon.tab.addEventListener("urlChange", async () => {
+    subtitleBox = await createSubtitleBox();
+  });
+  subtitleBox = await createSubtitleBox();
+
+  const addToSubtitlesBox = (text) => {
+    if (!subtitleBox) {
+      return;
+    }
+    subtitleBox.textContent += text + "\n";
+    subtitleBox.scrollTop = subtitleBox.scrollHeight;
+  };
+
+  // It needs to be on window.Promise for some reason
+  // Otherwise, there's an error that when googled yields zero results
+  window.Promise._race = Promise.race;
+  window.Promise.race = async (args) => {
+    const result = await Promise._race(args);
+    if (!("url" in result && result.url.startsWith("https://synthesis-service.scratch.mit.edu/synth?"))) {
+      return result;
+    }
+    const text = new URL(result.url).searchParams.get("text");
+    addToSubtitlesBox(text);
+    return result;
+  };
+}

--- a/addons/tts-subtitles/userscript.js
+++ b/addons/tts-subtitles/userscript.js
@@ -26,11 +26,9 @@ export default async function ({ addon, console }) {
     subtitleBox.scrollTop = subtitleBox.scrollHeight;
   };
 
-  // It needs to be on window.Promise for some reason
-  // Otherwise, there's an error that when googled yields zero results
-  window.Promise._race = Promise.race;
+  const oldRace = Promise.race;
   window.Promise.race = (args) => {
-    const result = Promise._race(args);
+    const result = oldRace.bind(Promise)(args);
     result.then((result) => {
       if (!("url" in result && result.url.startsWith("https://synthesis-service.scratch.mit.edu/synth?"))) {
         return result;

--- a/addons/tts-subtitles/userscript.js
+++ b/addons/tts-subtitles/userscript.js
@@ -29,13 +29,15 @@ export default async function ({ addon, console }) {
   // It needs to be on window.Promise for some reason
   // Otherwise, there's an error that when googled yields zero results
   window.Promise._race = Promise.race;
-  window.Promise.race = async (args) => {
-    const result = await Promise._race(args);
-    if (!("url" in result && result.url.startsWith("https://synthesis-service.scratch.mit.edu/synth?"))) {
-      return result;
-    }
-    const text = new URL(result.url).searchParams.get("text");
-    addToSubtitlesBox(text);
+  window.Promise.race = (args) => {
+    const result = Promise._race(args);
+    result.then((result) => {
+      if (!("url" in result && result.url.startsWith("https://synthesis-service.scratch.mit.edu/synth?"))) {
+        return result;
+      }
+      const text = new URL(result.url).searchParams.get("text");
+      addToSubtitlesBox(text);
+    });
     return result;
   };
 }

--- a/addons/tts-subtitles/userstyle.css
+++ b/addons/tts-subtitles/userstyle.css
@@ -1,0 +1,22 @@
+.sa-tts-subtitles-box {
+  margin-top: 1rem;
+  height: 5rem;
+  /* from .project-description */
+  border: 1px solid var(--darkWww-border-5, #4d97ff1a);
+  border-radius: 8px;
+  background-color: var(--darkWww-blue, #4d97ff1a);
+  padding: 0.5rem;
+  overflow: auto;
+  white-space: pre-line;
+  overflow-wrap: break-word;
+}
+
+.sa-body-editor .sa-tts-subtitles-box {
+  margin-top: 0.5rem;
+  background-color: var(--editorDarkMode-accent, white);
+  border-color: var(--editorDarkMode-border, #00000026);
+}
+
+.sa-tts-subtitles-box:empty {
+  display: none;
+}


### PR DESCRIPTION
Resolves #5483

### Changes

Create an addon called "Text-to-speech subtitles" which adds subtitles to projects using text to speech. This is done by trapping calls to `Promise.race`, which the "speak" block uses.

![The Scratch project page with subtitles below the project](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/b825e2f2-4d77-4f68-b2dc-fdacddf65561)
![The Scratch editor with subtitles below the stage](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/6d8c5de8-e663-4a1b-b524-0aac5b004ccc)

### Reason for changes

Accessibility - it's also a relatively widely requested feature on Scratch

### Tests

Tested in Edge.