### PR TITLE
Lighter shadows when high contrast enabled

### DIFF
--- a/addons/custom-block-text/userscript.js
+++ b/addons/custom-block-text/userscript.js
@@ -40,6 +40,11 @@ export default async function ({ addon, console }) {
     .blocklyDraggable > .blocklyText,
     .blocklyDraggable > g > text {
       text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
+    }
+    
+    div[theme="high-contrast"] .blocklyDraggable > .blocklyText,
+    div[theme="high-contrast"] .blocklyDraggable > g > text {
+      text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.15);
     }`;
   textShadowCss.disabled = true;
   document.head.appendChild(textShadowCss);


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #7061

### Changes

Changes the opacity of text shadows from .4 to .15 when Scratch's high contrast mode is enabled.

### Reason for changes

Blocks appear blurry and hard to read when the text shadow is too strong.

### Tests

Version 121.0.6167.16 (Official Build) beta (arm64)
macOS Sonoma Version 14.2 Beta (23C5047e)
