### PR TITLE
debugger: Scroll to the running thread

### DIFF
--- a/addons/debugger/log-view.js
+++ b/addons/debugger/log-view.js
@@ -112,15 +112,27 @@ class LogView {
     }
   }
 
-  scrollIntoView(index) {
-    const distanceFromTop = index * this.rowHeight;
+  /**
+   * @param {number} index
+   * @param {number} [margin] # of pixels on top and bottom that are not considered part of the view
+   * @returns {boolean}
+   */
+  isInView(index, margin = 0) {
+    const topEdgeFromTop = index * this.rowHeight;
+    const bottomEdgeFromTop = topEdgeFromTop + this.rowHeight;
     const viewportStart = this.scrollTop;
-    const viewportEnd = this.scrollTop + this.height;
-    const isInView = distanceFromTop > viewportStart && distanceFromTop < viewportEnd;
-    if (!isInView) {
-      this.scrollTop = distanceFromTop;
-      this.innerElement.scrollTop = distanceFromTop;
-    }
+    const viewportEnd = viewportStart + this.height;
+    return topEdgeFromTop >= (viewportStart + margin) && bottomEdgeFromTop <= (viewportEnd - margin);
+  }
+
+  /**
+   * @param {number} index
+   */
+  scrollTo(index) {
+    // Try to leave the item above still visible to make it more obvious to the user that they can
+    // still scroll.
+    this.scrollTop = index * this.rowHeight - this.rowHeight * 0.3;
+    this.innerElement.scrollTop = this.scrollTop;
   }
 
   _queueScrollToEnd() {

--- a/addons/debugger/log-view.js
+++ b/addons/debugger/log-view.js
@@ -122,7 +122,7 @@ class LogView {
     const bottomEdgeFromTop = topEdgeFromTop + this.rowHeight;
     const viewportStart = this.scrollTop;
     const viewportEnd = viewportStart + this.height;
-    return topEdgeFromTop >= (viewportStart + margin) && bottomEdgeFromTop <= (viewportEnd - margin);
+    return topEdgeFromTop >= viewportStart + margin && bottomEdgeFromTop <= viewportEnd - margin;
   }
 
   /**

--- a/addons/debugger/log-view.js
+++ b/addons/debugger/log-view.js
@@ -129,9 +129,12 @@ class LogView {
    * @param {number} index
    */
   scrollTo(index) {
-    // Try to leave the item above still visible to make it more obvious to the user that they can
+    // There is one extra pixel from this.endElement
+    const maximumScrollTop = Math.max(0, this.rows.length * this.rowHeight - this.height) + 1;
+
+    // Try to leave the item above slightly visible to make it more obvious to the user that they can
     // still scroll.
-    this.scrollTop = index * this.rowHeight - this.rowHeight * 0.3;
+    this.scrollTop = Math.min(maximumScrollTop, index * this.rowHeight - this.rowHeight * 0.3);
     this.innerElement.scrollTop = this.scrollTop;
   }
 

--- a/addons/debugger/log-view.js
+++ b/addons/debugger/log-view.js
@@ -130,7 +130,7 @@ class LogView {
    */
   scrollTo(index) {
     // There is one extra pixel from this.endElement
-    const maximumScrollTop = Math.max(0, this.rows.length * this.rowHeight - this.height) + 1;
+    const maximumScrollTop = Math.max(0, this.rows.length * this.rowHeight - this.height + 1);
 
     // Try to leave the item above slightly visible to make it more obvious to the user that they can
     // still scroll.

--- a/addons/debugger/threads.js
+++ b/addons/debugger/threads.js
@@ -95,6 +95,7 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
     const newRows = [];
     const threads = vm.runtime.threads;
     const visitedThreads = new Set();
+    const runningThread = getRunningThread();
 
     const createThreadInfo = (thread, depth) => {
       if (visitedThreads.has(thread)) {
@@ -118,7 +119,6 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
       }
       const cacheInfo = threadInfoCache.get(thread);
 
-      const runningThread = getRunningThread();
       const createBlockInfo = (block, stackFrameIdx) => {
         const blockId = block.id;
         if (!block) return;
@@ -213,7 +213,29 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
   handlePauseChanged(isPaused());
   onPauseChanged(handlePauseChanged);
 
-  onSingleStep(updateContent);
+  onSingleStep(() => {
+    updateContent();
+    queueMicrotask(() => {
+      const runningIndex = logView.rows.findIndex((i) => i.running);
+      if (runningIndex !== -1 && !logView.isInView(runningIndex, logView.rowHeight)) {
+        // Try to show the entire thread if we can fit it on screen
+        let found = false;
+        const maxScrollback = Math.floor(logView.height / logView.rowHeight) - 2;
+        for (let i = 1; i < maxScrollback; i++) {
+          const checkIndex = runningIndex - i;
+          if (logView.rows[checkIndex].type === 'thread-header') {
+            logView.scrollTo(checkIndex);
+            found = true;
+            break;
+          }
+        }
+
+        if (!found) {
+          logView.scrollTo(runningIndex);
+        }
+      }
+    })
+  });
 
   const show = () => {
     logView.show();

--- a/addons/debugger/threads.js
+++ b/addons/debugger/threads.js
@@ -220,7 +220,7 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
       if (runningIndex !== -1 && !logView.isInView(runningIndex, logView.rowHeight)) {
         // Try to show the entire thread if we can fit it on screen
         let found = false;
-        const maxScrollback = Math.floor(logView.height / logView.rowHeight) - 2;
+        const maxScrollback = Math.floor(logView.height / logView.rowHeight);
         for (let i = 1; i < maxScrollback; i++) {
           const checkIndex = runningIndex - i;
           if (logView.rows[checkIndex].type === 'thread-header') {
@@ -231,7 +231,10 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
         }
 
         if (!found) {
-          logView.scrollTo(runningIndex);
+          // We somehow couldn't find the header or the stack is too big for us to show the header
+          // and the current stack item at the same time. Settle for showing as much of the stack
+          // as we can while also leaving some room on the bottom for the stack to grow.
+          logView.scrollTo(Math.max(0, runningIndex - maxScrollback + 5));
         }
       }
     })

--- a/addons/debugger/threads.js
+++ b/addons/debugger/threads.js
@@ -223,7 +223,7 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
         const maxScrollback = Math.floor(logView.height / logView.rowHeight);
         for (let i = 1; i < maxScrollback; i++) {
           const checkIndex = runningIndex - i;
-          if (logView.rows[checkIndex].type === 'thread-header') {
+          if (logView.rows[checkIndex].type === "thread-header") {
             logView.scrollTo(checkIndex);
             found = true;
             break;
@@ -237,7 +237,7 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
           logView.scrollTo(Math.max(0, runningIndex - maxScrollback + 5));
         }
       }
-    })
+    });
   });
 
   const show = () => {


### PR DESCRIPTION
When single stepping, the addon's thread list now automatically scrolls so that you can see the thread and block that is being run instead of hoping you'll figure out where it is on your own.