### PR TITLE
folders: fix duplicated sprite order

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -998,6 +998,14 @@ export default async function ({ addon, console, msg }) {
       });
     };
 
+    const originalDuplicateSprite = vm.duplicateSprite;
+    vm.duplicateSprite = function (...args) {
+      return originalDuplicateSprite.call(this, ...args).then((r) => {
+        fixTargetOrder();
+        return r;
+      });
+    };
+
     const originalAddCostume = RenderedTarget.prototype.addCostume;
     RenderedTarget.prototype.addCostume = function (...args) {
       if (currentAssetFolder !== null) {


### PR DESCRIPTION
Resolves #6564

### Changes

Makes duplicated sprites in folders appear at the end of the folders, not at the end of the sprite list. Duplicating costumes and sounds already works correctly.

### Reason for changes

In the current version, duplicating a sprite in a folder can create another copy of the folder.

### Tests

Tested on Edge and Firefox.