### PR TITLE
custom-block-shape: fix empty inputs

### DIFF
--- a/addons/custom-block-shape/userscript.js
+++ b/addons/custom-block-shape/userscript.js
@@ -123,24 +123,24 @@ export default async function ({ addon, console }) {
       BlockSvg.INPUT_SHAPE_HEXAGONAL_WIDTH = 12 * GRID_UNIT * multiplier;
       BlockSvg.INPUT_SHAPE_ROUND =
         "M " +
-        4 * GRID_UNIT +
+        4 * GRID_UNIT * multiplier +
         ",0" +
         " h " +
-        4 * GRID_UNIT +
+        4 * GRID_UNIT * multiplier +
         " a " +
-        4 * GRID_UNIT +
+        4 * GRID_UNIT * multiplier +
         " " +
-        4 * GRID_UNIT +
+        4 * GRID_UNIT * multiplier +
         " 0 0 1 0 " +
-        8 * GRID_UNIT +
+        8 * GRID_UNIT * multiplier +
         " h " +
-        -4 * GRID_UNIT +
+        -4 * GRID_UNIT * multiplier +
         " a " +
-        4 * GRID_UNIT +
+        4 * GRID_UNIT * multiplier +
         " " +
-        4 * GRID_UNIT +
+        4 * GRID_UNIT * multiplier +
         " 0 0 1 0 -" +
-        8 * GRID_UNIT +
+        8 * GRID_UNIT * multiplier +
         " z";
       BlockSvg.INPUT_SHAPE_ROUND_WIDTH = 12 * GRID_UNIT * multiplier;
       BlockSvg.INPUT_SHAPE_HEIGHT = 8 * GRID_UNIT * multiplier;


### PR DESCRIPTION
Resolves #6667

### Changes

Makes the padding setting of the `custom-block-shape` addon affect empty round inputs.

### Reason for changes

Some TurboWarp extensions use this type of input:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/267c24fc-98f7-45b3-850d-0f47bb2cf76d)

It currently looks like this with `custom-block-shape`:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/edaf737f-e051-4e08-96cc-c96a42d96416)

### Tests

Tested by opening [this project](https://scratch.mit.edu/projects/560198467/editor) on Edge and Firefox.
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/e0da6c23-c2ba-4819-a4a3-b4fa795c8a93)