### PR TITLE
`editor-theme3`: fix settings no longer dynamic after creating custom block

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -573,6 +573,7 @@ export default async function ({ addon, console, msg }) {
     Blockly.FieldNumber.NUMPAD_DELETE_ICON = originalNumpadDeleteIcon.replace("white", safeTextColor);
 
     const workspace = addon.tab.traps.getWorkspace();
+    if (!workspace) return;
     const flyout = workspace.getFlyout();
     const toolbox = workspace.getToolbox();
 

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -572,7 +572,7 @@ export default async function ({ addon, console, msg }) {
     const safeTextColor = encodeURIComponent(uncoloredTextColor());
     Blockly.FieldNumber.NUMPAD_DELETE_ICON = originalNumpadDeleteIcon.replace("white", safeTextColor);
 
-    const workspace = Blockly.getMainWorkspace();
+    const workspace = addon.tab.traps.getWorkspace();
     const flyout = workspace.getFlyout();
     const toolbox = workspace.getToolbox();
 


### PR DESCRIPTION
To repro:
1. Create custom block
2. Edit addon's settings
3. Notice no changes to the toolbox.