### PR TITLE
Do not open "permissions" page on every startup

### DIFF
--- a/background/handle-permissions.js
+++ b/background/handle-permissions.js
@@ -51,3 +51,12 @@ chrome.permissions.onRemoved?.addListener(() => {
 
 checkSitePermissions(() => {}, { isStartup: true });
 checkOptionalPermissions();
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === "install") {
+    // If the user just installed the extension, we do not consider this startup,
+    // it's fine to open a new tab if needed in this case.
+    // This happens on Firefox when loading the extension as temporary.
+    checkSitePermissions(() => {}, { isStartup: false });
+  }
+});

--- a/background/handle-permissions.js
+++ b/background/handle-permissions.js
@@ -4,11 +4,11 @@ import { getMissingOptionalPermissions } from "./imports/util.js";
 const onPermissionsRevoked = ({ isStartup }) => {
   console.error("Site access is not granted.");
   if (!isStartup) {
-  chrome.tabs.create({
-    active: true,
-    url: "/webpages/settings/permissions.html",
-  });
-}
+    chrome.tabs.create({
+      active: true,
+      url: "/webpages/settings/permissions.html",
+    });
+  }
 };
 
 const checkSitePermissions = (sendResponse, { isStartup }) => {


### PR DESCRIPTION
### Changes

The `/webpages/settings/permissions.html` page now opens if:
1. If the user has just revoked a host permission moments ago.
2. If the user has opened the popup and a permission is missing
3. If the user has opened the settings page and a permission is missing
4. NEW: if the user has just installed the extension, and the browser didn't grant host permissions by default.

It no longer opens that page on every extension startup. That means that if a permission is missing and the extension looks broken, the user is expected to interact with the extension in some way to know why it isn't working.

### Reason for changes

In manifest V3, it's not that straight forward to open the page once per extension session.
Also, we usually try to avoid opening new tabs unless there's user interaction. For example, we only show the "unsupported browser" page if the user opens the popup or the settings page.

### Tests

Tested in Chromium. It's just a new boolean parameter, though.