### PR TITLE
Make `dango-rain`'s description clearer

### DIFF
--- a/addons/dango-rain/addon.json
+++ b/addons/dango-rain/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Dango rain on profiles (April Fools Day)",
-  "description": "Users that include the word \"dango\" on their \"About Me\" will have dango emojis raining on the sides of their profile.",
+  "description": "Users that include the word \"dango\" on their \"About me\" or \"What I'm working on\" will have dango emojis raining on the sides of their profile.",
   "info": [
     {
       "type": "notice",


### PR DESCRIPTION
Resolves #6858

### Changes

Changes the description from `Users that include the word "dango" on their "About Me" will have dango emojis raining on the sides of their profile.` to `Users that include the word "dango" on their "About me" or "What I'm working on" will have dango emojis raining on the sides of their profile.`.

### Reason for changes

This is a very important change that'll benefit all of humanity for centuries to come.

### Tests

\-
