### PR TITLE
Bug fix for empty labels not working with reorder-custom-inputs addon

### DIFF
--- a/addons/reorder-custom-inputs/modified-funcs.js
+++ b/addons/reorder-custom-inputs/modified-funcs.js
@@ -27,7 +27,7 @@ export function modifiedCreateAllInputs(connectionMap) {
       this.populateArgument_(argumentType, argumentCount, connectionMap, id, input);
       argumentCount++;
     } else {
-      labelText = component.trim().replace("%l ", "");
+      labelText = component == "%l" ? " " : component.replace("%l", "").trim();
     }
     this.addProcedureLabel_(labelText.replace(/\\%/, "%"));
   }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves  #7478

### Changes

Solved by checking if label is empty and adding a space character instead

### Reason for changes

without this change the empty label would cause the %l to not get removed, causing all kinds of strange problems

### Tests

Tested on chrome. See video of new functionality below:


https://github.com/ScratchAddons/ScratchAddons/assets/48254978/eb4a7f1b-82db-43b9-b21e-a2ad73bdf27f

