### PR TITLE
editor-compact: fix sprite-properties compatibility issue

### DIFF
--- a/addons/editor-compact/sprite-properties.css
+++ b/addons/editor-compact/sprite-properties.css
@@ -4,6 +4,10 @@
 .sa-sprite-properties-wide-locale.sa-show-sprite-properties [class^="sprite-info_sprite-info_"] {
   height: calc(5.25rem + 1px);
 }
+.sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"],
+.sa-sprite-properties-wide-locale.sa-show-sprite-properties [class^="sprite-selector_scroll-wrapper_"] {
+  height: calc(100% - 5.25rem - 1px);
+}
 .sa-sprite-properties-close-btn {
   height: 1rem;
   padding-top: 0.25rem;


### PR DESCRIPTION
Resolves #7527

### Changes

Sets the height of the sprite pane correctly when `editor-compact` and `sprite-properties` are both enabled and the properties are visible.

### Tests

Tested on Edge and Firefox.