### PR TITLE
dark-www: fix "report profile" modal bugs

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2150,6 +2150,10 @@
       "matches": ["editingScreens"]
     },
     {
+      "url": "profile.js",
+      "matches": ["profiles"]
+    },
+    {
       "url": "scratchstats.js",
       "matches": ["profiles"],
       "runAtComplete": false

--- a/addons/dark-www/profile.js
+++ b/addons/dark-www/profile.js
@@ -1,0 +1,10 @@
+export default async function ({ addon, console }) {
+  const oldAnimate = $.fn.animate;
+  $.fn.animate = function (style, ...args) {
+    if (!addon.self.disabled && style && style.backgroundColor === "pink") {
+      // Scratch calls animate({ backgroundColor: "pink" }) to highlight elements
+      style.backgroundColor = addon.settings.get("box");
+    }
+    return oldAnimate.call(this, style, ...args);
+  };
+}


### PR DESCRIPTION
Resolves #7082
Resolves #7182

### Changes

Changes the color of white highlights in the "report profile" modal.
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/5878bd68-f2c5-479d-b30a-d0b15257ccb4)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/994e585a-85ed-4a13-b1e9-0c9cb82aeac6)

### Reason for changes

To make text readable.

### Tests

Tested on Edge and Firefox.