### PR TITLE
Change minimum browser requirements in preparation for MV3

### DIFF
--- a/background/handle-unsupported-version.js
+++ b/background/handle-unsupported-version.js
@@ -6,7 +6,11 @@ const checkIfUnsupported = () => {
   };
 
   let { browser, version } = getVersion();
-  return (browser === "Chrome" && version < 80) || (browser === "Firefox" && version < 86);
+  const MIN_CHROME_VERSION = 96;
+  const MIN_FIREFOX_VERSION = 109;
+  return (
+    (browser === "Chrome" && version < MIN_CHROME_VERSION) || (browser === "Firefox" && version < MIN_FIREFOX_VERSION)
+  );
 };
 
 if (checkIfUnsupported()) {


### PR DESCRIPTION
See #6876

### Changes

Increases the minimum browser requirements.

- Chrome 96: released in November 2021, it supports `declarativeNetRequestWithHostAccess` and most MV3 features.
- Firefox 109: released in January 2023, it's the first stable Firefox version to support MV3.

Page https://scratchaddons.com/unsupported-browser will need to be updated.

### Reason for changes

See #6876 for the reasoning on increasing the requirements before the actual MV3 upgrade.
By the way, #7252 was recently merged, which allows users to export their extension settings even if their browser is unsupported.

### Tests

Working on it