### PR TITLE
Fix `better-quoter` not quoting anything when not selecting anything with `show-bbcode`

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -221,7 +221,13 @@ function setup() {
           )})[/small]`
         : "";
     const selection = window.getSelection();
-    const text = post.find("[data-show-bbcode]").length !== 0 ? selection : await getPostText(id, post[0], selection);
+    const showBbcode = post.find("[data-show-bbcode]");
+    const text =
+      showBbcode.length !== 0
+        ? selection.toString() === ""
+          ? showBbcode[0].innerText
+          : selection
+        : await getPostText(id, post[0], selection);
     paste(`[quote=${username}]${idText}\n${text}\n[/quote]\n`);
   };
 }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #6964

### Changes

Adds a check for whether the user has actually selected anything, and in that case output the entire BBCode.

### Reason for changes

To fix a bug.

### Tests

Tested, hopefully to full extent, in Edge