### PR TITLE
Use `event.key` instead of `code` and `keyCode`

### DIFF
--- a/addons/2d-color-picker/paint-editor.js
+++ b/addons/2d-color-picker/paint-editor.js
@@ -129,10 +129,10 @@ export default async ({ addon, console, msg }) => {
     saColorLabel.appendChild(saColorLabelName);
     saColorLabel.appendChild(saColorLabelVal);
 
-    let keyPressed = -1;
+    let keyPressed = null;
     let originalPos = { x: 0, y: 0 };
-    window.addEventListener("keydown", (e) => (keyPressed = e.keyCode));
-    window.addEventListener("keyup", () => (keyPressed = -1));
+    window.addEventListener("keydown", (e) => (keyPressed = e.key));
+    window.addEventListener("keyup", () => (keyPressed = null));
 
     let origHue = 0;
     let el = null;
@@ -149,7 +149,7 @@ export default async ({ addon, console, msg }) => {
     function updateHandle(e, keyPressed, originalPos) {
       let cx = Math.min(Math.max(e.clientX - saColorPicker.getBoundingClientRect().x, 0), 150);
       let cy = Math.min(Math.max(e.clientY - saColorPicker.getBoundingClientRect().y, 0), 150);
-      if (keyPressed === 16) {
+      if (keyPressed === "Shift") {
         if (Math.abs(cx - originalPos.x) > Math.abs(cy - originalPos.y)) cy = originalPos.y;
         else cx = originalPos.x;
       }
@@ -179,7 +179,7 @@ export default async ({ addon, console, msg }) => {
       rateLimiter.limit(() => {
         let ox = Math.min(Math.max(e.clientX - saColorPicker.getBoundingClientRect().x, 0), 150);
         let oy = Math.min(Math.max(e.clientY - saColorPicker.getBoundingClientRect().y, 0), 150);
-        if (keyPressed === 16) {
+        if (keyPressed === "Shift") {
           if (Math.abs(ox - originalPos.x) > Math.abs(oy - originalPos.y)) oy = originalPos.y;
           else ox = originalPos.x;
         }

--- a/addons/ctrl-enter-post/comments.js
+++ b/addons/ctrl-enter-post/comments.js
@@ -19,7 +19,7 @@ export default async function ({ addon, console, msg }) {
     }
 
     textbox.addEventListener("keydown", (e) => {
-      if (!addon.self.disabled && (e.ctrlKey || e.metaKey) && (e.code === "Enter" || e.code === "NumpadEnter")) {
+      if (!addon.self.disabled && (e.ctrlKey || e.metaKey) && e.key === "Enter") {
         button.click();
       }
     });

--- a/addons/ctrl-enter-post/forums.js
+++ b/addons/ctrl-enter-post/forums.js
@@ -10,7 +10,7 @@ export default async function ({ addon }) {
 
   if (!textarea) return;
   textarea.addEventListener("keydown", (e) => {
-    if (!addon.self.disabled && (e.ctrlKey || e.metaKey) && (e.code === "Enter" || e.code === "NumpadEnter")) {
+    if (!addon.self.disabled && (e.ctrlKey || e.metaKey) && e.key === "Enter") {
       postButton.click();
     }
   });

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -632,7 +632,7 @@ export default class DevTools {
 
     let ctrlKey = e.ctrlKey || e.metaKey;
 
-    if (e.keyCode === 37 && ctrlKey) {
+    if (e.key === "ArrowLeft" && ctrlKey) {
       // Ctrl + Left Arrow Key
       if (document.activeElement.tagName === "INPUT") {
         return;
@@ -646,7 +646,7 @@ export default class DevTools {
       }
     }
 
-    if (e.keyCode === 39 && ctrlKey) {
+    if (e.key === "ArrowRight" && ctrlKey) {
       // Ctrl + Right Arrow Key
       if (document.activeElement.tagName === "INPUT") {
         return;

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -105,7 +105,7 @@ export default async function ({ addon }) {
 
   document.body.addEventListener("keydown", (e) => {
     if (addon.self.disabled) return;
-    if (!["ArrowUp", "ArrowDown"].includes(e.code)) return;
+    if (!["ArrowUp", "ArrowDown"].includes(e.key)) return;
     if (!isSupportedElement(e.target)) return;
     if (!e.target.value) return;
     if (!isValidNumber(e.target.value)) return;
@@ -115,7 +115,7 @@ export default async function ({ addon }) {
     // If this is a number input, it will prevent the default browser behavior when pressing up/down in a
     // number input (increase or decrease by 1). If we didn't prevent, the user would be increasing twice.
 
-    let changeBy = e.code === "ArrowUp" ? 1 : -1;
+    let changeBy = e.key === "ArrowUp" ? 1 : -1;
     if (addon.settings.get("useCustom")) {
       let settingValue = e.shiftKey
         ? addon.settings.get("shiftCustom")

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -117,13 +117,13 @@ export default async function ({ addon, msg, console }) {
       this.dropdown.inputKeyDown(e);
 
       // Enter
-      if (e.keyCode === 13) {
+      if (e.key === "Enter") {
         this.findInput.blur();
         return;
       }
 
       // Escape
-      if (e.keyCode === 27) {
+      if (e.key === "Escape") {
         if (this.findInput.value.length > 0) {
           this.findInput.value = ""; // Clear search first, then close on second press
           this.inputChange();
@@ -140,7 +140,7 @@ export default async function ({ addon, msg, console }) {
 
       let ctrlKey = e.ctrlKey || e.metaKey;
 
-      if (e.key === "f" && ctrlKey && !e.shiftKey) {
+      if (e.key.toLowerCase() === "f" && ctrlKey && !e.shiftKey) {
         // Ctrl + F (Override default Ctrl+F find)
         this.findInput.focus();
         this.findInput.select();
@@ -149,7 +149,7 @@ export default async function ({ addon, msg, console }) {
         return true;
       }
 
-      if (e.keyCode === 37 && ctrlKey) {
+      if (e.key === "ArrowLeft" && ctrlKey) {
         // Ctrl + Left Arrow Key
         if (document.activeElement.tagName === "INPUT") {
           return;
@@ -163,7 +163,7 @@ export default async function ({ addon, msg, console }) {
         }
       }
 
-      if (e.keyCode === 39 && ctrlKey) {
+      if (e.key === "ArrowRight" && ctrlKey) {
         // Ctrl + Right Arrow Key
         if (document.activeElement.tagName === "INPUT") {
           return;
@@ -427,21 +427,21 @@ export default async function ({ addon, msg, console }) {
 
     inputKeyDown(e) {
       // Up Arrow
-      if (e.keyCode === 38) {
+      if (e.key === "ArrowUp") {
         this.navigateFilter(-1);
         e.preventDefault();
         return;
       }
 
       // Down Arrow
-      if (e.keyCode === 40) {
+      if (e.key === "ArrowDown") {
         this.navigateFilter(1);
         e.preventDefault();
         return;
       }
 
       // Enter
-      if (e.keyCode === 13) {
+      if (e.key === "Enter") {
         // Any selected on enter? if not select now
         if (this.selected) {
           this.navigateFilter(1);
@@ -727,14 +727,14 @@ export default async function ({ addon, msg, console }) {
 
     inputKeyDown(e) {
       // Left Arrow
-      if (e.keyCode === 37) {
+      if (e.key === "ArrowLeft") {
         if (this.el && this.blocks) {
           this.navLeft(e);
         }
       }
 
       // Right Arrow
-      if (e.keyCode === 39) {
+      if (e.key === "ArrowRight") {
         if (this.el && this.blocks) {
           this.navRight(e);
         }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -19,7 +19,7 @@ export default async function ({ addon, console, msg }) {
   onPauseChanged(setSrc);
 
   document.addEventListener("keydown", function (e) {
-    if (e.altKey && e.code === "KeyX" && !addon.self.disabled) {
+    if (e.altKey && e.key.toLowerCase() === "x" && !addon.self.disabled) {
       e.preventDefault();
       setPaused(!isPaused());
     }


### PR DESCRIPTION
Resolves #6455
Resolves #6456

### Changes

Replaces most uses of `event.code` and `event.keyCode` with `event.key` (`event.key.toLowerCase()` for letters). Code that interacts with Blockly wasn't changed.

### Reason for changes

`event.code` represents the physical key, not the character associated with it. `event.keyCode` is deprecated and depends on the browser and platform.

### Tests

Tested on Edge and Firefox. The find bar shortcut now works with Caps Lock. The pause shortcut now works on keyboard layouts other than QWERTY - I tested this by changing the layout to Dvorak in Windows settings.