### PR TITLE
Support "Welcome to Scratch" message

### DIFF
--- a/addons-l10n/en/scratch-messaging.json
+++ b/addons-l10n/en/scratch-messaging.json
@@ -56,5 +56,6 @@
   "scratch-messaging/comment-error-reply-limit": "Studio comments can no longer have more than 25 replies.",
   "scratch-messaging/studio-host-transfers": "Studio host transfers",
   "scratch-messaging/studio-host-transfer": "{actor} made you the host of the studio \"{title}\"",
-  "scratch-messaging/st": "A Scratch Team member"
+  "scratch-messaging/st": "A Scratch Team member",
+  "scratch-messaging/welcome-to-scratch": "Welcome to Scratch! After you make projects and comments, you'll get messages about them here."
 }

--- a/addons/message-filters/userscript.js
+++ b/addons/message-filters/userscript.js
@@ -118,7 +118,7 @@ export default async function ({ addon, console, msg }) {
       }
       // Message types without a specific filter are always visible
       // https://github.com/ScratchAddons/ScratchAddons/issues/2853#issuecomment-1724115504
-      if (!Object.values(filter).some(className => message.classList.contains(className))) {
+      if (!Object.values(filter).some((className) => message.classList.contains(className))) {
         count++;
         message.style.display = "list-item";
       }

--- a/addons/message-filters/userscript.js
+++ b/addons/message-filters/userscript.js
@@ -116,6 +116,12 @@ export default async function ({ addon, console, msg }) {
           //message.style.display = "none";
         }
       }
+      // Message types without a specific filter are always visible
+      // https://github.com/ScratchAddons/ScratchAddons/issues/2853#issuecomment-1724115504
+      if (!Object.values(filter).some(className => message.classList.contains(className))) {
+        count++;
+        message.style.display = "list-item";
+      }
     }
     // Set the localStorage item.
     localStorage.setItem("scratchAddonsMessageFiltersSettings", JSON.stringify(active));

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -269,6 +269,10 @@ a.message-type-title-text {
   font-variant: tabular-nums;
 }
 
+.welcome-message {
+  padding: 6px 16px;
+}
+
 .status-container {
   padding-top: 10px;
   padding-bottom: 20px;

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -427,6 +427,11 @@
             </div>
           </div>
         </div>
+
+        <!-- Welcome to Scratch -->
+        <div class="message-type" v-show="welcomeToScratch">
+          <div class="message-type-details welcome-message">{{ uiMessages.welcomeToScratchMsg }}</div>
+        </div>
       </div>
 
       <!-- Show errors, loading, etc. -->

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -264,6 +264,8 @@ export default async ({ addon, msg, safeMsg }) => {
       profiles: [],
       studios: [],
       projects: [],
+      // There can't be more than one "welcome to Scratch" message
+      welcomeToScratch: false,
 
       // For UI
       messageTypeExtended: {
@@ -303,6 +305,7 @@ export default async ({ addon, msg, safeMsg }) => {
         openMessagesMsg: msg("open-messages"),
         studioPromotionsMsg: msg("studio-promotions"),
         studioHostTransfersMsg: msg("studio-host-transfers"),
+        welcomeToScratchMsg: msg("welcome-to-scratch"),
       },
     },
     watch: {
@@ -319,6 +322,7 @@ export default async ({ addon, msg, safeMsg }) => {
         this.profiles = [];
         this.studios = [];
         this.projects = [];
+        this.welcomeToScratch = false;
         this.analyzeMessages(newVal);
       },
     },
@@ -669,6 +673,8 @@ export default async ({ addon, msg, safeMsg }) => {
             else if (message.comment_type === 2)
               resourceObject = this.getStudioObject(resourceId, message.comment_obj_title);
             resourceObject.unreadComments++;
+          } else if (message.type === "userjoin") {
+            this.welcomeToScratch = true;
           }
         }
         this.messagesReady = true;


### PR DESCRIPTION
Resolves #2853

### Changes

`message-filters` now never hides the "Welcome to Scratch" message. `scratch-messaging` now displays it properly:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/c52f6882-77d6-4c18-a4c8-ce215f87c309)

I didn't change `scratch-notifier` because it already handles this message type appropriately - it shows a generic notification:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/d54daeb1-c621-4ca4-870a-cd2a69409d5a)

### Tests

Tested on Edge and Firefox.