### PR TITLE
cat-blocks: fix "watch mouse cursor" setting

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -182,7 +182,7 @@ export default async function ({ addon, console }) {
       // Set to the correct initial position
       this.svgFace_.style.transform = "translate(-87px, 0px)";
     }
-    if (this.shouldWatchMouse()) {
+    if (shouldWatchMouseCursor) {
       this.windowListener = function (event) {
         var time = Date.now();
         if (time < that.lastCallTime + that.CALL_FREQUENCY_MS) return;


### PR DESCRIPTION
Resolves #2391

### Changes

Makes the "watch mouse cursor" setting in the cat blocks addon work more consistently.

### Tests

Tested on Edge.