### PR TITLE
hide-flyout: new setting "open by default" (auto-hide block pallete addon)

### DIFF
--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -19,7 +19,10 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "latestUpdate": "1.36.0",
+  "latestUpdate": {
+    "version": "1.36.0",
+    "newSettings": ["lockLoad"]
+  }.
   "customCssVariables": [
     {
       "name": "lockDisplay",

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -81,7 +81,11 @@
         {
           "id": "category",
           "name": "Category click"
-        }
+        },
+        {
+          "id": "pageload",
+          "name": "page load",
+        },
       ],
       "default": "cathover"
     },

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -19,6 +19,7 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "latestUpdate": "1.36.0",
   "customCssVariables": [
     {
       "name": "lockDisplay",

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -19,10 +19,6 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "latestUpdate": {
-    "version": "1.36.0",
-    "newSettings": ["lockLoad"]
-  }.
   "customCssVariables": [
     {
       "name": "lockDisplay",
@@ -122,8 +118,7 @@
   ],
   "tags": ["editor", "codeEditor", "recommended"],
   "latestUpdate": {
-    "version": "1.27.0",
-    "temporaryNotice": "This addon was revised and many bugs were fixed.",
-    "isMajor": true
+    "version": "1.36.0",
+    "newSettings": ["lockLoad"]
   }
 }

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -110,7 +110,7 @@
       "default": "default"
     },
     {
-      "name": "Lock by default",
+      "name": "Open by default",
       "id": "lockLoad",
       "type": "boolean",
       "default": false

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -84,8 +84,8 @@
         },
         {
           "id": "pageload",
-          "name": "page load",
-        },
+          "name": "page load"
+        }
       ],
       "default": "cathover"
     },

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -81,10 +81,6 @@
         {
           "id": "category",
           "name": "Category click"
-        },
-        {
-          "id": "pageload",
-          "name": "page load"
         }
       ],
       "default": "cathover"
@@ -112,6 +108,12 @@
         }
       ],
       "default": "default"
+    },
+    {
+      "name": "Lock by default",
+      "id": "lockLoad",
+      "type": "boolean",
+      "default": false
     }
   ],
   "tags": ["editor", "codeEditor", "recommended"],

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -52,8 +52,8 @@ export default async function ({ addon, console, msg }) {
     if (option) {
       flyOut.classList.remove("sa-flyoutClose");
       scrollBar.classList.remove("sa-flyoutClose");
-      updateLockDisplay()
-    };
+      updateLockDisplay();
+    }
   }
 
   function onmouseenter(e, speed = {}) {
@@ -310,7 +310,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock()
+    autoLock();
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -172,7 +172,13 @@ export default async function ({ addon, console, msg }) {
           toggle = false;
         }
       } else {
-        onmouseleave();
+        // switching from category click to a different mode
+        if (addon.settings.get("lockLoad")) {
+          flyoutLock = true;
+          updateLockDisplay();
+        } else {
+          onmouseleave();
+        }
         Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
       }
       // update workspace dimensions

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -308,7 +308,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock()
+    autoLock();
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -50,17 +50,17 @@ export default async function ({ addon, console, msg }) {
     const option = addon.settings.get("lockLoad");
     if (option) {
       if (getToggleSetting() === "category") {
-        console.log(Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected)
+        console.log(Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected);
         Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
         onmouseleave(null, 0);
         toggle = true;
       } else {
         flyoutLock = option;
-        updateLockDisplay()
+        updateLockDisplay();
       }
       flyOut.classList.remove("sa-flyoutClose");
       scrollBar.classList.remove("sa-flyoutClose");
-    };
+    }
   }
 
   function onmouseenter(e, speed = {}) {
@@ -317,7 +317,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock()
+    autoLock();
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -139,7 +139,7 @@ export default async function ({ addon, console, msg }) {
       }
     });
 
-    if (addon.self.enabledLate && getToggleSetting() === "category") {
+    if (addon.self.enabledLate && getToggleSetting() === "category" && !addon.settings.get("lockLoad")) {
       Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(false);
     }
     addon.self.addEventListener("disabled", () => {
@@ -148,7 +148,7 @@ export default async function ({ addon, console, msg }) {
       Blockly.svgResize(Blockly.getMainWorkspace());
     });
     addon.self.addEventListener("reenabled", () => {
-      if (getToggleSetting() === "category") {
+      if (getToggleSetting() === "category" && !addon.settings.get("lockLoad")) {
         Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(false);
         onmouseleave(null, 0);
         toggle = false;

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -50,7 +50,6 @@ export default async function ({ addon, console, msg }) {
     const option = addon.settings.get("lockLoad");
     if (option) {
       if (getToggleSetting() === "category") {
-        console.log(Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected);
         Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
         onmouseleave(null, 0);
         toggle = true;

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -48,12 +48,19 @@ export default async function ({ addon, console, msg }) {
 
   function autoLock() {
     const option = addon.settings.get("lockLoad");
-    flyoutLock = option;
     if (option) {
+      if (getToggleSetting() === "category") {
+        console.log(Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected)
+        Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
+        onmouseleave(null, 0);
+        toggle = true;
+      } else {
+        flyoutLock = option;
+        updateLockDisplay()
+      }
       flyOut.classList.remove("sa-flyoutClose");
       scrollBar.classList.remove("sa-flyoutClose");
-      updateLockDisplay();
-    }
+    };
   }
 
   function onmouseenter(e, speed = {}) {
@@ -310,7 +317,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock();
+    autoLock()
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -54,11 +54,11 @@ export default async function ({ addon, console, msg }) {
         toggle = true;
       } else {
         flyoutLock = option;
-        updateLockDisplay()
+        updateLockDisplay();
       }
       flyOut.classList.remove("sa-flyoutClose");
       scrollBar.classList.remove("sa-flyoutClose");
-    };
+    }
   }
 
   function onmouseenter(e, speed = {}) {
@@ -315,7 +315,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock()
+    autoLock();
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -46,6 +46,14 @@ export default async function ({ addon, console, msg }) {
     lockIcon.src = addon.self.dir + `/${flyoutLock ? "" : "un"}lock.svg`;
   }
 
+  function autoLock() {
+    const option = addon.settings.get("lockLoad");
+    flyoutLock = option;
+    flyOut.classList.remove("sa-flyoutClose");
+    scrollBar.classList.remove("sa-flyoutClose");
+    if (option) updateLockDisplay();
+  }
+
   function onmouseenter(e, speed = {}) {
     // If a mouse event was passed, only open flyout if the workspace isn't being dragged
     if (
@@ -300,6 +308,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
+    autoLock()
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -50,16 +50,15 @@ export default async function ({ addon, console, msg }) {
     const option = addon.settings.get("lockLoad");
     if (option) {
       if (getToggleSetting() === "category") {
-        Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
         onmouseleave(null, 0);
         toggle = true;
       } else {
         flyoutLock = option;
-        updateLockDisplay();
+        updateLockDisplay()
       }
       flyOut.classList.remove("sa-flyoutClose");
       scrollBar.classList.remove("sa-flyoutClose");
-    }
+    };
   }
 
   function onmouseenter(e, speed = {}) {
@@ -186,7 +185,7 @@ export default async function ({ addon, console, msg }) {
       const previousSelection = this.selectedItem_;
       oldSetSelectedItem.call(this, item, shouldScroll);
       if (addon.self.disabled || getToggleSetting() !== "category") return;
-      if (!shouldScroll) {
+      if (!shouldScroll && !toggle) {
         // ignore initial selection when updating the toolbox
         item.setSelected(false);
       } else if (item === previousSelection) {
@@ -316,7 +315,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock();
+    autoLock()
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -49,9 +49,11 @@ export default async function ({ addon, console, msg }) {
   function autoLock() {
     const option = addon.settings.get("lockLoad");
     flyoutLock = option;
-    flyOut.classList.remove("sa-flyoutClose");
-    scrollBar.classList.remove("sa-flyoutClose");
-    if (option) updateLockDisplay();
+    if (option) {
+      flyOut.classList.remove("sa-flyoutClose");
+      scrollBar.classList.remove("sa-flyoutClose");
+      updateLockDisplay()
+    };
   }
 
   function onmouseenter(e, speed = {}) {
@@ -308,7 +310,7 @@ export default async function ({ addon, console, msg }) {
     };
 
     doOneTimeSetup();
-    autoLock();
+    autoLock()
     if (getToggleSetting() !== "hover") {
       // update workspace dimensions
       Blockly.svgResize(Blockly.getMainWorkspace());


### PR DESCRIPTION
adds a new option to Auto-hiding block palette which makes the flyout lock when the page is loaded 

tested on chrome and firefox :)

(sorry for low framerate, for some reason obs decided to die)

https://github.com/ScratchAddons/ScratchAddons/assets/116295240/e93ebaf6-017d-46e5-8193-a5f20e165a07