### PR TITLE
Expand the clickable area of the theme button like the settings button

### DIFF
--- a/webpages/popup/index.html
+++ b/webpages/popup/index.html
@@ -24,7 +24,7 @@
           <a id="version" :href="changelogLink" target="_blank" title="{{ msg('changelog') }}">v{{ version }}</a>
         </span>
       </div>
-      <div id="settings" @click="openSettingsPage()">
+      <div class="header-button" @click="openSettingsPage()">
         <img src="../../images/icons/settings.svg" id="settings-icon" title="{{ msg('settings') }}" />
       </div>
     </div>

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -20,6 +20,13 @@ body {
   display: flex;
   height: 60px;
 }
+.header-button {
+  right: 0;
+  position: fixed;
+  cursor: pointer;
+  padding: 17.5px;
+  line-height: 0;
+}
 #title-text,
 #settings {
   font-size: 18px;
@@ -37,18 +44,10 @@ body {
   margin-inline-end: 20px;
   vertical-align: middle;
 }
-#settings {
-  padding: 0 20px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-#settings > img {
+#settings-icon {
   width: 24px;
   height: 24px;
 }
-
 #popups {
   background-color: var(--content-background);
   width: 100%;

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -28,7 +28,7 @@ body {
   line-height: 0;
 }
 #title-text,
-#settings {
+.header-button {
   font-size: 18px;
   font-weight: 400;
 }

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -24,7 +24,7 @@ body {
   right: 0;
   position: fixed;
   cursor: pointer;
-  padding: 17.5px;
+  padding: 18px;
   line-height: 0;
 }
 #title-text,

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -21,8 +21,6 @@ body {
   height: 60px;
 }
 .header-button {
-  right: 0;
-  position: fixed;
   cursor: pointer;
   padding: 18px;
   line-height: 0;

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -123,7 +123,7 @@
       <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
       <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" />
       <h1 v-cloak>{{ msg("settings") }}</h1>
-      <div @click="setTheme(!theme)" id="theme-div">
+      <div @click="setTheme(!theme)" class="header-button">
         <img v-cloak class="theme-switch" :src="themePath" />
       </div>
     </div>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -123,7 +123,9 @@
       <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
       <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" />
       <h1 v-cloak>{{ msg("settings") }}</h1>
-      <img v-cloak @click="setTheme(!theme)" class="theme-switch" :src="themePath" />
+      <<div @click="setTheme(!theme)" id="theme-div">
+        <img v-cloak class="theme-switch" :src="themePath" />
+      </div>
     </div>
     <div class="main">
       <div

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -123,7 +123,7 @@
       <img :src="switchPath" class="toggle" @click="sidebarToggle()" v-cloak v-show="smallMode" alt="Logo" />
       <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" />
       <h1 v-cloak>{{ msg("settings") }}</h1>
-      <<div @click="setTheme(!theme)" id="theme-div">
+      <div @click="setTheme(!theme)" id="theme-div">
         <img v-cloak class="theme-switch" :src="themePath" />
       </div>
     </div>

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -137,7 +137,8 @@ h1 {
   right: 0;
   position: fixed;
   cursor: pointer;
-  padding: 16px;
+  padding: 17.5px;
+  line-height: 0;
 }
 [dir="rtl"] .theme-switch {
   right: auto;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -129,16 +129,15 @@ h1 {
 .reverted {
   transform: scaleY(-1);
 }
-
-.theme-switch {
-  height: 25px;
-}
 .header-button {
   right: 0;
   position: fixed;
   cursor: pointer;
   padding: 17.5px;
   line-height: 0;
+}
+.theme-switch {
+  height: 25px;
 }
 [dir="rtl"] .theme-switch {
   right: auto;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -132,9 +132,13 @@ h1 {
 
 .theme-switch {
   height: 25px;
-  right: 25px;
+}
+#theme-div {
+  right: 0;
   position: fixed;
   cursor: pointer;
+  padding: 16px;
+  transition: 0.2s ease;
 }
 [dir="rtl"] .theme-switch {
   right: auto;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -138,7 +138,6 @@ h1 {
   position: fixed;
   cursor: pointer;
   padding: 16px;
-  transition: 0.2s ease;
 }
 [dir="rtl"] .theme-switch {
   right: auto;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -133,7 +133,7 @@ h1 {
 .theme-switch {
   height: 25px;
 }
-#theme-div {
+.header-button {
   right: 0;
   position: fixed;
   cursor: pointer;


### PR DESCRIPTION
### Changes
More clickable area of the theme button in the settings like the settings button in the popup as currently you need to click exactly on the image by:
<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
- Enclosed it in a div with padding which has the on click event

### Reason for changes
So that it's more easy to click on the theme button and we don't need to click exactly on the image.
<!-- Why should these changes be made? -->

### Tests
Microsoft Edge 122.0.2365.92 (Official build) (64-bit) 
<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->
