### PR TITLE
find-bar: ignore case when comparing broadcasts

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -640,7 +640,10 @@ export default async function ({ addon, msg, console }) {
 
         for (const id of Object.keys(blocks._blocks)) {
           const block = blocks._blocks[id];
-          if (block.opcode === "event_whenbroadcastreceived" && block.fields.BROADCAST_OPTION.value === name) {
+          if (
+            block.opcode === "event_whenbroadcastreceived" &&
+            block.fields.BROADCAST_OPTION.value.toLowerCase() === name.toLowerCase()
+          ) {
             uses.push(new BlockInstance(target, block));
           } else if (block.opcode === "event_broadcast" || block.opcode === "event_broadcastandwait") {
             const broadcastInputBlockId = block.inputs.BROADCAST_INPUT.block;
@@ -652,7 +655,7 @@ export default async function ({ addon, msg, console }) {
               } else {
                 eventName = msg("complex-broadcast");
               }
-              if (eventName === name) {
+              if (eventName.toLowerCase() === name.toLowerCase()) {
                 uses.push(new BlockInstance(target, block));
               }
             }


### PR DESCRIPTION
Resolves #3584

### Changes

Adds `.toLowerCase()` to the code in `find-bar` that compares broadcast names.

### Reason for changes

Broadcasts aren't case-sensitive, so the previous code sometimes didn't find all instances. See https://github.com/ScratchAddons/ScratchAddons/issues/3584#issuecomment-943107668 for an example project and reproduction steps.

### Tests

Tested in Edge and Firefox.