### PR TITLE
Fix `addon.tab.direction` bugs and implement `__addon` global

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -367,7 +367,8 @@ export default class Tab extends Listenable {
   get direction() {
     // https://github.com/scratchfoundation/scratch-l10n/blob/master/src/supported-locales.js
     const rtlLocales = ["ar", "ckb", "fa", "he"];
-    const lang = scratchAddons.globalState.auth.scratchLang.split("-")[0];
+    const rawLang = this._addonObj.auth.scratchLang; // Guaranteed to exist
+    const lang = rawLang.split("-")[0];
     return rtlLocales.includes(lang) ? "rtl" : "ltr";
   }
 

--- a/content-scripts/inject/run-userscript.js
+++ b/content-scripts/inject/run-userscript.js
@@ -2,6 +2,7 @@ import Addon from "../../addon-api/content-script/Addon.js";
 
 export default async function runAddonUserscripts({ addonId, scripts, enabledLate = false }) {
   const addonObj = new Addon({ id: addonId, enabledLate });
+  if (window.__addon === undefined) window.__addon = addonObj;
   addonObj.auth._update(scratchAddons.session);
   for (const scriptInfo of scripts) {
     const { url: scriptPath, runAtComplete } = scriptInfo;


### PR DESCRIPTION
### Changes

- Resolves #7374. Tested by deleting the `scratchlanguage` cookie and making sure `addon.tab.direction === "ltr"` unless your browser language is RTL (for example Arabic)
- If at least one userscript is available, `window.__addon` can be used from the console, which may be the addon object from any addon, but should be useful for experimenting. Idea from #7368
