### PR TITLE
custom-menu-bar: rewrite compact-dropdown userscript

### DIFF
--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -4,7 +4,7 @@
   "credits": [
     {
       "name": "philipp2007",
-      "link": "https://iqnite.gihub.io/"
+      "link": "https://iqnite.github.io/"
     },
     {
       "name": "CST1229",

--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -22,7 +22,7 @@
   "info": [
     {
       "id": "tutorials-button-update",
-      "text": "The \"hide tutorials button\" addon has been moved here as a setting."
+      "text": "The \"Hide tutorials button\" addon has been moved here as a setting."
     },
     {
       "type": "notice",

--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -22,7 +22,7 @@
   "info": [
     {
       "id": "tutorials-button-update",
-      "text": "The \"Hide Tutorials button\" addon has been moved here as a setting."
+      "text": "The \"hide tutorials button\" addon has been moved here as a setting."
     },
     {
       "type": "notice",

--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -22,7 +22,7 @@
   "info": [
     {
       "id": "tutorials-button-update",
-      "text": "The \"Hide tutorials button\" addon has been moved here as a setting."
+      "text": "The \"Hide Tutorials button\" addon has been moved here as a setting."
     },
     {
       "type": "notice",

--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -4,7 +4,7 @@
   "credits": [
     {
       "name": "philipp2007",
-      "link": "https://ggigabyte.repl.co/"
+      "link": "https://iqnite.gihub.io/"
     },
     {
       "name": "CST1229",

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -1,6 +1,6 @@
 export default async function ({ addon }) {
   while (true) {
-    const menuItem = await addon.tab.waitForElement('[class^=account-nav_user-info_] + div > ul > :first-child', {
+    const menuItem = await addon.tab.waitForElement("[class^=account-nav_user-info_] + div > ul > :first-child", {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/menus/OPEN_MENU"],
       reduxCondition: (state) => state.scratchGui.menus.accountMenu,

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -5,6 +5,7 @@ export default async function ({ addon }) {
       reduxEvents: ["scratch-gui/menus/OPEN_MENU"],
       reduxCondition: (state) => state.scratchGui.menus.accountMenu,
     });
+    if (!addon.settings.get("compact-username")) continue;
     const usernameSpan = document.createElement("span");
     usernameSpan.textContent = await addon.auth.fetchUsername();
     usernameSpan.className = "sa-profile-name";

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -1,5 +1,4 @@
 export default async function ({ addon }) {
-  const username = await addon.auth.fetchUsername();
   while (true) {
     const menuItem = await addon.tab.waitForElement("[class^=menu_menu_] > :first-child", {
       markAsSeen: true,
@@ -7,7 +6,7 @@ export default async function ({ addon }) {
       reduxCondition: (state) => state.scratchGui.menus.accountMenu,
     });
     const usernameSpan = document.createElement("span");
-    usernameSpan.textContent = username;
+    usernameSpan.textContent = await addon.auth.fetchUsername();
     usernameSpan.className = "sa-profile-name";
     menuItem.appendChild(usernameSpan);
   }

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -1,14 +1,16 @@
 export default async function ({ addon }) {
   while (true) {
+    // Profile account menu item
     const menuItem = await addon.tab.waitForElement("[class^=account-nav_user-info_] + div > ul > :first-child", {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/menus/OPEN_MENU"],
       reduxCondition: (state) => state.scratchGui.menus.accountMenu,
     });
-    if (!addon.settings.get("compact-username")) continue;
-    const usernameSpan = document.createElement("span");
-    usernameSpan.textContent = await addon.auth.fetchUsername();
-    usernameSpan.className = "sa-profile-name";
-    menuItem.appendChild(usernameSpan);
+    if (addon.settings.get("compact-username")) {
+      const usernameSpan = document.createElement("span");
+      usernameSpan.textContent = await addon.auth.fetchUsername();
+      usernameSpan.className = "sa-profile-name";
+      menuItem.appendChild(usernameSpan);
+    }
   }
 }

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -1,6 +1,5 @@
 export default async function ({ addon }) {
   const username = await addon.auth.fetchUsername();
-  if (!username) return;
   while (true) {
     const menuItem = await addon.tab.waitForElement("[class^=menu_menu_] > :first-child", {
       markAsSeen: true,

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -1,14 +1,15 @@
 export default async function ({ addon }) {
-  if (await addon.auth.fetchIsLoggedIn()) {
-    const username = await addon.auth.fetchUsername();
-    addon.tab.redux.initialize(); // Start listening to Redux events
-    addon.tab.redux.addEventListener("statechanged", async (e) => {
-      if (!addon.settings.get("compact-username")) return; // Skip if the option is disabled
-      if (e.detail.action.type !== "scratch-gui/menus/OPEN_MENU" || e.detail.action.menu !== "accountMenu") return; // Skip if another Redux event occurs
-      const profileSpans = await addon.tab.waitForElement(".menu_menu-item_3EwYA.menu_hoverable_3u9dt"); // Do this if the menu is opened
-      const profile = profileSpans.appendChild(document.createElement("span")); // Add username to "Profile" menu option
-      profile.textContent = username;
-      profile.className = "sa-profile-name";
+  const username = await addon.auth.fetchUsername();
+  if (!username) return;
+  while (true) {
+    const menuItem = await addon.tab.waitForElement("[class^=menu_menu_] > :first-child", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/menus/OPEN_MENU"],
+      reduxCondition: (state) => state.scratchGui.menus.accountMenu,
     });
+    const usernameSpan = document.createElement("span");
+    usernameSpan.textContent = username;
+    usernameSpan.className = "sa-profile-name";
+    menuItem.appendChild(usernameSpan);
   }
 }

--- a/addons/custom-menu-bar/username.js
+++ b/addons/custom-menu-bar/username.js
@@ -1,6 +1,6 @@
 export default async function ({ addon }) {
   while (true) {
-    const menuItem = await addon.tab.waitForElement("[class^=menu_menu_] > :first-child", {
+    const menuItem = await addon.tab.waitForElement('[class^=account-nav_user-info_] + div > ul > :first-child', {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/menus/OPEN_MENU"],
       reduxCondition: (state) => state.scratchGui.menus.accountMenu,

--- a/addons/editor-compact/addon.json
+++ b/addons/editor-compact/addon.json
@@ -15,7 +15,7 @@
   "info": [
     {
       "id": "hide-icons-update",
-      "text": "To hide the menu bar icons, use the \"Customizable menu bar\" addon."
+      "text": "To hide menu bar icons, use the \"Customizable menu bar\" addon."
     }
   ],
   "userstyles": [

--- a/addons/editor-compact/addon.json
+++ b/addons/editor-compact/addon.json
@@ -15,7 +15,7 @@
   "info": [
     {
       "id": "hide-icons-update",
-      "text": "To hide menu bar icons, use the \"Customizable menu bar\" addon."
+      "text": "To hide the menu bar icons, use the \"customizable menu bar\" addon."
     }
   ],
   "userstyles": [

--- a/addons/editor-compact/addon.json
+++ b/addons/editor-compact/addon.json
@@ -15,7 +15,7 @@
   "info": [
     {
       "id": "hide-icons-update",
-      "text": "To hide the menu bar icons, use the \"customizable menu bar\" addon."
+      "text": "To hide the menu bar icons, use the \"Customizable menu bar\" addon."
     }
   ],
   "userstyles": [


### PR DESCRIPTION
See the post-merge reviews on #6297.

### Changes

Rewrites `custom-menu-bar`'s userscript to use the Redux as part of the `addon.tab.waitForElemet`.

### Reason for changes

To stop using a hashed selector and using Redux and `waitForElement` separately is unnecessary.

### Tests

Tested on Firefox
