### PR TITLE
mediarecorder: prefer VP9 when possible and add mp4 fallback

### DIFF
--- a/addons-l10n/en/mediarecorder.json
+++ b/addons-l10n/en/mediarecorder.json
@@ -10,7 +10,7 @@
   "mediarecorder/record-audio-description": "This does not include Text-to-Speech.",
   "mediarecorder/record-after-flag": "Do not start recording until the Green Flag is clicked",
   "mediarecorder/record-until-stop": "Stop recording after the project has stopped",
-  "mediarecorder/record-description": "Record the stage as a WebM file. You can save it to your computer after the recording is finished.\nNote: variable and list monitors will not be visible.",
+  "mediarecorder/record-description": "Record the stage as a {extension} file. You can save it to your computer after the recording is finished.\nNote: variable and list monitors will not be visible.",
   "mediarecorder/start": "Start",
   "mediarecorder/cancel": "Cancel",
   "mediarecorder/added-by": "Added by Scratch Addons browser extension",

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -11,10 +11,15 @@ export default async ({ addon, console, msg }) => {
   let recorder;
   let timeout;
 
-  // All browsers we care about will support at least one of these.
   const mimeType = [
-    "video/webm", // Chrome, Firefox
-    "video/mp4" // Safari
+    // Chrome and Firefox only support encoding webm
+    // VP9 is preferred as its playback is more universally supported
+    // For example iOS can't play VP8 but can play VP9
+    "video/webm; codecs=vp9",
+    // Firefox only supports encoding VP8
+    "video/webm",
+    // Safari only supports encoding H264 as mp4
+    "video/mp4"
   ].find(i => MediaRecorder.isTypeSupported(i));
 
   while (true) {
@@ -223,7 +228,8 @@ export default async ({ addon, console, msg }) => {
       } else {
         recorder.onstop = () => {
           const blob = new Blob(recordBuffer, { type: mimeType });
-          downloadBlob(`video.${mimeType.split("/")[1]}`, blob);
+          const fileExtension = mimeType.split(';')[0].split('/')[1];
+          downloadBlob(`video.${fileExtension}`, blob);
           disposeRecorder();
         };
         recorder.stop();

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -19,8 +19,8 @@ export default async ({ addon, console, msg }) => {
     // Firefox only supports encoding VP8
     "video/webm",
     // Safari only supports encoding H264 as mp4
-    "video/mp4"
-  ].find(i => MediaRecorder.isTypeSupported(i));
+    "video/mp4",
+  ].find((i) => MediaRecorder.isTypeSupported(i));
 
   while (true) {
     const elem = await addon.tab.waitForElement('div[class*="menu-bar_file-group"] > div:last-child:not(.sa-record)', {
@@ -228,7 +228,7 @@ export default async ({ addon, console, msg }) => {
       } else {
         recorder.onstop = () => {
           const blob = new Blob(recordBuffer, { type: mimeType });
-          const fileExtension = mimeType.split(';')[0].split('/')[1];
+          const fileExtension = mimeType.split(";")[0].split("/")[1];
           downloadBlob(`video.${fileExtension}`, blob);
           disposeRecorder();
         };

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -38,7 +38,7 @@ export default async ({ addon, console, msg }) => {
       content.appendChild(
         Object.assign(document.createElement("p"), {
           textContent: msg("record-description", {
-            extension: `.${fileExtension}`
+            extension: `.${fileExtension}`,
           }),
           className: "recordOptionDescription",
         })

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -10,6 +10,13 @@ export default async ({ addon, console, msg }) => {
   let recordBuffer = [];
   let recorder;
   let timeout;
+
+  // All browsers we care about will support at least one of these.
+  const mimeType = [
+    "video/webm", // Chrome, Firefox
+    "video/mp4" // Safari
+  ].find(i => MediaRecorder.isTypeSupported(i));
+
   while (true) {
     const elem = await addon.tab.waitForElement('div[class*="menu-bar_file-group"] > div:last-child:not(.sa-record)', {
       markAsSeen: true,
@@ -215,8 +222,8 @@ export default async ({ addon, console, msg }) => {
         disposeRecorder();
       } else {
         recorder.onstop = () => {
-          const blob = new Blob(recordBuffer, { type: "video/webm" });
-          downloadBlob("video.webm", blob);
+          const blob = new Blob(recordBuffer, { type: mimeType });
+          downloadBlob(`video.${mimeType.split("/")[1]}`, blob);
           disposeRecorder();
         };
         recorder.stop();
@@ -283,7 +290,7 @@ export default async ({ addon, console, msg }) => {
       if (opts.audioEnabled || opts.micEnabled) {
         stream.addTrack(dest.stream.getAudioTracks()[0]);
       }
-      recorder = new MediaRecorder(stream, { mimeType: "video/webm" });
+      recorder = new MediaRecorder(stream, { mimeType });
       recorder.ondataavailable = (e) => {
         recordBuffer.push(e.data);
       };

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -20,6 +20,7 @@ export default async ({ addon, console, msg }) => {
     // Safari only supports encoding H264 as mp4
     "video/mp4",
   ].find((i) => MediaRecorder.isTypeSupported(i));
+  const fileExtension = mimeType.split(";")[0].split("/")[1];
 
   while (true) {
     const elem = await addon.tab.waitForElement('div[class*="menu-bar_file-group"] > div:last-child:not(.sa-record)', {
@@ -36,7 +37,9 @@ export default async ({ addon, console, msg }) => {
 
       content.appendChild(
         Object.assign(document.createElement("p"), {
-          textContent: msg("record-description"),
+          textContent: msg("record-description", {
+            extension: `.${fileExtension}`
+          }),
           className: "recordOptionDescription",
         })
       );
@@ -227,7 +230,6 @@ export default async ({ addon, console, msg }) => {
       } else {
         recorder.onstop = () => {
           const blob = new Blob(recordBuffer, { type: mimeType });
-          const fileExtension = mimeType.split(";")[0].split("/")[1];
           downloadBlob(`video.${fileExtension}`, blob);
           disposeRecorder();
         };

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -12,9 +12,8 @@ export default async ({ addon, console, msg }) => {
   let timeout;
 
   const mimeType = [
-    // Chrome and Firefox only support encoding webm
-    // VP9 is preferred as its playback is more universally supported
-    // For example iOS can't play VP8 but can play VP9
+    // Chrome and Firefox only support encoding as webm
+    // VP9 is preferred as its playback is better supported across platforms
     "video/webm; codecs=vp9",
     // Firefox only supports encoding VP8
     "video/webm",


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/issues/7055 (lots of discussion in there), based on changes in #7006

This logic is in this order:

1. Try to record as webm using VP9 (Chrome, best scenario)
2. Try to record as webm using whatever codec the browser gives us (Firefox will give us VP8)
3. Try to record as mp4 using whatever codec the browser gives us (Safari will give us H264)

Here is a video recorded by Chromium on Linux: https://github.com/ScratchAddons/ScratchAddons/assets/33787854/6e7ec5f3-aaab-4e25-94ec-5025bff8fc05 - mpv says this is vp9

Here is a video recorded by Firefox on Linux: https://github.com/ScratchAddons/ScratchAddons/assets/33787854/f4fb588a-08a0-4299-9dbd-0229c0686e57 - mpv says this is vp8

Here is a video recorded by Safari: https://github.com/ScratchAddons/ScratchAddons/assets/33787854/6d180f9e-117c-4b65-9b22-0c5ddca90ed2 - mpv says this is h264

