### PR TITLE
Add `injectStyleAsElt` to `colorblind`

### DIFF
--- a/addons/colorblind/addon.json
+++ b/addons/colorblind/addon.json
@@ -93,6 +93,7 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "injectAsStyleElt": true,
   "updateUserstylesOnSettingsChange": true,
   "versionAdded": "1.34.0",
   "tags": ["community", "theme"]


### PR DESCRIPTION
Resolves #7109

### Changes

Adds `"injectAsStyleElt": true` to the Customizable link style addon, to make links appear bold/underlined (depending on your settings) immediately on page load, instead of it taking a moment.

### Tests

Tested.
