### PR TITLE
[module.js] Modify user-agent everywhere on forums

### DIFF
--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -302,7 +302,7 @@ if (isScratchGui || isProject) {
   }
 }
 
-if (window.location.pathname.includes("topic") || window.location.pathname.includes("discuss/settings/")) {
+if (location.pathname.includes("topic") || location.pathname.includes("discuss/settings/")) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -302,7 +302,8 @@ if (isScratchGui || isProject) {
   }
 }
 
-if (location.pathname.match(/^(?:https?:\/\/scratch\.mit\.edu\/)?(topic|\/discuss\/settings)?/)) {
+// Same as editingScreens match
+if (location.pathname.match(/^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -302,7 +302,7 @@ if (isScratchGui || isProject) {
   }
 }
 
-if (window.location.pathname.includes("topic")) {
+if (window.location.pathname.includes("topic") || window.location.pathname.includes("discuss/settings/")) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -303,7 +303,7 @@ if (isScratchGui || isProject) {
 }
 
 // Same as editingScreens match
-if (location.pathname.match(/^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/) {
+if (location.pathname.match(/^\/discuss\/(?:topic\/\d+|\d+\/topic\/add|post\/\d+\/edit|settings\/[\w-]+)\/?$/)) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -302,7 +302,7 @@ if (isScratchGui || isProject) {
   }
 }
 
-if (location.pathname.includes("topic") || location.pathname.includes("discuss/settings/")) {
+if (location.pathname.match((?:https?:\/\/scratch\.mit\.edu)?\/(topic|discuss\/settings)\/;)) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -302,7 +302,7 @@ if (isScratchGui || isProject) {
   }
 }
 
-if (location.pathname.match((?:https?:\/\/scratch\.mit\.edu)?\/(topic|discuss\/settings)\/;)) {
+if (location.pathname.match(/^(?:https?:\/\/scratch\.mit\.edu\/)?(topic|\/discuss\/settings)?/)) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -302,7 +302,7 @@ if (isScratchGui || isProject) {
   }
 }
 
-if (location.pathname === "/discuss/3/topic/add/") {
+if (window.location.pathname.includes("topic")) {
   const checkUA = () => {
     if (!window.mySettings) return false;
     const ua = window.mySettings.markupSet.find((x) => x.className);


### PR DESCRIPTION
Resolves #6065

### Changes

~~Changes the if check condition to see if the URL includes `topic` (which means both topic creation and topic pages are now included) or `/discuss/settings/` (even though it's a bit broken on Scratch's side irregardless of SA, better everywhere than nowhere) instead of only checking if the URL is the new topic creation page on BaG.~~

~~AKA replaces the pathname comparison from a complete match to just if the pathname `includes` either one of the ones mentioned above~~
Uses RegExp to just check if the URL contains `topic` or `discuss/settings`, which makes it change UA everywhere on the forums.

### Reason for changes

if the question ends up in the wrong forum or the OP doesn't leave their user agent in the original post, then that ends up needing an extra question that might even be forgotten.

### Tests

Tested on Firefox 126.0.1 and Chromium (Vivaldi 6.7.3329.41 (Stable channel) (32 bit))

https://github.com/ScratchAddons/ScratchAddons/assets/150537842/fe113224-4bc2-4162-a041-80a8eeb61f1c

ironically encountering a bug where version is double-pluralized (`versionss` instead of `versions`), console had no err or warn though so not sure what happened there