### PR TITLE
Project video recorder: Make filename the project title

### DIFF
--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -230,7 +230,7 @@ export default async ({ addon, console, msg }) => {
       } else {
         recorder.onstop = () => {
           const blob = new Blob(recordBuffer, { type: mimeType });
-          downloadBlob(`video.${fileExtension}`, blob);
+          downloadBlob(`${addon.tab.redux.state?.preview?.projectInfo?.title || "video"}.${fileExtension}`, blob);
           disposeRecorder();
         };
         recorder.stop();


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #
#7194 
### Changes

added `${addon.tab.redux.state?.preview?.projectInfo?.title || "video"}` to the video download script

### Reason for changes

got the idea from a [discord suggestion](https://discord.com/channels/806602307750985799/1209113670681104424)

### Tests

Tested on chrome
