### PR TITLE
Allow opening /source in a new tab with `show-bbcode`

### DIFF
--- a/addons/show-bbcode/addon.json
+++ b/addons/show-bbcode/addon.json
@@ -14,7 +14,24 @@
       "matches": ["https://scratch.mit.edu/discuss/topic/*"]
     }
   ],
+  "settings": [
+    {
+      "id": "display-type",
+      "name": "Display type",
+      "type": "select",
+      "potentialValues": [
+        { "id": "source", "name": "Show source in post" },
+        { "id": "new-tab", "name": "Open in new tab" }
+      ],
+      "default": "source"
+    }
+  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "versionAdded": "1.9.0"
+  "versionAdded": "1.9.0",
+  "latestUpdate": {
+    "isMajor": false,
+    "version": "1.36.0",
+    "newSettings": ["display-type"]
+  }
 }

--- a/addons/show-bbcode/userscript.js
+++ b/addons/show-bbcode/userscript.js
@@ -1,46 +1,3 @@
-function viewSource(post, msg, addon) {
-  return function (event) {
-    event.preventDefault();
-    const body = post.querySelector(".postmsg");
-    if (event.target.getAttribute("data-state") === "post") {
-      const sourceLink = "https://scratch.mit.edu/discuss/post/" + post.id.substring(1) + "/source/";
-      if (addon.settings.get("display-type") === "new-tab") {
-        open(sourceLink);
-        return;
-      }
-      event.target.innerText = msg("source-button-active");
-      event.target.removeAttribute("title");
-      if (event.target.originalHTML === undefined) {
-        event.target.originalHTML = body.firstElementChild;
-      }
-      body.removeChild(body.firstElementChild);
-      const source = document.createElement("div");
-      body.insertBefore(source, body.firstElementChild);
-      source.className = "post_body_html";
-      source.dataset.showBbcode = "";
-      if (event.target.sourceText !== undefined) {
-        event.target.setAttribute("data-state", "source");
-        source.innerText = event.target.sourceText;
-        return;
-      }
-      event.target.setAttribute("data-state", "loading");
-      source.innerText = msg("loading");
-      fetch(sourceLink).then(function (res) {
-        res.text().then(function (text) {
-          event.target.setAttribute("data-state", "source");
-          source.innerText = event.target.sourceText = text;
-        });
-      });
-    } else if (event.target.getAttribute("data-state") === "source") {
-      event.target.innerText = msg("source-button");
-      event.target.title = msg("source-button-tooltip");
-      event.target.setAttribute("data-state", "post");
-      body.removeChild(body.firstElementChild);
-      body.insertBefore(event.target.originalHTML, body.firstElementChild);
-    }
-  };
-}
-
 export default async function ({ addon, console, msg }) {
   while (true) {
     const post = await addon.tab.waitForElement(".blockpost", { markAsSeen: true });
@@ -54,6 +11,45 @@ export default async function ({ addon, console, msg }) {
     sourceButton.innerText = msg("source-button");
     sourceButton.title = msg("source-button-tooltip");
     sourceButton.setAttribute("data-state", "post");
-    sourceButton.addEventListener("click", viewSource(post, msg, addon));
+    sourceButton.addEventListener("click", function (event) {
+      event.preventDefault();
+      const body = post.querySelector(".postmsg");
+      if (event.target.getAttribute("data-state") === "post") {
+        const sourceLink = "https://scratch.mit.edu/discuss/post/" + post.id.substring(1) + "/source/";
+        if (addon.settings.get("display-type") === "new-tab") {
+          open(sourceLink);
+          return;
+        }
+        event.target.innerText = msg("source-button-active");
+        event.target.removeAttribute("title");
+        if (event.target.originalHTML === undefined) {
+          event.target.originalHTML = body.firstElementChild;
+        }
+        body.removeChild(body.firstElementChild);
+        const source = document.createElement("div");
+        body.insertBefore(source, body.firstElementChild);
+        source.className = "post_body_html";
+        source.dataset.showBbcode = "";
+        if (event.target.sourceText !== undefined) {
+          event.target.setAttribute("data-state", "source");
+          source.innerText = event.target.sourceText;
+          return;
+        }
+        event.target.setAttribute("data-state", "loading");
+        source.innerText = msg("loading");
+        fetch(sourceLink).then(function (res) {
+          res.text().then(function (text) {
+            event.target.setAttribute("data-state", "source");
+            source.innerText = event.target.sourceText = text;
+          });
+        });
+      } else if (event.target.getAttribute("data-state") === "source") {
+        event.target.innerText = msg("source-button");
+        event.target.title = msg("source-button-tooltip");
+        event.target.setAttribute("data-state", "post");
+        body.removeChild(body.firstElementChild);
+        body.insertBefore(event.target.originalHTML, body.firstElementChild);
+      }
+    });
   }
 }

--- a/addons/show-bbcode/userscript.js
+++ b/addons/show-bbcode/userscript.js
@@ -1,8 +1,13 @@
-function viewSource(post, msg) {
+function viewSource(post, msg, addon) {
   return function (event) {
     event.preventDefault();
     const body = post.querySelector(".postmsg");
     if (event.target.getAttribute("data-state") === "post") {
+      const sourceLink = "https://scratch.mit.edu/discuss/post/" + post.id.substring(1) + "/source/";
+      if (addon.settings.get("display-type") === "new-tab") {
+        open(sourceLink);
+        return;
+      }
       event.target.innerText = msg("source-button-active");
       event.target.removeAttribute("title");
       if (event.target.originalHTML === undefined) {
@@ -20,7 +25,7 @@ function viewSource(post, msg) {
       }
       event.target.setAttribute("data-state", "loading");
       source.innerText = msg("loading");
-      fetch("https://scratch.mit.edu/discuss/post/" + post.id.substring(1) + "/source/").then(function (res) {
+      fetch(sourceLink).then(function (res) {
         res.text().then(function (text) {
           event.target.setAttribute("data-state", "source");
           source.innerText = event.target.sourceText = text;
@@ -49,6 +54,6 @@ export default async function ({ addon, console, msg }) {
     sourceButton.innerText = msg("source-button");
     sourceButton.title = msg("source-button-tooltip");
     sourceButton.setAttribute("data-state", "post");
-    sourceButton.addEventListener("click", viewSource(post, msg));
+    sourceButton.addEventListener("click", viewSource(post, msg, addon));
   }
 }


### PR DESCRIPTION
Resolves #6937

### Changes

Add a setting to `show-bbcode` allowing opening the source in a new tab.

![The "DISPLAY TYPE" setting with the options "Show source in post" and "Open in new tab".](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/b6b30ab6-590f-488e-9b6e-8c6d256daf79)

### Reason for changes

It's easier to go through.

### Tests

Tested in Edge.
