### PR TITLE
Remove `forums` match regex

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2269,7 +2269,7 @@
     },
     {
       "url": "pygments.css",
-      "matches": ["forums"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "if": {
         "settings": { "darkForumCode": true }
       }

--- a/addons/forum-search/addon.json
+++ b/addons/forum-search/addon.json
@@ -14,13 +14,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["forums"]
+      "matches": ["https://scratch.mit.edu/discuss/*"]
     }
   ],
   "userstyles": [
     {
       "url": "userscript.css",
-      "matches": ["forums"]
+      "matches": ["https://scratch.mit.edu/discuss/*"]
     }
   ],
   "tags": ["forums", "community"],

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/discuss/*"],
+      "matches": ["projects", "studios", "profiles", "https://scratch.mit.edu/discuss/*"],
       "runAtComplete": false
     }
   ],

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -9,7 +9,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["projects", "studios", "profiles", "forums"],
+      "matches": ["https://scratch.mit.edu/discuss/*"],
       "runAtComplete": false
     }
   ],

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -341,7 +341,6 @@ const WELL_KNOWN_PATTERNS = {
   topics: /^\/discuss\/topic\/\d+\/?$/,
   newPostScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add)\/?$/,
   editingScreens: /^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/,
-  forums: /^\/discuss(?!\/m(?:$|\/))(?:\/.*)?$/,
   // scratch-www routes, not including project pages
   // Matches /projects (an error page) but not /projects/<id>
   scratchWWWNoProject:


### PR DESCRIPTION
### Changes

Removes the `forums` match regular expression and replaces its uses with `https://scratch.mit.edu/discuss/*`

### Reason for changes

The mobile forums are gone and the regex doesn't seem to be doing anything useful.

### Tests

Tested on Chromium 123.