### PR TITLE
Bug-fix: clone manifests before caching them

### DIFF
--- a/background/load-addon-manifests.js
+++ b/background/load-addon-manifests.js
@@ -66,7 +66,7 @@ const localizeSettings = (addonId, setting, tableId) => {
       } else {
         const file = await (await fetch(`/addons/${addonId}/addon.json`)).json();
         manifest = file;
-        newCache[addonId] = file;
+        newCache[addonId] = JSON.parse(JSON.stringify(file));
       }
     } catch (ex) {
       console.error(`Failed to load addon manifest for ${addonId}, crashing:`, ex);


### PR DESCRIPTION
Resolves #7481
Resolves #7484

### Changes

Performs a deep clone on each addon-manifest cache entry.

### Reason for changes

Since manifests are cached before they are processed and processing happens whether or not the manifests were loaded from disk or from the cache, it only makes sense that the cache is not modified during processing. As an example, this fixes an issue where values that couldn't be serialized to JSON were ending up in the cache and causing errors because the processing code didn't expect such data.

### Tests

Tested.
