### PR TITLE
Fix spinner.css path (typo in URL)

### DIFF
--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -1,4 +1,4 @@
-@import url("%addon-self-dir%/../../libraries/common/css/spinner.css");
+@import url("../../libraries/common/cs/spinner.css");
 
 body > #pagewrapper {
   min-height: 0;

--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -1,4 +1,4 @@
-@import url("../../libraries/common/cs/spinner.css");
+@import url("%addon-self-dir%/../../libraries/common/cs/spinner.css");
 
 body > #pagewrapper {
   min-height: 0;


### PR DESCRIPTION
### Changes

Fixes a typo in the `spinner.css` import path and removes `%addon-self-dir%`.

### Reason for changes

The typo caused `scratchr2` to fail to load load the spinner on the forums and `%addon-self-dir%` is unnecessary since CSS imports are already relative.

### Tests

Untested.

Also my typo fix commit has a funny typo in its name.