### PR TITLE
[Readme] Fix broken URL to Chrome docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An addon mainly consists of one or more [userscripts](https://scratchaddons.com/
 
 Each addon declares its own [addon manifest](https://scratchaddons.com/docs/reference/addon-manifest/) (`addon.json` file). This file specifies under which circumstances each one of its userscripts and userstyles should be injected into the page. It also contains user-facing information, such as the description of the feature, and information about the addon's settings.
 
-Userscripts work similarly to [extension content scripts](https://developer.chrome.com/docs/extensions/content_scripts/) running in the "main world" (the unprivileged context where `chrome.*` extension APIs are not available). Userscripts have access to `addon.*` APIs. They can use these built-in utilities for various purposes: waiting until a certain element exists on the page, listening to settings change events, getting a reference to the Scratch VM object, etc.
+Userscripts work similarly to [extension content scripts](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) running in the "main world" (the unprivileged context where `chrome.*` extension APIs are not available). Userscripts have access to `addon.*` APIs. They can use these built-in utilities for various purposes: waiting until a certain element exists on the page, listening to settings change events, getting a reference to the Scratch VM object, etc.
 
 Addons are designed to be compatible with each other. They are also developed with performance, internationalization, accessibility, and privacy in mind.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An addon mainly consists of one or more [userscripts](https://scratchaddons.com/
 
 Each addon declares its own [addon manifest](https://scratchaddons.com/docs/reference/addon-manifest/) (`addon.json` file). This file specifies under which circumstances each one of its userscripts and userstyles should be injected into the page. It also contains user-facing information, such as the description of the feature, and information about the addon's settings.
 
-Userscripts work similarly to [extension content scripts](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) running in the "main world" (the unprivileged context where `chrome.*` extension APIs are not available). Userscripts have access to `addon.*` APIs. They can use these built-in utilities for various purposes: waiting until a certain element exists on the page, listening to settings change events, getting a reference to the Scratch VM object, etc.
+Userscripts work similarly to [extension content scripts](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts) running in the "main world" (the unprivileged context where `chrome.*` extension APIs are not available). Userscripts have access to `addon.*` APIs. They can use these built-in utilities for various purposes: waiting until a certain element exists on the page, listening to settings change events, getting a reference to the Scratch VM object, etc.
 
 Addons are designed to be compatible with each other. They are also developed with performance, internationalization, accessibility, and privacy in mind.
 


### PR DESCRIPTION
Resolves #6946
EDIT: Just realized the chrome docs one exists under a different name, committing

EDIT2: Commited, now uses the chrome docs one. Though if it's not the one it should be, please tell! I'm unsure if this and the one originally used in the `README.md` are really related or not.

This is a really minor change, so I think I don't really need to make an issue about this - Apologies if I am (EDIT: Just incase, I did)

### Changes

Fixes broken URL.

### Reason for changes

The URL is outdated.

### Tests

Tested with Firefox, the readme.md should work