### PR TITLE
Make `hide-backpack` adjust for `custom-zoom`'s autohide

### DIFF
--- a/addons/hide-backpack/button.css
+++ b/addons/hide-backpack/button.css
@@ -48,3 +48,7 @@
   width: 24px;
   height: 24px;
 }
+
+.sa-custom-zoom-area {
+  height: 184px; /* 148px (initial) + 36px */
+}


### PR DESCRIPTION
Resolves #7286

### Changes

Expand the `.sa-custom-zoom-area` when `hide-backpack` is active.

Note that this also makes hovering over the backpack icon show the zoom buttons.

### Reason for changes

Making zooming in possible while this addon is enabled

### Tests

Tested on Edge.