### PR TITLE
editor-square-inputs: add number option

### DIFF
--- a/addons/editor-square-inputs/addon.json
+++ b/addons/editor-square-inputs/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Square block text inputs",
-  "description": "Makes text and color inputs on blocks rectangular instead of round, like in Scratch 2.0.",
+  "description": "Makes text (not number) and color inputs on blocks rectangular instead of round, like in Scratch 2.0.",
   "credits": [
     {
       "name": "CST1229",
@@ -22,6 +22,12 @@
       "default": true
     },
     {
+      "name": "Number inputs",
+      "id": "number",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "Color inputs",
       "id": "color",
       "type": "boolean",
@@ -30,5 +36,10 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "versionAdded": "1.36.0"
+  "versionAdded": "1.36.0",
+  "latestUpdate": {
+    "version": "1.37.0",
+    "newSettings": ["number"],
+    "isMajor": false
+  }
 }

--- a/addons/editor-square-inputs/userscript.js
+++ b/addons/editor-square-inputs/userscript.js
@@ -8,6 +8,11 @@ export default async function ({ addon }) {
     text: "text",
     argument_editor_string_number: "text",
     math_number: "number",
+    math_integer: "number",
+    math_whole_number: "number",
+    math_positive_number: "number",
+    math_angle: "number",
+    note: "number",
     colour_picker: "color",
   };
 

--- a/addons/editor-square-inputs/userscript.js
+++ b/addons/editor-square-inputs/userscript.js
@@ -7,6 +7,7 @@ export default async function ({ addon }) {
   const opcodeToSettings = {
     text: "text",
     argument_editor_string_number: "text",
+    math_number: "number",
     colour_picker: "color",
   };
 


### PR DESCRIPTION
Resolves??? [#Square block text inputs doesn't apply to number inputs](https://discord.com/channels/806602307750985799/1209864567430062131/1209864567430062131)
Also addresses [feedback](https://github.com/ScratchAddons/ScratchAddons/pull/5331#issuecomment-1960402896)

### Changes

Adds a (disabled-by-default) option to the Square block text inputs addon to affect number inputs, and also adjusts the description. I'm not sure if the description change is needed, as it might seem a bit contradictory with the number option existing.

The number option also affects all the other inputs that only accept numbers (like direction and note inputs), meaning you can enable both the text and number options to make all typable inputs square.

### Reason for changes

Some people got confused about how the addon doesn't affect number inputs.

### Tests

Only tested a bit on Firefox,  but it's a fairly small thing.
![image](https://github.com/ScratchAddons/ScratchAddons/assets/68464103/f153fb9c-d28d-4fba-985d-2a4c46d867bd)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/68464103/97b5ea86-89ab-4859-b252-07964bc3adf4)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/68464103/3c9beb45-cfcb-4759-a530-0ffce1b8c07d)

