### PR TITLE
Add "Remove minimum height from signatures" addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -151,6 +151,7 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "signature-min-height",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/signature-min-height/addon.json
+++ b/addons/signature-min-height/addon.json
@@ -14,5 +14,7 @@
       "name": "mybearworld",
       "link": "https://scratch.mit.edu/users/mybearworld"
     }
-  ]
+  ],
+  "dynamicDisable": true,
+  "dynamicEnable": true
 }

--- a/addons/signature-min-height/addon.json
+++ b/addons/signature-min-height/addon.json
@@ -1,0 +1,18 @@
+{
+  "name": "Remove minimum height from signatures",
+  "description": "Allows signatures to shrink when there is enough space to.",
+  "tags": ["community", "forums"],
+  "userstyles": [
+    {
+      "matches": ["forums"],
+      "url": "userstyle.css"
+    }
+  ],
+  "versionAdded": "1.36.0",
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ]
+}

--- a/addons/signature-min-height/userstyle.css
+++ b/addons/signature-min-height/userstyle.css
@@ -1,0 +1,4 @@
+.postsignature {
+  height: auto;
+  max-height: 168px !important;
+}


### PR DESCRIPTION
Resolves #7068

### Changes

Add "Remove minimum height from signatures" addon.

<sup>(It's four lines of CSS, it can be moved into another addon pretty easily if need be)</sup>

### Reason for changes


> No matter how few space a signature actually needs, it'll always take up 168px. This can be very annoying, especially for 1 line signatures (like mine).

### Tests

Tested on Edge
