### PR TITLE
middle-click-popup: hide Blockly widgets when opened

### DIFF
--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -109,6 +109,8 @@ export default async function ({ addon, msg, console }) {
     if (addon.tab.editorMode !== "editor") return;
     if (addon.tab.redux.state.scratchGui.editorTab.activeTabIndex !== 0) return;
 
+    Blockly.hideChaff();
+
     blockTypes = BlockTypeInfo.getBlocks(Blockly, vm, Blockly.getMainWorkspace(), msg);
     querier.indexWorkspace([...blockTypes]);
     blockTypes.sort((a, b) => {


### PR DESCRIPTION
Resolves #4906

### Changes

Hides Blockly dropdowns and context menus when Ctrl+Space is pressed.

### Tests

Tested on Edge and Firefox.