### PR TITLE
Option to execute double-clicked scripts

### DIFF
--- a/addons/ctrl-click-run-scripts/addon.json
+++ b/addons/ctrl-click-run-scripts/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Ctrl+Click to run scripts",
-  "description": "Only run scripts on click if also holding the Ctrl key.",
+  "description": "Only execute clicked blocks and scripts if also holding the Ctrl key or, optionally, if double clicked.",
   "info": [
     {
       "text": "On macOS, use the Cmd key instead of the Ctrl key.",
@@ -15,6 +15,10 @@
     {
       "name": "apple502j",
       "link": "https://github.com/apple502j"
+    },
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
     }
   ],
   "dynamicEnable": true,
@@ -25,7 +29,20 @@
       "matches": ["projects"]
     }
   ],
+  "settings": [
+    {
+      "name": "Execute on double click",
+      "id": "double-click",
+      "type": "boolean",
+      "default": true
+    }
+  ],
   "tags": ["editor", "codeEditor"],
   "versionAdded": "1.15.0",
+  "latestUpdate": {
+    "version": "1.36.0",
+    "newSettings": ["double-click"],
+    "temporaryNotice": "Scripts can now be executed by double clicking."
+  },
   "enabledByDefault": false
 }

--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -17,10 +17,30 @@ export default async function ({ addon, console }) {
     }
   );
 
-  // Limits all script running to CTRL + click
+  let doubleClick = false;
+  let doubleClickTimeout;
+  function startDoubleClick() {
+    if (addon.settings.get("double-click")) {
+      doubleClick = true;
+      doubleClickTimeout = setTimeout(() => {
+        doubleClick = false;
+      }, 400);
+    }
+  }
+
+  // Capture clicks on scripts
   const newBlocklyListen = function (e) {
     if (!addon.self.disabled && e.element === "stackclick" && !ctrlKeyPressed) {
-      return;
+      if (doubleClick) {
+        // Allow script to execute on double click
+        clearTimeout(doubleClickTimeout);
+        startDoubleClick();
+        originalBlocklyListen.call(this, e);
+      } else {
+        // Start a double-click timeout and prevent script execution
+        startDoubleClick();
+        return;
+      }
     } else {
       originalBlocklyListen.call(this, e);
     }


### PR DESCRIPTION
Resolves #3958

### Changes

Adds a setting to the `ctrl-click-run-scripts` addon that enables the ability to double click scripts to execute them, instead of having to hold Ctrl. This option is on by default.

Here's how it works:
- When you click on a block stack, a 400ms timer is started and a "double click" flag is raised. If the timer ends, the "double click" flag is dropped. The script does not run yet.
- When you click a block stack while the flag is up (double-click), the script runs. Also, the timer is restarted but the flag stays raised, which allows you to repeatedly execute script as fast as you normally would.

The behavior can be disabled through the setting and works in tandem with Ctrl-clicking.

### Reason for changes

Not allowing scripts to be executed when clicked can be useful to prevent accidents, but requiring the Ctrl key to be used is a bit cumbersome. Requiring a double click is a simple and more user-friendly solution.

### Tests

Tested with:
- Edge 119
- Scratch Addons v1.36.0-pre (https://github.com/ScratchAddons/ScratchAddons/commit/8d2273099d8e261f4638458cb5339e7143f0b4e6)
- scratch.mit.edu