### PR TITLE
Don't escape BBCode tags with `better-quoter` and `show-bbcode`

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -209,7 +209,7 @@ function setup() {
   if (isSetup) return;
   isSetup = true;
   const originalCopyPaste = window.copy_paste;
-  window.copy_paste = function (id) {
+  window.copy_paste = async function (id) {
     const post = $("#" + id);
     const username = post.find(".username").text();
     const idText =
@@ -220,8 +220,8 @@ function setup() {
             false
           )})[/small]`
         : "";
-    getPostText(id, post[0], window.getSelection()).then((text) => {
-      paste(`[quote=${username}]${idText}\n${text}\n[/quote]\n`);
-    });
+    const selection = window.getSelection();
+    const text = post.find("[data-show-bbcode]").length !== 0 ? selection : await getPostText(id, post[0], selection);
+    paste(`[quote=${username}]${idText}\n${text}\n[/quote]\n`);
   };
 }

--- a/addons/show-bbcode/userscript.js
+++ b/addons/show-bbcode/userscript.js
@@ -12,6 +12,7 @@ function viewSource(post, msg) {
       const source = document.createElement("div");
       body.insertBefore(source, body.firstElementChild);
       source.className = "post_body_html";
+      source.dataset.showBbcode = "";
       if (event.target.sourceText !== undefined) {
         event.target.setAttribute("data-state", "source");
         source.innerText = event.target.sourceText;


### PR DESCRIPTION
Resolves #6948

### Changes

Add a data attribute to the element added by `show-bbcode`, so that `better-quoter` can see it and not escape brackets.

### Reason for changes

To make the interop make more sense and be useful.

### Tests

Tested in Edge.
