### PR TITLE
Enable redirect-mobile-forums by default

### DIFF
--- a/addons/redirect-mobile-forums/addon.json
+++ b/addons/redirect-mobile-forums/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Redirect to standard forums",
-  "description": "Redirects you to the standard (\"main\") forums when you click a link to the mobile forums.",
+  "name": "Fix mobile forum links",
+  "description": "Redirects you to the standard (\"main\") forums when you click a broken link to the mobile forums.",
   "credits": [
     {
       "name": "Weredime (9gr)",
@@ -10,11 +10,11 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/discuss/m/*"],
+      "matches": ["https://scratch.mit.edu/discuss/m/*", "https://scratch.mit.edu/404"],
       "runAtComplete": false
     }
   ],
   "versionAdded": "1.16.0",
   "tags": ["community", "forums"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/redirect-mobile-forums/addon.json
+++ b/addons/redirect-mobile-forums/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Fix mobile forum links",
-  "description": "Redirects you to the standard (\"main\") forums when you click a broken link to the mobile forums.",
+  "name": "Redirect to standard forums",
+  "description": "Redirects you to the standard (\"main\") view of the forums when you follow a link to the mobile forums (which doesn't work anymore).",
   "credits": [
     {
       "name": "Weredime (9gr)",

--- a/addons/redirect-mobile-forums/userscript.js
+++ b/addons/redirect-mobile-forums/userscript.js
@@ -1,3 +1,5 @@
-export default async function ({ addon, console, msg }) {
-  window.location.replace(window.location.href.replace("m/", ""));
+export default async function ({ addon, console }) {
+  if (window.location.pathname.startsWith("/discuss/m/")) {
+    window.location.replace(window.location.href.replace("m/", ""));
+  }
 }

--- a/addons/redirect-mobile-forums/userscript.js
+++ b/addons/redirect-mobile-forums/userscript.js
@@ -1,3 +1,3 @@
-export default async function ({ addon, console }) {
+export default async function ({ addon, console, msg }) {
   window.location.replace(window.location.href.replace("m/", ""));
 }

--- a/addons/redirect-mobile-forums/userscript.js
+++ b/addons/redirect-mobile-forums/userscript.js
@@ -1,5 +1,3 @@
 export default async function ({ addon, console }) {
-  if (window.location.pathname.startsWith("/discuss/m/")) {
-    window.location.replace(window.location.href.replace("m/", ""));
-  }
+  window.location.replace(window.location.href.replace("m/", ""));
 }


### PR DESCRIPTION
Closes #6910

### Changes

Enables the Redirect to standard forums addon by default and adjusts the name and description to indicate that the links are broken. Also fixes a race conditon in the addon by also running on `/404`.

### Reason for changes

All links to the mobile forums such as from google search results are broken so there's no reason not to redirect users to the correct URL by default.

### Tests

Tested on Firefox 120
