### PR TITLE
Add deprecation warning to image-uploader

### DIFF
--- a/addons/image-uploader/addon.json
+++ b/addons/image-uploader/addon.json
@@ -6,10 +6,11 @@
       "name": "Jeffalo"
     }
   ],
-  "userscripts": [
+  "info": [
     {
-      "url": "userscript.js",
-      "matches": ["editingScreens"]
+      "id": "deprecated",
+      "type": "warning",
+      "text": "This addon is no longer supported and does not work anymore."
     }
   ],
   "userstyles": [


### PR DESCRIPTION
### Changes

- The userscript is still in the source, but I removed references to it from addon.json
- Adds an (untranslated in the release) warning to the addon stating that it no longer works

cc @DNin01 