### PR TITLE
editor-dark-mode: dark alerts

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -591,6 +591,28 @@
       }
     },
     {
+      "name": "accent-success",
+      "value": {
+        "type": "alphaBlend",
+        "opaqueSource": {
+          "type": "settingValue",
+          "settingId": "accent"
+        },
+        "transparentSource": "#08bd8c33"
+      }
+    },
+    {
+      "name": "accent-error",
+      "value": {
+        "type": "alphaBlend",
+        "opaqueSource": {
+          "type": "settingValue",
+          "settingId": "accent"
+        },
+        "transparentSource": "#ff8c1a23"
+      }
+    },
+    {
       "name": "input-text",
       "value": {
         "type": "textColor",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -228,6 +228,16 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="font-dropdown_font-dropdown_"][class*="dropdown_mod-open_"] {
   color: var(--editorDarkMode-accent-openFontDropdownText);
 }
+[class*="alert_alert_"][class*="alert_success_"] {
+  background-color: var(--editorDarkMode-accent-success);
+  box-shadow: 0 0 0 2px var(--editorDarkMode-accent-success);
+}
+[class*="alert_alert_"][class*="alert_warn_"] {
+  background-color: var(--editorDarkMode-accent-error);
+}
+[class*="alert_alert-message_"] {
+  color: var(--editorDarkMode-accent-text);
+}
 
 /* Input background */
 .u-dropdown-searchbar:hover,


### PR DESCRIPTION
Resolves #7354

### Changes

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/873b1f07-ebd0-48af-b4e4-8b9c936716be)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/9544c56e-5764-4d39-a93e-639967008c4a)

### Tests

Tested on Edge and Firefox.