### PR TITLE
Minor addons group

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -50,6 +50,12 @@
   "beta": {
     "message": "Beta"
   },
+  "minor": {
+    "message": "Bug fixes"
+  },
+  "minorDisableWarning": {
+    "message": "The \"$1\" addon fixes undesireable behavior in Scratch and we strongly recommend having it enabled. Are you sure you want to disable it?"
+  },
   "danger": {
     "message": "Dangerous"
   },

--- a/addons/disable-sprite-wobble/addon.json
+++ b/addons/disable-sprite-wobble/addon.json
@@ -48,8 +48,8 @@
       "default": "none"
     }
   ],
-  "tags": ["editor", "recommended"],
-  "enabledByDefault": false,
+  "tags": ["editor", "recommended", "minor"],
+  "enabledByDefault": true,
   "versionAdded": "1.24.0",
   "latestUpdate": {
     "version": "1.35.0",

--- a/addons/faster-project-loading/addon.json
+++ b/addons/faster-project-loading/addon.json
@@ -17,7 +17,7 @@
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
-  "tags": ["editor", "recommended"],
+  "tags": ["editor", "recommended", "minor"],
   "versionAdded": "1.32.0",
   "enabledByDefault": true
 }

--- a/addons/fix-pasted-scripts/addon.json
+++ b/addons/fix-pasted-scripts/addon.json
@@ -23,7 +23,7 @@
       "matches": ["projects"]
     }
   ],
-  "tags": ["editor", "recommended", "codeEditor"],
+  "tags": ["editor", "recommended", "minor", "codeEditor"],
   "versionAdded": "1.15.0",
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/place-backpack-code-at-cursor/addon.json
+++ b/addons/place-backpack-code-at-cursor/addon.json
@@ -13,7 +13,7 @@
     }
   ],
   "versionAdded": "1.36.0",
-  "tags": ["editor", "codeEditor", "recommended"],
+  "tags": ["editor", "codeEditor", "recommended", "minor"],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "enabledByDefault": true

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -92,7 +92,7 @@ async function transitionToNewStorageKeys(addonSettings) {
 }
 
 const ADDON_SETTINGS_KEYS = ["addonSettings", "addonSettings1", "addonSettings2", "addonSettings3"];
-chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems) => {
+chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled", "lastVersion"], (storageItems) => {
   const isSettingsStorageTransitionPending = storageItems.addonSettings && !storageItems.addonSettings3;
   if (isSettingsStorageTransitionPending) {
     transitionToNewStorageKeys(storageItems.addonSettings);
@@ -103,6 +103,8 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
   const addonSettings = areAddonSettingsEmpty
     ? {} // Default value
     : { ...storageItems.addonSettings1, ...storageItems.addonSettings2, ...storageItems.addonSettings3 };
+  const lastVersionStr = storageItems.lastVersion;
+  const lastVersion = lastVersionStr?.split(".") || ["0", "0", "0"];
   const func = () => {
     // Start by migrating settings (sometimes we add new settings or make changes to
     // the available settings in some addons between versions)
@@ -686,10 +688,16 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
     // Finally, minify the settings and store them in the scratchAddons object
     const prerelease = chrome.runtime.getManifest().version_name.endsWith("-prerelease");
+    const currentVersion = chrome.runtime.getManifest().version;
+    console.log(`Transitioned from ${lastVersionStr} \u2192 ${currentVersion}`);
+    if (currentVersion !== lastVersionStr) {
+      madeAnyChanges = true;
+    }
     if (madeAnyChanges)
       chrome.storage.sync.set({
         ...minifySettings(addonSettings, prerelease ? null : scratchAddons.manifests),
         addonsEnabled,
+        lastVersion: currentVersion,
       });
     scratchAddons.globalState.addonSettings = addonSettings;
     scratchAddons.localState.addonsEnabled = addonsEnabled;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -163,6 +163,13 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled", "lastVersion"]
       }
     }
 
+    if (lastVersion[1] < 37) {
+      // Enable addons that became enabled by default starting v1.37.0
+      addonsEnabled["disable-sprite-wobble"] = true;
+      addonsEnabled["fix-pasted-scripts"] = true;
+      madeAnyChanges = true;
+    }
+
     for (const { manifest, addonId } of scratchAddons.manifests) {
       // TODO: we should be using Object.create(null) instead of {}
       const settings = addonSettings[addonId] || {};

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -89,6 +89,10 @@ export default async function ({ template }) {
           const confirmation = confirm(chrome.i18n.getMessage("dangerWarning", [this.addon.name]));
           if (!confirmation) return;
         }
+        if (this.addon._enabled && this.addon.tags.includes("minor")) {
+          const confirmation = confirm(chrome.i18n.getMessage("minorDisableWarning", [this.addon.name]));
+          if (!confirmation) return;
+        }
         if (!this.addon._enabled && requiredPermissions.length) {
           const result = requiredPermissions.every((p) => this.$root.grantedOptionalPermissions.includes(p));
           if (result === false) {

--- a/webpages/settings/data/addon-groups.js
+++ b/webpages/settings/data/addon-groups.js
@@ -85,6 +85,14 @@ export default [
     fullscreenShow: true,
   },
   {
+    id: "minor",
+    name: chrome.i18n.getMessage("minor"),
+    addonIds: [],
+    expanded: false,
+    iframeShow: false,
+    fullscreenShow: true,
+  },
+  {
     id: "beta",
     name: chrome.i18n.getMessage("beta"),
     addonIds: [],

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -590,10 +590,11 @@ let fuse;
       if (iframeData?.addonsCurrentlyOnTab.includes(addonId)) manifest._groups.push("runningOnTab");
       else if (iframeData?.addonsPreviouslyOnTab.includes(addonId)) manifest._groups.push("recentlyUsed");
 
-      if (manifest._enabled) manifest._groups.push("enabled");
+      if (manifest._enabled && !manifest.tags.includes("minor")) manifest._groups.push("enabled");
       else {
         // Addon is disabled
-        if (manifest.tags.includes("recommended")) manifest._groups.push("recommended");
+        if (manifest.tags.includes("minor")) manifest._groups.push("minor");
+        else if (manifest.tags.includes("recommended")) manifest._groups.push("recommended");
         else if (manifest.tags.includes("featured")) manifest._groups.push("featured");
         else if (manifest.tags.includes("beta") || manifest.tags.includes("danger")) manifest._groups.push("beta");
         else if (manifest.tags.includes("forums")) manifest._groups.push("forums");


### PR DESCRIPTION
Resolves #2617, resolves #7152

### Changes

Adds a group to the addon list in the settings page called "Bug fixes" (we can change this as we see fit). These addons...
- do not appear under Enabled, but can still be searched
- show a confirmation before disabling

### Reason for changes

Some addons fix bugs and those addons deserve to be enabled by default, but that would also clutter the "Enabled" group in the list of addons. The "bug fixes" group allows us to set them aside, making more room for addons that users would actually want to take a look at.

### Tests

Tested on Edge 122.

### To-Dos

- [ ] Update the manifest schema
- [ ] What should we do with these addons in the extension popup's "Addons on this tab" group?
- [ ] What should we do with `fix-uploaded-svgs`?

We might also want to address any confusion around why these addons aren't showing up under "Enabled".
