### PR TITLE
Draft - MV3 manifest supported by Chrome & Firefox

### DIFF
--- a/background/test/_module.js
+++ b/background/test/_module.js
@@ -1,0 +1,1 @@
+export default "Hello!";

--- a/background/test/modulescript.js
+++ b/background/test/modulescript.js
@@ -1,0 +1,6 @@
+// For Firefox
+
+import x from "./_module.js";
+
+console.log(x);
+console.log("I have access to the DOM!", window.document);

--- a/background/test/serviceworker.js
+++ b/background/test/serviceworker.js
@@ -1,0 +1,8 @@
+// For Chrome
+
+import x from "./_module.js";
+
+console.log(x);
+console.log("I am a service worker!");
+console.log("window is", typeof window);
+console.log("My `self` object is:", self);

--- a/manifest.json
+++ b/manifest.json
@@ -68,12 +68,12 @@
   "web_accessible_resources": [
     {
       "resources": [
-    "content-scripts/inject/*",
-    "addon-api/*",
-    "addons/*",
-    "libraries/*/cs/*",
-    "addons-l10n/*/*.json",
-    "images/cs/*"
+        "content-scripts/inject/*",
+        "addon-api/*",
+        "addons/*",
+        "libraries/*/cs/*",
+        "addons-l10n/*/*.json",
+        "images/cs/*"
       ],
       "matches": ["https://*.scratch.mit.edu/*", "https://scratchaddons.com/*"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,17 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "1.36.0",
   "version_name": "1.36.0-prerelease",
   "default_locale": "en",
   "background": {
-    "page": "background/background.html"
+    "service_worker": "background/test/serviceworker.js",
+    "type": "module",
+
+    "scripts": ["background/test/modulescript.js"]
   },
-  "browser_action": { "default_popup": "webpages/popup/index.html" },
+  "action": { "default_popup": "webpages/popup/index.html" },
   "icons": {
     "16": "images/icon-blue-16.png",
     "32": "images/icon-blue-32.png",
@@ -44,13 +47,15 @@
   },
   "homepage_url": "https://scratchaddons.com",
   "incognito": "spanning",
-  "permissions": [
+  "host_permissions": [
     "https://scratch.mit.edu/*",
     "https://api.scratch.mit.edu/*",
     "https://clouddata.scratch.mit.edu/*",
     "https://scratchfoundation.github.io/scratch-gui/*",
     "http://localhost:8333/*",
-    "http://localhost:8601/*",
+    "http://localhost:8601/*"
+  ],
+  "permissions": [
     "cookies",
     "webRequest",
     "webRequestBlocking",
@@ -61,12 +66,17 @@
   ],
   "optional_permissions": ["notifications", "clipboardWrite"],
   "web_accessible_resources": [
+    {
+      "resources": [
     "content-scripts/inject/*",
     "addon-api/*",
     "addons/*",
     "libraries/*/cs/*",
     "addons-l10n/*/*.json",
     "images/cs/*"
+      ],
+      "matches": ["https://*.scratch.mit.edu/*", "https://scratchaddons.com/*"]
+    }
   ],
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
The extension is not functional at this state. This is just a demo.
This PR requires Chrome 121+ and Firefox 121+. Try downloading Chrome Canary and Firefox Nightly. The stable versions won't work as of November 2023.

### Changes

This extension features a `manifest.json` file which is accepted by both browsers.
In Chrome, a service worker is used as the background context. In Firefox, a background page is used instead.