### PR TITLE
Create "Addons By Name" table

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *.md export-ignore
 LICENSE export-ignore
 .* export-ignore
+dev export-ignore
 typedef.js export-ignore
 
 libraries/README.md -export-ignore

--- a/addons/README.md
+++ b/addons/README.md
@@ -1,0 +1,178 @@
+# Addons By Name
+
+| Addon Name | Addon ID |
+|---|---|
+| 2D color picker | [2d-color-picker](/addons/2d-color-picker) |
+| 3.0 Scratchblocks on forums | [scratchblocks](/addons/scratchblocks) |
+| Alternating nested block colors | [zebra-striping](/addons/zebra-striping) |
+| Always show number pad | [number-pad](/addons/number-pad) |
+| Arrow key incrementation in editor | [editor-number-arrow-keys](/addons/editor-number-arrow-keys) |
+| Auto-hiding block palette | [hide-flyout](/addons/hide-flyout) |
+| Automatically add extensions | [load-extensions](/addons/load-extensions) |
+| BBCode source button | [show-bbcode](/addons/show-bbcode) |
+| Better editor comments | [fix-editor-comments](/addons/fix-editor-comments) |
+| Better emojis | [better-emojis](/addons/better-emojis) |
+| Better forum post editor buttons | [material-forum-editor-buttons](/addons/material-forum-editor-buttons) |
+| Better forum quoter | [better-quoter](/addons/better-quoter) |
+| Bitmap images copying | [bitmap-copy](/addons/bitmap-copy) |
+| Block count | [block-count](/addons/block-count) |
+| Block dropdown search | [editor-searchable-dropdowns](/addons/editor-searchable-dropdowns) |
+| Block palette category icons | [block-palette-icons](/addons/block-palette-icons) |
+| Block switching | [block-switching](/addons/block-switching) |
+| Block transparency | [transparent-orphans](/addons/transparent-orphans) |
+| Browse followers button in studios | [studio-followers](/addons/studio-followers) |
+| Capitalized Account Settings | [account-settings-capitalize](/addons/account-settings-capitalize) |
+| Cat blocks | [cat-blocks](/addons/cat-blocks) |
+| Clone counter | [clones](/addons/clones) |
+| Cloud games | [cloud-games](/addons/cloud-games) |
+| Collapsing sprite properties | [sprite-properties](/addons/sprite-properties) |
+| Colored context menus | [editor-colored-context-menus](/addons/editor-colored-context-menus) |
+| Compact editor | [editor-compact](/addons/editor-compact) |
+| Compact messages | [compact-messages](/addons/compact-messages) |
+| Confirmations | [confirm-actions](/addons/confirm-actions) |
+| Copy code button on forums | [forum-copy-code](/addons/forum-copy-code) |
+| Copy link to comment button | [copy-message-link](/addons/copy-message-link) |
+| Copy reporter values | [copy-reporter](/addons/copy-reporter) |
+| Costume editor snapping | [paint-snap](/addons/paint-snap) |
+| Ctrl+Click to run scripts | [ctrl-click-run-scripts](/addons/ctrl-click-run-scripts) |
+| Ctrl+Enter to post | [ctrl-enter-post](/addons/ctrl-enter-post) |
+| Customizable block colors | [editor-theme3](/addons/editor-theme3) |
+| Customizable block shape | [custom-block-shape](/addons/custom-block-shape) |
+| Customizable block text style | [custom-block-text](/addons/custom-block-text) |
+| Customizable code area zoom | [custom-zoom](/addons/custom-zoom) |
+| Customizable default costume editor colors | [default-costume-editor-color](/addons/default-costume-editor-color) |
+| Customizable default project | [default-project](/addons/default-project) |
+| Customizable link style | [colorblind](/addons/colorblind) |
+| Customizable menu bar | [custom-menu-bar](/addons/custom-menu-bar) |
+| Customizable navigation bar | [discuss-button](/addons/discuss-button) |
+| Customizable new sprite position | [initialise-sprite-position](/addons/initialise-sprite-position) |
+| Customizable profile picture border | [customize-avatar-border](/addons/customize-avatar-border) |
+| Customizable quotes and code blocks on forums | [forum-quote-code-beautifier](/addons/forum-quote-code-beautifier) |
+| Dango rain on profiles (April Fools Day) | [dango-rain](/addons/dango-rain) |
+| Data category tweaks | [data-category-tweaks-v2](/addons/data-category-tweaks-v2) |
+| Debugger | [debugger](/addons/debugger) |
+| Developer tools | [editor-devtools](/addons/editor-devtools) |
+| Disable auto-save | [disable-auto-save](/addons/disable-auto-save) |
+| Display stage on left side | [editor-stage-left](/addons/editor-stage-left) |
+| Do not automatically run duplicated blocks | [fix-pasted-scripts](/addons/fix-pasted-scripts) |
+| Do not automatically space overlapping scripts | [no-script-bumping](/addons/no-script-bumping) |
+| Do not shift pasted items | [disable-paste-offset](/addons/disable-paste-offset) |
+| Duplicate script with Alt key | [block-duplicate](/addons/block-duplicate) |
+| Echo effect button | [echo-effect](/addons/echo-effect) |
+| Editor comment previews | [editor-comment-previews](/addons/editor-comment-previews) |
+| Editor dark mode and customizable colors | [editor-dark-mode](/addons/editor-dark-mode) |
+| Editor find bar | [find-bar](/addons/find-bar) |
+| Editor sound effects | [editor-sounds](/addons/editor-sounds) |
+| Emoji picker for comments | [emoji-picker](/addons/emoji-picker) |
+| Enhanced full screen | [fullscreen](/addons/fullscreen) |
+| Expandable search bar | [expanding-search-bar](/addons/expanding-search-bar) |
+| Extra key options | [editor-extra-keys](/addons/editor-extra-keys) |
+| Faster project loading | [faster-project-loading](/addons/faster-project-loading) |
+| Feature unshared projects | [feature-unshared](/addons/feature-unshared) |
+| Featured dangos | [featured-dangos-v2](/addons/featured-dangos-v2) |
+| File drag and drop | [drag-drop](/addons/drag-drop) |
+| Fix sprite pane glitching | [disable-sprite-wobble](/addons/disable-sprite-wobble) |
+| Follow topics after posting | [auto-follow-topics](/addons/auto-follow-topics) |
+| Forum post cooldown display | [forum-post-countdown](/addons/forum-post-countdown) |
+| Forum search | [forum-search](/addons/forum-search) |
+| Forums image uploader | [image-uploader](/addons/image-uploader) |
+| Front page curator link | [curator-link](/addons/curator-link) |
+| Full areas | [full-signature](/addons/full-signature) |
+| Gamepad support | [gamepad](/addons/gamepad) |
+| Grab single block with Ctrl key | [block-cherry-picking](/addons/block-cherry-picking) |
+| HD image uploads | [better-img-uploads](/addons/better-img-uploads) |
+| Hex color picker | [color-picker](/addons/color-picker) |
+| Hide delete button | [hide-delete-button](/addons/hide-delete-button) |
+| Hide forum signatures | [hide-signatures](/addons/hide-signatures) |
+| Hide new variables | [hide-new-variables](/addons/hide-new-variables) |
+| Hide project stats | [hide-project-stats](/addons/hide-project-stats) |
+| Hide stage and sprite pane | [hide-stage](/addons/hide-stage) |
+| High resolution thumbnails | [hi-res-thumbnails](/addons/hi-res-thumbnails) |
+| Higher character limit in "What I'm Working On" | [longer-wiwo](/addons/longer-wiwo) |
+| Higher project framerate mode | [60fps](/addons/60fps) |
+| Highlight project creator in comments | [op-badge](/addons/op-badge) |
+| Horizontal tabs on My Stuff | [horizontal-mystuff-tabs](/addons/horizontal-mystuff-tabs) |
+| Infinite scrolling | [infinite-scroll](/addons/infinite-scroll) |
+| Insert blocks by name | [middle-click-popup](/addons/middle-click-popup) |
+| Jump to custom block definition | [jump-to-def](/addons/jump-to-def) |
+| Line breaks in comments | [comments-linebreaks](/addons/comments-linebreaks) |
+| Live featured project | [live-featured-project](/addons/live-featured-project) |
+| Live forum post preview | [forum-live-preview](/addons/forum-live-preview) |
+| Local timezone on forums | [forum-time-zones](/addons/forum-time-zones) |
+| Message count on extension icon | [msg-count-badge](/addons/msg-count-badge) |
+| Message filters | [message-filters](/addons/message-filters) |
+| Messages in editor | [editor-messages](/addons/editor-messages) |
+| More forum toolbar buttons | [forum-toolbar](/addons/forum-toolbar) |
+| More items per row | [items-per-row](/addons/items-per-row) |
+| More links | [more-links](/addons/more-links) |
+| Mouse position display | [mouse-pos](/addons/mouse-pos) |
+| Move costume to top or bottom | [move-to-top-bottom](/addons/move-to-top-bottom) |
+| Move sprite to front layer | [move-to-top-layer](/addons/move-to-top-layer) |
+| Multiple rows in backpack | [expanded-backpack](/addons/expanded-backpack) |
+| Muted project player mode | [mute-project](/addons/mute-project) |
+| Name scripts before placing in backpack | [name-backpack-items](/addons/name-backpack-items) |
+| Necropost highlighter | [necropost-highlighter](/addons/necropost-highlighter) |
+| Non-draggable sprites in editor | [disable-stage-drag-select](/addons/disable-stage-drag-select) |
+| Number inputs in color picker | [color-inputs](/addons/color-inputs) |
+| ocular integration | [my-ocular](/addons/my-ocular) |
+| Old studio layout | [old-studio-layout](/addons/old-studio-layout) |
+| One-click studio invites | [one-click-studio-invites](/addons/one-click-studio-invites) |
+| Onion skinning | [onion-skinning](/addons/onion-skinning) |
+| Opacity slider | [opacity-slider](/addons/opacity-slider) |
+| Paint costume by default | [paint-by-default](/addons/paint-by-default) |
+| Pause button | [pause](/addons/pause) |
+| Pick colors on stage with eyedropper | [pick-colors-from-stage](/addons/pick-colors-from-stage) |
+| Place backpack code at mouse | [place-backpack-code-at-cursor](/addons/place-backpack-code-at-cursor) |
+| Point towards random direction block | [editor-random-direction-block](/addons/editor-random-direction-block) |
+| Preview project instructions and notes | [preview-project-description](/addons/preview-project-description) |
+| Profile page banner | [better-featured-project](/addons/better-featured-project) |
+| Profile statistics | [scratchstats](/addons/scratchstats) |
+| Project notes tabs | [project-notes-tabs](/addons/project-notes-tabs) |
+| Project progress bar | [progress-bar](/addons/progress-bar) |
+| Project video recorder | [mediarecorder](/addons/mediarecorder) |
+| Project volume slider | [vol-slider](/addons/vol-slider) |
+| Quote post number | [forum-id](/addons/forum-id) |
+| Rearrangeable custom block inputs | [reorder-custom-inputs](/addons/reorder-custom-inputs) |
+| Redirect to standard forums | [redirect-mobile-forums](/addons/redirect-mobile-forums) |
+| Remember collapsed forum categories | [remember-collapsed-categories](/addons/remember-collapsed-categories) |
+| Remix button in own projects | [remix-button](/addons/remix-button) |
+| Remix tree button | [remix-tree-button](/addons/remix-tree-button) |
+| Remove autocomplete from search bar | [remove-search-bar-autocomplete](/addons/remove-search-bar-autocomplete) |
+| Remove curved stage border | [remove-curved-stage-border](/addons/remove-curved-stage-border) |
+| Rename broadcasts | [rename-broadcasts](/addons/rename-broadcasts) |
+| Resizable comment input | [resizable-comment-input](/addons/resizable-comment-input) |
+| Reverse order of project controls | [editor-buttons-reverse-order](/addons/editor-buttons-reverse-order) |
+| Running block border | [editor-stepping](/addons/editor-stepping) |
+| Save blocks as image | [blocks2image](/addons/blocks2image) |
+| Scratch 2.0 → 3.0 | [scratchr2](/addons/scratchr2) |
+| Scratch Messaging | [scratch-messaging](/addons/scratch-messaging) |
+| Scratch Notifier | [scratch-notifier](/addons/scratch-notifier) |
+| Search bar on My Stuff | [search-my-stuff](/addons/search-my-stuff) |
+| Search box in sprite pane | [search-sprites](/addons/search-sprites) |
+| Semicolon glitch | [semicolon](/addons/semicolon) |
+| Share through My Stuff | [share-through-mystuff](/addons/share-through-mystuff) |
+| Shared/edited dates tooltip | [last-edit-tooltip](/addons/last-edit-tooltip) |
+| Show exact count | [exact-count](/addons/exact-count) |
+| Show user IDs | [user-id](/addons/user-id) |
+| Skewing in costume editor | [paint-skew](/addons/paint-skew) |
+| Snap scripts to grid | [script-snap](/addons/script-snap) |
+| Sound duration display | [sounds-duration](/addons/sounds-duration) |
+| Sprite and script count | [project-info](/addons/project-info) |
+| Sprite deletion confirmation | [remove-sprite-confirm](/addons/remove-sprite-confirm) |
+| Sprite folders | [folders](/addons/folders) |
+| Square block text inputs | [editor-square-inputs](/addons/editor-square-inputs) |
+| Sticky footer | [collapse-footer](/addons/collapse-footer) |
+| Studio tools | [studio-tools](/addons/studio-tools) |
+| SVG uploads fix | [fix-uploaded-svgs](/addons/fix-uploaded-svgs) |
+| Switch variables between "For all sprites" and "For this sprite only" | [swap-local-global](/addons/swap-local-global) |
+| Thumbnails setter | [animated-thumb](/addons/animated-thumb) |
+| True forums YouTube links | [true-youtube-links](/addons/true-youtube-links) |
+| TurboWarp button | [turbowarp-player](/addons/turbowarp-player) |
+| Two-column category menu | [columns](/addons/columns) |
+| Unshare button in editor | [editor-unshare-button](/addons/editor-unshare-button) |
+| Username search | [search-profile](/addons/search-profile) |
+| Variable manager | [variable-manager](/addons/variable-manager) |
+| Website dark mode and customizable colors | [dark-www](/addons/dark-www) |
+| YouTube full screen | [youtube-fullscreen](/addons/youtube-fullscreen) |
+
+Adding something new? Run [gen-addon-table.py](/dev/gen-addon-table.py) to regenerate this list.

--- a/dev/gen-addon-table.py
+++ b/dev/gen-addon-table.py
@@ -1,0 +1,46 @@
+import os
+import json
+import time
+
+# Change to the addons directory
+file_path = os.path.abspath(__file__)
+root_dir = os.path.dirname(os.path.dirname(file_path))
+addons_dir = os.path.join(root_dir, "addons")
+os.chdir(addons_dir)
+print(f"Finding addon IDs and names in {addons_dir}...")
+
+# Get all addon IDs
+addons = []
+with open("addons.json", "rt") as f:
+  addons = json.loads(f.read())
+
+# Exclude comments
+addons = [i for i in addons if i[:2] != "//"]
+
+# Get all addon names and build the table
+table_cnts = []
+print(f"Reading {len(addons)} addon manifests...")
+for id in addons:
+  with open(f"{id}/addon.json", "rt") as f:
+    name = json.loads(f.read())["name"]
+    table_cnts.append(f"| {name} | [{id}](/addons/{id}) |")
+
+table_cnts.sort(key=lambda s: s.lower())
+
+# Turn it all into a Markdown document
+print("Generating README.md...")
+nlsval = "\n".join(table_cnts)
+contents = f"""# Addons By Name
+
+| Addon Name | Addon ID |
+|---|---|
+{nlsval}
+
+Adding something new? Run [gen-addon-table.py](/dev/gen-addon-table.py) to regenerate this list.
+"""
+
+with open("README.md", "w", encoding="utf-8") as f:
+  f.write(contents)
+
+print("All done!")
+time.sleep(0.75)


### PR DESCRIPTION
Partially addresses #5674

### Changes

Adds a new "Addons By Name" document as `/addons/README.md`. It's a table of addon names (in alphabetical order) along with their IDs.

The table is automatically generated via the `gen-addon-table.py` Python script. Every time new addons are added or addon names are changed, this script must be re-run to update the addon table.

I'm new to Python, so let me know if there's something I can improve!

I'm also not sure if we need this, but I'll leave this open.

### Reason for changes

It can be hard to find the addon IDs of certain addons because sometimes they do not closely correspond to their addon's name or are ambiguous. The table solves that problem. It's also useful if you want to reference an addon by its ID but don't know it.

### Tests

Tested on Windows with Python 3.11.
