### PR TITLE
Automatically omit `-prerelease` when packing

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -18,6 +18,7 @@ const PERMISSIONS_ALWAYS_IGNORED = [
 export default (env, manifest) => {
   // Deep-clone
   manifest = JSON.parse(JSON.stringify(manifest));
+  manifest.version_name = manifest.version;
   manifest.icons["1024"] = "images/icon.png";
   manifest.icons["32"] = "images/icon-32.png";
   manifest.icons["16"] = "images/icon-16.png";


### PR DESCRIPTION
Related to #6929

Not sure if this is really necessary, but...

### Changes

Modifies the `gen-manifest` script used when packing the extension for releases to automatically omit `-prerelease` from `version_name`, by setting it to `version`.

### Reason for changes

- If this is done automatically, we won't have to bump the version to a non-prerelease before releasing the extension or bump it to a prerelease when starting work on the next version. We would still have to change the version before releasing minor updates, but at least no worrying about whether it's a prerelease or not.
- It benefits developers who install releases through GitHub (if `version_name` is always a prerelease, the extension will always remain in developer mode).
- To avoid [prereñease moments](https://github.com/ScratchAddons/ScratchAddons/issues/3834). 😄

Our workflow before and after:
```diff
 We're on version 1.36.0 stable

 ⬆️ Bump to version 1.37.0 prerelease
 🛠️ Updates, updates, updates...
-✅ Bump to version 1.37.0 stable
 🚀 Release as 1.37.0 stable

 ⬆️ Bump to version 1.38.0 prerelease
 🐞 Oops! A bug or two.
-✅ Bump to version 1.37.1 stable
+✅ Bump to version 1.37.1 prerelease
 🚀 Release as 1.37.1 stable

 ⬆️ Bump to version 1.38.0 prerelease again
 🛠️ Everything else...
-✅ Bump to version 1.38.0 stable
 🚀 Release as 1.38.0 stable
```

### Tests

Not tested. Might want to do a test run after merging.
