### PR TITLE
middle-click-popup: only show popup in editor

### DIFF
--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -106,6 +106,7 @@ export default async function ({ addon, msg, console }) {
     if (addon.self.disabled) return;
 
     // Don't show the menu if we're not in the code editor
+    if (addon.tab.editorMode !== "editor") return;
     if (addon.tab.redux.state.scratchGui.editorTab.activeTabIndex !== 0) return;
 
     blockTypes = BlockTypeInfo.getBlocks(Blockly, vm, Blockly.getMainWorkspace(), msg);


### PR DESCRIPTION
Resolves #7011

Tested on Edge and Firefox.