### PR TITLE
Global addon api

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -156,6 +156,7 @@
   "reorder-custom-inputs",
   "place-backpack-code-at-cursor",
   "big-save-button",
+  "global-addon-api",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/global-addon-api/addon.json
+++ b/addons/global-addon-api/addon.json
@@ -1,0 +1,28 @@
+{
+  "name": "Global Addon API",
+  "description": "Makes the Addon API accessible as the `window.addon` global variable in the console, for addon prototyping.",
+  "tags": ["community", "easterEgg"],
+  "versionAdded": "1.38.0",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/*"]
+    }
+  ],
+  "runAtComplete": false,
+  "credits": [
+    {
+      "name": "View documentation",
+      "link": "https://scratchaddons.com/docs/reference/addon-api"
+    }
+  ],
+  "info": [
+    {
+      "type": "notice",
+      "text": "For Scratch Addon developers.",
+      "id": "forDev"
+    }
+  ],
+  "dynamicDisable": true,
+  "dynamicEnable": true
+}

--- a/addons/global-addon-api/addon.json
+++ b/addons/global-addon-api/addon.json
@@ -6,10 +6,10 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/*"]
+      "matches": ["https://scratch.mit.edu/*"],
+      "runAtComplete": false
     }
   ],
-  "runAtComplete": false,
   "credits": [
     {
       "name": "View documentation",

--- a/addons/global-addon-api/userscript.js
+++ b/addons/global-addon-api/userscript.js
@@ -1,0 +1,5 @@
+export default async function ({ addon }) {
+  window.addon = addon;
+  addon.self.addEventListener("disabled", () => delete window.addon);
+  addon.self.addEventListener("reenabled", () => (window.addon = addon));
+}


### PR DESCRIPTION
### Changes

Add an new addon that makes the Addon API accessible as a global variable `window.addon`.

### Reason for changes

Useful for prototyping an addon in the devtools console in particular by getting `vm` or `blockly` without having to create a new addon with all the files that this implies (`addons.json`,` addon.json`, `userscript.js`)

### Tests

Google Chrome: Version 123.0.6312.124 (Build officiel) (64 bits)
