### PR TITLE
download-button: fix spinner not adapting to background contrast

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1425,7 +1425,7 @@
       "value": {
         "type": "textColor",
         "black": "brightness(0.4)",
-        "white": "initial",
+        "white": "none",
         "source": {
           "type": "settingValue",
           "settingId": "button"

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -1425,7 +1425,7 @@
       "value": {
         "type": "textColor",
         "black": "brightness(0.4)",
-        "white": "none",
+        "white": "initial",
         "source": {
           "type": "settingValue",
           "settingId": "button"

--- a/addons/download-button/style.css
+++ b/addons/download-button/style.css
@@ -40,7 +40,7 @@
 #sa-download-button.loading:before {
   background-image: url(https://scratch.mit.edu/svgs/modal/spinner-blue.svg);
   background-size: 100%;
-  filter: grayscale(100%) brightness(0) invert(1);
+  filter: grayscale(100%) brightness(0) invert(1) var(--darkWww-button-filter, grayscale(100%) brightness(0) invert(1));
   animation-name: spin-intro, spin;
   animation-duration: 0.25s, 1s;
   animation-timing-function: cubic-bezier(0.3, -3, 0.6, 3), cubic-bezier(0.4, 0.1, 0.4, 1);

--- a/addons/download-button/style.css
+++ b/addons/download-button/style.css
@@ -38,9 +38,9 @@
 }
 
 #sa-download-button.loading:before {
-  background-image: url(https://scratch.mit.edu/svgs/modal/spinner-blue.svg);
+  background-image: url(https://scratch.mit.edu/svgs/modal/spinner-white.svg);
   background-size: 100%;
-  filter: grayscale(100%) brightness(0) invert(1) var(--darkWww-button-filter, grayscale(100%) brightness(0) invert(1));
+  filter: var(--darkWww-button-filter);
   animation-name: spin-intro, spin;
   animation-duration: 0.25s, 1s;
   animation-timing-function: cubic-bezier(0.3, -3, 0.6, 3), cubic-bezier(0.4, 0.1, 0.4, 1);


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #7296 

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->
just changes the logic so it goes dark when a light highlight colour is chosen

### Reason for changes

<!-- Why should these changes be made? -->
obvious

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->
works on brave

@WorldLanguages this should be a quick merge, just need to know if setting this to inital instead of none is bad, doesnt seem to be 
![image](https://github.com/ScratchAddons/ScratchAddons/assets/81956724/6ac1fab8-abf4-41f7-88dd-89fd0727a1f0)

