### PR TITLE
Update Markdown note block

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To load the extension into most Chromium-based browsers, go to `chrome://extensi
 
 Go to `about:debugging`, select "This Firefox", click "Load Temporary Add-on...", and select the `manifest.json` file in the `ScratchAddons` folder.
 
-> **Note**
+> [!NOTE]
 > Firefox extensions loaded this way are removed when the browser is closed.
 
 ## Contributing


### PR DESCRIPTION
### Changes

GitHub seems to have updated the renderer and `> **Note**` no longer displays a styled note block (is that what it's called?). Not sure if that's intentional, but `> [!NOTE]` still works and is pretty standard so I've updated the syntax to use that.

### Reason for changes

To make it render correctly.

![Quote block reading, "Note: Firefox extensions loaded this way are removed when the browser is closed."](https://github.com/ScratchAddons/ScratchAddons/assets/106490990/a1e33f42-5a63-48d8-9d34-c48a94ec739c)

### Tests

Tested on GitHub.com.
