### PR TITLE
Fix MV3 on Firefox for Android

### DIFF
--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -32,26 +32,24 @@ chrome.storage.local.get("muted", (obj) => {
   scratchAddons.muted = obj.muted;
 });
 
+chrome.contextMenus?.removeAll();
 let currentMenuItem = null;
 
-// chrome.contextMenus is broken on Android Firefox with MV3
-if (chrome.contextMenus !== undefined) {
-  chrome.contextMenus.removeAll();
+// NOTE: chrome.contextMenus equals `undefined` on Firefox for Android!
 
-  chrome.contextMenus.onClicked.addListener(({ parentMenuItemId, menuItemId }) => {
-    if (parentMenuItemId === "mute") {
-      const mins = Number(menuItemId.split("_")[1]);
-      contextMenuMuted();
-      muteForMins(mins);
-    } else if (menuItemId === "unmute") {
-      contextMenuUnmuted();
-      unmute();
-    }
-  });
-}
+chrome.contextMenus?.onClicked.addListener(({ parentMenuItemId, menuItemId }) => {
+  if (parentMenuItemId === "mute") {
+    const mins = Number(menuItemId.split("_")[1]);
+    contextMenuMuted();
+    muteForMins(mins);
+  } else if (menuItemId === "unmute") {
+    contextMenuUnmuted();
+    unmute();
+  }
+});
 
 function contextMenuUnmuted() {
-  if (chrome.contextMenus === undefined) return;
+  if (chrome.contextMenus === undefined) return; // Firefox for Android
   if (currentMenuItem === "unmute") chrome.contextMenus.remove("unmute");
   currentMenuItem = "mute";
   chrome.contextMenus.create({
@@ -76,7 +74,7 @@ function contextMenuUnmuted() {
 }
 
 function contextMenuMuted() {
-  if (chrome.contextMenus === undefined) return;
+  if (chrome.contextMenus === undefined) return; // Firefox for Android
   if (currentMenuItem === "mute") chrome.contextMenus.remove("mute");
   currentMenuItem = "unmute";
   chrome.contextMenus.create({

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -75,6 +75,8 @@ function contextMenuUnmuted() {
 
 function contextMenuMuted() {
   if (chrome.contextMenus === undefined) return; // Firefox for Android
+  // Note: in theory, this function is unreachable
+  // in FF for Android, but we early-return anyway.
   if (currentMenuItem === "mute") chrome.contextMenus.remove("mute");
   currentMenuItem = "unmute";
   chrome.contextMenus.create({

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -35,7 +35,7 @@ chrome.storage.local.get("muted", (obj) => {
 let currentMenuItem = null;
 
 // chrome.contextMenus is broken on Android Firefox with MV3
-if (!chrome.contextMenus === undefined) {
+if (chrome.contextMenus !== undefined) {
   chrome.contextMenus.removeAll();
 
   chrome.contextMenus.onClicked.addListener(({ parentMenuItemId, menuItemId }) => {
@@ -69,8 +69,8 @@ function contextMenuUnmuted() {
   }
   chrome.browserAction.setIcon({
     path: {
-      16: chrome.runtime.getManifest().icons["16"],
-      32: chrome.runtime.getManifest().icons["32"],
+      16: chrome.runtime.getURL(chrome.runtime.getManifest().icons["16"]),
+      32: chrome.runtime.getURL(chrome.runtime.getManifest().icons["32"]),
     },
   });
 }

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -71,8 +71,8 @@ function contextMenuUnmuted() {
   }
   chrome.browserAction.setIcon({
     path: {
-      16: chrome.chrome.runtime.getManifest().icons["16"],
-      32: chrome.chrome.runtime.getManifest().icons["32"],
+      16: chrome.runtime.getManifest().icons["16"],
+      32: chrome.runtime.getManifest().icons["32"],
     },
   });
 }

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -2,9 +2,6 @@ import { updateBadge } from "./message-cache.js";
 
 const BROWSER_ACTION = globalThis.MANIFEST_VERSION === 2 ? "browser_action" : "action";
 
-// chrome.contextMenu is broken on Firefox mobile
-const isAndroidFirefox = navigator.userAgent.includes("Firefox") && navigator.userAgent.includes("Android");
-
 const periods = [
   {
     // Unfortunately, users on Chrome 96-99 will not get translations for these strings.
@@ -37,7 +34,8 @@ chrome.storage.local.get("muted", (obj) => {
 
 let currentMenuItem = null;
 
-if (!isAndroidFirefox) {
+// chrome.contextMenus is broken on Android Firefox with MV3
+if (!chrome.contextMenus === undefined) {
   chrome.contextMenus.removeAll();
 
   chrome.contextMenus.onClicked.addListener(({ parentMenuItemId, menuItemId }) => {
@@ -53,7 +51,7 @@ if (!isAndroidFirefox) {
 }
 
 function contextMenuUnmuted() {
-  if (isAndroidFirefox) return;
+  if (chrome.contextMenus === undefined) return;
   if (currentMenuItem === "unmute") chrome.contextMenus.remove("unmute");
   currentMenuItem = "mute";
   chrome.contextMenus.create({
@@ -78,7 +76,7 @@ function contextMenuUnmuted() {
 }
 
 function contextMenuMuted() {
-  if (isAndroidFirefox) return;
+  if (chrome.contextMenus === undefined) return;
   if (currentMenuItem === "mute") chrome.contextMenus.remove("mute");
   currentMenuItem = "unmute";
   chrome.contextMenus.create({

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -69,12 +69,10 @@ function contextMenuUnmuted() {
       contexts: [BROWSER_ACTION],
     });
   }
-  // This seems to be run when the extension is loaded, so we'll just set the right icon here.
-  const prerelease = chrome.runtime.getManifest().version_name.includes("-prerelease");
   chrome.browserAction.setIcon({
     path: {
-      16: prerelease ? chrome.runtime.getURL("images/icon-blue-16.png") : chrome.runtime.getURL("images/icon-16.png"),
-      32: prerelease ? chrome.runtime.getURL("images/icon-blue-32.png") : chrome.runtime.getURL("images/icon-32.png"),
+      16: chrome.chrome.runtime.getManifest().icons["16"],
+      32: chrome.chrome.runtime.getManifest().icons["32"],
     },
   });
 }

--- a/webpages/popup/index.html
+++ b/webpages/popup/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="../set-lang.js" type="module"></script>
     <script src="../check-unsupported.js" defer></script>
     <style>

--- a/webpages/popup/index.html
+++ b/webpages/popup/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="../set-lang.js" type="module"></script>
     <script src="../check-unsupported.js" defer></script>
     <style>


### PR DESCRIPTION
Resolves #6976
Resolves #7461

### Changes

Sets the viewport on the popup and checks if `chrome.contextMenus` is defined before using it since it errors on Firefox for Android now.

Also removes some weird icon handling I added back in #4810. Now it always uses the icons set in the extension's manifest.

### Reason for changes

The popup wasn't scaling correctly and after MV3 the extension completely broke. It's also nice to be able distinguish Git versions even if they're stable.

### Tests

Tested on Andorid Firefox Beta, desktop Firefox and Chromium. The viewport doesn't seem to change the popup on Desktop and Firefox works on Android again including Scratch notifier.