### PR TITLE
Mv3 progress background

### DIFF
--- a/background/declare-scratchaddons-object.js
+++ b/background/declare-scratchaddons-object.js
@@ -2,7 +2,7 @@ import globalStateProxy from "./imports/global-state.js";
 import localStateProxy from "./imports/local-state.js";
 import BackgroundLocalizationProvider from "./l10n.js";
 
-window.scratchAddons = {};
+globalThis.scratchAddons = {};
 
 // Event target for local background page events
 scratchAddons.localEvents = new EventTarget();

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -1,5 +1,7 @@
 import { updateBadge } from "./message-cache.js";
 
+const BROWSER_ACTION = globalThis.MANIFEST_VERSION === 2 ? "browser_action" : "action";
+
 const periods = [
   {
     name: chrome.i18n.getMessage("15min"),
@@ -49,14 +51,14 @@ function contextMenuUnmuted() {
   chrome.contextMenus.create({
     id: "mute",
     title: chrome.i18n.getMessage("muteFor"),
-    contexts: ["browser_action"],
+    contexts: [BROWSER_ACTION],
   });
   for (const period of periods) {
     chrome.contextMenus.create({
       id: `mute_${period.mins}`,
       title: period.name,
       parentId: "mute",
-      contexts: ["browser_action"],
+      contexts: [BROWSER_ACTION],
     });
   }
   // This seems to be run when the extension is loaded, so we'll just set the right icon here.
@@ -75,7 +77,7 @@ function contextMenuMuted() {
   chrome.contextMenus.create({
     id: "unmute",
     title: chrome.i18n.getMessage("unmute"),
-    contexts: ["browser_action"],
+    contexts: [BROWSER_ACTION],
   });
   chrome.browserAction.setIcon({
     path: {

--- a/background/handle-permissions.js
+++ b/background/handle-permissions.js
@@ -10,9 +10,11 @@ const onPermissionsRevoked = () => {
 };
 
 const checkSitePermissions = (sendResponse) => {
+  const HOST_PERMISSIONS_KEY_NAME = globalThis.MANIFEST_VERSION === 2 ? "permissions" : "host_permissions";
+
   chrome.permissions.contains(
     {
-      origins: chrome.runtime.getManifest().permissions.filter((url) => url.startsWith("https://")),
+      origins: chrome.runtime.getManifest()[HOST_PERMISSIONS_KEY_NAME].filter((url) => url.startsWith("https://")),
     },
     (hasPermissions) => {
       if (!hasPermissions) {

--- a/background/transition.js
+++ b/background/transition.js
@@ -1,3 +1,9 @@
+globalThis.MANIFEST_VERSION = 2;
+
+if (globalThis.MANIFEST_VERSION === 3) {
+  chrome.browserAction = chrome.action;
+}
+
 const utm = `utm_source=extension&utm_medium=tabscreate&utm_campaign=v${chrome.runtime.getManifest().version}`;
 const uiLanguage = chrome.i18n.getUILanguage();
 const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;

--- a/webpages/settings/permissions.js
+++ b/webpages/settings/permissions.js
@@ -25,9 +25,13 @@ const promisify =
   (...args) =>
     new Promise((resolve) => callbackFn(...args, resolve));
 
+const MANIFEST_VERSION = 2;
+
 document.getElementById("permissionsBtn").addEventListener("click", async () => {
+  const HOST_PERMISSIONS_KEY_NAME = MANIFEST_VERSION === 2 ? "permissions" : "host_permissions";
+
   const manifest = chrome.runtime.getManifest();
-  const origins = manifest.permissions.filter((url) => url.startsWith("https://"));
+  const origins = manifest[HOST_PERMISSIONS_KEY_NAME].filter((url) => url.startsWith("https://"));
 
   const granted = await promisify(chrome.permissions.request)({ origins });
   if (granted) {


### PR DESCRIPTION
Resolves #1533
Related to #1538 - Service workers do not have a global `window` object

Related: see draft PR #6877 for a preview of a manifest.json file with MV3.

### Changes

- Use `globalThis` instead of `window` for globals in the background context. It is equivalent to `self` in this case
- Consider the rename of "browser action" to "action" in multiple APIs
- Consider upcoming `host_permissions` field in extension manifest

- [ ] TODO: modify code that assumes top-level code runs once for each extension session. Instead, explicitly wrap those in a "startup" event (unsure if there's a `chrome.*` API for that or if we're supposed to use service worker lifetime events)
- [ ] TODO: make sure all event listeners are top level (see https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#register-listeners)

### Reason for changes

These are relatively small changes that can get into an MV2 update if we want, but still get us closer to MV3.

### Tests

Tested under MV2 in Chrome and Firefox