### PR TITLE
discuss-button: hide username using CSS

### DIFF
--- a/addons/discuss-button/compact-nav.css
+++ b/addons/discuss-button/compact-nav.css
@@ -5,6 +5,10 @@
   display: none;
 }
 
+#topnav ul.account-nav .logged-in-user .dropdown-toggle {
+  font-size: 0 !important;
+}
+
 .sa-profile-name {
   display: block;
   font-size: 0.75rem;

--- a/addons/discuss-button/r2.js
+++ b/addons/discuss-button/r2.js
@@ -5,24 +5,14 @@ export default async function ({ addon }) {
   const add = async () => {
     if (!span && (await addon.auth.fetchIsLoggedIn())) {
       const username = await addon.auth.fetchUsername();
-      const container = await addon.tab.waitForElement(".dropdown");
-      const dropdown = await addon.tab.waitForElement(".dropdown-menu .user-nav");
       (await addon.tab.waitForElement(".user-icon")).classList.add("sa-compact-profile-icon");
-      const profileSpans = dropdown.childNodes[0].childNodes[0];
+      const profileSpans = await addon.tab.waitForElement(".dropdown-menu .user-nav > :first-child > :first-child");
       span = profileSpans.appendChild(document.createElement("span"));
       span.className = "sa-profile-name";
       span.textContent = username;
-
-      // Remove username next to icon.
-      container.firstChild.childNodes[1].textContent = "";
     }
   };
   const remove = async () => {
-    const container = document.querySelector(".dropdown");
-    if (container) {
-      const username = await addon.auth.fetchUsername();
-      container.firstChild.childNodes[1].textContent = username;
-    }
     span?.remove();
     span = null;
     const icon = document.querySelector(".user-icon");


### PR DESCRIPTION
Resolves #6880

### Changes

Uses CSS instead of JavaScript to hide the username when the "compact user dropdown" setting is enabled.

### Reason for changes

To fix a race condition and make the code simpler.

### Tests

Tested on Edge and Firefox.