### PR TITLE
editor-theme3: fix labels in custom block editor

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -93,6 +93,31 @@
       }
     },
     {
+      "name": "inputColor-editableLabel",
+      "value": {
+        "type": "alphaBlend",
+        "opaqueSource": {
+          "type": "map",
+          "source": {
+            "type": "settingValue",
+            "settingId": "text"
+          },
+          "options": {
+            "colorOnWhite": "#ffffff",
+            "colorOnBlack": "#282828"
+          },
+          "default": {
+            "type": "settingValue",
+            "settingId": "custom-color"
+          }
+        },
+        "transparentSource": {
+          "type": "settingValue",
+          "settingId": "input-color"
+        }
+      }
+    },
+    {
       "name": "commentText",
       "value": {
         "type": "textColor",

--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -6,6 +6,10 @@
 .blocklyEditableText > text {
   fill: var(--editorTheme3-inputColor-blackText);
 }
+.sa-theme3-editable-label .blocklyHtmlInput {
+  /* Labels in custom block editor */
+  color: var(--editorTheme3-inputColor-blackText);
+}
 
 .blocklyDropDownDiv .goog-menuitem {
   color: black;

--- a/addons/editor-theme3/color_on_white.css
+++ b/addons/editor-theme3/color_on_white.css
@@ -4,6 +4,10 @@
   opacity: 0.6;
 }
 
+.blocklyEditableText > .blocklyEditableLabel {
+  fill: black;
+}
+
 .u-dropdown-searchbar,
 .u-dropdown-searchbar:focus,
 .blocklyDropDownDiv .goog-menuitem {

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -8,6 +8,11 @@
   color: transparent;
   caret-color: var(--editorTheme3-inputColor-text);
 }
+.sa-theme3-editable-label .blocklyHtmlInput {
+  /* Labels in custom block editor */
+  background-color: var(--editorTheme3-inputColor-editableLabel);
+  color: var(--editorTheme3-inputColor-text);
+}
 
 /* Override Scratch's high contrast theme */
 .blocklyDropDownDiv .goog-menuitem {

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -255,7 +255,16 @@ export default async function ({ addon, console, msg }) {
     oldFieldTextInputInit.call(this);
     if (this.sourceBlock_.isShadow()) return;
     // Labels in custom block editor
-    this.box_.setAttribute("fill", fieldBackground(this));
+    this.box_.setAttribute("fill", isColoredTextMode() ? fieldBackground(this) : this.sourceBlock_.getColourTertiary());
+  };
+
+  const oldFieldTextInputRemovableShowEditor = Blockly.FieldTextInputRemovable.prototype.showEditor_;
+  Blockly.FieldTextInputRemovable.prototype.showEditor_ = function () {
+    oldFieldTextInputRemovableShowEditor.call(this);
+    if (!this.sourceBlock_.isShadow()) {
+      // Labels in custom block editor
+      Blockly.WidgetDiv.DIV.classList.add("sa-theme3-editable-label");
+    }
   };
 
   const oldFieldImageSetValue = Blockly.FieldImage.prototype.setValue;


### PR DESCRIPTION
Resolves #7015

### Changes

Changes the background of labels in the custom block modal:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/23451885-2f1e-491f-b2cb-67ffd9561b9b)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/306a1b46-a932-455d-8d54-33eef1c5ae81)

Also fixes the text color in the "color on white" mode:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/cd3fee1f-e7d2-4f95-8fc3-ac3f61017ab5)

It looks like this on master:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/4b427e5d-a5d2-4e71-9868-c0c5d5ead71c)

### Reason for changes

To make the label text readable.

### Tests

Tested on Edge and Firefox.