### PR TITLE
`scratchr2`: Style comment warnings correctly

### DIFF
--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -180,17 +180,17 @@
   /* emoji-picker compatibility */
   width: auto;
 }
-#comments #comment-form .control-group.tooltip {
+#comments .control-group.tooltip {
   display: flex;
   flex-direction: column;
 }
-#comments #comment-form .tooltip textarea {
+#comments .control-group.tooltip textarea {
   margin-bottom: 0.5rem;
 }
-#comments #comment-form .tooltip.error textarea {
+#comments .control-group.tooltip.error textarea {
   box-shadow: none;
 }
-#comments #comment-form .tooltip.error #comment-alert {
+#comments .control-group.tooltip.error .hovertext {
   position: static;
   box-shadow: none;
   order: -1;
@@ -202,10 +202,10 @@
   padding: 0.25rem;
   width: 100%;
 }
-#comments #comment-form .tooltip.error textarea:focus + #comment-alert {
+#comments .control-group.tooltip.error textarea:focus + .hovertext {
   display: block !important;
 }
-#comments #comment-form .tooltip.error #comment-alert::after,
-#comments #comment-form .tooltip.error .arrow {
+#comments .control-group.tooltip.error .hovertext::after,
+#comments .control-group.tooltip.error .arrow {
   display: none;
 }

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -202,6 +202,9 @@
   padding: 4px;
   width: 100%;
 }
+#comments .control-group.tooltip.error .hovertext .text {
+  font-size: 13px;
+}
 #comments .control-group.tooltip.error textarea:focus + .hovertext {
   display: block !important;
 }

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -199,7 +199,7 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 5px;
   background-color: #ffab1a;
-  padding: 0.25rem;
+  padding: 4px;
   width: 100%;
 }
 #comments .control-group.tooltip.error textarea:focus + .hovertext {

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -195,7 +195,7 @@
   box-shadow: none;
   order: -1;
   box-sizing: border-box;
-  margin-bottom: 0.5rem;
+  margin-bottom: 8px;
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 5px;
   background-color: #ffab1a;

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -185,7 +185,7 @@
   flex-direction: column;
 }
 #comments .control-group.tooltip textarea {
-  margin-bottom: 0.5rem;
+  margin-bottom: 8px;
 }
 #comments .control-group.tooltip.error textarea {
   box-shadow: none;

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -180,3 +180,32 @@
   /* emoji-picker compatibility */
   width: auto;
 }
+#comments #comment-form .control-group.tooltip {
+  display: flex;
+  flex-direction: column;
+}
+#comments #comment-form .tooltip textarea {
+  margin-bottom: 0.5rem;
+}
+#comments #comment-form .tooltip.error textarea {
+  box-shadow: none;
+}
+#comments #comment-form .tooltip.error #comment-alert {
+  position: static;
+  box-shadow: none;
+  order: -1;
+  box-sizing: border-box;
+  margin-bottom: 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+  background-color: #ffab1a;
+  padding: 0.25rem;
+  width: 100%;
+}
+#comments #comment-form .tooltip.error textarea:focus + #comment-alert {
+  display: block !important;
+}
+#comments #comment-form .tooltip.error #comment-alert::after,
+#comments #comment-form .tooltip.error .arrow {
+  display: none;
+}


### PR DESCRIPTION
Resolves #6859

### Changes

Styles comment warnings on profiles so they look as they do in scratchr2. This also makes the issue linked above no longer apply.

![An empty comment with a warning saying "You can't post an empty comment!" on a scratchr2 page with the scratchr2 addon enabled, with the warning looking just as with scratch-www.](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/21743a3a-2f53-4c6f-9ee5-bc3d5ad75709)

### Reason for changes

Making it more consistent, and fixing a bug.

### Tests

Tested in Edge.
