### PR TITLE
Add some styles to the error  page

### DIFF
--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -10,7 +10,7 @@
   </head>
 
   <body>
-    <h2 id="problem-title">Scratch Addons encountered a problem:</h2>
+    <h2>Scratch Addons encountered a problem:</h2>
 
     <h1 id="problem-type">(unknown error)</h1>
 

--- a/webpages/error/index.html
+++ b/webpages/error/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <title>Error - Scratch Addons</title>
     <!-- <script src="../set-lang.js" type="module"></script> -->
     <script src="./index.js" type="module"></script>
     <script src="./export.js" type="module"></script>

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -1,5 +1,5 @@
 @import url("../../libraries/thirdparty/Sora.css");
-@import url("../styles/colors.css");
+@import url("../styles/colors-light.css");
 
 body {
   color: var(--content-text);

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -1,11 +1,10 @@
-@import url("../../libraries/thirdparty/Sora.css");
 @import url("../styles/colors-light.css");
 
 body {
   color: var(--content-text);
   background-color: var(--page-background);
   font-size: 1rem;
-  font-family: "Sora", sans-serif;
+  font-family: sans-serif;
 }
 
 a {

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -1,6 +1,15 @@
-html {
-  font-size: 20px;
-  background-color: white;
+@import url("../../libraries/thirdparty/Sora.css");
+@import url("../styles/colors.css");
+
+body {
+  color: var(--content-text);
+  background-color: var(--page-background);
+  font-size: 1.25rem;
+  font-family: "Sora", sans-serif;
+}
+
+a {
+  color: var(--blue-text);
 }
 
 #browser-info {
@@ -13,6 +22,6 @@ html {
 
 #restart-url {
   display: inline-block;
-  margin: 0 6px 0 6px;
+  margin: 0 6px;
   font-family: monospace;
 }

--- a/webpages/error/style.css
+++ b/webpages/error/style.css
@@ -4,7 +4,7 @@
 body {
   color: var(--content-text);
   background-color: var(--page-background);
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-family: "Sora", sans-serif;
 }
 

--- a/webpages/styles/colors-light.css
+++ b/webpages/styles/colors-light.css
@@ -1,7 +1,7 @@
 :root {
   --brand-orange-min-font-weight: 600;
   --green-text: var(--green);
-  --blue-text: var(--blue);
+  --blue-text: #175ef8;
 
   --page-background: #fcfcfc;
   --content-background: #f7f7f7;


### PR DESCRIPTION
### Changes

Adds some basic styles on the error page.
![image](https://github.com/ScratchAddons/ScratchAddons/assets/81489795/c77b89cc-8a49-41e3-92ae-20c4fbe3f102)


### Reason for changes

No styling looks ugly especially in the popup.

### Tests

Tested on Chromium and Firefox.