### PR TITLE
big-save-button: less space around the button

### DIFF
--- a/addons/big-save-button/userstyle.css
+++ b/addons/big-save-button/userstyle.css
@@ -1,6 +1,10 @@
+[class*="menu-bar_account-info-group_"] > [class*="menu-bar_menu-bar-item_"]:first-child {
+  padding: 0;
+}
+
 [class*="save-status_save-now"] {
   height: 100%;
-  padding: 0 12px;
+  padding: 0 0.75rem;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
### Changes

v1.37.1:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/12ff8e19-8942-41bf-a7c7-d10d8683f07e)

After this change:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/3e5e0bf3-f026-487c-baf8-c3d15fc37b5b)

Without the addon:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/0d6961a3-c08e-414e-a736-3ebe9b56e253)

### Reason for changes

The extra padding is ugly and there's already very little space in the menu bar on small screens.

### Tests

Tested on Edge and Firefox.