### PR TITLE
Fix capitalized account settings when using a teacher account

### DIFF
--- a/addons/account-settings-capitalize/style.css
+++ b/addons/account-settings-capitalize/style.css
@@ -1,5 +1,5 @@
-.account-nav .dropdown > li:nth-child(3),
-ul.user-nav > li:nth-child(3),
-[class*="menu-bar_account-info-group_"] [class*="menu_menu_"] > [class*="menu_menu-item_"]:nth-child(3) {
+.account-nav .dropdown > li:nth-last-child(2),
+ul.user-nav > li:nth-last-child(2),
+[class*="menu-bar_account-info-group_"] [class*="menu_menu_"] > [class*="menu_menu-item_"]:nth-last-child(2) {
   text-transform: capitalize;
 }


### PR DESCRIPTION
Resolves #7148

### Changes

Makes `account-settings-capitalize` select the menu item form the bottom instead of the top so it woks with teacher accounts.

### Reason for changes

To fix an incredibility niche bug.

### Tests

No, I don't have a teacher account. @Open137 could you test this?
