### PR TITLE
Remove `MANIFEST_VERSION` and related constants

### DIFF
--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -1,7 +1,5 @@
 import { updateBadge } from "./message-cache.js";
 
-const BROWSER_ACTION = globalThis.MANIFEST_VERSION === 2 ? "browser_action" : "action";
-
 const periods = [
   {
     // Unfortunately, users on Chrome 96-99 will not get translations for these strings.
@@ -55,17 +53,17 @@ function contextMenuUnmuted() {
   chrome.contextMenus.create({
     id: "mute",
     title: (chrome.i18n.getMessage && chrome.i18n.getMessage("muteFor")) || "Do not disturb",
-    contexts: [BROWSER_ACTION],
+    contexts: ["action"],
   });
   for (const period of periods) {
     chrome.contextMenus.create({
       id: `mute_${period.mins}`,
       title: period.name,
       parentId: "mute",
-      contexts: [BROWSER_ACTION],
+      contexts: ["action"],
     });
   }
-  chrome.browserAction.setIcon({
+  chrome.action.setIcon({
     path: {
       16: chrome.runtime.getURL(chrome.runtime.getManifest().icons["16"]),
       32: chrome.runtime.getURL(chrome.runtime.getManifest().icons["32"]),
@@ -82,9 +80,9 @@ function contextMenuMuted() {
   chrome.contextMenus.create({
     id: "unmute",
     title: (chrome.i18n.getMessage && chrome.i18n.getMessage("unmute")) || "Turn off Do not disturb",
-    contexts: [BROWSER_ACTION],
+    contexts: ["action"],
   });
-  chrome.browserAction.setIcon({
+  chrome.action.setIcon({
     path: {
       16: chrome.runtime.getURL("images/icon-gray-16.png"),
       32: chrome.runtime.getURL("images/icon-gray-32.png"),

--- a/background/handle-permissions.js
+++ b/background/handle-permissions.js
@@ -12,11 +12,9 @@ const onPermissionsRevoked = ({ isStartup }) => {
 };
 
 const checkSitePermissions = (sendResponse, { isStartup }) => {
-  const HOST_PERMISSIONS_KEY_NAME = globalThis.MANIFEST_VERSION === 2 ? "permissions" : "host_permissions";
-
   chrome.permissions.contains(
     {
-      origins: chrome.runtime.getManifest()[HOST_PERMISSIONS_KEY_NAME].filter((url) => url.startsWith("https://")),
+      origins: chrome.runtime.getManifest().host_permissions.filter((url) => url.startsWith("https://")),
     },
     (hasPermissions) => {
       if (!hasPermissions) {

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -43,8 +43,8 @@ export async function updateBadge(defaultStoreId) {
         const text = isLoggedIn ? String(count) : "?";
         // The badge will show incorrect message count in other auth contexts.
         // Blocked on Chrome implementing store ID-based tab query
-        await promisify(chrome.browserAction.setBadgeBackgroundColor.bind(chrome.browserAction))({ color });
-        await promisify(chrome.browserAction.setBadgeText.bind(chrome.browserAction))({ text });
+        await promisify(chrome.action.setBadgeBackgroundColor.bind(chrome.action))({ color });
+        await promisify(chrome.action.setBadgeText.bind(chrome.action))({ text });
         return;
       }
     }
@@ -57,7 +57,7 @@ export async function updateBadge(defaultStoreId) {
   // Hide badge when logged out and showOffline is false,
   // or when the logged-in user has no unread messages,
   // or when the addon is disabled
-  await promisify(chrome.browserAction.setBadgeText.bind(chrome.browserAction))({ text: "" });
+  await promisify(chrome.action.setBadgeText.bind(chrome.action))({ text: "" });
 }
 
 /**

--- a/background/transition.js
+++ b/background/transition.js
@@ -1,9 +1,3 @@
-globalThis.MANIFEST_VERSION = 3;
-
-if (globalThis.MANIFEST_VERSION === 3) {
-  chrome.browserAction = chrome.action;
-}
-
 const utm = `utm_source=extension&utm_medium=tabscreate&utm_campaign=v${chrome.runtime.getManifest().version}`;
 // Note: chrome.i18n.getUILanguage is not available Chrome 96-99
 const uiLanguage = (chrome.i18n.getUILanguage && chrome.i18n.getUILanguage()) || navigator.language;

--- a/webpages/settings/permissions.js
+++ b/webpages/settings/permissions.js
@@ -25,13 +25,9 @@ const promisify =
   (...args) =>
     new Promise((resolve) => callbackFn(...args, resolve));
 
-const MANIFEST_VERSION = 3;
-
 document.getElementById("permissionsBtn").addEventListener("click", async () => {
-  const HOST_PERMISSIONS_KEY_NAME = MANIFEST_VERSION === 2 ? "permissions" : "host_permissions";
-
   const manifest = chrome.runtime.getManifest();
-  const origins = manifest[HOST_PERMISSIONS_KEY_NAME].filter((url) => url.startsWith("https://"));
+  const origins = manifest.host_permissions.filter((url) => url.startsWith("https://"));
 
   const granted = await promisify(chrome.permissions.request)({ origins });
   if (granted) {


### PR DESCRIPTION
Resolves #7476 

Also changes every instance of `chrome.browserAction` to `chrome.action` and removes the runtime polyfill.