### PR TITLE
New addon: Disable auto nesting

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -156,6 +156,7 @@
   "reorder-custom-inputs",
   "place-backpack-code-at-cursor",
   "big-save-button",
+  "disable-auto-nesting",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/disable-auto-nesting/addon.json
+++ b/addons/disable-auto-nesting/addon.json
@@ -1,0 +1,41 @@
+{
+  "name": "Disable auto nesting with C-Blocks",
+  "description": "When holding the ctrl key (customisable) while dragging a C-Block, they will not expand around the block stack, and will instead place like a normal block.",
+  "credits": [
+    {
+      "name": "Jazza",
+      "link": "https://scratch.mit.edu/users/greeny--231/"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "tags": ["editor", "featured"],
+  "versionAdded": "1.39.0",
+
+  "info": [
+    {
+      "type": "notice",
+      "text": "Examples of a C-Block are if statements or forever loops.",
+      "id": "cBlockExample"
+    }
+  ],
+  "settings": [
+    {
+      "name": "Modifier key",
+      "type": "select",
+      "id": "key",
+      "default": "ctrl",
+      "potentialValues": [
+        { "id": "ctrl", "name": "Control" },
+        { "id": "alt", "name": "Alt" },
+        { "id": "shift", "name": "Shift" }
+      ]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/disable-auto-nesting/userscript.js
+++ b/addons/disable-auto-nesting/userscript.js
@@ -1,0 +1,69 @@
+export default async function ({ addon, console }) {
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const oldFunction = ScratchBlocks.Block.prototype.getFirstStatementConnection;
+  const settingsToKey = {
+    ctrl: "Control",
+    alt: "Alt Meta",
+    shift: "Shift",
+  };
+
+  let modifierHeld = false;
+
+  function keyDown(e, key) {
+    if (settingsToKey[key].includes(e.key)) {
+      modifierHeld = true;
+    }
+  }
+
+  function keyUp(e, key) {
+    if (settingsToKey[key].includes(e.key)) {
+      modifierHeld = false;
+    }
+  }
+
+  let currentKey;
+  const keyDownListener = (e) => keyDown(e, currentKey);
+  const keyUpListener = (e) => keyUp(e, currentKey);
+
+  function addEventListeners(key) {
+    currentKey = key;
+    document.addEventListener("keydown", keyDownListener);
+    document.addEventListener("keyup", keyUpListener);
+  }
+
+  function removeEventListeners() {
+    document.removeEventListener("keydown", keyDownListener);
+    document.removeEventListener("keyup", keyUpListener);
+  }
+
+  function polluteFunction() {
+    ScratchBlocks.Block.prototype.getFirstStatementConnection = function () {
+      if (modifierHeld) return null;
+
+      for (var i = 0, input; (input = this.inputList[i]); i++) {
+        if (input.connection && input.connection.type == ScratchBlocks.NEXT_STATEMENT) {
+          return input.connection;
+        }
+      }
+      return null;
+    };
+  }
+
+  polluteFunction();
+  addEventListeners(addon.settings.get("key"));
+
+  addon.self.addEventListener(
+    "disabled",
+    () => (ScratchBlocks.Block.prototype.getFirstStatementConnection = oldFunction)
+  );
+  addon.self.addEventListener("reenabled", () => {
+    polluteFunction();
+    removeEventListeners();
+    addEventListeners(addon.settings.get("key"));
+  });
+
+  addon.settings.addEventListener("change", () => {
+    removeEventListeners();
+    addEventListeners(addon.settings.get("key"));
+  });
+}

--- a/addons/disable-auto-nesting/userscript.js
+++ b/addons/disable-auto-nesting/userscript.js
@@ -13,6 +13,39 @@ export default async function ({ addon, console }) {
     if (settingsToKey[key].includes(e.key)) {
       modifierHeld = true;
     }
+
+    // const workspace = ScratchBlocks.getMainWorkspace();
+    // const gesture = workspace.currentGesture_;
+
+    // console.log(gesture.targetBlock_);
+
+    // const thing = { workspace_: ScratchBlocks.mainWorkspace };
+    // console.log(thing.workspace_);
+
+    // ScratchBlocks.InsertionMarkerManager.prototype.update = function (dxy, deleteArea) {
+    //   var candidate = this.getCandidate_.call(gesture.targetBlock_, dxy);
+
+    //   this.wouldDeleteBlock_ = this.shouldDelete_(candidate, deleteArea);
+    //   var shouldUpdate = this.wouldDeleteBlock_ || this.shouldUpdatePreviews_(candidate, dxy);
+
+    //   if (shouldUpdate) {
+    //     // Don't fire events for insertion marker creation or movement.
+    //     ScratchBlocks.Events.disable();
+    //     this.maybeHidePreview_(candidate);
+    //     this.maybeShowPreview_(candidate);
+    //     ScratchBlocks.Events.enable();
+    //   }
+    // };
+
+    // if (gesture !== null) {
+
+    // ****Cannot read properties of undefined (reading 'length') at Blockly.InsertionMarkerManager.getCandidate_****
+
+    //   ScratchBlocks.InsertionMarkerManager.prototype.update(
+    //     ScratchBlocks.BlockDragger.prototype.pixelsToWorkspaceUnits_.call(thing, gesture.currentDragDeltaXY_),
+    //     1
+    //   );
+    // }
   }
 
   function keyUp(e, key) {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves https://discord.com/channels/806602307750985799/1247667402079207514

### Changes

Adds a new addon that lets you hold a modifier key to stop a c block expanding around the blocks below it

### Reason for changes

Convenience, its so freaking useful, and griffpatch suggested it (even tho I suggested it two years ago)

### Tests

Works when you hold ctrl and drag, doesn't update when you press or unpress ctrl without dragging enough for a new connection spot to be made, garbo might help with that
