### PR TITLE
editor-colored-context-menus: support high contrast mode

### DIFF
--- a/addons/editor-colored-context-menus/userscript.css
+++ b/addons/editor-colored-context-menus/userscript.css
@@ -11,5 +11,5 @@
   border-top-color: var(--sa-contextmenu-border) !important;
 }
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {
-  color: white;
+  color: var(--sa-contextmenu-text);
 }

--- a/addons/editor-colored-context-menus/userscript.js
+++ b/addons/editor-colored-context-menus/userscript.js
@@ -14,9 +14,11 @@ export default async function ({ addon, console }) {
     }
     const fill = removeAlpha(background.getAttribute("fill"));
     const border = background.getAttribute("stroke") || "#0003";
+    const text = ScratchBlocks.Colours.text;
     widgetDiv.classList.add("sa-contextmenu-colored");
     widgetDiv.style.setProperty("--sa-contextmenu-bg", fill);
     widgetDiv.style.setProperty("--sa-contextmenu-border", border);
+    widgetDiv.style.setProperty("--sa-contextmenu-text", text);
   };
 
   const originalHandleRightClick = ScratchBlocks.Gesture.prototype.handleRightClick;

--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -10,8 +10,7 @@
   color: var(--editorTheme3-inputColor-blackText);
 }
 
-.blocklyDropDownDiv .goog-menuitem,
-.sa-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {
+.blocklyDropDownDiv .goog-menuitem {
   color: black;
 }
 .blocklyDropDownDiv .blocklyText {

--- a/addons/editor-theme3/color_on_white.css
+++ b/addons/editor-theme3/color_on_white.css
@@ -6,8 +6,7 @@
 
 .u-dropdown-searchbar,
 .u-dropdown-searchbar:focus,
-.blocklyDropDownDiv .goog-menuitem,
-.sa-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {
+.blocklyDropDownDiv .goog-menuitem {
   color: #575e75;
 }
 .u-dropdown-searchbar:focus {

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -417,6 +417,7 @@ export default async function ({ addon, console, msg }) {
     Blockly.Colours.textField = otherColor("input-color", "textField");
     if (textMode() === "colorOnWhite") Blockly.Colours.fieldShadow = "rgba(0, 0, 0, 0.15)";
     else Blockly.Colours.fieldShadow = originalColors.fieldShadow;
+    Blockly.Colours.text = uncoloredTextColor(); // used by editor-colored-context-menus
 
     const workspace = Blockly.getMainWorkspace();
     const flyout = workspace.getFlyout();


### PR DESCRIPTION
Resolves #6776

### Changes

Makes text in colored context menus black if Scratch's high contrast mode is enabled.

### Reason for changes

To make the text readable.

### Tests

Tested on Edge and Firefox.