### PR TITLE
editor-dark-mode: fix dangerous context menu items

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -374,11 +374,14 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="audio-trimmer_selection-background_"],
 [class*="tag-button_tag-button_"]:not([class*="tag-button_active_"]),
 [class*="action-menu_button_"],
-[class*="context-menu_menu-item_"]:not([class*="context-menu_menu-item-danger_"]):hover,
+[class*="context-menu_menu-item_"]:hover,
 .blocklyWidgetDiv .goog-menuitem-highlight,
 .blocklyWidgetDiv .goog-menuitem-hover {
   background-color: var(--editorDarkMode-primary);
   color: var(--editorDarkMode-primary-text);
+}
+[class*="context-menu_menu-item-danger_"]:hover {
+  background-color: hsla(30, 100%, 55%, 1);
 }
 [class*="gui_extension-button-container_"],
 [class*="prompt_button-row_"] button[class*="prompt_ok-button_"],


### PR DESCRIPTION
### Changes

Makes dangerous context menu items styled correctly when editor dark mode is enabled.
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/19f7567a-128e-4fc1-98bb-0f0740d53842)

### Reason for changes

They were broken by #5595. The screenshot in https://github.com/ScratchAddons/ScratchAddons/pull/7030#issuecomment-1878020628 shows what they currently look like.

### Tests

Tested on Edge and Firefox.