### PR TITLE
New addon: Hide avdertising comments

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -150,6 +150,7 @@
   "paint-skew",
   "preview-project-description",
   "collapse-footer",
+  "hide-ads",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/hide-ads/addon.json
+++ b/addons/hide-ads/addon.json
@@ -1,0 +1,37 @@
+{
+  "name": "Hide advertising comments",
+  "description": "Automatically hides comments that contain certain strings deemed as advertising.",
+  "tags": ["comments", "community"],
+  "versionAdded": "1.37.0",
+  "credits": [{ "name": "Jazza", "link": "http://scratch.mit.edu/users/greeny--231" }],
+  "userscripts": [{ "matches": ["profiles", "projects", "studios"], "url": "userscript.js" }],
+  "settings": [
+    { "name": "Project comments", "type": "boolean", "default": true, "id": "projects" },
+    { "name": "Studio comments", "type": "boolean", "default": true, "id": "studios" },
+    { "name": "Profile comments", "type": "boolean", "default": true, "id": "profiles" },
+    {
+      "id": "matchingStrings",
+      "name": "Strings that match as advertising",
+      "type": "table",
+      "default": [
+        {
+          "match": "scratch.mit.edu/projects"
+        }
+      ],
+      "row": [
+        {
+          "name": "String/Link",
+          "id": "match",
+          "type": "untranslated",
+          "default": ""
+        }
+      ],
+      "presets": [
+        { "name": "Project links", "values": { "match": "scratch.mit.edu/projects" } },
+        { "name": "Profile links", "values": { "match": "scratch.mit.edu/users" } },
+        { "name": "Written advertising", "values": { "match": "Check out my game" } }
+      ]
+    }
+  ],
+  "info": [{ "type": "info", "id": "caseInsensitive", "text": "All string matches are case case insensitive." }]
+}

--- a/addons/hide-ads/userscript.js
+++ b/addons/hide-ads/userscript.js
@@ -1,0 +1,29 @@
+export default async function ({ addon }) {
+  let el;
+  let url;
+  const settings = { projects: "projects", studios: "studios", profiles: "users" };
+  const matches = addon.settings.get("matchingStrings").map((obj) => obj.match.toLowerCase());
+
+  url = window.location.href;
+
+  if (url.includes("projects")) el = ".comment-container";
+  else if (url.includes("studios")) el = ".comment-container";
+  else if (url.includes("users")) el = ".top-level-reply";
+
+  for (const key in settings) {
+    console.log(key);
+    if (settings.hasOwnProperty.call(settings, key)) {
+      if (url.includes(settings[key]) && addon.settings.get(key)) {
+        while (true) {
+          const commentContainer = await addon.tab.waitForElement(el, { markAsSeen: true });
+          matches.forEach((match) => {
+            if (commentContainer.innerHTML.toLowerCase().includes(match)) {
+              commentContainer.style.display = "none";
+              return;
+            }
+          });
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves community suggestion

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
Adds a new addon that hides comments that contain certain strings deemed as advertising by the user. Presets are supplied.

### Reason for changes

<!-- Why should these changes be made? -->
Advertising is so so prevelant on scratch, and it is really annoying to see. Since reporting on the user's behalf is not a good idea, hiding them is the next best idea.

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->
Wroks on the latest version of brave.

### ToDo
Add the option to replace the offending text with something like [Marked as advertising], with the option to show it when clicked on.
Change logic for what to hide, only hide the whole thread of messages if the top is advertising, not if advertising is present in any of the thread
