### PR TITLE
Remove `addon.self.lib` in favor of relative URLs in other APIs

### DIFF
--- a/addon-api/common/Self.js
+++ b/addon-api/common/Self.js
@@ -21,6 +21,19 @@ export default class Self extends Listenable {
   }
 
   /**
+   * Identical to import() keyword but takes a relative URL
+   * @param {string} relativeUrl - URL relative to the extension's origin
+   */
+  dynamicImport(relativeUrl) {
+    const urlObj = new URL(import.meta.url);
+    urlObj.pathname = relativeUrl;
+
+    const url = urlObj.href;
+
+    return import(url);
+  }
+
+  /**
    * path to the addon's directory.
    * @type {string}
    */

--- a/addon-api/common/Self.js
+++ b/addon-api/common/Self.js
@@ -42,14 +42,6 @@ export default class Self extends Listenable {
   }
 
   /**
-   * path to libraries directory.
-   * @type {string}
-   */
-  get lib() {
-    return `${this._addonObj._path}libraries`;
-  }
-
-  /**
    * @private
    */
   get _eventTargetKey() {

--- a/addon-api/content-script/Addon.js
+++ b/addon-api/content-script/Addon.js
@@ -13,7 +13,7 @@ export default class UserscriptAddon extends Addon {
     super(info);
     this._addonId = info.id;
     this.__path = `${new URL(import.meta.url).origin}/`;
-    this.tab = new Tab(info);
+    this.tab = new Tab(this, info);
     this.auth.dispose();
     this.auth = new Auth(this);
     this.self.disabled = false;

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -96,7 +96,12 @@ export default class Tab extends Listenable {
    * @param {string} url - script URL.
    * @returns {Promise}
    */
-  loadScript(url) {
+  loadScript(relativeUrl) {
+    const urlObj = new URL(import.meta.url);
+    urlObj.pathname = relativeUrl;
+
+    const url = urlObj.href;
+
     return new Promise((resolve, reject) => {
       if (scratchAddons.loadedScripts[url]) {
         const obj = scratchAddons.loadedScripts[url];

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -367,8 +367,7 @@ export default class Tab extends Listenable {
   get direction() {
     // https://github.com/scratchfoundation/scratch-l10n/blob/master/src/supported-locales.js
     const rtlLocales = ["ar", "ckb", "fa", "he"];
-    const rawLang = this._addonObj.auth.scratchLang; // Guaranteed to exist
-    const lang = rawLang.split("-")[0];
+    const lang = scratchAddons.globalState.auth.scratchLang.split("-")[0];
     return rtlLocales.includes(lang) ? "rtl" : "ltr";
   }
 

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -19,12 +19,13 @@ let createdAnyBlockContextMenus = false;
  * @property {ReduxHandler} redux
  */
 export default class Tab extends Listenable {
-  constructor(info) {
+  constructor(addonObj, info) {
     super();
     this._addonId = info.id;
     this.traps = new Trap(this);
     this.redux = new ReduxHandler();
     this._waitForElementSet = new WeakSet();
+    this._addonObj = addonObj;
   }
   /**
    * Version of the renderer (scratch-www, scratchr2, or null if it cannot be determined).
@@ -361,7 +362,8 @@ export default class Tab extends Listenable {
   get direction() {
     // https://github.com/scratchfoundation/scratch-l10n/blob/master/src/supported-locales.js
     const rtlLocales = ["ar", "ckb", "fa", "he"];
-    const lang = scratchAddons.globalState.auth.scratchLang.split("-")[0];
+    const rawLang = this._addonObj.auth.scratchLang; // Guaranteed to exist
+    const lang = rawLang.split("-")[0];
     return rtlLocales.includes(lang) ? "rtl" : "ltr";
   }
 

--- a/addons/2d-color-picker/userscript.js
+++ b/addons/2d-color-picker/userscript.js
@@ -2,6 +2,6 @@ import paintEditorHandler from "./paint-editor.js";
 
 export default async (api) => {
   const { addon } = api;
-  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/tinycolor-min.js");
+  await addon.tab.loadScript("/libraries/thirdparty/cs/tinycolor-min.js");
   paintEditorHandler(api);
 };

--- a/addons/color-picker/userscript.js
+++ b/addons/color-picker/userscript.js
@@ -5,7 +5,7 @@ import paintEditorHandler from "./paint-editor.js";
 // Note that we don't await other scripts (they block!)
 export default async (api) => {
   const { addon } = api;
-  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/tinycolor-min.js");
+  await addon.tab.loadScript("/libraries/thirdparty/cs/tinycolor-min.js");
   codeEditorHandler(api);
   paintEditorHandler(api);
 };

--- a/addons/dark-www/scratchstats.js
+++ b/addons/dark-www/scratchstats.js
@@ -3,7 +3,7 @@ import { textColor } from "../../libraries/common/cs/text-color.esm.js";
 export default async function ({ addon, console }) {
   // Style the chart added by the scratchstats addon
   const canvas = await addon.tab.waitForElement("#sa-scratchstats-chart", { markAsSeen: true });
-  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
+  await addon.tab.loadScript("/libraries/thirdparty/cs/chart.min.js");
   const updateChart = () => {
     const chart = Chart.getChart(canvas);
     if (!chart) return;

--- a/addons/debugger/performance.js
+++ b/addons/debugger/performance.js
@@ -3,7 +3,7 @@ import { onPauseChanged, isPaused } from "./module.js";
 export default async function createPerformanceTab({ debug, addon, console, msg }) {
   const vm = addon.tab.traps.vm;
 
-  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
+  await addon.tab.loadScript("/libraries/thirdparty/cs/chart.min.js");
 
   // In optimized graphs everything still looks good
   const fancyGraphs = addon.settings.get("fancy_graphs");

--- a/addons/forum-search/userscript.js
+++ b/addons/forum-search/userscript.js
@@ -235,7 +235,7 @@ function appendSearch(box, query, page, term, msg) {
 
 export default async function ({ addon, console, msg }) {
   if (!window.scratchAddons._scratchblocks3Enabled) {
-    window.scratchblocks = (await import(addon.self.lib + "/thirdparty/cs/scratchblocks.min.es.js")).default;
+    window.scratchblocks = (await addon.self.dynamicImport("/libraries/thirdparty/cs/scratchblocks.min.es.js")).default;
   }
 
   // create the search bar

--- a/addons/image-uploader/userscript.js
+++ b/addons/image-uploader/userscript.js
@@ -1,6 +1,6 @@
 import { insert } from "../../libraries/thirdparty/cs/text-field-edit.js";
 export default async function ({ addon, msg, console }) {
-  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/spark-md5.min.js");
+  await addon.tab.loadScript("/libraries/thirdparty/cs/spark-md5.min.js");
 
   const toolbar =
     document.querySelector("#markItUpId_body > div > div.markItUpHeader > ul") ||

--- a/addons/opacity-slider/userscript.js
+++ b/addons/opacity-slider/userscript.js
@@ -1,5 +1,5 @@
 export default async function ({ addon, console, msg }) {
-  await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/tinycolor-min.js");
+  await addon.tab.loadScript("/libraries/thirdparty/cs/tinycolor-min.js");
 
   const CONTAINER_WIDTH = 150;
   const HANDLE_WIDTH = 26;

--- a/addons/scratchblocks/userscript.js
+++ b/addons/scratchblocks/userscript.js
@@ -53,8 +53,8 @@ export default async function ({ addon, msg }) {
   oldScript.remove();
 
   const [sb, loadTranslations] = await Promise.all([
-    import(addon.self.lib + "/thirdparty/cs/scratchblocks.min.es.js").then((mod) => mod.default),
-    import(addon.self.lib + "/thirdparty/cs/translations-all-es.js").then((mod) => mod.default),
+    addon.self.dynamicImport("/libraries/thirdparty/cs/scratchblocks.min.es.js").then((mod) => mod.default),
+    addon.self.dynamicImport("/libraries/thirdparty/cs/translations-all-es.js").then((mod) => mod.default),
   ]);
   window.scratchblocks = sb;
   loadTranslations(sb);

--- a/addons/scratchstats/userscript.js
+++ b/addons/scratchstats/userscript.js
@@ -155,7 +155,7 @@ export default async function ({ addon, msg, console }) {
       const historyData = await response.json();
       if (historyData.length === 0) throw new Error("scratchstats: No history data");
       chartLoadingSpinner.remove();
-      await addon.tab.loadScript(addon.self.lib + "/thirdparty/cs/chart.min.js");
+      await addon.tab.loadScript("/libraries/thirdparty/cs/chart.min.js");
       const canvas = document.createElement("canvas");
       chartSection.appendChild(canvas);
       canvas.id = "sa-scratchstats-chart";


### PR DESCRIPTION
### Changes

- Removes `addon.self.lib` string, which was previously used to build relative URLs, similarly to `addon.self.dir`.
- New API: `addon.self.dynamicImport()` which works exactly like the `import()` keyword but it takes a relative URL.
- The existing `addon.tab.loadScript()` method now takes a relative URL.

The now removed `addon.self.lib` It was used in two ways:
1. Together with `addon.tab.loadScript()`, but as that API now takes relative URLs it is no longer needed.
2. For dynamic imports (`import()`) but this PR also adds `addon.tab.loadScript()` which should be useful for that case.

### Reason for changes

Manifest V3 extensions, when reviewed by the Chrome Web Store, are very strict about remote code execution. That is, we shouldn't execute any code (or even CSS) that isn't part of the extension package.
We have followed that rule for some time now, but at first glance our code might look like we might be executing remote JavaScript. By slightly changing some APIs so that only extension package URLs are accepted, our extension becomes easier to review by a human if that is ever the case.

These changes shouldn't be seen as security measures. It might be possible to bypass the relative URL check somehow. The purpose of this PR is to ensure to - any human reading the Tab.js and Self.js files - that we only ever intend to load scripts from the `chrome-extension://` protocol, and not `https://`.

### Tests

Untested for now.