### PR TITLE
pause: fix keyboard shortcut on macOS

### DIFF
--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -19,8 +19,11 @@ export default async function ({ addon, console, msg }) {
   onPauseChanged(setSrc);
 
   document.addEventListener("keydown", function (e) {
-    // On macOS, option+x types ≈ and shift+option+x types ˛ pretty universally across keyboard layouts
-    if (e.altKey && (e.key.toLowerCase() === "x" || e.key === "≈" || e.key === "˛") && !addon.self.disabled) {
+    // e.code is not enough because that corresponds to physical keys, ignoring keyboard layouts.
+    // e.key is not enough because on macOS, option+x types ≈ and shift+option+x types ˛
+    // e.keyCode is always 88 when pressing x regardless of modifier keys, so that's how we'll handle macOS.
+    // Because keyCode is deprecated we'll still check e.key in case keyCode is not as reliable as we think it is
+    if (e.altKey && (e.key.toLowerCase() === "x" || e.keyCode === 88) && !addon.self.disabled) {
       e.preventDefault();
       setPaused(!isPaused());
     }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -19,7 +19,8 @@ export default async function ({ addon, console, msg }) {
   onPauseChanged(setSrc);
 
   document.addEventListener("keydown", function (e) {
-    if (e.altKey && e.key.toLowerCase() === "x" && !addon.self.disabled) {
+    // Need to use e.code here as option+x on macOS actually types ≈
+    if (e.altKey && e.code === "KeyX" && !addon.self.disabled) {
       e.preventDefault();
       setPaused(!isPaused());
     }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -19,8 +19,8 @@ export default async function ({ addon, console, msg }) {
   onPauseChanged(setSrc);
 
   document.addEventListener("keydown", function (e) {
-    // Need to use e.code here as option+x on macOS actually types ≈
-    if (e.altKey && e.code === "KeyX" && !addon.self.disabled) {
+    // On macOS, option+x types ≈ pretty universally across keyboard layouts
+    if (e.altKey && (e.key.toLowerCase() === "x" || e.key === "≈") && !addon.self.disabled) {
       e.preventDefault();
       setPaused(!isPaused());
     }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -19,8 +19,8 @@ export default async function ({ addon, console, msg }) {
   onPauseChanged(setSrc);
 
   document.addEventListener("keydown", function (e) {
-    // On macOS, option+x types ≈ pretty universally across keyboard layouts
-    if (e.altKey && (e.key.toLowerCase() === "x" || e.key === "≈") && !addon.self.disabled) {
+    // On macOS, option+x types ≈ and shift+option+x types ˛ pretty universally across keyboard layouts
+    if (e.altKey && (e.key.toLowerCase() === "x" || e.key === "≈" || e.key === "˛") && !addon.self.disabled) {
       e.preventDefault();
       setPaused(!isPaused());
     }


### PR DESCRIPTION
On macOS, option+x types ≈ and shift+option+x types ˛