### PR TITLE
Responsive permissions page

### DIFF
--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -318,13 +318,14 @@ body.iframe .search-box input {
 .permissions div.main {
   display: block;
   box-sizing: border-box;
-  max-width: 1000px;
+  max-width: fit-content;
   margin: auto;
   padding: 1rem;
   overflow-y: scroll;
 }
 
 .permissions-block {
+  margin-top: 2rem;
   font-size: 1.25rem;
 }
 
@@ -336,7 +337,7 @@ body.iframe .search-box input {
 .permissions-steps {
   display: flex;
   align-items: flex-end;
-  gap: 3rem;
+  gap: 2rem;
 }
 
 .permissions-steps > div {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -320,12 +320,12 @@ body.iframe .search-box input {
   box-sizing: border-box;
   max-width: fit-content;
   margin: auto;
-  padding: 1rem;
-  overflow-y: scroll;
+  padding: 2rem;
+  overflow-y: auto;
 }
 
 .permissions-block {
-  margin-top: 2rem;
+  margin-top: 1rem;
   font-size: 1.25rem;
 }
 
@@ -362,7 +362,8 @@ body.iframe .search-box input {
 }
 
 #screenshot {
-  height: 10rem;
+  width: 24rem;
+  max-width: 100%;
 }
 
 color-picker {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -322,6 +322,8 @@ body.iframe .search-box input {
   margin: auto;
   padding: 2rem;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-text) transparent;
 }
 
 .permissions-block {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -346,10 +346,10 @@ body.iframe .search-box input {
 }
 
 @media (max-width: 1000px) {
-    .permissions-steps {
-      flex-direction: column;
-      align-items: center;
-    }
+  .permissions-steps {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 #permissionsBtn {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -316,13 +316,15 @@ body.iframe .search-box input {
 }
 
 .permissions div.main {
-  justify-content: center;
-  display: grid;
-  grid-template-rows: 14rem 10rem;
+  display: block;
+  box-sizing: border-box;
+  max-width: 1000px;
+  margin: auto;
+  padding: 1rem;
+  overflow-y: scroll;
 }
 
 .permissions-block {
-  margin-top: 3rem;
   font-size: 1.25rem;
 }
 
@@ -334,6 +336,7 @@ body.iframe .search-box input {
 .permissions-steps {
   display: flex;
   align-items: flex-end;
+  gap: 3rem;
 }
 
 .permissions-steps > div {
@@ -342,11 +345,15 @@ body.iframe .search-box input {
   align-items: center;
 }
 
-.permissions-steps > div:not(:last-child) {
-  margin-right: 2rem;
+@media (max-width: 1000px) {
+    .permissions-steps {
+      flex-direction: column;
+      align-items: center;
+    }
 }
 
 #permissionsBtn {
+  display: block;
   height: 6rem;
   width: 18rem;
   font-size: 2.5rem;


### PR DESCRIPTION
Resolves #6844
Resolves https://github.com/ScratchAddons/ScratchAddons/pull/7464#issuecomment-2131309393

### Changes

Makes the permissions page responsive, adds a scrollbar and fixes the button text.

### Reason for changes

The permissions page was not designed for phones or short screens.

### Tests

Tested on Chromium. Since I didn't put the scrollbar on the body it won't necessarily be on the edge of the window. The image is also slightly too wide for the IPhone SE in devtools.