### PR TITLE
Change "argument" to "parameter"

### DIFF
--- a/addons/block-switching/addon.json
+++ b/addons/block-switching/addon.json
@@ -85,24 +85,24 @@
       }
     },
     {
-      "name": "Custom block arguments",
+      "name": "Custom block parameters",
       "id": "customargs",
       "type": "boolean",
       "default": true
     },
     {
-      "name": "Shown custom block arguments options",
+      "name": "Shown custom block parameters options",
       "id": "customargsmode",
       "type": "select",
       "default": "defOnly",
       "potentialValues": [
         {
           "id": "defOnly",
-          "name": "Arguments in own custom block"
+          "name": "Parameters in own custom block"
         },
         {
           "id": "all",
-          "name": "Arguments in all custom blocks in sprite"
+          "name": "Parameters in all custom blocks in sprite"
         }
       ],
       "if": {


### PR DESCRIPTION
### Changes

In the `block-switching` addon, changes occurrences of the word "argument" to "parameter". To my knowledge, the computer science terms "argument" and "parameter" are used interchangeably, but in Scratch, they are officially called parameters, according to the Scratch Team's latest [tutorial video](https://youtu.be/596LEqy6p7M). IMO, I also think "custom block parameter" might be understood by more users.

### Reason for changes

Consistency with the official terminology.

### Tests

Not tested.