### PR TITLE
custom-menu-bar: Fix versionAdded

### DIFF
--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -128,5 +128,5 @@
   "dynamicEnable": true,
   "updateUserstylesOnSettingsChange": true,
   "enabledByDefault": false,
-  "versionAdded": "1.35.0"
+  "versionAdded": "1.36.0"
 }


### PR DESCRIPTION
Chnages `custom-menu-bar`'s `versionAdded` from 1.35 to 1.36.