### PR TITLE
Allow links to be clickable in the messages page

### DIFF
--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -9,7 +9,12 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects", "https://scratch.mit.edu/studios/*", "https://scratch.mit.edu/users/*"]
+      "matches": [
+        "projects",
+        "https://scratch.mit.edu/studios/*",
+        "https://scratch.mit.edu/users/*",
+        "https://scratch.mit.edu/messages/"
+      ]
     }
   ],
   "versionAdded": "1.0.0",

--- a/addons/more-links/userscript.js
+++ b/addons/more-links/userscript.js
@@ -52,6 +52,12 @@ export default async function ({ addon, console }) {
       linkifyTextNode(desc);
       break;
     }
+
+    case "messages":
+      while (true) {
+        const message = await addon.tab.waitForElement(".comment-text p", { markAsSeen: true });
+        linkifyTextNode(message);
+      }
   }
 
   (async () => {

--- a/addons/more-links/userscript.js
+++ b/addons/more-links/userscript.js
@@ -58,12 +58,21 @@ export default async function ({ addon, console }) {
         const message = await addon.tab.waitForElement(".comment-text p", { markAsSeen: true });
 
         if (message.textContent.length === 250) {
+          console.log(message);
           // The message is truncated (unless it happens to be ecxactly 250 characters long), and so links may break. We now fetch the rest of the text for link making
 
           const username = await addon.auth.fetchUsername();
 
           const messageInfo = message.parentElement.parentElement.parentElement.firstChild;
           const link = messageInfo.querySelector("a:not(.social-messages-profile-link)").href;
+
+          async function getContentFromResponse(response, message) {
+            const blob = await response.blob();
+            const usableResponse = JSON.parse(await blob.text());
+
+            // Yes, using innerHTML here, this is so the browser can handle things like &apos; for a comma
+            message.innerHTML = usableResponse.content;
+          }
 
           if (link.includes("projects")) {
             const regex = /\/projects\/(\d+)\/#comments-(\d+)/;
@@ -75,12 +84,18 @@ export default async function ({ addon, console }) {
             const response = await fetch(
               `https://api.scratch.mit.edu/users/${username}/projects/${projectId}/comments/${commentId}`
             );
-            const blob = await response.blob();
-            const usableResponse = JSON.parse(await blob.text());
-            console.log(usableResponse);
 
-            // Yes, using innerHTML here, this is so the browser can handle things like &apos; for a comma
-            message.innerHTML = usableResponse.content;
+            await getContentFromResponse(response, message);
+          } else if (link.includes("studios")) {
+            const regex = /\/studios\/(\d+)\/comments\/#comments-(\d+)/;
+            const match = link.match(regex);
+
+            const studioId = match[1];
+            const commentId = match[2];
+
+            const response = await fetch(`https://api.scratch.mit.edu/studios/${studioId}/comments/${commentId}`);
+
+            await getContentFromResponse(response, message);
           }
         }
         linkifyTextNode(message);


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #5334

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
Adds a few lines to allow links to be linkified when in the messages tab of scratch. small change

### Reason for changes

<!-- Why should these changes be made? -->
Consistency and makes sense

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->

works fine on brave
