### PR TITLE
Make `forum-post-cooldown` use `auto-follow-topic`'s logic

### DIFF
--- a/addons/auto-follow-topics/module.js
+++ b/addons/auto-follow-topics/module.js
@@ -1,3 +1,4 @@
+// This module should run after page load - only use this with `runAtComplete:true`
 const getTopics = () => JSON.parse(sessionStorage.getItem("auto-follow-topics") || "[]");
 const setTopics = (topics) => sessionStorage.setItem("auto-follow-topics", JSON.stringify(topics));
 const postError = () => Boolean(document.querySelector(".errorlist"));

--- a/addons/auto-follow-topics/module.js
+++ b/addons/auto-follow-topics/module.js
@@ -1,0 +1,30 @@
+const getTopics = () => JSON.parse(sessionStorage.getItem("auto-follow-topics") || "[]");
+const setTopics = (topics) => sessionStorage.setItem("auto-follow-topics", JSON.stringify(topics));
+const postError = () => Boolean(document.querySelector(".errorlist"));
+const topicID = location.href.split("/")[5];
+
+document.querySelector("[name=AddPostForm]")?.addEventListener("click", (event) => {
+  const ids = getTopics();
+  ids.push(topicID);
+  setTopics(ids);
+  onPostCallbacks.forEach((callback) => callback());
+});
+
+const topics = getTopics();
+let success = false;
+if (topics.includes(topicID) && !postError()) {
+  success = true;
+  setTopics(topics.filter((topic) => topic !== topicID));
+}
+
+const onPostCallbacks = [];
+export const onPost = (callback) => {
+  onPostCallbacks.push(callback);
+};
+
+export const onSuccessfulPost = (callback) => {
+  if (success) callback(topicID);
+};
+export const onNonSuccessfulPost = (callback) => {
+  if (!success) callback(topicID);
+};

--- a/addons/auto-follow-topics/module.js
+++ b/addons/auto-follow-topics/module.js
@@ -12,7 +12,8 @@ document.querySelector("[name=AddPostForm]")?.addEventListener("click", (event) 
 
 const topics = getTopics();
 let success = false;
-if (topics.includes(topicID) && !postError()) {
+const hasTopic = topics.includes(topicID);
+if (hasTopic && !postError()) {
   success = true;
   setTopics(topics.filter((topic) => topic !== topicID));
 }
@@ -23,8 +24,8 @@ export const onPost = (callback) => {
 };
 
 export const onSuccessfulPost = (callback) => {
-  if (success) callback(topicID);
+  if (hasTopic && success) callback(topicID);
 };
 export const onNonSuccessfulPost = (callback) => {
-  if (!success) callback(topicID);
+  if (hasTopic && !success) callback(topicID);
 };

--- a/addons/auto-follow-topics/userscript.js
+++ b/addons/auto-follow-topics/userscript.js
@@ -1,22 +1,9 @@
+import { onSuccessfulPost } from "./module.js";
+
 export default async function ({ addon, console, msg }) {
-  const getTopics = () => JSON.parse(sessionStorage.getItem("auto-follow-topics") || "[]");
-  const setTopics = (topics) => sessionStorage.setItem("auto-follow-topics", JSON.stringify(topics));
-  const postError = () => Boolean(document.querySelector(".errorlist"));
-  const topicID = location.href.split("/")[5];
-
-  document.querySelector("[name=AddPostForm]")?.addEventListener("click", (event) => {
-    const ids = getTopics();
-    ids.push(topicID);
-    setTopics(ids);
-  });
-
-  const topics = getTopics();
-  if (topics.includes(topicID) && !postError()) {
-    // Check if the user ran into the 60 second rule as well
+  onSuccessfulPost(() => {
     const followBtn = document.querySelectorAll(".follow-button")[1];
     followBtn.focus();
     followBtn.click();
-    // Remove the topic we've followed now
-    setTopics(topics.filter((topic) => topic !== topicID));
-  }
+  });
 }

--- a/addons/forum-post-countdown/userscript.js
+++ b/addons/forum-post-countdown/userscript.js
@@ -1,10 +1,13 @@
+import { onPost, onNonSuccessfulPost } from "../auto-follow-topics/module.js";
+
 export default async function ({ addon, msg }) {
   const submitButton = document.querySelector("#djangobbwrap .form-submit [type=submit]");
 
-  submitButton.addEventListener("click", () => {
-    if (!localStorage.getItem("sa-forum-post-countdown")) {
-      localStorage.setItem("sa-forum-post-countdown", Date.now());
-    }
+  onPost(() => {
+    localStorage.setItem("sa-forum-post-countdown", Date.now());
+  });
+  onNonSuccessfulPost(() => {
+    localStorage.removeItem("sa-forum-post-countdown");
   });
 
   const countdown = localStorage.getItem("sa-forum-post-countdown");


### PR DESCRIPTION
Resolves #6926
Probably resolves #7269
Resolves (possibly) #6914 (not sure about this one, I can't seem to replicate that issue even on stable)

### Changes

Turn `auto-follow-topic` into a module, and make `forum-post-cooldown` use it.

### Reason for changes

Improving `forum-post-cooldown`.

### Tests

Tested in Edge.
