### PR TITLE
Fix monitor color scheme

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -4,7 +4,8 @@ body {
   background-color: var(--darkWww-page);
   color-scheme: var(--darkWww-page-colorScheme);
 }
-.sa-body-editor {
+.sa-body-editor,
+[class*="stage-wrapper_stage-canvas-wrapper_"] {
   /* If website dark mode is enabled and editor dark mode
   is disabled, inputs and scrollbars in the editor should
   have a light background. */

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -63,6 +63,18 @@
       }
     },
     {
+      "name": "page-colorScheme",
+      "value": {
+        "type": "textColor",
+        "black": "light",
+        "white": "dark",
+        "source": {
+          "type": "settingValue",
+          "settingId": "page"
+        }
+      }
+    },
+    {
       "name": "page-compactScrollbar",
       "value": {
         "type": "textColor",

--- a/addons/editor-dark-mode/stage.css
+++ b/addons/editor-dark-mode/stage.css
@@ -2,6 +2,7 @@
 [class*="monitor_list-body_"] {
   background-color: var(--editorDarkMode-page);
   color: var(--editorDarkMode-page-text);
+  color-scheme: var(--editorDarkMode-page-colorScheme);
 }
 [class*="monitor_list-index_"] {
   color: var(--editorDarkMode-page-text);


### PR DESCRIPTION
Resolves #5393

### Changes

Chooses the `color-scheme` of stage monitors based on editor dark mode settings instead of website dark mode. This affects sliders and list scrollbars.

### Tests

Tested on Edge and Firefox.