### PR TITLE
Style WebGL modal with `editor-dark-mode`

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -378,7 +378,6 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="tag-button_tag-button_"]:not([class*="tag-button_active_"]),
 [class*="action-menu_button_"],
 [class*="context-menu_menu-item_"]:not([class*="context-menu_menu-item-danger_"]):hover,
-[class*="webgl-modal_button-row"] > button,
 .blocklyWidgetDiv .goog-menuitem-highlight,
 .blocklyWidgetDiv .goog-menuitem-hover {
   background-color: var(--editorDarkMode-primary);
@@ -387,7 +386,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="gui_extension-button-container_"],
 [class*="prompt_button-row_"] button[class*="prompt_ok-button_"],
 [class*="custom-procedures_button-row_"] button[class*="custom-procedures_ok-button_"],
-[class*="record-modal_button-row_"] button[class*="record-modal_ok-button_"] {
+[class*="record-modal_button-row_"] button[class*="record-modal_ok-button_"],
+[class*="webgl-modal_button-row"] > button {
   background-color: var(--editorDarkMode-primary);
   border-color: var(--editorDarkMode-primary);
 }

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -23,7 +23,8 @@
 [class*="menu-bar_menu-bar_"],
 [class*="menu_menu_"],
 [class*="menu_submenu_"] > [class*="menu_menu_"]::-webkit-scrollbar-track,
-[class*="modal_header_"] {
+[class*="modal_header_"],
+[class*="webgl-modal_illustration"] {
   background-color: var(--editorDarkMode-menuBar);
   color: var(--editorDarkMode-menuBar-text);
 }
@@ -172,6 +173,7 @@
 [class*="custom-procedures_body_"],
 [class*="slider-prompt_body_"],
 [class*="record-modal_body_"],
+[class*="webgl-modal_body_"],
 .sa-debugger-interface,
 .sa-debugger-tabs li.sa-debugger-tab-selected {
   background-color: var(--editorDarkMode-accent);
@@ -190,6 +192,7 @@
 [class*="sound-editor_effect-button_"],
 [class*="library-item_featured-extension-metadata_"],
 [class*="record-modal_help-text_"],
+[class*="webgl-modal_body_"] > *,
 .sa-editor-modal-content p {
   color: var(--editorDarkMode-accent-text);
 }
@@ -375,6 +378,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="tag-button_tag-button_"]:not([class*="tag-button_active_"]),
 [class*="action-menu_button_"],
 [class*="context-menu_menu-item_"]:not([class*="context-menu_menu-item-danger_"]):hover,
+[class*="webgl-modal_button-row"] > button,
 .blocklyWidgetDiv .goog-menuitem-highlight,
 .blocklyWidgetDiv .goog-menuitem-hover {
   background-color: var(--editorDarkMode-primary);


### PR DESCRIPTION
Resolves #7037

### Changes

Add the classes from the WebGL not supported modal to some preexisting rules.

![The WebGL modal in dark mode](https://i.ibb.co/5rRW633/yay.png)

### Reason for changes

Consistency.

### Tests

Tested in Edge.