### PR TITLE
preview-project-description: simpler implementation

### DIFF
--- a/addons/preview-project-description/addon.json
+++ b/addons/preview-project-description/addon.json
@@ -10,7 +10,7 @@
       "name": "World_Languages"
     }
   ],
-  "tags": ["community", "projectPage", "beta", "featured"],
+  "tags": ["community", "projectPage", "featured"],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/preview-project-description/userscript.js
+++ b/addons/preview-project-description/userscript.js
@@ -29,27 +29,10 @@ export default async function ({ addon, console, msg }) {
     togglePreview(checkboxInput.checked);
   });
 
+  const REACT_CONTAINER_PREFIX = "__reactContainere$";
+
   let currentlyEnabled = false;
   let wasEverEnabled = false;
-  let currentlyRerendering = false;
-
-  // We don't want to introduce infinite loops, if a statechanged event by itself changes state.
-  let avoidInfiniteLoops = 0;
-  addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
-    // We don't want a state change to disable the preview mode.
-    if (!addon.tab.redux.state.scratchGui.mode.isPlayerOnly) return;
-    if (e.detail.action._saProjectDescription) return;
-    if (avoidInfiniteLoops > 5) console.log("Avoiding an infinite loop");
-    else if (currentlyEnabled) {
-      const num = ++avoidInfiniteLoops;
-      // Restore preview mode.
-      queueMicrotask(() => enablePreview());
-      setTimeout(() => {
-        if (avoidInfiniteLoops === num) avoidInfiniteLoops = 0;
-      }, 0);
-    }
-  });
 
   async function injectToggle() {
     // Remove our element if it's already on the page
@@ -105,7 +88,7 @@ export default async function ({ addon, console, msg }) {
 
     if (oldCurentlyEnabled === true && currentlyEnabled === false) {
       // Disabling the preview is as simple as forcing a React
-      // rerender with the traps off.
+      // rerender.
       forceReactRerender();
       // This case will not cause waitForElement to fire.
       // Manually run the injectToggle() function:
@@ -124,9 +107,7 @@ export default async function ({ addon, console, msg }) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
-    currentlyRerendering = true;
     forceReactRerender();
-    currentlyRerendering = false;
 
     if (!document.querySelector(".project-description")) {
       // Something went wrong for some reason...
@@ -138,7 +119,6 @@ export default async function ({ addon, console, msg }) {
 
   function forceReactRerender() {
     // We dispatch some Redux update to force React to rerender.
-    // This will call the function mapStateToProps (scratch-www/src/views/preview/project-view.jsx) again.
     addon.tab.redux.dispatch({
       type: "SET_FETCH_STATUS",
       infoType: "parent",
@@ -148,77 +128,22 @@ export default async function ({ addon, console, msg }) {
   }
 
   function addTraps() {
-    const { redux } = addon.tab;
-
-    const beingCalledByMapStateToProps = () => {
-      // We want to know if we're being called from function mapStateToProps (scratch-www/src/views/preview/project-view.jsx)
-      // That function declares a variable `isEditable` which determines whether the user can edit the project notes or not.
-      // The mapStateToProps function is then passed to Redux's "connect" utility and the return value of the connect() call
-      // is exported as module.exports.View: https://github.com/scratchfoundation/scratch-www/blob/59fa9cd12744ec6fcfc73d0d92c4fbbe5ca73d38/src/views/preview/project-view.jsx#L1213
-      try {
-        const stack = new Error().stack;
-        // In Firefox, `View` is part of the call stack returned with new Error().stack, so we just check if it's there.
-        // In Chrome, `View` is not listed, so instead we look for `Function.mapToProps`, which is internally used by Redux's
-        // connect() implementation: https://github.com/reduxjs/react-redux/blob/v5.0.7/src/connect/wrapMapToProps.js#L43
-        return Boolean(
-          stack
-            .split("\n")
-            .slice(0, 4) // No need to look deeper than 4 lines of the error stack.
-            .find((s) => s.trimStart().startsWith("at Function.mapToProps ") || s.startsWith("e.exports.View"))
-        );
-      } catch {
-        // Not sure if anything could theoretically throw inside the "try", but let's be careful
-        return false;
-      }
+    // Override the render function of the Preview component
+    // https://github.com/scratchfoundation/scratch-www/blob/fdcb700/src/views/preview/project-view.jsx
+    const reactRootElement = document.querySelector("#app");
+    const reactContainerKey = Object.keys(reactRootElement).find((key) => key.startsWith(REACT_CONTAINER_PREFIX));
+    let instance = reactRootElement[reactContainerKey];
+    while (!instance.stateNode || typeof instance.stateNode.handleUpdateProjectId !== "function") {
+      instance = instance.child;
+    }
+    const PreviewComponent = instance.stateNode.constructor;
+    const oldRender = PreviewComponent.prototype.render;
+    PreviewComponent.prototype.render = function () {
+      const oldProps = this.props;
+      this.props = { ...this.props, isEditable: !currentlyEnabled };
+      const result = oldRender.call(this);
+      this.props = oldProps;
+      return result;
     };
-
-    let step = 0;
-    // https://github.com/scratchfoundation/scratch-www/blob/59fa9cd12744ec6fcfc73d0d92c4fbbe5ca73d38/src/views/preview/project-view.jsx#L1028
-    // 1. A call to author.id.toString() with a matching function stack.
-    // 2. A call to state.session.user.id.toString() with a matching function stack (author ID = user ID).
-    // 3. A getter to `state.session.session.user.username` on the same event loop cycle. Reset to step 0.
-
-    const originalNumberToString = Number.prototype.toString;
-    Number.prototype.toString = function (...args) {
-      if (!currentlyRerendering) return originalNumberToString.apply(this, args);
-      if (this !== redux.state?.session?.session?.user?.id) return originalNumberToString.apply(this, args);
-      if (!beingCalledByMapStateToProps()) return originalNumberToString.apply(this, args);
-
-      step++;
-      if (step === 3) {
-        // Huh, weird
-        step = 0;
-        return originalNumberToString.apply(this, args);
-      }
-
-      queueMicrotask(() => (step = 0));
-
-      return originalNumberToString.apply(this, args);
-    };
-
-    // The `isEditable` variable is declared as follows: (scratch-www/src/views/preview/project-view.jsx)
-    //   isEditable = isLoggedIn && (authorUsername === state.session.session.user.username || state.permissions.admin === true)
-    // The idea is to modify the Redux state object so that `state.session.session.user.username` is actually different from
-    // the project author, making the expression `false`. However, actually modifying Redux state can cause issues, so instead
-    // we use a Proxy to return a fake username just for this getter call.
-    redux.state.session.session.user = new Proxy(redux.state.session.session.user, {
-      get(target, property, receiver) {
-        if (!currentlyRerendering || property !== "username") {
-          // In these cases, proxy but do nothing different.
-          return Reflect.get(target, property, receiver);
-        }
-
-        if (step === 2 && beingCalledByMapStateToProps()) {
-          // Return an empty string, which will not be equal to `authorUsername`, turning `isEditable` into `false`.
-          step = 0;
-          console.groupCollapsed("[SA] preview-project-description [page]");
-          console.trace("Returning a fake username to mapStateByProps");
-          console.groupEnd();
-          return "";
-        }
-
-        return Reflect.get(target, property, receiver);
-      },
-    });
   }
 }

--- a/addons/preview-project-description/userscript.js
+++ b/addons/preview-project-description/userscript.js
@@ -123,7 +123,6 @@ export default async function ({ addon, console, msg }) {
       type: "SET_FETCH_STATUS",
       infoType: "parent",
       status: addon.tab.redux.state.preview.status.parent, // We do not actually change anything here.
-      _saProjectDescription: true,
     });
   }
 


### PR DESCRIPTION
Resolves #6884
Resolves #6782

### Changes

Changes the way `preview-project-description` works. It now overrides the `render` function of the `Preview` component, which makes the code much simpler.

### Reason for changes

Forcing the whole page to rerender after each state change is bad for performance.

### Tests

Tested on Edge and Firefox.