### PR TITLE
Fix `onion-skinning` and `paint-snap` settings menus not opening

### DIFF
--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -585,7 +585,7 @@ export default async function ({ addon, console, msg }) {
   settingButton.appendChild(createButtonImage("settings"));
 
   document.body.addEventListener("click", (e) => {
-    if (areSettingsOpen() && !e.target.matches(".sa-onion-settings *")) setSettingsOpen(false);
+    if (areSettingsOpen() && !e.target.matches(".sa-onion-group *")) setSettingsOpen(false);
   });
 
   //

--- a/addons/paint-snap/ui.js
+++ b/addons/paint-snap/ui.js
@@ -78,7 +78,7 @@ export function initUI({ addon, msg }) {
   controlsGroup.appendChild(settingButton);
 
   document.body.addEventListener("click", (e) => {
-    if (areSettingsOpen() && !e.target.matches(".sa-paint-snap-settings *")) setSettingsOpen(false);
+    if (areSettingsOpen() && !e.target.matches(".sa-paint-snap-group *")) setSettingsOpen(false);
   });
 
   const settingsOpenUpdaters = [];


### PR DESCRIPTION
Resolves #6840

### Changes

#6801, in its final form, caused a regression which made it impossible to open the settings menus for the Onion skinning and Costume editor snapping addons. This change fixes that.

### Notes

Tested in Edge 119. One side effect of this change is that clicking the toggle buttons next to the settings buttons doesn't close the menus, but that might be a good thing as they are kind of part of the settings, depending on how you think about them.