### PR TITLE
New setting in "Customizable navgation bar" addon, "Expand the width"

### DIFF
--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -29,6 +29,15 @@
       }
     },
     {
+      "url": "expand-width.css",
+      "matches": ["https://scratch.mit.edu/*"],
+      "if": {
+        "settings": {
+          "expand-width": true
+        }
+      }
+    },
+    {
       "url": "stick.css",
       "matches": ["https://scratch.mit.edu/*"],
       "if": {
@@ -97,6 +106,12 @@
       "default": false
     },
     {
+      "name": "Expand the width",
+      "id": "expand-width",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "Stick to",
       "id": "stick",
       "type": "select",
@@ -117,8 +132,8 @@
   "dynamicDisable": true,
   "versionAdded": "1.0.0",
   "latestUpdate": {
-    "version": "1.32.0",
-    "newSettings": ["stick"],
+    "version": "1.36.0",
+    "newSettings": ["expand-width"],
     "isMajor": false
   },
   "tags": ["community", "featured"],

--- a/addons/discuss-button/expand-width.css
+++ b/addons/discuss-button/expand-width.css
@@ -1,0 +1,3 @@
+#navigation > .inner{
+	width: 97%;
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->
https://github.com/ScratchAddons/ScratchAddons/issues/7175

Resolves # Adds more space for the search bar by shattering scratch's width limit (for the nav bar)

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
Added a new setting in the "Customizable Navigation bar" addon, whose id is "discuss-button", named "Expand the width" when enabled, shatters scratch width limit (in the nav bar) and gives more space for the search bar

### Reason for changes

<!-- Why should these changes be made? -->
Increases width of the search bar thus incrementing the truncate limit and makes text in the search bar easier to see.

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->
Tested on: MS Edge