### PR TITLE
Remove recently added `addon.self.dynamicImport` API

### DIFF
--- a/addon-api/common/Self.js
+++ b/addon-api/common/Self.js
@@ -21,19 +21,6 @@ export default class Self extends Listenable {
   }
 
   /**
-   * Identical to import() keyword but takes a relative URL
-   * @param {string} relativeUrl - URL relative to the extension's origin
-   */
-  dynamicImport(relativeUrl) {
-    const urlObj = new URL(import.meta.url);
-    urlObj.pathname = relativeUrl;
-
-    const url = urlObj.href;
-
-    return import(url);
-  }
-
-  /**
    * path to the addon's directory.
    * @type {string}
    */

--- a/addons/forum-search/userscript.js
+++ b/addons/forum-search/userscript.js
@@ -235,7 +235,7 @@ function appendSearch(box, query, page, term, msg) {
 
 export default async function ({ addon, console, msg }) {
   if (!window.scratchAddons._scratchblocks3Enabled) {
-    window.scratchblocks = (await addon.self.dynamicImport("/libraries/thirdparty/cs/scratchblocks.min.es.js")).default;
+    window.scratchblocks = (await import("../../libraries/thirdparty/cs/scratchblocks.min.es.js")).default;
   }
 
   // create the search bar

--- a/addons/scratchblocks/userscript.js
+++ b/addons/scratchblocks/userscript.js
@@ -53,8 +53,8 @@ export default async function ({ addon, msg }) {
   oldScript.remove();
 
   const [sb, loadTranslations] = await Promise.all([
-    addon.self.dynamicImport("/libraries/thirdparty/cs/scratchblocks.min.es.js").then((mod) => mod.default),
-    addon.self.dynamicImport("/libraries/thirdparty/cs/translations-all-es.js").then((mod) => mod.default),
+    import("../../libraries/thirdparty/cs/scratchblocks.min.es.js").then((mod) => mod.default),
+    import("../../libraries/thirdparty/cs/translations-all-es.js").then((mod) => mod.default),
   ]);
   window.scratchblocks = sb;
   loadTranslations(sb);


### PR DESCRIPTION
Partially reverts #7376

### Changes

Removed the `addon.tab.dynamicImport` API in favour of relative `import()`s

### Reason for changes

`dynamicImport` was only used in 2 places and relative imports don't need anything special.

### Tests

Tested on Chromium 124.