### PR TITLE
editor-dark-mode: opaque workspace dots

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -763,11 +763,29 @@
       "name": "workspace-dots",
       "value": {
         "type": "textColor",
-        "black": "rgba(0, 0, 0, 0.13)",
-        "white": "rgba(255, 255, 255, 0.13)",
         "source": {
           "type": "settingValue",
           "settingId": "workspace"
+        },
+        "black": {
+          "type": "multiply",
+          "source": {
+            "type": "settingValue",
+            "settingId": "workspace"
+          },
+          "r": 0.87,
+          "g": 0.87,
+          "b": 0.87
+        },
+        "white": {
+          "type": "brighten",
+          "source": {
+            "type": "settingValue",
+            "settingId": "workspace"
+          },
+          "r": 0.87,
+          "g": 0.87,
+          "b": 0.87
         }
       }
     },


### PR DESCRIPTION
### Changes

Uses a non-transparent color for workspace dots even if editor dark mode is enabled.

### Reason for changes

See discussion on #7525

### Tests

Tested on Edge and Firefox. The color of the dots is the same as in v1.38.2.