### PR TITLE
reorder-custom-inputs: change description

### DIFF
--- a/addons/reorder-custom-inputs/addon.json
+++ b/addons/reorder-custom-inputs/addon.json
@@ -1,10 +1,16 @@
 {
   "name": "Rearrangeable custom block inputs",
-  "description": "Adds buttons for rearranging custom block inputs.",
+  "description": "Allows rearranging custom block parameters with the editor's \"Make a block\" screen.",
   "credits": [
     {
       "name": "Chrome_Cat",
       "link": "https://scratch.mit.edu/users/Chrome_Cat/"
+    }
+  ],
+  "info": [
+    {
+      "id": "editCustomBlock",
+      "text": "To edit a custom block, right click it and choose the edit option."
     }
   ],
   "userscripts": [

--- a/addons/reorder-custom-inputs/addon.json
+++ b/addons/reorder-custom-inputs/addon.json
@@ -1,16 +1,10 @@
 {
   "name": "Rearrangeable custom block inputs",
-  "description": "Allows rearranging custom block parameters with the editor's \"Make a block\" screen.",
+  "description": "Allows rearranging custom block parameters on the \"Make a block\" screen.",
   "credits": [
     {
       "name": "Chrome_Cat",
       "link": "https://scratch.mit.edu/users/Chrome_Cat/"
-    }
-  ],
-  "info": [
-    {
-      "id": "editCustomBlock",
-      "text": "To edit a custom block, right click it and choose the edit option."
     }
   ],
   "userscripts": [


### PR DESCRIPTION
### Changes

- Changes the addon description. It was previously just a rewording of the addon name. Thanks samq for the suggestion in the comment: https://github.com/ScratchAddons/ScratchAddons/pull/7020#issuecomment-1892957777
- I'm not sure if it's necessary, but I added a reminder on how to edit an existing custom block.
