### PR TITLE
Specify version for Prettier action

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -24,6 +24,7 @@ jobs:
         uses: ScratchAddons/prettier_action@master
         with:
           prettier_options: --write .
+          prettier_version: 3.1.0
           commit_message: Format code
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -33,6 +34,7 @@ jobs:
         uses: ScratchAddons/prettier_action@master
         with:
           prettier_options: --write .
+          prettier_version: 3.1.0
           commit_message: Format code
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves #6882

### Changes

Sets the version of Prettier to use to 3.1.0. This will keep us on the current version of Prettier even if it is updated. We can always update manually.

### Reason for changes

Currently, Prettier updates can cause our code formatting style to change unexpectedly, causing disruptions for contributors and us. This doesn't mean we'll never update, but if we do:
1. Currently open pull requests will still have status checks fail, but since the version will also be hardcoded on their branches, their code's formatting won't change automatically until their authors merge `upstream/master` into their branches, which updates the formatting anyway.
2. We might be able to take precautions (like notifying contributors) before updating the version to reduce the number of headaches.

### Tests

Tested with GitHub Actions.
