### PR TITLE
Call background alarms less often (`msg-count-badge` affected)

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -246,26 +246,20 @@ chrome.webRequest.onBeforeRequest.addListener(
 // Example: going to https://scratch.mit.edu/studios/104 (no slash after 104)
 // will redirect to /studios/104/ (with a slash)
 // If a cache entry is too old, remove it
-const alarmFrequency =
-  typeof browser !== "undefined"
-    ? // ↓ Firefox (event page)
-      1
-    : // ↓ Chromium (service worker)
-      5;
-chrome.alarms.create("cleanCsInfoCache", { periodInMinutes: alarmFrequency });
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === "cleanCsInfoCache") {
-    csInfoCache.forEach((obj, key) => {
-      if (!obj.loading) {
-        const currentTimestamp = Date.now();
-        const objTimestamp = obj.timestamp;
-        if (currentTimestamp - objTimestamp > 45000) {
-          csInfoCache.delete(key);
-        }
+setInterval(() => {
+  csInfoCache.forEach((obj, key) => {
+    if (!obj.loading) {
+      const currentTimestamp = Date.now();
+      const objTimestamp = obj.timestamp;
+      if (currentTimestamp - objTimestamp > 45000) {
+        csInfoCache.delete(key);
       }
-    });
-  }
-});
+    }
+  });
+}, 30000);
+// This interval may possibly be missed if the background context gets
+// killed or stopped - but at that point, the csInfoCache no longer
+// exists, so we have nothing to clear anyway.
 
 chrome.webRequest.onResponseStarted.addListener(
   (request) => {

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,5 +1,6 @@
 import changeAddonState from "./imports/change-addon-state.js";
 import { getMissingOptionalPermissions } from "./imports/util.js";
+import { setUserAsActive } from "./imports/inactivity.js"
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.replaceTabWithUrl) chrome.tabs.update(sender.tab.id, { url: request.replaceTabWithUrl });
@@ -223,6 +224,7 @@ const csInfoCache = new Map();
 // (example: on browser startup, with a Scratch page opening on startup).
 chrome.webRequest.onBeforeRequest.addListener(
   async (request) => {
+    setUserAsActive();
     if (!scratchAddons.localState.allReady) return;
     const identity = createCsIdentity({ tabId: request.tabId, frameId: request.frameId, url: request.url });
     const loadingObj = { loading: true };

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,6 +1,6 @@
 import changeAddonState from "./imports/change-addon-state.js";
 import { getMissingOptionalPermissions } from "./imports/util.js";
-import { setUserAsActive } from "./imports/inactivity.js"
+import { setUserAsActive } from "./imports/inactivity.js";
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.replaceTabWithUrl) chrome.tabs.update(sender.tab.id, { url: request.replaceTabWithUrl });

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -2,10 +2,12 @@ import changeAddonState from "./imports/change-addon-state.js";
 import minifySettings from "../libraries/common/minify-settings.js";
 import { updateBadge } from "./message-cache.js";
 import { onReady } from "./imports/on-ready.js";
+import { setUserAsActive } from "./imports/inactivity.js";
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   // Message used to load popups as well
   if (request === "getSettingsInfo") {
+    setUserAsActive(); // User opened the popup or the settings page, consider them active.
     return onReady(() => {
       sendResponse({
         manifests: scratchAddons.manifests,

--- a/background/imports/inactivity.js
+++ b/background/imports/inactivity.js
@@ -1,0 +1,37 @@
+import { handleBadgeAlarm } from "../message-cache.js";
+
+const INACTIVITY_DELAY_MINS = 10;
+const INACTIVITY_ALARM = "inactivityAlarm";
+
+// This function should be called each time the user interacts with scratch.mit.edu or with the extension.
+// We consider the user inactive if it's been some minutes since this function was last called.
+export function setUserAsActive() {
+  chrome.alarms.clear(INACTIVITY_ALARM);
+  chrome.storage.session?.set({ inactivity: false });
+
+  chrome.alarms.create(INACTIVITY_ALARM, {
+    delayInMinutes: INACTIVITY_DELAY_MINS,
+  });
+
+  handleBadgeAlarm();
+}
+
+chrome.storage.session?.get("inactivity", (o) => {
+  if (o.inactivity === undefined) {
+    setUserAsActive(); // Consider user active on startup
+  }
+});
+
+chrome.alarms.onAlarm.addListener(async (al) => {
+  if (al.name === INACTIVITY_ALARM) {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true, url: "https://scratch.mit.edu/*" });
+    if (tabs.length > 0) setUserAsActive();
+    else {
+      // Consider user inactive starting now.
+      chrome.storage.session?.set({ inactivity: true });
+
+      // Adjust other alarms to run less often until user is active again.
+      handleBadgeAlarm();
+    }
+  }
+});

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -103,9 +103,9 @@ export function handleBadgeAlarm() {
       if (badgeAddonEnabled) {
         calculateBadgeAlarmInterval().then((newPeriod) => {
           if (!alarmExists || currentAlarm.periodInMinutes !== newPeriod)
-          chrome.alarms.create(BADGE_ALARM_NAME, {
-            periodInMinutes: newPeriod,
-          });
+            chrome.alarms.create(BADGE_ALARM_NAME, {
+              periodInMinutes: newPeriod,
+            });
         });
       }
       if (!badgeAddonEnabled && alarmExists) {

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -86,23 +86,36 @@ export async function startCache(defaultStoreId, forceClear) {
   });
 }
 
+async function calculateBadgeAlarmInterval() {
+  const DEFAULT_MINS = 1;
+  const INACTIVITY_MINS = 2.5;
+  if (!chrome.storage.session) return DEFAULT_MINS;
+  const o = await chrome.storage.session.get("inactivity");
+  return o.inactivity ? INACTIVITY_MINS : DEFAULT_MINS;
+}
+
 // Update badge without fetching messages
 export function handleBadgeAlarm() {
-  chrome.alarms.get(BADGE_ALARM_NAME, (a) => {
-    const alarmExists = a !== undefined;
-    const badgeAddonEnabled = scratchAddons.localState.addonsEnabled["msg-count-badge"];
-    if (badgeAddonEnabled && !alarmExists) {
-      chrome.alarms.create(BADGE_ALARM_NAME, {
-        periodInMinutes: 1,
-      });
-    }
-    if (!badgeAddonEnabled && alarmExists) {
-      // Remove unnecessary alarm
-      chrome.alarms.clear(BADGE_ALARM_NAME);
-    }
+  onReady(() => {
+    chrome.alarms.get(BADGE_ALARM_NAME, (currentAlarm) => {
+      const alarmExists = currentAlarm !== undefined;
+      const badgeAddonEnabled = scratchAddons.localState.addonsEnabled["msg-count-badge"];
+      if (badgeAddonEnabled) {
+        calculateBadgeAlarmInterval().then((newPeriod) => {
+          if (!alarmExists || currentAlarm.periodInMinutes !== newPeriod)
+          chrome.alarms.create(BADGE_ALARM_NAME, {
+            periodInMinutes: newPeriod,
+          });
+        });
+      }
+      if (!badgeAddonEnabled && alarmExists) {
+        // Remove unnecessary alarm
+        chrome.alarms.clear(BADGE_ALARM_NAME);
+      }
+    });
   });
 }
-onReady(handleBadgeAlarm);
+handleBadgeAlarm();
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (!ready) return;


### PR DESCRIPTION
- Removed an unnecessary (since MV3) alarm that was previously named `cleanCsInfoCache`. See comment https://github.com/ScratchAddons/ScratchAddons/issues/7473#issuecomment-2138037284
- If the user is considered inactive, the background context of the extension should only wake up every 150 seconds (2.5 minutes). This is achieved by reducing the frequency of "the alarm that runs most often" (`updateBadge`)

.

After this PR, these are the events that may trigger the background context of the extension to wake up:
- The `updateBadge` alarm every 1 minute, **but every 2.5 minutes if user is considered inactive.**
- The `fetchMessages` alarm every 5 minutes.
- Opening the popup or settings page, changing settings, using the muting feature, etc.
- Navigating to a new Scratch page.
- Any scratch.mit.edu cookies changing for any reason (such as other browser extensions)

.

The user is considered inactive if none of the following have happened for the last 10 minutes:
- Opening the popup or settings page
- Navigating to a new Scratch page

Additionally, even if other conditions are met, if the selected browser tab is a scratch.mit.edu page after the 10 minutes have passed, the period is renewed for another 10 minutes.