### PR TITLE
[README change] Fix border appearing inside of logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scratch Addons<img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
+# <img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>Scratch Addons
 
 [![Chrome Web Store](.github/readme-images/cws-badge.png)](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco)
 [![Firefox Add-ons](.github/readme-images/ff-addon-badge.png)](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-<img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
-# Scratch Addons
+<h1>
+  Scratch Addons
+  <img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
+</h1>
 
 [![Chrome Web Store](.github/readme-images/cws-badge.png)](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco)
 [![Firefox Add-ons](.github/readme-images/ff-addon-badge.png)](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-<h1>
-  Scratch Addons
-  <img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
-</h1>
+# Scratch Addons <img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
 
 [![Chrome Web Store](.github/readme-images/cws-badge.png)](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco)
 [![Firefox Add-ons](.github/readme-images/ff-addon-badge.png)](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scratch Addons <img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
+# Scratch Addons<img src="images/icon.svg" alt="Scratch Addons logo" align="right" width="128px"></img>
 
 [![Chrome Web Store](.github/readme-images/cws-badge.png)](https://chrome.google.com/webstore/detail/fbeffbjdlemaoicjdapfpikkikjoneco)
 [![Firefox Add-ons](.github/readme-images/ff-addon-badge.png)](https://addons.mozilla.org/firefox/addon/scratch-messaging-extension/)


### PR DESCRIPTION
Resolves #7313

### Changes

Move the image inside the `<h1>`, which causes it not to be affected by the border.

### Reason for changes

It looks a bit better.

### Tests

Tested in Edge
