### PR TITLE
Convert `fullscreen` toolbar toggles to a select setting

### DIFF
--- a/addons/fullscreen/addon.json
+++ b/addons/fullscreen/addon.json
@@ -93,7 +93,7 @@
   "latestUpdate": {
     "version": "1.36.0",
     "isMajor": false,
-    "newSettings": ["toolbar"]
+    "newSettings": ["hoverToolbar"]
   },
   "enabledByDefault": false
 }

--- a/addons/fullscreen/addon.json
+++ b/addons/fullscreen/addon.json
@@ -10,7 +10,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "If you choose to hide the toolbar, remember that you can use the Esc key to exit the project player's full screen mode.",
+      "text": "If you choose to always hide the toolbar, remember that you can use the Esc key to exit the project player's full screen mode.",
       "id": "hideToolbarNotice"
     }
   ],
@@ -22,19 +22,24 @@
       "default": true
     },
     {
-      "name": "Hide toolbar in full screen",
-      "id": "hideToolbar",
-      "type": "boolean",
-      "default": false
-    },
-    {
-      "name": "Show toolbar when hovered",
-      "id": "hoverToolbar",
-      "type": "boolean",
-      "default": true,
-      "if": {
-        "settings": { "hideToolbar": true }
-      }
+      "name": "Toolbar visibility",
+      "id": "toolbar",
+      "type": "select",
+      "potentialValues": [
+        {
+          "name": "Always",
+          "id": "show"
+        },
+        {
+          "name": "When hovered",
+          "id": "hover"
+        },
+        {
+          "name": "Never",
+          "id": "hide"
+        }
+      ],
+      "default": "show"
     }
   ],
   "dynamicEnable": true,
@@ -54,7 +59,7 @@
       "matches": ["projects"],
       "if": {
         "settings": {
-          "hideToolbar": false
+          "toolbar": "show"
         }
       }
     },
@@ -63,7 +68,7 @@
       "matches": ["projects"],
       "if": {
         "settings": {
-          "hideToolbar": true
+          "toolbar": ["hide", "hover"]
         }
       }
     },
@@ -71,7 +76,9 @@
       "url": "hideToolbar.css",
       "matches": ["projects"],
       "if": {
-        "settings": { "hideToolbar": true }
+        "settings": {
+          "toolbar": ["hide", "hover"]
+        }
       }
     }
   ],
@@ -86,7 +93,7 @@
   "latestUpdate": {
     "version": "1.36.0",
     "isMajor": false,
-    "newSettings": ["hoverToolbar"]
+    "newSettings": ["toolbar"]
   },
   "enabledByDefault": false
 }

--- a/addons/fullscreen/addon.json
+++ b/addons/fullscreen/addon.json
@@ -10,7 +10,7 @@
   "info": [
     {
       "type": "notice",
-      "text": "If you choose to always hide the toolbar, remember that you can use the Esc key to exit the project player's full screen mode.",
+      "text": "If you choose to never show the toolbar, remember that you can use the Esc key to exit the project player's full screen mode.",
       "id": "hideToolbarNotice"
     }
   ],

--- a/addons/fullscreen/userscript.js
+++ b/addons/fullscreen/userscript.js
@@ -37,8 +37,7 @@ export default async function ({ addon, console }) {
     if (
       !addon.self.disabled &&
       addon.tab.redux.state.scratchGui.mode.isFullScreen &&
-      addon.settings.get("hideToolbar") &&
-      addon.settings.get("hoverToolbar")
+      addon.settings.get("toolbar") === "hover"
     ) {
       const canvas = await addon.tab.waitForElement('[class*="stage_full-screen"] canvas');
       const header = await addon.tab.waitForElement('[class^="stage-header_stage-header-wrapper"]');

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -674,6 +674,15 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
           delete settings.links;
           madeAnyChanges = madeChangesToAddon = true;
         }
+
+        if (addonId === "fullscreen" && settings.hideToolbar !== undefined) {
+          // Transition v1.35 to v1.36
+          console.log(settings)
+          settings.toolbar = settings.hideToolbar ? "hide" : "show";
+          delete settings.hideToolbar;
+          console.log(settings)
+          madeAnyChanges = madeChangesToAddon = true;
+        }
       }
 
       if (addonsEnabled[addonId] === undefined) addonsEnabled[addonId] = !!manifest.enabledByDefault;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -679,7 +679,8 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
           // Transition v1.36 to v1.37
           if (!settings.hideToolbar) {
             settings.toolbar = "show";
-          } else if (settings?.hoverToolbar) {
+          } else if (!!settings.hoverToolbar) {
+            // hoverToolbar doesn't exist pre-1.36
             settings.toolbar = "hover";
           } else {
             settings.toolbar = "hide";

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -679,8 +679,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
           // Transition v1.36 to v1.37
           if (!settings.hideToolbar) {
             settings.toolbar = "show";
-          } else if (!!settings.hoverToolbar) {
-            // hoverToolbar doesn't exist pre-1.36
+          } else if (settings.hoverToolbar) {
             settings.toolbar = "hover";
           } else {
             settings.toolbar = "hide";

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -677,10 +677,10 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
         if (addonId === "fullscreen" && settings.hideToolbar !== undefined) {
           // Transition v1.35 to v1.36
-          console.log(settings)
+          console.log(settings);
           settings.toolbar = settings.hideToolbar ? "hide" : "show";
           delete settings.hideToolbar;
-          console.log(settings)
+          console.log(settings);
           madeAnyChanges = madeChangesToAddon = true;
         }
       }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -677,10 +677,8 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
         if (addonId === "fullscreen" && settings.hideToolbar !== undefined) {
           // Transition v1.35 to v1.36
-          console.log(settings);
           settings.toolbar = settings.hideToolbar ? "hide" : "show";
           delete settings.hideToolbar;
-          console.log(settings);
           madeAnyChanges = madeChangesToAddon = true;
         }
       }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -677,10 +677,12 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
         if (addonId === "fullscreen" && settings.hideToolbar !== undefined) {
           // Transition v1.36 to v1.37
-          if (settings.hoverToolbar) {
-            settings.toolbar = "hover";
+          if (!settings.hideToolbar) {
+            settings.toolbar = "show"
+          } else if (settings?.hoverToolbar) {
+            settings.toolbar = "hover"
           } else {
-            settings.toolbar = settings.hideToolbar ? "hide" : "show";
+            settings.toolbar = "hide";
           }
           delete settings.hideToolbar;
           delete settings.hoverToolbar;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -676,9 +676,14 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
         }
 
         if (addonId === "fullscreen" && settings.hideToolbar !== undefined) {
-          // Transition v1.35 to v1.36
-          settings.toolbar = settings.hideToolbar ? "hide" : "show";
+          // Transition v1.36 to v1.37
+          if (settings.hoverToolbar) {
+            settings.toolbar = "hover";
+          } else {
+            settings.toolbar = settings.hideToolbar ? "hide" : "show";
+          }
           delete settings.hideToolbar;
+          delete settings.hoverToolbar;
           madeAnyChanges = madeChangesToAddon = true;
         }
       }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -678,9 +678,9 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
         if (addonId === "fullscreen" && settings.hideToolbar !== undefined) {
           // Transition v1.36 to v1.37
           if (!settings.hideToolbar) {
-            settings.toolbar = "show"
+            settings.toolbar = "show";
           } else if (settings?.hoverToolbar) {
-            settings.toolbar = "hover"
+            settings.toolbar = "hover";
           } else {
             settings.toolbar = "hide";
           }


### PR DESCRIPTION
Suggested in this comment: https://github.com/ScratchAddons/ScratchAddons/issues/7147#issuecomment-1939420029

### Changes

Merges the "Hide toolbar in full screen" and "Show toolbar when hovered" settings into one select setting.

### Reason for changes

To keep all 3 toolbar visibility options together and avoid hidden settings.

### Tests

tested on Firefox and Brave.