### PR TITLE
Temp solution for `necropost-highlighter` crash

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -446,6 +446,12 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
 }
 
 function urlMatchesLegacyPattern(pattern, urlUrl) {
+  try {
+    new URL(pattern);
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
   const patternUrl = new URL(pattern);
   // We assume both URLs start with https://scratch.mit.edu
 


### PR DESCRIPTION
Partially addresses #7481

The `necropost-highlighter` addon uses regex match patterns which can't be serialized to JSON. When loaded from cache, the regex is lost and causes an "invalid URL" error. This temporary solution catches that error.

### Tests

Tested.
