### PR TITLE
dark-www: fix "Choose a tutorial" icon

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -498,6 +498,7 @@ body:not(.sa-body-editor) .formik-input:focus,
 #footer .inner .media li img {
   filter: var(--darkWww-button-filter);
 }
+.banner-wrapper .banner-button img /* "Choose a tutorial" icon */,
 .forms-close-button img,
 .os-chooser .button:not(.active) img {
   filter: none;


### PR DESCRIPTION
### Changes

Adds `filter: none` to the "Choose a tutorial" icon on the Ideas page.

### Reason for changes

Currently, setting the highlight color to a lighter color makes the icon dark brown.

### Tests

Tested on Edge.