### PR TITLE
faster-project-loading: Fix dropping code into sprite-pane

### DIFF
--- a/addons/faster-project-loading/userscript.js
+++ b/addons/faster-project-loading/userscript.js
@@ -4,6 +4,9 @@ export default async function ({ addon }) {
   const BACKPACK_URL = "https://backpack.scratch.mit.edu/";
   // Inserting sprites from the backpack requests a ZIP archive from backpack.scratch.mit.edu, so we want to allow those
   const SPRITE_FILE_EXTENSION = ".zip";
+  // Dropping a code item from the backpack into a specific sprite within the sprite-pane (NOT into the code area)
+  // requests a JSON file (https://backpack.scratch.mit.edu/{hash}.json) which we shouldn't block
+  const CODE_FILE_EXTENSION = ".json";
 
   const originalOpen = XMLHttpRequest.prototype.open;
   XMLHttpRequest.prototype.open = function (method, url, ...moreArgs) {
@@ -11,7 +14,8 @@ export default async function ({ addon }) {
       !addon.self.disabled &&
       method === "GET" &&
       url.startsWith(BACKPACK_URL) &&
-      !url.endsWith(SPRITE_FILE_EXTENSION)
+      !url.endsWith(SPRITE_FILE_EXTENSION) &&
+      !url.endsWith(CODE_FILE_EXTENSION)
     ) {
       /*
               We don't want to block actual requests for backpack assets.


### PR DESCRIPTION
Resolves #7036

### Changes

Never blocks URLs ending in `.json` (as suggested by the bug report issue). Not aware of any better alternatives. Searched on Discord where this issue was brought up with no luck.

### Reason for changes

Fixes a bug we have missed for months.

### Tests

Can now drag backpack code into specific sprites in Chromium.