### PR TITLE
Layer emoji picker over Report and Delete buttons

### DIFF
--- a/addons/emoji-picker/userstyle.css
+++ b/addons/emoji-picker/userstyle.css
@@ -7,7 +7,7 @@
   border-radius: 8px;
   border: 2px solid rgba(0, 0, 0, 0.15);
   box-shadow: 0px 0px 5px #00000022;
-  z-index: 1;
+  z-index: 2;
   padding: 5px;
   padding-bottom: 0;
   overflow: hidden;


### PR DESCRIPTION
### Changes

Fixes a bug where the "Report" and "Delete" buttons are displayed on top of the emoji picker on scratchr2 pages when the `scratchr2` addon is enabled. This happens because the `scratchr2` addon sets their `z-index` property to 1, causing them to be layered over the emoji picker.

![Emoji picker window with Report and Delete buttons from a comment displaying on top](https://github.com/ScratchAddons/ScratchAddons/assets/106490990/b7c77206-6c0b-49b4-bbf7-600f5996aef9)

This change increases the emoji picker's z-index to 2, fixing the problem.

### Tests

Tested in Edge 119.
