### PR TITLE
`collapse-footer`: fix grammar mistake in description

### DIFF
--- a/addons/collapse-footer/addon.json
+++ b/addons/collapse-footer/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Sticky footer",
-  "description": "Makes the website footer stick out slightly from the bottom of the window and makes it expand when hovering over it, allowing it to be quickly accessed from anywhere on the page. Previously part of \"Infinite scolling\".",
+  "description": "Makes the website footer stick out slightly from the bottom of the window and makes it expand when hovering over it, allowing it to be quickly accessed from anywhere on the page. Previously part of \"Infinite scrolling\".",
   "credits": [
     {
       "name": "Samq64",


### PR DESCRIPTION
Resolves #7535

### Changes

added a singular R:
![kép](https://github.com/ScratchAddons/ScratchAddons/assets/150537842/49e3dcd2-0bee-49eb-a29b-96ffec86a06a)

### Reason for changes

grammer
![kép](https://github.com/ScratchAddons/ScratchAddons/assets/150537842/6d6d1066-8e46-4c29-9792-4d8dcbe0546e)

### Tests

tested on firefox 126.0.1