### PR TITLE
`custom-menu-bar`: change addon name, added word "editor"

### DIFF
--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Customizable menu bar",
+  "name": "Customizable editor menu bar",
   "description": "Allows you to hide specific editor menu bar items or remove their labels or icons.",
   "credits": [
     {


### PR DESCRIPTION
### Changes

Mentions the word editor in "Customizable menu bar".

### Reason for changes

Someone mentioned the navigation and meubar addons could be confused with each other without reading the description.

### Tests

Tested on Chromium.