### PR TITLE
Fix positive integer setting type to yse the min and max values

### DIFF
--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -79,7 +79,8 @@
           v-model="addonSettings[setting.id]"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
-          min="0"
+          :min="(setting.min && setting.min > 0) ? setting.min : 0"
+          :max="setting.max"
           number
         />
       </template>
@@ -335,11 +336,7 @@
       linear-gradient(45deg, transparent 75%, #777 75%), linear-gradient(-45deg, transparent 75%, #777 75%);
     background-color: white;
     background-size: 6px 6px;
-    background-position:
-      0 0,
-      0 3px,
-      3px -3px,
-      -3px 0px;
+    background-position: 0 0, 0 3px, 3px -3px, -3px 0px;
   }
   .setting-dropdown .color-preview span {
     display: inline-block;


### PR DESCRIPTION
### Changes

In addon-settings.html it changes
```html
      <template v-if="setting.type === 'positive_integer'">
        <input
          type="number"
          class="setting-input number"
          v-model="addonSettings[setting.id]"
          @change="checkValidity() || updateSettings()"
          :disabled="!addon._enabled"
          min="0"
          number
        />
      </template>
``` 
to
```html
      <template v-if="setting.type === 'positive_integer'">
        <input
          type="number"
          class="setting-input number"
          v-model="addonSettings[setting.id]"
          @change="checkValidity() || updateSettings()"
          :disabled="!addon._enabled"
          :min="(setting.min && setting.min > 0) ? setting.min : 0"
          :max="setting.max"
          number
        />
      </template>
```

### Reason for changes

The positive integer setting type should respect min and max.
This actually causes the paint-snap addon which uses positive_integer (the only one) to have its min and max values not respected.

### Tests

Works both in the main settings page and the poup settings on brave (chromium)
