### PR TITLE
Link to commit history on dev versions

### DIFF
--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -14,6 +14,9 @@ function calculatePopupSize() {
   document.body.classList.remove("loading");
 }
 
+const res = await fetch("../../.git/ORIG_HEAD");
+const commitHash = await res.text();
+
 window.addEventListener("load", () => setTimeout(calculatePopupSize, 0));
 
 const vue = new Vue({
@@ -53,10 +56,14 @@ const vue = new Vue({
   },
   computed: {
     changelogLink() {
-      const uiLanguage = chrome.i18n.getUILanguage();
-      const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
-      const utm = `utm_source=extension&utm_medium=popup&utm_campaign=v${chrome.runtime.getManifest().version}`;
-      return `https://scratchaddons.com/${localeSlash}changelog/?${utm}#v${chrome.runtime.getManifest().version}`;
+      if (chrome.runtime.getManifest().version_name.includes("-prerelease")) {
+        return `https://github.com/ScratchAddons/ScratchAddons/commits/${commitHash}`;
+      } else {
+        const uiLanguage = chrome.i18n.getUILanguage();
+        const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
+        const utm = `utm_source=extension&utm_medium=popup&utm_campaign=v${chrome.runtime.getManifest().version}`;
+        return `https://scratchaddons.com/${localeSlash}changelog/?${utm}#v${chrome.runtime.getManifest().version}`;
+      }
     },
     version() {
       const prerelease = chrome.runtime.getManifest().version_name.includes("-prerelease");

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -15,11 +15,9 @@ function calculatePopupSize() {
 }
 
 const commitHash = await fetch("../../.git/HEAD")
-.then(res => res.text())
-.then(data => data.replace("ref: ",""))
-.then(branch => fetch(`../../.git/${branch}`)
-.then(res => res.text())
-)
+  .then((res) => res.text())
+  .then((data) => data.replace("ref: ", ""))
+  .then((branch) => fetch(`../../.git/${branch}`).then((res) => res.text()));
 
 window.addEventListener("load", () => setTimeout(calculatePopupSize, 0));
 

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -14,8 +14,12 @@ function calculatePopupSize() {
   document.body.classList.remove("loading");
 }
 
-const res = await fetch("../../.git/ORIG_HEAD");
-const commitHash = await res.text();
+const commitHash = await fetch("../../.git/HEAD")
+.then(res => res.text())
+.then(data => data.replace("ref: ",""))
+.then(branch => fetch(`../../.git/${branch}`)
+.then(res => res.text())
+)
 
 window.addEventListener("load", () => setTimeout(calculatePopupSize, 0));
 

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -27,6 +27,7 @@ const vue = new Vue({
     popups: [],
     currentPopup: null,
     popupsWithIframes: [],
+    devMode: false,
   },
   methods: {
     msg(message, ...params) {
@@ -58,7 +59,7 @@ const vue = new Vue({
   },
   computed: {
     changelogLink() {
-      if (chrome.runtime.getManifest().version_name.includes("-prerelease")) {
+      if (this.devMode) {
         return `https://github.com/ScratchAddons/ScratchAddons/commits/${commitHash}`;
       } else {
         const uiLanguage = chrome.i18n.getUILanguage();
@@ -68,9 +69,8 @@ const vue = new Vue({
       }
     },
     version() {
-      const prerelease = chrome.runtime.getManifest().version_name.includes("-prerelease");
       const ver = chrome.runtime.getManifest().version;
-      return prerelease ? ver + "-pre" : ver;
+      return this.devMode ? ver + "-pre" : ver;
     },
   },
 });
@@ -138,6 +138,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       }
     }
   }
+});
+
+chrome.management.getSelf((info) => {
+  if (info.installType === "development") vue.devMode = true;
 });
 
 chrome.runtime.sendMessage("checkPermissions");


### PR DESCRIPTION
Resolves #6451

### Changes

When installed logically the changelog link in the popup links to the commit history instead. Also I was wrong about `ORIG_HEAD`, fetching the actual latest commit requires two fetches as far as I can tell.

### Reason for changes

Linking to the release notes doesn't make much sense for development versions and it makes it easier to know exactly which version is being run.

### Tests

Tested on Brave. Maybe I'm just missing something obvious but I couldn't get fetch to work inside 
`computed` so I stored the hash in a global variable.