### PR TITLE
Prevent Alt+X (pause) from cutting blocks

### DIFF
--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -25,6 +25,7 @@ export default async function ({ addon, console, msg }) {
     // Because keyCode is deprecated we'll still check e.key in case keyCode is not as reliable as we think it is
     if (e.altKey && (e.key.toLowerCase() === "x" || e.keyCode === 88) && !addon.self.disabled) {
       e.preventDefault();
+      e.stopImmediatePropagation();
       setPaused(!isPaused());
     }
   });

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -18,17 +18,21 @@ export default async function ({ addon, console, msg }) {
   setSrc();
   onPauseChanged(setSrc);
 
-  document.addEventListener("keydown", function (e) {
-    // e.code is not enough because that corresponds to physical keys, ignoring keyboard layouts.
-    // e.key is not enough because on macOS, option+x types ≈ and shift+option+x types ˛
-    // e.keyCode is always 88 when pressing x regardless of modifier keys, so that's how we'll handle macOS.
-    // Because keyCode is deprecated we'll still check e.key in case keyCode is not as reliable as we think it is
-    if (e.altKey && (e.key.toLowerCase() === "x" || e.keyCode === 88) && !addon.self.disabled) {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      setPaused(!isPaused());
-    }
-  }, { capture: true });
+  document.addEventListener(
+    "keydown",
+    function (e) {
+      // e.code is not enough because that corresponds to physical keys, ignoring keyboard layouts.
+      // e.key is not enough because on macOS, option+x types ≈ and shift+option+x types ˛
+      // e.keyCode is always 88 when pressing x regardless of modifier keys, so that's how we'll handle macOS.
+      // Because keyCode is deprecated we'll still check e.key in case keyCode is not as reliable as we think it is
+      if (e.altKey && (e.key.toLowerCase() === "x" || e.keyCode === 88) && !addon.self.disabled) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        setPaused(!isPaused());
+      }
+    },
+    { capture: true }
+  );
 
   while (true) {
     await addon.tab.waitForElement("[class^='green-flag']", {

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -28,7 +28,7 @@ export default async function ({ addon, console, msg }) {
       e.stopImmediatePropagation();
       setPaused(!isPaused());
     }
-  });
+  }, { capture: true });
 
   while (true) {
     await addon.tab.waitForElement("[class^='green-flag']", {


### PR DESCRIPTION
Resolves #7225

### Changes

When the `pause` addon is enabled, pressing <kbd>Alt</kbd>+<kbd>X</kbd> will now stop immediate propagation, to avoid activating other shortcuts (specifically, cutting blocks).

### Reason for changes

The Scratch editor's Blockly workspace cuts the focused block (usually the last one that was touched) when pressing <kbd>Ctrl</kbd>+<kbd>X</kbd>, <kbd>Cmd</kbd>+<kbd>X</kbd> (Mac), <kbd>Alt</kbd>+<kbd>X</kbd>, or <kbd>Option</kbd>+<kbd>X</kbd> (Mac), two of which conflict with our pause keyboard shortcut.

I wonder why part of this shortcut was bound to the <kbd>Alt</kbd> key in the first place.

### Tests

Tested with Edge 121.

Should probably check that this doesn't cause any other problems, like preventing other keyboard shortcuts from working.
