### PR TITLE
gamepad: dark mode support

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -458,6 +458,17 @@
       }
     },
     {
+      "name": "accent-formControlText",
+      "value": {
+        "type": "textColor",
+        "source": {
+          "type": "settingValue",
+          "settingId": "accent"
+        },
+        "threshold": 128
+      }
+    },
+    {
       "name": "accent-filter",
       "value": {
         "type": "textColor",

--- a/addons/gamepad/dot.svg
+++ b/addons/gamepad/dot.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 2.117 2.117"><circle cx="1.058" cy="1.058" r="1.058" fill="red"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 2.117 2.117"><circle cx="1.058" cy="1.058" r="1.058" fill="#E64D00"/></svg>

--- a/addons/gamepad/gamepadlib.css
+++ b/addons/gamepad/gamepadlib.css
@@ -26,22 +26,27 @@
   width: 75px;
   height: 25px;
   border-radius: 0;
-  border: 1px solid black;
-  background: white;
-  color: black;
+  border: 1px solid var(--editorDarkMode-input-text, #575e75);
+  background: var(--editorDarkMode-input, white);
+  color: var(--editorDarkMode-input-text, #575e75);
+  outline-color: var(--editorDarkMode-primary, #855cd6);
   box-sizing: border-box;
   padding: 0;
   margin: 0;
 }
 .gamepadlib-mapping[data-value="1"] .gamepadlib-keyinput {
-  background: yellow;
+  background: #ffd966;
+  color: black;
 }
 .gamepadlib-keyinput[data-accepting-input="true"] {
-  background: #d6fff9;
+  background: var(--editorDarkMode-primary-transparent35, hsla(260, 60%, 60%, 0.35));
 }
 .gamepadlib-keyinput[data-empty="true"]:not([data-accepting-input="true"]) {
-  color: #aaa;
+  color: var(--editorDarkMode-input-transparentText, hsla(225, 15%, 40%, 0.6));
   font-style: italic;
+}
+.gamepadlib-mapping[data-value="1"] .gamepadlib-keyinput[data-empty="true"]:not([data-accepting-input="true"]) {
+  color: hsla(0, 0%, 0%, 0.6);
 }
 
 .gamepadlib-axis {
@@ -52,7 +57,7 @@
   position: relative;
   width: 150px;
   height: 150px;
-  border: 1px solid black;
+  border: 1px solid var(--editorDarkMode-accent-text, #575e75);
   overflow: hidden;
 }
 .gamepadlib-axis-dot {

--- a/addons/gamepad/style.css
+++ b/addons/gamepad/style.css
@@ -20,11 +20,15 @@
   flex-direction: column;
 }
 .sa-gamepad-popup-content {
-  background-color: white !important;
-  color: #575e75 !important;
   padding: 1.5rem 2.25rem;
   height: 100%;
   overflow-y: auto;
+  color-scheme: var(--editorDarkMode-accent-colorScheme, light);
+  accent-color: var(--editorDarkMode-primary, #855cd6);
+}
+.sa-gamepad-popup-content button,
+.sa-gamepad-popup-content select {
+  color: var(--editorDarkMode-accent-formControlText, #575e75);
 }
 
 .sa-gamepad-popup [class*="modal_header-item-title"] {


### PR DESCRIPTION
### Changes

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/efe58e75-c314-4c7a-9466-636cfc1bac1c)

The light mode colors were also changed to be more consistent with Scratch's color palette.

### Tests

Tested on Edge and Firefox.