### PR TITLE
Move de- & serializeSettings into its own module

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -8,7 +8,7 @@ import categories from "./data/categories.js";
 import exampleManifest from "./data/example-manifest.js";
 import fuseOptions from "./data/fuse-options.js";
 import globalTheme from "../../libraries/common/global-theme.js";
-import minifySettings from "../../libraries/common/minify-settings.js";
+import { deserializeSettings, serializeSettings } from "./settings-utils.js";
 
 let isIframe = false;
 if (window.parent !== window) {
@@ -66,102 +66,6 @@ let fuse;
   updateGrantedPermissions();
   chrome.permissions.onAdded?.addListener(updateGrantedPermissions);
   chrome.permissions.onRemoved?.addListener(updateGrantedPermissions);
-
-  const promisify =
-    (callbackFn) =>
-    (...args) =>
-      new Promise((resolve) => callbackFn(...args, resolve));
-
-  let handleConfirmClicked = null;
-
-  const serializeSettings = async () => {
-    const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
-    const storedSettings = await syncGet([
-      "globalTheme",
-      "addonSettings1",
-      "addonSettings2",
-      "addonSettings3",
-      "addonsEnabled",
-    ]);
-    const addonSettings = {
-      ...storedSettings.addonSettings1,
-      ...storedSettings.addonSettings2,
-      ...storedSettings.addonSettings3,
-    };
-    const serialized = {
-      core: {
-        lightTheme: storedSettings.globalTheme,
-        version: chrome.runtime.getManifest().version_name,
-      },
-      addons: {},
-    };
-    for (const addonId of Object.keys(storedSettings.addonsEnabled)) {
-      serialized.addons[addonId] = {
-        enabled: storedSettings.addonsEnabled[addonId],
-        settings: addonSettings[addonId] || {},
-      };
-    }
-    return JSON.stringify(serialized);
-  };
-
-  const deserializeSettings = async (str, manifests, confirmElem) => {
-    const obj = JSON.parse(str);
-    const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
-    const syncSet = promisify(chrome.storage.sync.set.bind(chrome.storage.sync));
-    const { addonsEnabled, ...storageItems } = await syncGet([
-      "addonSettings1",
-      "addonSettings2",
-      "addonSettings3",
-      "addonsEnabled",
-    ]);
-    const addonSettings = {
-      ...storageItems.addonSettings1,
-      ...storageItems.addonSettings2,
-      ...storageItems.addonSettings3,
-    };
-    const pendingPermissions = {};
-    for (const addonId of Object.keys(obj.addons)) {
-      const addonValue = obj.addons[addonId];
-      const addonManifest = manifests.find((m) => m._addonId === addonId);
-      if (!addonManifest) continue;
-      const permissionsRequired = addonManifest.permissions || [];
-      const browserPermissionsRequired = permissionsRequired.filter((p) => browserLevelPermissions.includes(p));
-      if (addonValue.enabled && browserPermissionsRequired.length) {
-        pendingPermissions[addonId] = browserPermissionsRequired;
-      } else {
-        addonsEnabled[addonId] = addonValue.enabled;
-      }
-      addonSettings[addonId] = Object.assign({}, addonSettings[addonId]);
-      delete addonSettings[addonId]._version;
-      Object.assign(addonSettings[addonId], addonValue.settings);
-    }
-    if (handleConfirmClicked) confirmElem.removeEventListener("click", handleConfirmClicked, { once: true });
-    let resolvePromise = null;
-    const resolveOnConfirmPromise = new Promise((resolve) => {
-      resolvePromise = resolve;
-    });
-    handleConfirmClicked = async () => {
-      handleConfirmClicked = null;
-      if (Object.keys(pendingPermissions).length) {
-        const granted = await promisify(chrome.permissions.request.bind(chrome.permissions))({
-          permissions: Object.values(pendingPermissions).flat(),
-        });
-        Object.keys(pendingPermissions).forEach((addonId) => {
-          addonsEnabled[addonId] = granted;
-        });
-      }
-      const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
-      await syncSet({
-        globalTheme: !!obj.core.lightTheme,
-        addonsEnabled,
-        ...minifySettings(addonSettings, prerelease ? null : manifests),
-      });
-      resolvePromise();
-    };
-    confirmElem.classList.remove("hidden-button");
-    confirmElem.addEventListener("click", handleConfirmClicked, { once: true });
-    return resolveOnConfirmPromise;
-  };
 
   vue = window.vue = new Vue({
     el: "body",
@@ -352,7 +256,7 @@ let fuse;
             inputElem.remove();
             const confirmElem = document.getElementById("confirmImport");
             try {
-              await deserializeSettings(text, vue.manifests, confirmElem);
+              await deserializeSettings(text, vue.manifests, confirmElem, { browserLevelPermissions });
             } catch (e) {
               console.warn("Error when importing settings:", e);
               confirmElem.classList.add("hidden-button");

--- a/webpages/settings/settings-utils.js
+++ b/webpages/settings/settings-utils.js
@@ -1,0 +1,97 @@
+import minifySettings from "../../libraries/common/minify-settings.js";
+
+const promisify =
+  (callbackFn) =>
+  (...args) =>
+    new Promise((resolve) => callbackFn(...args, resolve));
+
+let handleConfirmClicked = null;
+
+export const serializeSettings = async () => {
+  const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
+  const storedSettings = await syncGet([
+    "globalTheme",
+    "addonSettings1",
+    "addonSettings2",
+    "addonSettings3",
+    "addonsEnabled",
+  ]);
+  const addonSettings = {
+    ...storedSettings.addonSettings1,
+    ...storedSettings.addonSettings2,
+    ...storedSettings.addonSettings3,
+  };
+  const serialized = {
+    core: {
+      lightTheme: storedSettings.globalTheme,
+      version: chrome.runtime.getManifest().version_name,
+    },
+    addons: {},
+  };
+  for (const addonId of Object.keys(storedSettings.addonsEnabled)) {
+    serialized.addons[addonId] = {
+      enabled: storedSettings.addonsEnabled[addonId],
+      settings: addonSettings[addonId] || {},
+    };
+  }
+  return JSON.stringify(serialized);
+};
+
+export const deserializeSettings = async (str, manifests, confirmElem, { browserLevelPermissions }) => {
+  const obj = JSON.parse(str);
+  const syncGet = promisify(chrome.storage.sync.get.bind(chrome.storage.sync));
+  const syncSet = promisify(chrome.storage.sync.set.bind(chrome.storage.sync));
+  const { addonsEnabled, ...storageItems } = await syncGet([
+    "addonSettings1",
+    "addonSettings2",
+    "addonSettings3",
+    "addonsEnabled",
+  ]);
+  const addonSettings = {
+    ...storageItems.addonSettings1,
+    ...storageItems.addonSettings2,
+    ...storageItems.addonSettings3,
+  };
+  const pendingPermissions = {};
+  for (const addonId of Object.keys(obj.addons)) {
+    const addonValue = obj.addons[addonId];
+    const addonManifest = manifests.find((m) => m._addonId === addonId);
+    if (!addonManifest) continue;
+    const permissionsRequired = addonManifest.permissions || [];
+    const browserPermissionsRequired = permissionsRequired.filter((p) => browserLevelPermissions.includes(p));
+    if (addonValue.enabled && browserPermissionsRequired.length) {
+      pendingPermissions[addonId] = browserPermissionsRequired;
+    } else {
+      addonsEnabled[addonId] = addonValue.enabled;
+    }
+    addonSettings[addonId] = Object.assign({}, addonSettings[addonId]);
+    delete addonSettings[addonId]._version;
+    Object.assign(addonSettings[addonId], addonValue.settings);
+  }
+  if (handleConfirmClicked) confirmElem.removeEventListener("click", handleConfirmClicked, { once: true });
+  let resolvePromise = null;
+  const resolveOnConfirmPromise = new Promise((resolve) => {
+    resolvePromise = resolve;
+  });
+  handleConfirmClicked = async () => {
+    handleConfirmClicked = null;
+    if (Object.keys(pendingPermissions).length) {
+      const granted = await promisify(chrome.permissions.request.bind(chrome.permissions))({
+        permissions: Object.values(pendingPermissions).flat(),
+      });
+      Object.keys(pendingPermissions).forEach((addonId) => {
+        addonsEnabled[addonId] = granted;
+      });
+    }
+    const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
+    await syncSet({
+      globalTheme: !!obj.core.lightTheme,
+      addonsEnabled,
+      ...minifySettings(addonSettings, prerelease ? null : manifests),
+    });
+    resolvePromise();
+  };
+  confirmElem.classList.remove("hidden-button");
+  confirmElem.addEventListener("click", handleConfirmClicked, { once: true });
+  return resolveOnConfirmPromise;
+};


### PR DESCRIPTION
### Changes

The `serializeSettings` and `deserializeSettings` functions were moved into its own module.
These functions are used in the settings page to import and export settings (the buttons inside More Settings).
The extension should continue to work the same after these changes.

### Reason for changes

In preparation for #6876.
Users will be able to export their settings from their unsupported-browser page soon, so the `serializeSettings` method will be imported from a second page.
Most likely, `deserializeSettings` will only ever be useful to the settings page, but it was modularized anyway.

### Tests

Importing, exporting, and viewing settings as a file should continue to work normally from the settings page.