### PR TITLE
Multiple addons: Add wildcards to /mystuff URL matches

### DIFF
--- a/addons/hide-project-stats/addon.json
+++ b/addons/hide-project-stats/addon.json
@@ -56,42 +56,42 @@
     },
     {
       "url": "hide_remix_count.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "settings": { "remixes": true, "myStuff": true }
       }
     },
     {
       "url": "hide_view_count.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "settings": { "views": true, "myStuff": true }
       }
     },
     {
       "url": "hide_love_count.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "settings": { "loves": true, "myStuff": true }
       }
     },
     {
       "url": "hide_favorite_count.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "settings": { "favorites": true, "myStuff": true }
       }
     },
     {
       "url": "hide_comment_count.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "settings": { "comments": true, "myStuff": true }
       }
     },
     {
       "url": "hide_studio_count.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "settings": { "studios": true, "myStuff": true }
       }

--- a/addons/horizontal-mystuff-tabs/addon.json
+++ b/addons/horizontal-mystuff-tabs/addon.json
@@ -15,11 +15,11 @@
   "userstyles": [
     {
       "url": "style.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"]
+      "matches": ["https://scratch.mit.edu/mystuff/*"]
     },
     {
       "url": "scratchr2.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "if": {
         "addonEnabled": ["scratchr2"]
       }

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -82,7 +82,7 @@
     },
     {
       "url": "mystuff.css",
-      "matches": ["https://scratch.mit.edu/mystuff/"]
+      "matches": ["https://scratch.mit.edu/mystuff/*"]
     },
     {
       "url": "settings.css",

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -74,7 +74,7 @@
     {
       "url": "v_tabs.css",
       "matches": [
-        "https://scratch.mit.edu/mystuff/",
+        "https://scratch.mit.edu/mystuff/*",
         "https://scratch.mit.edu/accounts/settings/*",
         "https://scratch.mit.edu/accounts/password_change/",
         "https://scratch.mit.edu/accounts/email_change/"

--- a/addons/search-my-stuff/addon.json
+++ b/addons/search-my-stuff/addon.json
@@ -18,13 +18,13 @@
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["https://scratch.mit.edu/mystuff"]
+      "matches": ["https://scratch.mit.edu/mystuff/*"]
     }
   ],
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/mystuff"]
+      "matches": ["https://scratch.mit.edu/mystuff/*"]
     }
   ],
   "libraries": ["fuse"],

--- a/addons/share-through-mystuff/addon.json
+++ b/addons/share-through-mystuff/addon.json
@@ -10,13 +10,13 @@
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["https://scratch.mit.edu/mystuff"]
+      "matches": ["https://scratch.mit.edu/mystuff/*"]
     }
   ],
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/mystuff"],
+      "matches": ["https://scratch.mit.edu/mystuff/*"],
       "runAtComplete": true
     }
   ],


### PR DESCRIPTION
Resolves #6945 
see there for more context, tl;dr: add whatever besides a section to mystuff and if you have addons that have a match related to mystuff then they won't load for the entire millenium
Also fixes these not loading:
- `share-through-mystuff`
- `scratchr2` (things related to this issue)
- `hide-project-stats`
- `search-my-stuff`

### Changes

Adds wildcards after most MyStuff matches 

### Reason for changes

Make the addons load even if it's technically not really needed, not needed to merge.

### Tests

Tested on LibreWolf v120.0-2 32 bit.