### PR TITLE
`editor-dark-mode`: Scratch Lab theme

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1373,6 +1373,31 @@
         "stageHeader": "#e8edf1",
         "border": "#00000026"
       }
+    },
+          {
+      "name": "ScratchLab",
+      "id": "scratch-lab",
+      "description": "Colors used by the ScratchLab editor.",
+      "values": {
+        "page": "#e5f0ff",
+        "primary": "#4d97ff",
+        "highlightText": "#4d97ff",
+        "menuBar": "#0fbd8c",
+        "popup": "#4d97ffe6",
+        "activeTab": "#ffffff",
+        "tab": "#d9e3f2",
+        "selector": "#e9f1fc",
+        "selector2": "#d9e3f2",
+        "selectorSelection": "#ffffff",
+        "accent": "#ffffff",
+        "input": "#ffffff",
+        "workspace": "#f9f9f9",
+        "categoryMenu": "#ffffff",
+        "palette": "#f9f9f9cc",
+        "fullscreen": "#ffffff",
+        "stageHeader": "#e8edf1",
+        "border": "#00000026"
+      }
     }
   ],
   "addonPreview": {

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1374,7 +1374,7 @@
         "border": "#00000026"
       }
     },
-          {
+    {
       "name": "Scratch Lab",
       "id": "scratch-lab",
       "description": "The colors used by the Scratch Lab's project editor.",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1377,7 +1377,7 @@
     {
       "name": "Scratch Lab",
       "id": "scratch-lab",
-      "description": "The colors used by the Scratch Lab's project editor.",
+      "description": "The colors used by Scratch Lab's project editor.",
       "values": {
         "page": "#e5f0ff",
         "primary": "#4d97ff",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1375,9 +1375,9 @@
       }
     },
           {
-      "name": "ScratchLab",
+      "name": "Scratch Lab",
       "id": "scratch-lab",
-      "description": "The colors used by the ScratchLab's project editor.",
+      "description": "The colors used by the Scratch Lab's project editor.",
       "values": {
         "page": "#e5f0ff",
         "primary": "#4d97ff",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1377,7 +1377,7 @@
           {
       "name": "ScratchLab",
       "id": "scratch-lab",
-      "description": "Colors used by the ScratchLab editor.",
+      "description": "The colors used by the ScratchLab's project editor.",
       "values": {
         "page": "#e5f0ff",
         "primary": "#4d97ff",


### PR DESCRIPTION
Resolves #7581

### Changes

Adds a singular new theme.
Not sure if this is needed since a user can always just change to the blue preset and then change header to #0fbd8c, but convenience I guess

### Reason for changes

Some people want a scratchlab preset (according to #7581)

### Tests

Tested on Firefox/Gecko 127.0.1 (32 bit) - haven't tested on chrome/chromium
ScratchLab only seems to have a green navbar (with blue colors) and nothing else changes color-wise besides that. Please correct me if I'm wrong though, from what I can tell thats literally all that's different on scratchlab.