### PR TITLE
Error in settings-page if background ctx unavailable

### DIFF
--- a/background/background-sucess-status.js
+++ b/background/background-sucess-status.js
@@ -1,0 +1,6 @@
+// If this script is running, then none of the previews scripts threw any errors.
+
+chrome.storage.session?.set({ backgroundContextOk: true });
+// Ideally we would only run this once per service worker startup, but
+// there's no straight-forward way it seems. A combination of
+// onStartup and onUpdate might not cover all cases.

--- a/background/background.js
+++ b/background/background.js
@@ -30,3 +30,5 @@ import "./get-popups.js";
 // Respond to requests by the settings page and others
 import "./handle-settings-page.js";
 import "./handle-licenses.js";
+
+import "./background-sucess-status.js";


### PR DESCRIPTION
Resolves #5306

### Changes

![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/4103b447-bd46-4553-8670-c9a5fa0f0637)

- The error page is still not localized - so it's English only
- The popup still doesn't show any error message if the background context is unavailable. 

### Tests

Tested in Chrome and Firefox on MV3