### PR TITLE
better-quoter: fix typo in emoji data

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -78,7 +78,7 @@ function getSelectionBBCode(selection) {
     tongue: ":P",
     lol: ":lol:",
     mad: ":mad:",
-    roll: ":rolleyes",
+    roll: ":rolleyes:",
     cool: ":cool:",
   });
 


### PR DESCRIPTION
Resolves #7120

### Changes

adds a missing colon

### Reason for changes

~~its the biggest change in existance and should be considered as it restores balance in reality~~

bug fix - "rolleyes" has a colon skipped so it doesnt get rendered

https://github.com/ScratchAddons/ScratchAddons/blob/0fca0cedec08b27a101ec973e0434e684f739a97/addons/better-quoter/module.js#L81

### Tests

firefox 122.0, works fine
