### PR TITLE
editor-compact: fix backpack on costume tab

### DIFF
--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -364,8 +364,10 @@ body:not(.sa-columns-enabled) [class*="gui_tab-panel"] [class*="gui_extension-bu
 [class*="paint-editor_top-align-row"] {
   padding-top: 0.5rem;
 }
-[class*="paint-editor_mode-selector"] {
-  width: min-content;
+@media (min-height: 710px) {
+  [class*="paint-editor_mode-selector"] {
+    width: min-content;
+  }
 }
 
 [class*="sound-editor_row_"] + [class*="sound-editor_row_"] {


### PR DESCRIPTION
Resolves #6862

### Changes

Only changes the paint editor tool selector to a single column if there's enough space.

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/0a6ec594-1e9d-4d06-8954-0542e8ae3237) ![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/6fc27a89-12fa-4629-9458-730b0b8353d2)

### Reason for changes

To make space for the backpack on small screens.

### Tests

Tested on Edge and Firefox with different zoom levels and window sizes.