### PR TITLE
Stop window scrolling when you scroll over a comment

### DIFF
--- a/addons/fix-editor-comments/scroll.css
+++ b/addons/fix-editor-comments/scroll.css
@@ -4,4 +4,5 @@
 .scratchCommentTextarea {
   overflow-y: auto;
   background-color: transparent;
+  pointer-events: none;
 }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves bug report in SA server

### Changes

Just added pointer-events: none; to scroll.css

### Reason for changes

Comments should be ignored and should just scroll the code area

### Tests

Works on brave
