### PR TITLE
`name-backpack-items`: Use `addon.tab.prompt` instead of `window.prompt`

### DIFF
--- a/addons-l10n/en/name-backpack-items.json
+++ b/addons-l10n/en/name-backpack-items.json
@@ -1,3 +1,4 @@
 {
+  "name-backpack-items/title": "Put script into backpack",
   "name-backpack-items/prompt": "Name this script:"
 }

--- a/addons-l10n/en/name-backpack-items.json
+++ b/addons-l10n/en/name-backpack-items.json
@@ -1,4 +1,4 @@
 {
-  "name-backpack-items/title": "Put script into backpack",
+  "name-backpack-items/title": "Add to Backpack",
   "name-backpack-items/prompt": "Name this script:"
 }

--- a/addons/name-backpack-items/userscript.js
+++ b/addons/name-backpack-items/userscript.js
@@ -2,16 +2,22 @@ export default async function ({ addon, msg, console }) {
   const oldSend = XMLHttpRequest.prototype.send;
 
   XMLHttpRequest.prototype.send = function () {
-    if (!addon.self.disabled && this.method === "POST" && this.url?.startsWith("https://backpack.scratch.mit.edu/")) {
-      try {
-        const arg = JSON.parse(arguments[0]);
-        if (arg.type === "script") {
-          arg.name = prompt(msg("prompt"), arg.name).substring(0, 255);
-        }
-        arguments[0] = JSON.stringify(arg);
-      } catch {}
-    }
+    (async () => {
+      if (!addon.self.disabled && this.method === "POST" && this.url?.startsWith("https://backpack.scratch.mit.edu/")) {
+        try {
+          const arg = JSON.parse(arguments[0]);
+          if (arg.type === "script") {
+            arg.name = (
+              await addon.tab.prompt(msg("title"), msg("prompt"), arg.name, {
+                useEditorClasses: true,
+              })
+            ).substring(0, 255);
+          }
+          arguments[0] = JSON.stringify(arg);
+        } catch {}
+      }
 
-    return oldSend.call(this, ...arguments);
+      oldSend.call(this, ...arguments);
+    })();
   };
 }


### PR DESCRIPTION
### Changes

Made `name-backpack-items` use `addon.tab.prompt` instead of `window.prompt`.

### Reason for changes

Makes the UX for it a lot better - it's really confusing to me when I try putting something into my backpack and nothing happens, and then I realize that it's because of this addon.

### Tests

Tested in Edge