### PR TITLE
Remove unneeded async call (upcoming Firefox support)

### DIFF
--- a/webpages/settings/permissions.js
+++ b/webpages/settings/permissions.js
@@ -29,11 +29,6 @@ document.getElementById("permissionsBtn").addEventListener("click", async () => 
   const manifest = chrome.runtime.getManifest();
   const origins = manifest.permissions.filter((url) => url.startsWith("https://"));
 
-  const isAlreadyGranted = await promisify(chrome.permissions.contains)({ origins });
-  if (isAlreadyGranted) {
-    return window.close();
-  }
-
   const granted = await promisify(chrome.permissions.request)({ origins });
   if (granted) {
     return chrome.runtime.reload();


### PR DESCRIPTION
### Changes

On the `/webpages/settings/permissions.html` page, no longer checks if the extension already has the permissions we're about to request.
This means that, in some rare cases, we might unnecessarily reload the extension, instead of just closing the tab.

As a reminder, browsers won't show any UI to the user if the permissions we're requesting are already granted. Of course, users shouldn't be shown this page unless there are missing permissions, or type in the URL manually.

### Reason for changes

For manifest V3, Firefox will begin to allow users to revoke host permissions, so this page may show in Firefox.
Firefox does not allow any async operations between the click and the permission request, so it's less flexible than Chrome.

### Tests

Tested in Chrome and Firefox