### PR TITLE
Confirm clicking Reply while writing a comment

### DIFF
--- a/addons/confirm-actions/userscript.js
+++ b/addons/confirm-actions/userscript.js
@@ -48,14 +48,21 @@ export default async function ({ addon, console, msg }) {
       } else if (addon.settings.get("closingtopic") && e.target.closest("dd form button")) {
         title = msg("closetopic-title");
         cancelMessage = msg("closetopic");
-      } else if (
-        addon.settings.get("cancelcomment") &&
-        e.target.closest("div[data-control='cancel'] > a, .compose-cancel")
-      ) {
-        // Do not ask to confirm canceling empty comments
-        if (e.target.closest("form").querySelector("textarea").value === "") return;
-        title = msg("cancelcomment-title");
-        cancelMessage = msg("cancelcomment");
+      } else if (addon.settings.get("cancelcomment")) {
+        if (e.target.closest("div[data-control='cancel'] > a, .compose-cancel")) {
+          // Do not ask to confirm canceling empty comments
+          if (e.target.closest("form").querySelector("textarea").value === "") return;
+          title = msg("cancelcomment-title");
+          cancelMessage = msg("cancelcomment");
+        }
+        // Clicking "Reply" while writing a reply also discards the comment
+        else if (e.target.closest("a[data-control='reply-to'], .comment-reply")) {
+          // Do not ask to confirm canceling empty comments
+          if (e.target.closest(".comment .info, .comment-body").querySelector("textarea")?.value.length > 0) {
+            title = msg("cancelcomment-title");
+            cancelMessage = msg("cancelcomment");
+          }
+        }
       } else if (addon.settings.get("removingprojects") && e.target.closest(".media-trash")) {
         title = msg("removeproject-title");
         cancelMessage = msg("removeproject");


### PR DESCRIPTION
Resolves #7000

https://github.com/ScratchAddons/ScratchAddons/assets/106490990/ae2df17a-fc3f-4d0a-97a6-645e59fa00c2

### Changes

Each comment on Scratch has a reply button that shows the comment box when clicked. If you click on the reply button again, the comment box is removed and your comment gets discarded. This update shows a confirmation before this action, if you've enabled "Confirm canceling comments", of course.

### Reason for changes

To prevent accidentally discarding comments.

### Tests

Tested on profile pages, projects, and studios, only a little bit.
