### PR TITLE
Set paint-snap to use integer

### DIFF
--- a/addons/paint-snap/addon.json
+++ b/addons/paint-snap/addon.json
@@ -97,7 +97,7 @@
       "default": false
     },
     {
-      "type": "positive_integer",
+      "type": "integer",
       "id": "threshold",
       "name": "Snapping distance",
       "default": 10,


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves https://github.com/ScratchAddons/ScratchAddons/pull/7550#issuecomment-2181066266

### Changes

Makes `paint-snap` threshold setting use integer

### Reason for changes

See resolves
