### PR TITLE
Background: import JS from a single module instead of script tags

### DIFF
--- a/background/background.html
+++ b/background/background.html
@@ -1,35 +1,5 @@
 <head>
   <meta charset="UTF-8" />
 
-  <!-- Transition from Scratch Messaging Extension -->
-  <script src="transition.js" type="module"></script>
-
-  <!-- Load idb -->
-  <script src="../libraries/thirdparty/idb.js" defer></script>
-
-  <!-- Declare scratchAddons object, create global and local state -->
-  <script src="declare-scratchaddons-object.js" type="module"></script>
-
-  <!-- Load manifests into memory -->
-  <script src="load-addon-manifests.js" type="module"></script>
-
-  <!-- When manifests are ready, check addon settings -->
-  <script src="get-addon-settings.js" type="module"></script>
-
-  <!-- Load handlers. Some expose methods through scratchAddons.methods -->
-  <script src="handle-fetch.js" type="module"></script>
-  <script src="handle-auth.js" type="module"></script>
-  <script src="handle-l10n.js" type="module"></script>
-  <script src="handle-clipboard.js" type="module"></script>
-  <script src="handle-notifications.js" type="module"></script>
-  <script src="handle-permissions.js" type="module"></script>
-
-  <!-- When everything is ready, run scripts and communicate with content scripts -->
-  <script src="get-userscripts.js" type="module"></script>
-  <script src="get-popups.js" type="module"></script>
-
-  <!-- Respond to requests by the settings page and others -->
-  <script src="handle-settings-page.js" type="module"></script>
-  <script src="handle-licenses.js" type="module"></script>
-  <script src="handle-unsupported-version.js" type="module"></script>
+  <script src="background.js" type="module"></script>
 </head>

--- a/background/background.js
+++ b/background/background.js
@@ -1,0 +1,34 @@
+// This file is loaded as ESM.
+
+// Transition from Scratch Messaging Extension
+import "./transition.js";
+
+// Load idb
+// TODO before merging: can we run this as an ES module?
+import "../libraries/thirdparty/idb.js";
+
+// Declare scratchAddons object, create global and local state
+import "./declare-scratchaddons-object.js";
+
+// Load manifests into memory
+import "./load-addon-manifests.js";
+
+// When manifests are ready, check addon settings
+import "./get-addon-settings.js";
+
+//  Load handlers. Some expose methods through scratchAddons.methods
+import "./handle-fetch.js";
+import "./handle-auth.js";
+import "./handle-l10n.js";
+import "./handle-clipboard.js";
+import "./handle-notifications.js";
+import "./handle-permissions.js";
+
+// When everything is ready, run scripts and communicate with content scripts
+import "./get-userscripts.js";
+import "./get-popups.js";
+
+// Respond to requests by the settings page and others
+import "./handle-settings-page.js";
+import "./handle-licenses.js";
+import "./handle-unsupported-version.js";

--- a/background/background.js
+++ b/background/background.js
@@ -4,7 +4,6 @@
 import "./transition.js";
 
 // Load idb
-// TODO before merging: can we run this as an ES module?
 import "../libraries/thirdparty/idb.js";
 
 // Declare scratchAddons object, create global and local state


### PR DESCRIPTION
### Changes

For the extension background environment entrypoint, we import all JS code from JavaScript itself, instead of doing it through multiple HTML script tags.

### Reason for changes

Our manifest V3 Chrome extension will only be able to use a service_worker background environment.

### Tests

- [x] Make sure idb.js is fine to run in a module environment