### PR TITLE
Ignore permission webRequestBlocking in Chrome (gen-manifest.mjs)

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -1,4 +1,4 @@
-const PERMISSIONS_IGNORED_IN_CHROME = ["clipboardWrite"];
+const PERMISSIONS_IGNORED_IN_CHROME = ["clipboardWrite", "webRequestBlocking"];
 const PERMISSIONS_IGNORED_IN_FIREFOX = [];
 // These host permissions below should be removed during production manifest gen.
 const PERMISSIONS_ALWAYS_IGNORED = [


### PR DESCRIPTION
The webRequestBlocking permission is meaningless in Chrome MV3.