### PR TITLE
`localhost` fixes

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -2,9 +2,13 @@ const PERMISSIONS_IGNORED_IN_CHROME = ["clipboardWrite", "webRequestBlocking"];
 const PERMISSIONS_IGNORED_IN_FIREFOX = [];
 // These host permissions below should be removed during production manifest gen.
 const PERMISSIONS_ALWAYS_IGNORED = [
+  "scripting",
   "https://scratchfoundation.github.io/scratch-gui/*",
+  "https://scratchfoundation.github.io/*",
   "http://localhost:8333/*",
   "http://localhost:8601/*",
+  "http://localhost:8602/*",
+  "http://localhost/*",
 ];
 
 /**
@@ -24,8 +28,8 @@ export default (env, manifest) => {
   manifest.icons["16"] = "images/icon-16.png";
 
   const removePermission = (permToRemove) => {
-    // Affects `permissions`, `host_permissions`, `optional_permissions`, `optional_host_permissions`
-    // as well as content script matches.
+    // Affects `permissions`, `host_permissions`, `optional_permissions`, `optional_host_permissions`,
+    // `web_accessible_resources[i].matches`, and content_scripts[i].matches
     manifest.permissions = manifest.permissions.filter((perm) => perm !== permToRemove);
     manifest.host_permissions = manifest.host_permissions.filter((perm) => perm !== permToRemove);
     manifest.optional_permissions = manifest.optional_permissions.filter((perm) => perm !== permToRemove);
@@ -34,6 +38,9 @@ export default (env, manifest) => {
     }
     manifest.content_scripts.forEach((contentScript) => {
       contentScript.matches = contentScript.matches.filter((match) => match !== permToRemove);
+    });
+    manifest.web_accessible_resources.forEach((resourcesObj) => {
+      resourcesObj.matches = resourcesObj.matches.filter((match) => match !== permToRemove);
     });
   };
 

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -8,6 +8,9 @@ import * as modal from "./modal.js";
 
 const DATA_PNG = "data:image/png;base64,";
 
+const isScratchGui =
+  location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
+
 const contextMenuCallbacks = [];
 const CONTEXT_MENU_ORDER = ["editor-devtools", "block-switching", "blocks2image", "swap-local-global"];
 let createdAnyBlockContextMenus = false;
@@ -213,7 +216,7 @@ export default class Tab extends Listenable {
    * @type {?string}
    */
   get editorMode() {
-    if (location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port)) {
+    if (isScratchGui) {
       // Note that scratch-gui does not change the URL when going fullscreen.
       if (this.redux.state?.scratchGui?.mode?.isFullScreen) return "fullscreen";
       return "editor";
@@ -298,8 +301,6 @@ export default class Tab extends Listenable {
     const isProject =
       location.pathname.split("/")[1] === "projects" &&
       !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
-    const isScratchGui =
-      location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
     if (!isProject && !isScratchGui) {
       scratchAddons.console.warn("addon.tab.scratchClass() was used outside a project page");
       return "";
@@ -339,8 +340,6 @@ export default class Tab extends Listenable {
     const isProject =
       location.pathname.split("/")[1] === "projects" &&
       !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
-    const isScratchGui =
-      location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
     if (!isProject && !isScratchGui) return Promise.resolve();
 
     this._calledScratchClassReady = true;

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -213,7 +213,7 @@ export default class Tab extends Listenable {
    * @type {?string}
    */
   get editorMode() {
-    if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601") {
+    if (location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port)) {
       // Note that scratch-gui does not change the URL when going fullscreen.
       if (this.redux.state?.scratchGui?.mode?.isFullScreen) return "fullscreen";
       return "editor";
@@ -298,7 +298,8 @@ export default class Tab extends Listenable {
     const isProject =
       location.pathname.split("/")[1] === "projects" &&
       !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
-    const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
+    const isScratchGui =
+      location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
     if (!isProject && !isScratchGui) {
       scratchAddons.console.warn("addon.tab.scratchClass() was used outside a project page");
       return "";
@@ -338,7 +339,8 @@ export default class Tab extends Listenable {
     const isProject =
       location.pathname.split("/")[1] === "projects" &&
       !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
-    const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
+    const isScratchGui =
+      location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
     if (!isProject && !isScratchGui) return Promise.resolve();
 
     this._calledScratchClassReady = true;

--- a/background/background.js
+++ b/background/background.js
@@ -1,5 +1,7 @@
 // This file is loaded as ESM.
 
+import "./firefox-localhost-support.js";
+
 // Transition from Scratch Messaging Extension
 import "./transition.js";
 

--- a/background/firefox-localhost-support.js
+++ b/background/firefox-localhost-support.js
@@ -1,0 +1,18 @@
+if (typeof browser === "object") {
+  const manifest = chrome.runtime.getManifest();
+  const manifestScripts = manifest.content_scripts.filter((script) =>
+    script.matches.includes("http://localhost:8602/*")
+  );
+  const scripts = manifestScripts.map((scriptObj, i) => ({
+    id: `ff_${i}`,
+    matches: ["http://localhost/*"],
+    js: scriptObj.js.map((url) => new URL(url).pathname),
+    runAt: scriptObj.run_at,
+    allFrames: scriptObj.all_frames,
+  }));
+  chrome.scripting.registerContentScripts(scripts);
+}
+
+// Scripting API should only be used for local development purposes.
+// At the moment, the scripting permission is not present in the release version.
+chrome.scripting = "sa_no_scripting";

--- a/background/firefox-localhost-support.js
+++ b/background/firefox-localhost-support.js
@@ -10,7 +10,7 @@ if (typeof browser === "object") {
     runAt: scriptObj.run_at,
     allFrames: scriptObj.all_frames,
   }));
-  chrome.scripting.registerContentScripts(scripts);
+  chrome.scripting.registerContentScripts(scripts).catch((e) => console.error(e));
 }
 
 // Scripting API should only be used for local development purposes.

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -408,7 +408,7 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
 
   let _url = data.url;
   let _parsedURL = new URL(_url);
-  if (_parsedURL.origin === "https://scratchfoundation.github.io" || _parsedURL.port === "8601") {
+  if (_parsedURL.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(_parsedURL.port)) {
     // Run addons on scratch-gui
     _url = "https://scratch.mit.edu/projects/editor/";
     _parsedURL = new URL(_url);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -11,6 +11,11 @@ try {
 if (window.frameElement && window.frameElement.getAttribute("src") === null)
   throw "Scratch Addons: iframe without src attribute ignored";
 if (document.documentElement instanceof SVGElement) throw "Scratch Addons: SVG document ignored";
+if (new URL(location.href).hostname === "localhost") {
+  if (!["8333", "8601", "8602"].includes(new URL(location.href).port)) {
+    throw "Scratch Addons: this localhost port is not supported";
+  }
+}
 
 const MAX_USERSTYLES_PER_ADDON = 100;
 

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -37,6 +37,9 @@ const comlinkIframe3 = document.getElementById("scratchaddons-iframe-3");
 const comlinkIframe4 = document.getElementById("scratchaddons-iframe-4");
 const _cs_ = Comlink.wrap(Comlink.windowEndpoint(comlinkIframe2.contentWindow, comlinkIframe1.contentWindow));
 
+const isScratchGui =
+  location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
+
 const page = {
   _globalState: null,
   get globalState() {
@@ -88,7 +91,7 @@ const page = {
   },
   isFetching: false,
   async refetchSession() {
-    if (location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port)) return;
+    if (isScratchGui) return;
     let res;
     let d;
     if (this.isFetching) return;
@@ -197,8 +200,7 @@ function onDataReady() {
 }
 
 function bodyIsEditorClassCheck() {
-  if (location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port))
-    return document.body.classList.add("sa-body-editor");
+  if (isScratchGui) return document.body.classList.add("sa-body-editor");
   const pathname = location.pathname.toLowerCase();
   const split = pathname.split("/").filter(Boolean);
   if (!split[0] || split[0] !== "projects") return;
@@ -280,8 +282,6 @@ function loadClasses() {
 const isProject =
   location.pathname.split("/")[1] === "projects" &&
   !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
-const isScratchGui =
-  location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
 if (isScratchGui || isProject) {
   // Stylesheets are considered to have loaded if this element exists
   const elementSelector = isScratchGui ? "div[class*=index_app_]" : ":root > body > .ReactModalPortal";

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -88,7 +88,7 @@ const page = {
   },
   isFetching: false,
   async refetchSession() {
-    if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601") return;
+    if (location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port)) return;
     let res;
     let d;
     if (this.isFetching) return;
@@ -197,7 +197,7 @@ function onDataReady() {
 }
 
 function bodyIsEditorClassCheck() {
-  if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601")
+  if (location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port))
     return document.body.classList.add("sa-body-editor");
   const pathname = location.pathname.toLowerCase();
   const split = pathname.split("/").filter(Boolean);
@@ -280,7 +280,8 @@ function loadClasses() {
 const isProject =
   location.pathname.split("/")[1] === "projects" &&
   !["embed", "remixes", "studios"].includes(location.pathname.split("/")[3]);
-const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
+const isScratchGui =
+  location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
 if (isScratchGui || isProject) {
   // Stylesheets are considered to have loaded if this element exists
   const elementSelector = isScratchGui ? "div[class*=index_app_]" : ":root > body > .ReactModalPortal";

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -11,7 +11,7 @@ function immediatelyRunFunctionInMainWorld(fn) {
   div.remove();
 }
 
-const isLocal = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
+const isLocal = location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
 if ((!(document.documentElement instanceof SVGElement) && location.pathname.split("/")[1] === "projects") || isLocal) {
   immediatelyRunFunctionInMainWorld(() => {
     const oldBind = Function.prototype.bind;

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,9 @@
       "matches": [
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-gui/*",
-        "http://localhost/*"
+        "http://localhost:8333/*",
+        "http://localhost:8601/*",
+        "http://localhost:8602/*"
       ],
       "run_at": "document_start",
       "js": ["libraries/thirdparty/cs/comlink.js", "libraries/common/cs/text-color.js", "content-scripts/cs.js"],
@@ -31,7 +33,9 @@
       "matches": [
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-gui/*",
-        "http://localhost/*"
+        "http://localhost:8333/*",
+        "http://localhost:8601/*",
+        "http://localhost:8602/*"
       ],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],
@@ -49,9 +53,7 @@
     "https://api.scratch.mit.edu/*",
     "https://clouddata.scratch.mit.edu/*",
     "https://scratchfoundation.github.io/scratch-gui/*",
-    "http://localhost:8333/*",
-    "http://localhost:8601/*",
-    "http://localhost:8602/*"
+    "http://localhost/*"
   ],
   "permissions": [
     "cookies",
@@ -60,7 +62,8 @@
     "declarativeNetRequestWithHostAccess",
     "storage",
     "contextMenus",
-    "alarms"
+    "alarms",
+    "scripting"
   ],
   "optional_permissions": ["notifications", "clipboardWrite"],
   "web_accessible_resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -73,7 +73,12 @@
         "addons-l10n/*/*.json",
         "images/cs/*"
       ],
-      "matches": ["https://*.scratch.mit.edu/*", "https://scratchaddons.com/*", "http://localhost/*"]
+      "matches": [
+        "https://*.scratch.mit.edu/*",
+        "https://scratchaddons.com/*",
+        "https://scratchfoundation.github.io/*",
+        "http://localhost/*"
+      ]
     }
   ],
   "browser_specific_settings": {

--- a/manifest.json
+++ b/manifest.json
@@ -21,9 +21,7 @@
       "matches": [
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-gui/*",
-        "http://localhost:8333/*",
-        "http://localhost:8601/*",
-        "http://localhost:8602/*"
+        "http://localhost/*"
       ],
       "run_at": "document_start",
       "js": ["libraries/thirdparty/cs/comlink.js", "libraries/common/cs/text-color.js", "content-scripts/cs.js"],
@@ -33,9 +31,7 @@
       "matches": [
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-gui/*",
-        "http://localhost:8333/*",
-        "http://localhost:8601/*",
-        "http://localhost:8602/*"
+        "http://localhost/*"
       ],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-gui/*",
         "http://localhost:8333/*",
-        "http://localhost:8601/*"
+        "http://localhost:8601/*",
+        "http://localhost:8602/*"
       ],
       "run_at": "document_start",
       "js": ["libraries/thirdparty/cs/comlink.js", "libraries/common/cs/text-color.js", "content-scripts/cs.js"],
@@ -33,7 +34,8 @@
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-gui/*",
         "http://localhost:8333/*",
-        "http://localhost:8601/*"
+        "http://localhost:8601/*",
+        "http://localhost:8602/*"
       ],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],
@@ -52,7 +54,8 @@
     "https://clouddata.scratch.mit.edu/*",
     "https://scratchfoundation.github.io/scratch-gui/*",
     "http://localhost:8333/*",
-    "http://localhost:8601/*"
+    "http://localhost:8601/*",
+    "http://localhost:8602/*"
   ],
   "permissions": [
     "cookies",

--- a/manifest.json
+++ b/manifest.json
@@ -74,7 +74,7 @@
         "addons-l10n/*/*.json",
         "images/cs/*"
       ],
-      "matches": ["https://*.scratch.mit.edu/*", "https://scratchaddons.com/*"]
+      "matches": ["https://*.scratch.mit.edu/*", "https://scratchaddons.com/*", "http://localhost/*"]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
Resolves #7455
Resolves #7456

### Changes

* Adds `localhost:8602` to `host_permissions` and updates other code that expects the GUI port to be 8601
* Replaces `localhost:8333` and `localhost:8601` content script matches with just `localhost` - Firefox doesn't like ports in match patterns for some reason
* Adds `localhost` and `scratchfoundation.github.io` to the `matches` field under `web_accessible_resources`
* **For up-to-date changes, see comment https://github.com/ScratchAddons/ScratchAddons/pull/7474#issuecomment-2197876142**

@WorldLanguages The `gen-manifest` script needs to be updated.

### Tests

Tested on Edge and Firefox with the develop branch of scratch-gui and scratch-www.