### PR TITLE
Fix double scrollbar in middle click popup

### DIFF
--- a/addons/middle-click-popup/userstyle.css
+++ b/addons/middle-click-popup/userstyle.css
@@ -70,6 +70,9 @@
 .sa-mcp-preview-container {
   flex: auto;
   overflow-y: scroll;
+}
+
+.sa-mcp-root /* <-- specificity */ .sa-mcp-preview-container {
   scrollbar-width: none;
 }
 


### PR DESCRIPTION
Resolves #7107

### Changes

Makes the selector that hides the middle click popup scrollbar more specific.

### Reason for changes

It was being overridden by `editor-compact`.

### Tests

Tested on Edge and Firefox.