### PR TITLE
Edits to the paragraph about Prettier

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Testing changes once you have downloaded the source code is very easy and you do
 
 ### Guidelines and tips
 
-We format our code with Prettier to make sure all of it follows the same style and looks nice and neat. You can install [Prettier for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or enable the "Format code using Prettier" workflow on your fork (by going to the Actions tab) to have Prettier format your code. If your pull request has formatting issues and you don't have Prettier, don't worry, we can fix it for you.
+We format our code with [Prettier](https://www.npmjs.com/package/prettier) to make sure all of it follows the same style and looks nice and neat. To have your code automatically formatted, enable Actions on your fork of the repository (in the Actions tab). If your pull request has formatting issues, don't worry, we can also fix it for you.
 
 It's a good idea to check "allow edits from maintainers" so that we can make adjustments and help fix things (like formatting) for you.
 


### PR DESCRIPTION
### Changes

I removed the mention of Prettier for VS Code as I think it always uses the latest version and you also need to change the settings for it to work with our code style, and I don't really want to take up space to explain how to configure it. The parser it uses also cannot format CSS, even though Prettier has an official CSS parser.

I was thinking of also linking to the [online Prettier playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEcAeAHCAnGACAEzgDMBDAVwBt9SBnATyjD2PKZgEto8AKYPUgQLQANHkhRaESnDwBfAJR5gAHSh4BDJizZhO3WqXoAJOJUoQAKhACqtONh5LV6jeOhSZAOgsBzHiogpuYQYoF4ANQCAO6kHDRC0F4UMAAWXsRwMGCpdg5QpAC2cE4KANxqGnJqlTFx+IYmZhbWeY7ltRKecD4Q-oHGENEC2LL0EOR4MBAERgD8gR1Q1VAgIiAQGPqSyKCk2NhDAAr7CLTIIKSUsfTn6wBG2KRgANZZAMpFcAAyHFBwyDIlHsDyerw+GGef18yBg2HIcHW9kKHFh8MRqEwDg4xVgV0s+X2HDg5yQQJBIFo0JkAEVyBB4ICrhSAFa0NDvalwOkMgFk5kYgCO9PgR0OGFJl1oAFp-nAiAQ1iA4XFKNCAMIQQqFUgXEkAViVVKgvhkAEEYHCOPdyKKHL9-kzgRjUjBCpQAOqpeIkyFgODvM7xDgAN3i9AuYFodxAIYRAEkoERYO8wNgOFszUn3jB6DInRSMId7B6nhgLkWSQ4QwD1n97LgxaRfDqCxjIdgGxd7qR7mYlUW-jAPRwCGlkABGABMAAZ1qNhRxRk2W7r+c71jBeyOx6lkFP1uR7JZe6TyRi4IU+0J5d9SCbyM24AAxHA6y3Qi4pCAgORyIA) as an easy-to-use alternative, but that also appears to only be able to use the latest version. That would be fine except that, like many developers, we hardcode a version, after we learned [how automatic updates go the hard way](https://github.com/ScratchAddons/ScratchAddons/pull/6362).

I haven't tried Prettier on RunKit yet, but that might be one other option for those who aren't ready to install Node.js just to format code. If anyone knows of any other easy ways to get code formatted with Prettier's algorithms _before committing changes_ that 1. can be configured and 2. can use a specific version, let me know.

Despite all of these removed references, I did add a link to the `prettier` package on npm, and continue to recommend enabling the Actions feature.