### PR TITLE
Add "export settings" button to unsupported-browser page

### DIFF
--- a/background/handle-unsupported-version.js
+++ b/background/handle-unsupported-version.js
@@ -12,10 +12,7 @@ const checkIfUnsupported = () => {
 if (checkIfUnsupported()) {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request === "checkIfUnsupported") {
-      const uiLanguage = chrome.i18n.getUILanguage();
-      const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
-      const utm = `utm_source=extension&utm_medium=tabscreate&utm_campaign=v${chrome.runtime.getManifest().version}`;
-      const url = `https://scratchaddons.com/${localeSlash}unsupported-browser/?${utm}`;
+      const url = chrome.runtime.getURL("webpages/error/unsupported-browser.html")
       if (sender.tab) chrome.tabs.update(sender.tab.id, { url });
       else chrome.tabs.create({ url });
     }

--- a/background/handle-unsupported-version.js
+++ b/background/handle-unsupported-version.js
@@ -12,7 +12,7 @@ const checkIfUnsupported = () => {
 if (checkIfUnsupported()) {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request === "checkIfUnsupported") {
-      const url = chrome.runtime.getURL("webpages/error/unsupported-browser.html")
+      const url = chrome.runtime.getURL("webpages/error/unsupported-browser.html");
       if (sender.tab) chrome.tabs.update(sender.tab.id, { url });
       else chrome.tabs.create({ url });
     }

--- a/webpages/error/unsupported-browser.html
+++ b/webpages/error/unsupported-browser.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/webpages/error/unsupported-browser.html
+++ b/webpages/error/unsupported-browser.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="../../images/icon.png" id="favicon" />
+    <script src="../set-lang.js" type="module"></script>
+    <script src="./unsupported-browser.js" type="module"></script>
+  </head>
+  <body>
+    <iframe
+      src="about:blank"
+      style="
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        width: 100%;
+        height: 100%;
+        border: none;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      "
+    >
+    </iframe>
+  </body>
+</html>

--- a/webpages/error/unsupported-browser.js
+++ b/webpages/error/unsupported-browser.js
@@ -12,7 +12,7 @@ const IFRAME_ORIGIN = "https://scratchaddons.com";
 
 window.onmessage = async (e) => {
   if (e.origin !== IFRAME_ORIGIN) return;
-  
+
   const message = e.data;
   console.log("[SA] Message received by extension", message);
 

--- a/webpages/error/unsupported-browser.js
+++ b/webpages/error/unsupported-browser.js
@@ -1,0 +1,52 @@
+const iframe = document.querySelector("iframe");
+
+try {
+  const uiLanguage = chrome.i18n.getUILanguage();
+  const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
+  iframe.src = `https://scratchaddons.com/${localeSlash}unsupported-browser/`;
+} catch (err) {
+  iframe.src = "https://scratchaddons.com/unsupported-browser/";
+}
+
+const IFRAME_ORIGIN = "https://scratchaddons.com";
+
+window.onmessage = async (e) => {
+  if (e.origin !== IFRAME_ORIGIN) return;
+  
+  const message = e.data;
+  console.log("[SA] Message received by extension", message);
+
+  if (message.msgType) {
+    if (message.msgType === "getVersionInfo") {
+      // Reply back to the website with the extension version
+      iframe.contentWindow.postMessage({ versionInfo: chrome.runtime.getManifest().version }, IFRAME_ORIGIN);
+    }
+    if (message.msgType === "pageTitleInfo") {
+      // Website wants us to set the tab title
+      document.title = message.msgContent;
+    }
+
+    if (["exportSettingsAsFile", "openSettingsAsTab"].includes(message.msgType)) {
+      // See webpages/settings/index.js for main import/export settings code
+      const { serializeSettings } = await import("../settings/settings-utils.js");
+      const downloadBlob = (await import("../../libraries/common/cs/download-blob.js")).default;
+
+      // Export extension settings as a .json file
+      if (message.msgType === "exportSettingsAsFile") {
+        serializeSettings().then((serialized) => {
+          const blob = new Blob([serialized], { type: "application/json" });
+          downloadBlob("scratch-addons-settings.json", blob);
+        });
+      }
+
+      // View settings file
+      if (message.msgType === "openSettingsAsTab") {
+        const openedWindow = window.open("about:blank");
+        serializeSettings().then((serialized) => {
+          const blob = new Blob([serialized], { type: "text/plain" });
+          openedWindow.location.replace(URL.createObjectURL(blob));
+        });
+      }
+    }
+  }
+};

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -229,6 +229,7 @@ let fuse;
           const blob = new Blob([serialized], { type: "application/json" });
           downloadBlob("scratch-addons-settings.json", blob);
         });
+        // See also unsupported-browser.js
       },
       viewSettings() {
         const openedWindow = window.open("about:blank");
@@ -236,6 +237,7 @@ let fuse;
           const blob = new Blob([serialized], { type: "text/plain" });
           openedWindow.location.replace(URL.createObjectURL(blob));
         });
+        // See also unsupported-browser.js
       },
       importSettings() {
         const inputElem = Object.assign(document.createElement("input"), {


### PR DESCRIPTION
Progress on #6876
Resolves #7125

### Changes

The unsupported-browser page is now a full-screen iframe. The user can now export and view their settings if their browser is unsupported.

### Reason for changes

We will be increasing our minimum browser version requirements very soon, and we don't want existing users to permanently lose access to their settings, which technically wouldn't be gone, but only developers would know how to access them if we changed nothing.

### Tests

You can emulate an unsupported browser by hardcoding `const checkIfUnsupported = () => true` on file background/handle-unsupported-version.js

- [x] Tested in old supported Chrome version
- [x] Tested in old supported Firefox version