### PR TITLE
Hide sprites via context menu addon

### DIFF
--- a/addons-l10n/en/hide-show-context-menu.json
+++ b/addons-l10n/en/hide-show-context-menu.json
@@ -1,0 +1,4 @@
+{
+  "hide-show-context-menu/hide": "hide",
+  "hide-show-context-menu/show": "show"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -153,6 +153,7 @@
   "collapse-footer",
   "reorder-custom-inputs",
   "place-backpack-code-at-cursor",
+  "hide-show-context-menu",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/hide-show-context-menu/addon.json
+++ b/addons/hide-show-context-menu/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hide sprites via context menu",
+  "name": "Hide sprites with context menu",
   "description": "Adds an option to a sprite's right click menu to hide or show it.",
   "tags": ["editor"],
   "versionAdded": "1.36.0",

--- a/addons/hide-show-context-menu/addon.json
+++ b/addons/hide-show-context-menu/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "Hide sprites via context menu",
+  "description": "Adds an option to a sprite's right click menu to hide or show it.",
+  "tags": ["editor"],
+  "versionAdded": "1.36.0",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/hide-show-context-menu/userscript.js
+++ b/addons/hide-show-context-menu/userscript.js
@@ -6,7 +6,7 @@ export default async function ({ addon, msg }) {
   const sharedOptions = {
     types: ["sprite"],
     position: "assetContextMenuAfterDelete",
-    order: 12, // after folders
+    order: 9, // before folders - it's unpredictable how many slots folders takes up
     border: true,
   };
   window.vm = vm;

--- a/addons/hide-show-context-menu/userscript.js
+++ b/addons/hide-show-context-menu/userscript.js
@@ -1,0 +1,28 @@
+export default async function ({ addon, msg }) {
+  const vm = addon.tab.traps.vm;
+  const getSprite = (name) => {
+    return vm.runtime.targets.find((target) => target.sprite.name === name);
+  };
+  const stateFromBool = (bool) => (bool ? "show" : "hide");
+  const sharedOptions = {
+    types: ["sprite"],
+    position: "assetContextMenuAfterDelete",
+    order: 12, // after folders
+    border: true,
+  };
+  window.vm = vm;
+
+  [true, false].forEach((visibility) => {
+    addon.tab.createEditorContextMenu(
+      (ctx) => {
+        getSprite(ctx.name).setVisible(visibility);
+      },
+      {
+        ...sharedOptions,
+        className: `sa-hide-show-context-menu-${stateFromBool(visibility)}`,
+        label: msg(stateFromBool(visibility)),
+        condition: (ctx) => getSprite(ctx.name).visible === !visibility,
+      }
+    );
+  });
+}

--- a/addons/hide-show-context-menu/userscript.js
+++ b/addons/hide-show-context-menu/userscript.js
@@ -9,7 +9,6 @@ export default async function ({ addon, msg }) {
     order: 9, // before folders - it's unpredictable how many slots folders takes up
     border: true,
   };
-  window.vm = vm;
 
   [true, false].forEach((visibility) => {
     addon.tab.createEditorContextMenu(

--- a/addons/hide-show-context-menu/userscript.js
+++ b/addons/hide-show-context-menu/userscript.js
@@ -1,8 +1,7 @@
 export default async function ({ addon, msg }) {
   const vm = addon.tab.traps.vm;
-  const getSprite = (name) => {
-    return vm.runtime.targets.find((target) => target.sprite.name === name);
-  };
+  const getSprite = (name) => vm.runtime.targets.find((target) => target.id === name);
+
   const stateFromBool = (bool) => (bool ? "show" : "hide");
   const sharedOptions = {
     types: ["sprite"],
@@ -15,13 +14,13 @@ export default async function ({ addon, msg }) {
   [true, false].forEach((visibility) => {
     addon.tab.createEditorContextMenu(
       (ctx) => {
-        getSprite(ctx.name).setVisible(visibility);
+        getSprite(ctx.itemId).setVisible(visibility);
       },
       {
         ...sharedOptions,
         className: `sa-hide-show-context-menu-${stateFromBool(visibility)}`,
         label: msg(stateFromBool(visibility)),
-        condition: (ctx) => getSprite(ctx.name).visible === !visibility,
+        condition: (ctx) => getSprite(ctx.itemId).visible === !visibility,
       }
     );
   });


### PR DESCRIPTION
Resolves #7077

### Changes

Adds a new addon that adds a context menu entry that hides/shows a sprite.

![A screenshot of the context menu with the option "hide".](https://github.com/ScratchAddons/ScratchAddons/assets/130385691/9e8ff5b4-25a7-4fb2-b046-fee7c0d28197)


### Reason for changes

Convenience, OneShot-Niko accidentally wanting to make duplicates 3 times

### Tests

Tested in Edge.