### PR TITLE
Fix z-index compat between `old-studio-layout`/`studio-followers` & `collapse-footer`

### DIFF
--- a/addons/collapse-footer/userstyle.css
+++ b/addons/collapse-footer/userstyle.css
@@ -48,6 +48,13 @@
   --footer-hover-height: 328px; /* How high the hovered footer is (for donor text fix) */
 }
 
-.studio-projects .studio-adder-section .studio-adder-row button ~ button:not(.sa-pseudobutton), .studio-tabs #sa-studio-followers-button /* old-studio-layout compatibility */ {
+/* old-studio-layout compatibility */
+
+.studio-projects .studio-adder-section .studio-adder-row button ~ button:not(.sa-pseudobutton),
+.studio-tabs #sa-studio-followers-button {
   bottom: 24px;
+}
+
+.ReactModalPortal .user-projects-modal {
+  bottom: 70px;
 }

--- a/addons/collapse-footer/userstyle.css
+++ b/addons/collapse-footer/userstyle.css
@@ -47,3 +47,7 @@
 :root {
   --footer-hover-height: 328px; /* How high the hovered footer is (for donor text fix) */
 }
+
+.studio-projects .studio-adder-section .studio-adder-row button ~ button:not(.sa-pseudobutton), .studio-tabs #sa-studio-followers-button /* old-studio-layout compatibility */ {
+  bottom: 24px;
+}

--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -98,7 +98,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  z-index: 21; /* Higher than infinite-scroll fixed footer */
+  z-index: 19;
   background-color: var(--darkWww-box, white);
   border-top: 1px solid var(--darkWww-border-15, #d9d9d9);
   border-radius: 0;


### PR DESCRIPTION
Resolves #6968

### Changes

Instead of making "Browse Projects" and "Browse Followers" override `collapse-footer`, make the footer appear below the pane.

### Reason for changes

To make the footer still accessible in studio pages.

![The footer being below the browse projects pane on a studio page scrolled to the bottom](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/53920f14-daaf-4b60-9e45-544e08b81310)

### Tests

Tested in Edge.
