### PR TITLE
scratch-messaging: show fragment if fetching comment failed

### DIFF
--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -529,12 +529,12 @@ export default async ({ addon, msg, safeMsg }) => {
           } else return true;
         } else return false;
       },
-      checkCommentLocation(resourceType, resourceId, commentIds, elementObject) {
+      checkCommentLocation(resourceType, resourceId, commentMessages, elementObject) {
         return Promise.all([
           API.fetchComments(addon, {
             resourceType,
             resourceId,
-            commentIds,
+            commentMessages,
           }),
           addon.self.getEnabledAddons(),
         ])
@@ -662,10 +662,10 @@ export default async ({ addon, msg, safeMsg }) => {
             const resourceId = message.comment_type === 1 ? message.comment_obj_title : message.comment_obj_id;
             let location = commentLocations[message.comment_type].find((obj) => obj.resourceId === resourceId);
             if (!location) {
-              location = { resourceId, commentIds: [] };
+              location = { resourceId, commentMessages: [] };
               commentLocations[message.comment_type].push(location);
             }
-            location.commentIds.push(message.comment_id);
+            location.commentMessages.push(message);
             let resourceObject;
             if (message.comment_type === 0)
               resourceObject = this.getProjectObject(resourceId, message.comment_obj_title);
@@ -685,7 +685,7 @@ export default async ({ addon, msg, safeMsg }) => {
         for (const profile of this.profilesOrdered) {
           const location = commentLocations[1].find((obj) => obj.resourceId === profile.username);
           if (location) {
-            await this.checkCommentLocation("user", location.resourceId, location.commentIds, profile);
+            await this.checkCommentLocation("user", location.resourceId, location.commentMessages, profile);
             locationsChecked++;
             this.commentsProgress = Math.round((locationsChecked / locationsToCheckAmt) * 100);
           }
@@ -693,7 +693,7 @@ export default async ({ addon, msg, safeMsg }) => {
         for (const studio of this.studios) {
           const location = commentLocations[2].find((obj) => obj.resourceId === studio.id);
           if (location) {
-            await this.checkCommentLocation("gallery", location.resourceId, location.commentIds, studio);
+            await this.checkCommentLocation("gallery", location.resourceId, location.commentMessages, studio);
             locationsChecked++;
             this.commentsProgress = Math.round((locationsChecked / locationsToCheckAmt) * 100);
           }
@@ -701,7 +701,7 @@ export default async ({ addon, msg, safeMsg }) => {
         for (const project of this.projectsOrdered) {
           const location = commentLocations[0].find((obj) => obj.resourceId === project.id);
           if (location) {
-            await this.checkCommentLocation("project", location.resourceId, location.commentIds, project);
+            await this.checkCommentLocation("project", location.resourceId, location.commentMessages, project);
             locationsChecked++;
             this.commentsProgress = Math.round((locationsChecked / locationsToCheckAmt) * 100);
           }


### PR DESCRIPTION
Resolves #2466
Resolves #3916

### Changes

If a comment can't be loaded, shows the fragment returned by the messages API instead, without context (note that the reply appears as a top-level comment in the screenshot below).

![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/257711e4-34e9-4804-8ad6-a0285bdfd546)

### Tests

Tested on Edge and Firefox. I only tested comments on an unshared project, but this should fix old threads too because the root cause of the bug is the same.

Trying to reply to a comment on an unshared project shows an error message.