### PR TITLE
old-studio-layout: fix mute message line height

### DIFF
--- a/addons/old-studio-layout/style.css
+++ b/addons/old-studio-layout/style.css
@@ -22,6 +22,9 @@
   height: 45px;
   line-height: 30px;
 }
+.studio-info textarea.studio-title ~ .validation-message {
+  line-height: normal;
+}
 .studio-info .sa-oldstudio-follow-section {
   position: absolute;
   width: 200px;


### PR DESCRIPTION
Resolves #7440

### Changes

Fixes an incorrect line height in the message that appears when trying to change the title of a studio while muted.

### Tests

Tested on Edge - I used a local instance of scratch-www and modified the code in `src/views/studio/studio-title.jsx` to show the message even if the user is not muted. I don't recommend commenting automodmute to test this because that sends the comment to the Scratch moderators to review.