### PR TITLE
find-bar: translate "flag"

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -255,7 +255,12 @@ export default async function ({ addon, msg, console }) {
         let fields = root.inputList[0];
         let desc;
         for (const fieldRow of fields.fieldRow) {
-          desc = (desc ? desc + " " : "") + fieldRow.getText();
+          desc = desc ? desc + " " : "";
+          if (fieldRow instanceof Blockly.FieldImage && fieldRow.src_.endsWith("green-flag.svg")) {
+            desc += msg("/_general/blocks/green-flag");
+          } else {
+            desc += fieldRow.getText();
+          }
         }
         return desc;
       }


### PR DESCRIPTION
Fixes a part of #6579

### Changes

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/577d84ca-122b-492f-a435-e032f78cc40c)

### Reason for changes

#6623 made the string "flag" translatable in `debugger` and `middle-click-popup`, but not in `find-bar`.

### Tests

Tested on Edge and Firefox.