### PR TITLE
Messaging: count identical studio-activity messages as many messages

### DIFF
--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -221,7 +221,7 @@
             </div>
             <span class="message-type-title-text">{{ uiMessages.forumMsg }}</span>
             <span class="float-right"
-              ><img class="small-icon" src="../../images/icons/forum.svg" /> {{ forumActivityAmt }}</span
+              ><img class="small-icon" src="../../images/icons/forum.svg" /> {{ forumActivity.length }}</span
             >
           </div>
           <div class="message-type-details" v-show="messageTypeExtended.forumActivity">

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -221,7 +221,7 @@
             </div>
             <span class="message-type-title-text">{{ uiMessages.forumMsg }}</span>
             <span class="float-right"
-              ><img class="small-icon" src="../../images/icons/forum.svg" /> {{ forumActivity.length }}</span
+              ><img class="small-icon" src="../../images/icons/forum.svg" /> {{ forumActivityAmt }}</span
             >
           </div>
           <div class="message-type-details" v-show="messageTypeExtended.forumActivity">
@@ -244,7 +244,7 @@
             </div>
             <span class="message-type-title-text">{{ uiMessages.studioActivityMsg }}</span>
             <span class="float-right"
-              ><img class="small-icon" src="../../images/icons/studio.svg" /> {{ studioActivity.length }}</span
+              ><img class="small-icon" src="../../images/icons/studio.svg" /> {{ studioActivityAmt }}</span
             >
           </div>
           <div class="message-type-details" v-show="messageTypeExtended.studioActivity">

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -259,7 +259,6 @@ export default async ({ addon, msg, safeMsg }) => {
       studioPromotions: [],
       studioHostTransfers: [],
       forumActivity: [],
-      forumActivityAmt: 0,
       studioActivity: [],
       studioActivityAmt: 0,
       remixes: [],
@@ -316,7 +315,6 @@ export default async ({ addon, msg, safeMsg }) => {
         this.studioPromotions = [];
         this.studioHostTransfers = [];
         this.forumActivity = [];
-        this.forumActivityAmt = 0;
         this.studioActivity = [];
         this.studioActivityAmt = 0;
         this.remixes = [];
@@ -631,7 +629,6 @@ export default async ({ addon, msg, safeMsg }) => {
                 topicTitle: message.topic_title,
               });
             }
-            this.forumActivityAmt++;
           } else if (message.type === "remixproject") {
             this.remixes.push({
               parentTitle: message.parent_title,

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -259,7 +259,9 @@ export default async ({ addon, msg, safeMsg }) => {
       studioPromotions: [],
       studioHostTransfers: [],
       forumActivity: [],
+      forumActivityAmt: 0,
       studioActivity: [],
+      studioActivityAmt: 0,
       remixes: [],
       profiles: [],
       studios: [],
@@ -314,7 +316,9 @@ export default async ({ addon, msg, safeMsg }) => {
         this.studioPromotions = [];
         this.studioHostTransfers = [];
         this.forumActivity = [];
+        this.forumActivityAmt = 0;
         this.studioActivity = [];
+        this.studioActivityAmt = 0;
         this.remixes = [];
         this.profiles = [];
         this.studios = [];
@@ -627,6 +631,7 @@ export default async ({ addon, msg, safeMsg }) => {
                 topicTitle: message.topic_title,
               });
             }
+            this.forumActivityAmt++;
           } else if (message.type === "remixproject") {
             this.remixes.push({
               parentTitle: message.parent_title,
@@ -642,6 +647,7 @@ export default async ({ addon, msg, safeMsg }) => {
                 studioTitle: message.title,
               });
             }
+            this.studioActivityAmt++;
           } else if (message.type === "loveproject") {
             const projectObject = this.getProjectObject(message.project_id, message.title);
             projectObject.loveCount++;


### PR DESCRIPTION
### Changes

If the user hasn't read messages for 20 days and they have received the same "there was activity in X studio" message multiple times, it is shown once, like it always has.

But the number of the "studio activity" row will reflect the actual number of messages that are "eaten" by the category:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/17484114/7e72a8bf-9fbc-4892-9585-eea7586e7181)


This was also added to forum activity messages.

### Reason for changes

I've seen users more than once get confused on why we don't display all of their messages. But yes we were displaying all of them. This should help clarify the situation.

### Tests

Tested but without identical messages.