### PR TITLE
`comments-linebreaks`: add notice about linebreaks not rendering on scratchr2 pages

### DIFF
--- a/addons/comments-linebreaks/addon.json
+++ b/addons/comments-linebreaks/addon.json
@@ -12,6 +12,11 @@
       "type": "notice",
       "text": "Line breaks are only visible to users with this addon enabled. They will appear as spaces for others.",
       "id": "ownLineBreaks"
+    },
+    {
+      "type": "notice",
+      "text": "Linebreaks currently do not appear on 2.0 pages.",
+      "id": "scratchr2Linebreaks"
     }
   ],
   "userscripts": [

--- a/addons/comments-linebreaks/addon.json
+++ b/addons/comments-linebreaks/addon.json
@@ -14,8 +14,8 @@
       "id": "ownLineBreaks"
     },
     {
-      "type": "notice",
-      "text": "Linebreaks currently do not appear on 2.0 pages.",
+      "type": "info",
+      "text": "On profile pages, line breaks at the beginning or end of a comment do not appear.",
       "id": "scratchr2Linebreaks"
     }
   ],


### PR DESCRIPTION
Temporary solution for #6995

### Changes

Added an extra notice to tell users that linebreaks don't work on scratchr2 yet. This'll probably need a bit better wording.

![kép](https://github.com/ScratchAddons/ScratchAddons/assets/150537842/ead83c01-06e6-4200-8557-d91a757539bb)

### Reason for changes

The addon description suggests that it's supposed to work on the whole site.

### Tests

Tested on Firefox 126.0.1 (32 bit)