### PR TITLE
Setting for full-width navigation bar

### DIFF
--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -29,6 +29,15 @@
       }
     },
     {
+      "url": "extend-nav.css",
+      "matches": ["https://scratch.mit.edu/*"],
+      "if": {
+        "settings": {
+          "full-width": true
+        }
+      }
+    },
+    {
       "url": "stick.css",
       "matches": ["https://scratch.mit.edu/*"],
       "if": {
@@ -97,6 +106,12 @@
       "default": false
     },
     {
+      "name": "Extend to page edges",
+      "id": "full-width",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "Stick to",
       "id": "stick",
       "type": "select",
@@ -117,8 +132,8 @@
   "dynamicDisable": true,
   "versionAdded": "1.0.0",
   "latestUpdate": {
-    "version": "1.32.0",
-    "newSettings": ["stick"],
+    "version": "1.37.0",
+    "newSettings": ["full-width"],
     "isMajor": false
   },
   "tags": ["community", "featured"],

--- a/addons/discuss-button/extend-nav.css
+++ b/addons/discuss-button/extend-nav.css
@@ -1,0 +1,4 @@
+#navigation > .inner,
+#topnav .container {
+  width: calc(100% - 30px);
+}


### PR DESCRIPTION
Resolves #7175

### Changes

Adds a setting to `discuss-button` identified as `full-width`, which, when enabled, extends the navigation bar content to the edges of the page.

I'll have a screenshot in a minute...

These changes are inspired by @Waakul's pull request #7176.

### Reason for changes

The navigation bar can get crowded with too many items. Making it wider can help, and it already doesn't take up the entire page's width on bigger windows. Some people also just like it better this way.

### Tests

Tested with Edge 122

Tested together with `scratchr2` addon
