### PR TITLE
New addon: blur background

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -153,6 +153,7 @@
   "collapse-footer",
   "reorder-custom-inputs",
   "place-backpack-code-at-cursor",
+  "background-blur",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/background-blur/addon.json
+++ b/addons/background-blur/addon.json
@@ -1,0 +1,12 @@
+{
+  "name": "Blur background",
+  "description": "Blurs the background when you are creating a new variable, list, or custom block.",
+  "tags": ["theme", "editor", "codeEditor"],
+  "versionAdded": "1.37.0",
+  "credits": [{ "name": "Jazza", "link": "https://scratch.mit.edu/users/greeny--231" }],
+  "userscripts": [{ "matches": ["projects"], "url": "userscript.js" }],
+  "userstyles": [{ "matches": ["projects"], "url": "userstyle.css" }],
+  "settings": [{ "id": "blurRadius", "default": 5, "type": "positive_integer", "name": "Blur radius (px)", "min": 0 }],
+  "dynamicDisable": true,
+  "dynamicEnable": true
+}

--- a/addons/background-blur/userscript.js
+++ b/addons/background-blur/userscript.js
@@ -1,0 +1,17 @@
+export default async function ({ addon, console }) {
+  const overlay = document.createElement("div");
+  overlay.classList.add("sa-blur-overlay");
+  document.body.insertBefore(overlay, document.body.firstChild);
+
+  while (true) {
+    await addon.tab.waitForElement(".ReactModal__Overlay", { markAsSeen: true });
+    overlay.classList.add("blur");
+
+    const intervalId = setInterval(() => {
+      if (!document.querySelector(".ReactModal__Overlay")) {
+        overlay.classList.remove("blur");
+        clearInterval(intervalId);
+      }
+    }, 100);
+  }
+}

--- a/addons/background-blur/userstyle.css
+++ b/addons/background-blur/userstyle.css
@@ -1,0 +1,17 @@
+.sa-blur-overlay {
+  top: 0;
+  position: fixed;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0 0 0 0.5);
+  backdrop-filter: blur(0px);
+  z-index: 500;
+  pointer-events: none;
+  transition-property: backdrop-filter;
+  transition-duration: 200ms;
+}
+
+.sa-blur-overlay.blur {
+  backdrop-filter: blur(5px);
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves community suggestion

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
Adds an overlay that shows when a new variable, list, or custom block is created to blur the background

### Reason for changes

<!-- Why should these changes be made? -->
It looks very nice, and just makes scratch more aesthetically pleasing.

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->
Works fine on brave.

### More
It doesn't do much on light mode purely because of the bright blue background overlay.
I current check for the modal going away using an interval loop. This isnt great, so if anyone knows the redux event (if it exists) or a better way, please feel free to reveiw this pr.