### PR TITLE
custom-block-shape: fix dropdown arrow position

### DIFF
--- a/addons/custom-block-shape/userscript.js
+++ b/addons/custom-block-shape/userscript.js
@@ -5,6 +5,7 @@ export default async function ({ addon, console }) {
 
   (function (Blockly) {
     const BlockSvg = BlocklyInstance.BlockSvg;
+    var originalDropdownObject = BlocklyInstance.FieldDropdown.prototype.positionArrow;
     var vm = addon.tab.traps.vm;
 
     const { GRID_UNIT } = BlockSvg;
@@ -157,9 +158,9 @@ export default async function ({ addon, console }) {
       BlockSvg.SHAPE_IN_SHAPE_PADDING[1][2] = 5 * GRID_UNIT * multiplier;
       BlockSvg.SHAPE_IN_SHAPE_PADDING[1][3] = 5 * GRID_UNIT * multiplier;
 
-      var originalDropdownObject = BlocklyInstance.FieldDropdown.prototype.positionArrow;
       BlocklyInstance.FieldDropdown.prototype.positionArrow = function (x) {
-        this.arrowY_ = 11 * multiplier;
+        const arrowHeight = 12;
+        this.arrowY_ = (BlockSvg.FIELD_HEIGHT - arrowHeight) / 2 + 1;
         return originalDropdownObject.call(this, x);
       };
 


### PR DESCRIPTION
Resolves #6692

### Changes

* Moves a variable declaration to fix #6692
* Changes how the arrow position is calculated - now it's actually centered even if the padding isn't 100%.

### Tests

Tested on Edge and Firefox.