### PR TITLE
Fix `ctrl-enter-post` not working on topic creation

### DIFF
--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -47,11 +47,7 @@
     },
     {
       "url": "comments.js",
-      "matches": [
-        "https://scratch.mit.edu/studios/*",
-        "https://scratch.mit.edu/users/*",
-        "projects"
-      ],
+      "matches": ["https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/users/*", "projects"],
       "if": {
         "settings": {
           "comments": true
@@ -60,8 +56,6 @@
     }
   ],
   "versionAdded": "1.18.0",
-  "tags": [
-    "community"
-  ],
+  "tags": ["community"],
   "enabledByDefault": false
 }

--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -32,10 +32,7 @@
   "userscripts": [
     {
       "url": "forums.js",
-      "matches": [
-        "editingScreens",
-        "https://scratch.mit.edu/discuss/misc/*"
-      ],
+      "matches": ["editingScreens", "https://scratch.mit.edu/discuss/misc/*"],
       "if": {
         "settings": {
           "forums": true

--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -33,11 +33,8 @@
     {
       "url": "forums.js",
       "matches": [
-        "https://scratch.mit.edu/discuss/topic/*",
-        "https://scratch.mit.edu/discuss/post/*",
-        "https://scratch.mit.edu/discuss/settings/*",
-        "https://scratch.mit.edu/discuss/misc/*",
-        "https://scratch.mit.edu/discuss/*/topic/add/"
+        "editingScreens",
+        "https://scratch.mit.edu/discuss/misc/*"
       ],
       "if": {
         "settings": {

--- a/addons/ctrl-enter-post/addon.json
+++ b/addons/ctrl-enter-post/addon.json
@@ -36,7 +36,8 @@
         "https://scratch.mit.edu/discuss/topic/*",
         "https://scratch.mit.edu/discuss/post/*",
         "https://scratch.mit.edu/discuss/settings/*",
-        "https://scratch.mit.edu/discuss/misc/*"
+        "https://scratch.mit.edu/discuss/misc/*",
+        "https://scratch.mit.edu/discuss/*/topic/add/"
       ],
       "if": {
         "settings": {
@@ -46,7 +47,11 @@
     },
     {
       "url": "comments.js",
-      "matches": ["https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/users/*", "projects"],
+      "matches": [
+        "https://scratch.mit.edu/studios/*",
+        "https://scratch.mit.edu/users/*",
+        "projects"
+      ],
       "if": {
         "settings": {
           "comments": true
@@ -55,6 +60,8 @@
     }
   ],
   "versionAdded": "1.18.0",
-  "tags": ["community"],
+  "tags": [
+    "community"
+  ],
   "enabledByDefault": false
 }


### PR DESCRIPTION
Resolves #6925

### Changes

Add a match for `/discuss/*/topic/add/` so that it works when creating a new topic in s subforum.
<details>
<summary>Fun Fact</summary>
<br>
Weird this was found so late, I guess mostly because users create new topics a lot lesser than the amount they post.
This is #6927, about 660 pull requests before, #6267 fixed this exact same issue but when reporting a post, and even that was by me 😄
</details>