### PR TITLE
search-my-stuff: don't show search bar when disabled

### DIFF
--- a/addons/search-my-stuff/userscript.js
+++ b/addons/search-my-stuff/userscript.js
@@ -104,6 +104,7 @@ export default async function ({ addon, console, msg }) {
    * updated.
    */
   async function inject() {
+    if (addon.self.disabled) return;
     // Determine which tab we're on and switch the placeholder text
     if (window.location.href.includes("galleries")) {
       searchBar.setAttribute("placeholder", msg("studio-placeholder"));


### PR DESCRIPTION
### Changes

Checks if the addon is enabled before adding the search bar.

To reproduce the bug in the current version:
* Enable the addon and open My Stuff
* Disable the addon
* Switch to a different tab (Project/Studios/Trash)

### Tests

Tested on Edge and Firefox.