### PR TITLE
`hide-flyout`: Remove code that shrinks Scratch coding workspace

### DIFF
--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -226,24 +226,6 @@ export default async function ({ addon, console, msg }) {
       }
       oldStepScrollAnimation.call(this);
     };
-
-    // add flyout size to the workspace dimensions
-    const oldGetMetrics = Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_;
-    Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_ = function () {
-      const metrics = oldGetMetrics.call(this);
-      if (addon.self.disabled || getToggleSetting() === "hover" || this.RTL) return metrics;
-      if (this.getToolbox()?.flyout_?.getWidth() === 310) {
-        // columns is enabled
-        return metrics;
-      }
-      return {
-        ...metrics,
-        absoluteLeft: metrics.absoluteLeft - 250,
-        viewWidth: metrics.viewWidth + 250,
-      };
-    };
-    if (Blockly.getMainWorkspace())
-      Blockly.getMainWorkspace().getMetrics = Blockly.WorkspaceSvg.getTopLevelWorkspaceMetrics_;
   }
 
   while (true) {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -297,9 +297,6 @@ export default async function ({ addon, console, msg }) {
 
     doOneTimeSetup();
     autoLock();
-    if (getToggleSetting() !== "hover") {
-      // update workspace dimensions
-      Blockly.svgResize(Blockly.getMainWorkspace());
-    }
+    Blockly.svgResize(Blockly.getMainWorkspace());
   }
 }

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -143,8 +143,6 @@ export default async function ({ addon, console, msg }) {
     }
     addon.self.addEventListener("disabled", () => {
       Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
-      // update workspace dimensions
-      Blockly.svgResize(Blockly.getMainWorkspace());
     });
     addon.self.addEventListener("reenabled", () => {
       if (getToggleSetting() === "category" && !addon.settings.get("lockLoad")) {
@@ -152,8 +150,6 @@ export default async function ({ addon, console, msg }) {
         onmouseleave(null, 0);
         toggle = false;
       }
-      // update workspace dimensions
-      Blockly.svgResize(Blockly.getMainWorkspace());
     });
 
     addon.settings.addEventListener("change", () => {
@@ -180,8 +176,6 @@ export default async function ({ addon, console, msg }) {
         }
         Blockly.getMainWorkspace().getToolbox().selectedItem_.setSelected(true);
       }
-      // update workspace dimensions
-      Blockly.svgResize(Blockly.getMainWorkspace());
     });
 
     // category click mode

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -297,9 +297,5 @@ export default async function ({ addon, console, msg }) {
 
     doOneTimeSetup();
     autoLock();
-    if (getToggleSetting() !== "hover") {
-      // update workspace dimensions
-      Blockly.svgResize(Blockly.getMainWorkspace());
-    }
   }
 }

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -297,5 +297,9 @@ export default async function ({ addon, console, msg }) {
 
     doOneTimeSetup();
     autoLock();
+    if (getToggleSetting() !== "hover") {
+      // update workspace dimensions
+      Blockly.svgResize(Blockly.getMainWorkspace());
+    }
   }
 }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->



### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->

There was some code in the Auto-hiding block palette (`hide-flyout`) addon that explicitly shrinks the width of the code workspace by 250 pixels if the toggle setting is "Category hover" or "Category click" (unless two-columns category menu addon is enabled). This causes problems on devices with smaller screens where the code palette blocks the user from easily accessing blocks underneath it by panning. This PR removes that code.

Video of **CURRENT BEHAVIOR** with an example work environment that triggers the problem below:

https://github.com/ScratchAddons/ScratchAddons/assets/61996651/4fc702a9-a79f-491a-a424-f08c755f6519

With the changes, the user can now actually pan to access the blocks underneath the block palette.

Video of **CHANGED BEHAVIOR** below:

https://github.com/ScratchAddons/ScratchAddons/assets/61996651/27128303-3c84-443b-9935-b82a32241b96


### Reason for changes

<!-- Why should these changes be made? -->

It is frustrating when you try to pan to a block input hidden underneath the block palette only to realize the workspace is fenced, so you then need to fidget around with zooming in and out... hiding the block palette... resizing the window... hiding the stage... considering buying a larger monitor... lmao not ideal

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->

- Tested on Brave and Firefox using a 1920x1080 display at 150% Windows display scale
- Tested both with and without Two-column category menu (`columns`) addon

I accidentally left my microphone on in the videos so enjoy hearing my mouse slam on my desk.