### PR TITLE
[String change] `60fps`: Rewrite the title and description for better clearness

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -1,10 +1,15 @@
 {
-  "name": "60FPS project player mode",
-  "description": "Alt+Click the green flag to toggle 60FPS.",
+  "name": "Custom project framerate",
+  "description": "Alt+Click the green flag to toggle between Scratch's default 30FPS and a custom framerate.",
   "info": [
     {
+      "type": "info",
+      "text": "The framerate (FPS) determines how many blocks are run per second. For example, running at 60FPS doubles the execution speed.",
+      "id": "fpsExplanation"
+    },
+    {
       "type": "notice",
-      "text": "Most projects will not behave properly when running at 60FPS, because increasing the frame rate also increases the speed at which scripts run. This should only be used on projects that support 60FPS.",
+      "text": "Most projects will not behave properly when running at different FPS, because increasing the frame rate also increases the speed at which scripts run. This should only be used on projects that support 60FPS.",
       "id": "projectRunsFasterNotice"
     }
   ],
@@ -28,7 +33,7 @@
   ],
   "settings": [
     {
-      "name": "Alt+GreenFlag FPS",
+      "name": "FPS",
       "id": "framerate",
       "type": "integer",
       "min": 31,


### PR DESCRIPTION
Many people don't know what FPS means on Scratch, and the title "60FPS project player mode" is partially incorrect because you can change the frame rate. Adding an explanation and changing the setting's name might help those users.