### PR TITLE
editor-theme3: fix transparent inputs

### DIFF
--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -6,9 +6,6 @@
 .blocklyEditableText > text {
   fill: var(--editorTheme3-inputColor-blackText);
 }
-.blocklyHtmlInput {
-  color: var(--editorTheme3-inputColor-blackText);
-}
 
 .blocklyDropDownDiv .goog-menuitem,
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -2,8 +2,11 @@
   fill: var(--editorTheme3-inputColor-text);
 }
 .blocklyHtmlInput {
-  background-color: var(--editorTheme3-inputColor);
-  color: var(--editorTheme3-inputColor-text);
+  /* Hide the HTML input so that only the SVG part is visible.
+     This is needed for transparent inputs. */
+  background-color: transparent;
+  color: transparent;
+  caret-color: var(--editorTheme3-inputColor-text);
 }
 
 /* Override Scratch's high contrast theme */


### PR DESCRIPTION
Resolves #6806

### Changes

Makes the HTML part of a focused block input invisible.

### Tests

Tested on Edge and Firefox.