### PR TITLE
editor-theme3: fix number pad bugs

### DIFF
--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -11,7 +11,8 @@
   color: var(--editorTheme3-inputColor-blackText);
 }
 
-.blocklyDropDownDiv .goog-menuitem {
+.blocklyDropDownDiv .goog-menuitem,
+.blocklyNumPadButton {
   color: black;
 }
 .blocklyDropDownDiv .blocklyText {

--- a/addons/editor-theme3/color_on_white.css
+++ b/addons/editor-theme3/color_on_white.css
@@ -10,7 +10,8 @@
 
 .u-dropdown-searchbar,
 .u-dropdown-searchbar:focus,
-.blocklyDropDownDiv .goog-menuitem {
+.blocklyDropDownDiv .goog-menuitem,
+.blocklyNumPadButton {
   color: #575e75;
 }
 .u-dropdown-searchbar:focus {

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -251,6 +251,8 @@ export default async function ({ addon, console, msg }) {
     tertiary: "#3aa8a4",
   };
 
+  const originalNumpadDeleteIcon = Blockly.FieldNumber.NUMPAD_DELETE_ICON;
+
   const fieldBackground = (category) => {
     // Background color for open dropdowns and (in some textModes) Boolean inputs
     // The argument can be a block, field, or category
@@ -397,6 +399,15 @@ export default async function ({ addon, console, msg }) {
       // Labels in custom block editor
       Blockly.WidgetDiv.DIV.classList.add("sa-theme3-editable-label");
     }
+  };
+
+  const oldFieldNumberUpdateDisplay = Blockly.FieldNumber.updateDisplay_;
+  Blockly.FieldNumber.updateDisplay_ = function (...args) {
+    /* Called when editing a number input using the numpad. Scratch's implementation
+       only updates the HTML input. The addon hides the HTML input, so the field itself
+       needs to be updated to make the change visible. */
+    oldFieldNumberUpdateDisplay.call(this, ...args);
+    Blockly.FieldNumber.activeField_.onHtmlInputChange_(new Event(""));
   };
 
   const oldFieldImageSetValue = Blockly.FieldImage.prototype.setValue;
@@ -557,6 +568,9 @@ export default async function ({ addon, console, msg }) {
     if (textMode() === "colorOnWhite") Blockly.Colours.fieldShadow = "rgba(0, 0, 0, 0.15)";
     else Blockly.Colours.fieldShadow = originalColors.fieldShadow;
     Blockly.Colours.text = uncoloredTextColor(); // used by editor-colored-context-menus
+
+    const safeTextColor = encodeURIComponent(uncoloredTextColor());
+    Blockly.FieldNumber.NUMPAD_DELETE_ICON = originalNumpadDeleteIcon.replace("white", safeTextColor);
 
     const workspace = Blockly.getMainWorkspace();
     const flyout = workspace.getFlyout();


### PR DESCRIPTION
Resolves #7206

### Changes

* Updates the displayed value when editing an input using the numpad.
* Fixes the text color of numpad buttons - it was previously always white, which is hard to see in high contrast mode and invisible if the text color is set to "colored on white background".

### Tests

Tested on Edge and Firefox.