### PR TITLE
New addon: Extend wrapped C blocks

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -151,6 +151,8 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "editor-block-chomping",
+
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -153,7 +153,6 @@
   "collapse-footer",
   "editor-block-chomping",
 
-
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",
   "// because the first in the list gets their CSS injected first,",

--- a/addons/editor-block-chomping/addon.json
+++ b/addons/editor-block-chomping/addon.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ScratchAddons/manifest-schema/dist/schema.json",
+  "name": "C block chomping",
+  "description": "Makes C blocks extend when you drag them around a script, like in Scratch 2.0.",
+  "credits": [
+    {
+      "name": "CST1229",
+      "link": "https://github.com/CST1229/"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "tags": [
+    "editor",
+    "codeEditor"
+  ],
+  "enabledByDefault": false,
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.36.0"
+}

--- a/addons/editor-block-chomping/addon.json
+++ b/addons/editor-block-chomping/addon.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ScratchAddons/manifest-schema/dist/schema.json",
-  "name": "C block chomping",
-  "description": "Makes C blocks extend when you drag them around a script, like in Scratch 2.0.",
+  "name": "Extend wrapped C blocks",
+  "description": "Makes C blocks extend when wrapping them around blocks, like in Scratch 2.0.",
   "credits": [
     {
       "name": "CST1229",

--- a/addons/editor-block-chomping/addon.json
+++ b/addons/editor-block-chomping/addon.json
@@ -14,10 +14,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": [
-    "editor",
-    "codeEditor"
-  ],
+  "tags": ["editor", "codeEditor"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true,

--- a/addons/editor-block-chomping/userscript.js
+++ b/addons/editor-block-chomping/userscript.js
@@ -1,0 +1,55 @@
+export default async function ({ addon, msg, console }) {
+	const ScratchBlocks = await addon.tab.traps.getBlockly();
+
+	const ogConnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_;
+	ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_ = function() {
+		ogConnectMarker.call(this);
+		if (this.firstMarker_) {
+			const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
+			if (block) block.render(false);
+		}
+	}
+	const ogDisconnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_;
+	ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_ = function() {
+		ogDisconnectMarker.call(this);
+		if (this.firstMarker_) {
+			const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
+			block.noMoveConnection = true;
+			if (block) block.render(false);
+		}
+	}
+
+	const ogDraw = ScratchBlocks.BlockSvg.prototype.renderDraw_;
+	const ogMoveConnections = ScratchBlocks.BlockSvg.prototype.renderMoveConnections_;
+	ScratchBlocks.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
+		if (addon.self.disabled) return ogDraw.call(this, iconWidth, inputRows);
+
+		let computeBlock = this;
+		if (this?.workspace?.currentGesture_?.blockDragger_?.draggedConnectionManager_) {
+			const dragger = this.workspace.currentGesture_.blockDragger_;
+			const manager = dragger.draggedConnectionManager_;
+			if (manager.markerConnection_ && manager.firstMarker_ && dragger.draggingBlock_ == this && dragger.draggingBlock_.type == manager.firstMarker_.type) {
+				computeBlock = manager.firstMarker_;
+			}
+		}
+		// change the height of substacks
+		// (if we set inputRows to computeBlock.renderCompute_,
+		// the references to the inputs would be wrong
+		// so they just won't update properly)
+		if (computeBlock !== this) {
+			const _inputRows = computeBlock.renderCompute_(iconWidth);
+			for (let i = 0; i < inputRows.length; i++) {
+				const row = inputRows[i];
+				row.height = _inputRows[i].height;
+			}
+		}
+
+		ogDraw.call(this, iconWidth, inputRows);
+		if (computeBlock === this && !this.noMoveConnection) ogMoveConnections.call(this);
+		this.noMoveConnection = false;
+	};
+	ScratchBlocks.BlockSvg.prototype.renderMoveConnections_ = function() {
+		if (addon.self.disabled) return ogDraw.call(this);
+		// do nothing (this function is instead called by renderDraw_)
+	};
+}

--- a/addons/editor-block-chomping/userscript.js
+++ b/addons/editor-block-chomping/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, msg, console }) {
+export default async function ({ addon }) {
 	const ScratchBlocks = await addon.tab.traps.getBlockly();
 
 	// Rerender the dragged block when updating the insertion marker

--- a/addons/editor-block-chomping/userscript.js
+++ b/addons/editor-block-chomping/userscript.js
@@ -1,18 +1,20 @@
 export default async function ({ addon, msg, console }) {
 	const ScratchBlocks = await addon.tab.traps.getBlockly();
 
+	// Rerender the dragged block when updating the insertion marker
 	const ogConnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_;
 	ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_ = function() {
 		ogConnectMarker.call(this);
-		if (this.firstMarker_) {
+		if (!addon.self.disabled && this.firstMarker_) {
 			const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
+			block.noMoveConnection = true;
 			if (block) block.render(false);
 		}
 	}
 	const ogDisconnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_;
 	ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_ = function() {
 		ogDisconnectMarker.call(this);
-		if (this.firstMarker_) {
+		if (!addon.self.disabled && this.firstMarker_) {
 			const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
 			block.noMoveConnection = true;
 			if (block) block.render(false);
@@ -24,32 +26,44 @@ export default async function ({ addon, msg, console }) {
 	ScratchBlocks.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
 		if (addon.self.disabled) return ogDraw.call(this, iconWidth, inputRows);
 
+		// If the block contains a statement (C) input and has an insertion marker,
+		// use that to calculate the height of the statement inputs
 		let computeBlock = this;
 		if (this?.workspace?.currentGesture_?.blockDragger_?.draggedConnectionManager_) {
 			const dragger = this.workspace.currentGesture_.blockDragger_;
 			const manager = dragger.draggedConnectionManager_;
 			if (manager.markerConnection_ && manager.firstMarker_ && dragger.draggingBlock_ == this && dragger.draggingBlock_.type == manager.firstMarker_.type) {
-				computeBlock = manager.firstMarker_;
+				if (inputRows.some(row => row.some(input => input.type === ScratchBlocks.NEXT_STATEMENT))) {
+					computeBlock = manager.firstMarker_;
+				}
 			}
 		}
-		// change the height of substacks
-		// (if we set inputRows to computeBlock.renderCompute_,
+
+		// Change the height of substacks
+		// (If we set inputRows to computeBlock.renderCompute_,
 		// the references to the inputs would be wrong
 		// so they just won't update properly)
 		if (computeBlock !== this) {
 			const _inputRows = computeBlock.renderCompute_(iconWidth);
 			for (let i = 0; i < inputRows.length; i++) {
 				const row = inputRows[i];
-				row.height = _inputRows[i].height;
+				let update = false;
+				for (const input of row) {
+					if (input.type === ScratchBlocks.NEXT_STATEMENT) update = true;
+				}
+				if (update) row.height = Math.max(row.height, _inputRows[i].height);
 			}
 		}
 
 		ogDraw.call(this, iconWidth, inputRows);
+
+		// Moving the connections of a block while it's being dragged breaks it,
+		// so don't
 		if (computeBlock === this && !this.noMoveConnection) ogMoveConnections.call(this);
 		this.noMoveConnection = false;
 	};
 	ScratchBlocks.BlockSvg.prototype.renderMoveConnections_ = function() {
-		if (addon.self.disabled) return ogDraw.call(this);
-		// do nothing (this function is instead called by renderDraw_)
+		if (addon.self.disabled) return ogMoveConnections.call(this);
+		// Do nothing (this function is instead called by renderDraw_)
 	};
 }

--- a/addons/editor-block-chomping/userscript.js
+++ b/addons/editor-block-chomping/userscript.js
@@ -1,69 +1,74 @@
 export default async function ({ addon }) {
-	const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
 
-	// Rerender the dragged block when updating the insertion marker
-	const ogConnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_;
-	ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_ = function() {
-		ogConnectMarker.call(this);
-		if (!addon.self.disabled && this.firstMarker_) {
-			const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
-			block.noMoveConnection = true;
-			if (block) block.render(false);
-		}
-	}
-	const ogDisconnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_;
-	ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_ = function() {
-		ogDisconnectMarker.call(this);
-		if (!addon.self.disabled && this.firstMarker_) {
-			const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
-			block.noMoveConnection = true;
-			if (block) block.render(false);
-		}
-	}
+  // Rerender the dragged block when updating the insertion marker
+  const ogConnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_;
+  ScratchBlocks.InsertionMarkerManager.prototype.connectMarker_ = function () {
+    ogConnectMarker.call(this);
+    if (!addon.self.disabled && this.firstMarker_) {
+      const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
+      block.noMoveConnection = true;
+      if (block) block.render(false);
+    }
+  };
+  const ogDisconnectMarker = ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_;
+  ScratchBlocks.InsertionMarkerManager.prototype.disconnectMarker_ = function () {
+    ogDisconnectMarker.call(this);
+    if (!addon.self.disabled && this.firstMarker_) {
+      const block = this?.workspace_?.currentGesture_?.blockDragger_?.draggingBlock_;
+      block.noMoveConnection = true;
+      if (block) block.render(false);
+    }
+  };
 
-	const ogDraw = ScratchBlocks.BlockSvg.prototype.renderDraw_;
-	const ogMoveConnections = ScratchBlocks.BlockSvg.prototype.renderMoveConnections_;
-	ScratchBlocks.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
-		if (addon.self.disabled) return ogDraw.call(this, iconWidth, inputRows);
+  const ogDraw = ScratchBlocks.BlockSvg.prototype.renderDraw_;
+  const ogMoveConnections = ScratchBlocks.BlockSvg.prototype.renderMoveConnections_;
+  ScratchBlocks.BlockSvg.prototype.renderDraw_ = function (iconWidth, inputRows) {
+    if (addon.self.disabled) return ogDraw.call(this, iconWidth, inputRows);
 
-		// If the block contains a statement (C) input and has an insertion marker,
-		// use that to calculate the height of the statement inputs
-		let computeBlock = this;
-		if (this?.workspace?.currentGesture_?.blockDragger_?.draggedConnectionManager_) {
-			const dragger = this.workspace.currentGesture_.blockDragger_;
-			const manager = dragger.draggedConnectionManager_;
-			if (manager.markerConnection_ && manager.firstMarker_ && dragger.draggingBlock_ == this && dragger.draggingBlock_.type == manager.firstMarker_.type) {
-				if (inputRows.some(row => row.some(input => input.type === ScratchBlocks.NEXT_STATEMENT))) {
-					computeBlock = manager.firstMarker_;
-				}
-			}
-		}
+    // If the block contains a statement (C) input and has an insertion marker,
+    // use that to calculate the height of the statement inputs
+    let computeBlock = this;
+    if (this?.workspace?.currentGesture_?.blockDragger_?.draggedConnectionManager_) {
+      const dragger = this.workspace.currentGesture_.blockDragger_;
+      const manager = dragger.draggedConnectionManager_;
+      if (
+        manager.markerConnection_ &&
+        manager.firstMarker_ &&
+        dragger.draggingBlock_ == this &&
+        dragger.draggingBlock_.type == manager.firstMarker_.type
+      ) {
+        if (inputRows.some((row) => row.some((input) => input.type === ScratchBlocks.NEXT_STATEMENT))) {
+          computeBlock = manager.firstMarker_;
+        }
+      }
+    }
 
-		// Change the height of substacks
-		// (If we set inputRows to computeBlock.renderCompute_,
-		// the references to the inputs would be wrong
-		// so they just won't update properly)
-		if (computeBlock !== this) {
-			const _inputRows = computeBlock.renderCompute_(iconWidth);
-			for (let i = 0; i < inputRows.length; i++) {
-				const row = inputRows[i];
-				let update = false;
-				for (const input of row) {
-					if (input.type === ScratchBlocks.NEXT_STATEMENT) update = true;
-				}
-				if (update) row.height = Math.max(row.height, _inputRows[i].height);
-			}
-		}
+    // Change the height of substacks
+    // (If we set inputRows to computeBlock.renderCompute_,
+    // the references to the inputs would be wrong
+    // so they just won't update properly)
+    if (computeBlock !== this) {
+      const _inputRows = computeBlock.renderCompute_(iconWidth);
+      for (let i = 0; i < inputRows.length; i++) {
+        const row = inputRows[i];
+        let update = false;
+        for (const input of row) {
+          if (input.type === ScratchBlocks.NEXT_STATEMENT) update = true;
+        }
+        if (update) row.height = Math.max(row.height, _inputRows[i].height);
+      }
+    }
 
-		ogDraw.call(this, iconWidth, inputRows);
+    ogDraw.call(this, iconWidth, inputRows);
 
-		// Moving the connections of a block while it's being dragged breaks it,
-		// so don't
-		if (computeBlock === this && !this.noMoveConnection) ogMoveConnections.call(this);
-		this.noMoveConnection = false;
-	};
-	ScratchBlocks.BlockSvg.prototype.renderMoveConnections_ = function() {
-		if (addon.self.disabled) return ogMoveConnections.call(this);
-		// Do nothing (this function is instead called by renderDraw_)
-	};
+    // Moving the connections of a block while it's being dragged breaks it,
+    // so don't
+    if (computeBlock === this && !this.noMoveConnection) ogMoveConnections.call(this);
+    this.noMoveConnection = false;
+  };
+  ScratchBlocks.BlockSvg.prototype.renderMoveConnections_ = function () {
+    if (addon.self.disabled) return ogMoveConnections.call(this);
+    // Do nothing (this function is instead called by renderDraw_)
+  };
 }


### PR DESCRIPTION
Resolves [this suggestion from the TurboWarp server
](https://discord.com/channels/837024174865776680/837024174865776683/1193279234618171444)

### Changes

Adds an addon that makes C blocks extend when they're wrapped around scripts ("chomping"):
![image](https://github.com/ScratchAddons/ScratchAddons/assets/68464103/3105e0f7-3ecf-4e8e-8dbc-666b945f55eb)

### Reason for changes

Someone asked for it, and it's a nice aesthetic change. This feature was also in Scratch 2.0 and 1.4:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/68464103/5c1585fb-17ee-43ec-a798-e09a74773b4e) ![image](https://github.com/ScratchAddons/ScratchAddons/assets/68464103/3b77666f-d254-49ec-9839-aaa1eb0204f1)

### Tests

Tested on Firefox, with dynamic enable/disable and exiting/entering the editor. Seems to work fine. I also enabled a bunch of code area-affecting addons too and it still seems to work fine.

(I'm not sure if this will get accepted, as it's a very minor thing. Also, this is the third "like in Scratch 2.0" addon lol)
