### PR TITLE
`full-signature`: Don't force signature height to be 168px

### DIFF
--- a/addons/full-signature/signature.css
+++ b/addons/full-signature/signature.css
@@ -1,7 +1,5 @@
 .postsignature {
   overflow-y: auto !important;
   resize: vertical;
-  max-height: -moz-fit-content !important;
-  max-height: fit-content !important;
-  height: 168px;
+  max-height: 168px;
 }


### PR DESCRIPTION
Resolves #7068

### Changes

`max-height: 168px;`

### Reason for changes

It makes more sense

### Tests

Tested in Edge
