### PR TITLE
exact-count: better exact count for studios

### DIFF
--- a/addons-l10n/en/exact-count.json
+++ b/addons-l10n/en/exact-count.json
@@ -1,0 +1,3 @@
+{
+  "exact-count/studio-tooltip": "Click to show exact count"
+}

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -38,7 +38,7 @@
     },
     {
       "url": "studio.js",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": ["studios"],
       "if": {
         "settings": { "studio": true }
       }
@@ -47,7 +47,7 @@
   "userstyles": [
     {
       "url": "studio.css",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": ["studios"],
       "if": {
         "settings": { "studio": true }
       }

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Show exact count",
-  "description": "Shows the exact count for user information.",
+  "description": "Shows exact numbers on profiles and the exact project count in studios.",
   "credits": [
     {
       "name": "TheColaber",
@@ -20,6 +20,12 @@
       "id": "user",
       "type": "boolean",
       "default": true
+    },
+    {
+      "name": "Exact count for studios",
+      "id": "studio",
+      "type": "boolean",
+      "default": true
     }
   ],
   "userscripts": [
@@ -28,6 +34,22 @@
       "matches": ["https://scratch.mit.edu/users/*/"],
       "if": {
         "settings": { "user": true }
+      }
+    },
+    {
+      "url": "studio.js",
+      "matches": ["https://scratch.mit.edu/studios/*"],
+      "if": {
+        "settings": { "studio": true }
+      }
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "studio.css",
+      "matches": ["https://scratch.mit.edu/studios/*"],
+      "if": {
+        "settings": { "studio": true }
       }
     }
   ],

--- a/addons/exact-count/studio.css
+++ b/addons/exact-count/studio.css
@@ -1,0 +1,43 @@
+@import url("../../libraries/common/cs/spinner.css");
+
+.studio-tab-nav li .tab-count {
+  position: relative;
+}
+
+.studio-tab-nav li .tab-count .sa-exact-count-tooltip {
+  display: none;
+  top: 100%;
+  left: 50%;
+  margin: 0;
+  margin-top: 1rem;
+  transform: translate(-50%, 0);
+  width: max-content;
+  pointer-events: none;
+}
+
+.studio-tab-nav li .tab-count:hover .sa-exact-count-tooltip {
+  display: block;
+}
+
+.studio-tab-nav li .tab-count .sa-exact-count-tooltip::before {
+  top: -0.5rem;
+  left: 50%;
+  margin-left: -0.5rem;
+  transform: rotate(135deg);
+}
+
+.studio-tab-nav li .tab-count.sa-exact-count-loading {
+  position: relative;
+  color: color-mix(in srgb, currentcolor, transparent);
+}
+
+.studio-tab-nav li .tab-count .sa-spinner {
+  position: absolute;
+  top: calc(50% - 11.4px);
+  left: calc(50% - 11.4px);
+}
+
+.studio-tab-nav .active > li .tab-count .sa-spinner {
+  background-image: url(https://scratch.mit.edu/svgs/modal/spinner-white.svg);
+  filter: var(--darkWww-button-filter, none);
+}

--- a/addons/exact-count/studio.css
+++ b/addons/exact-count/studio.css
@@ -6,6 +6,7 @@
 
 .studio-tab-nav li .tab-count .sa-exact-count-tooltip {
   display: none;
+  position: absolute;
   top: 100%;
   left: 50%;
   margin: 0;
@@ -20,6 +21,7 @@
 }
 
 .studio-tab-nav li .tab-count .sa-exact-count-tooltip::before {
+  display: block;
   top: -0.5rem;
   left: 50%;
   margin-left: -0.5rem;

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -63,8 +63,6 @@ export default async function ({ addon, msg }) {
   // Show exact count when "(100+)" is clicked
   async function onCountClick(e) {
     if (addon.self.disabled) return;
-    e.stopPropagation(); // don't switch to Projects tab
-    e.preventDefault();
     countElement.removeEventListener("click", onCountClick);
     countElement.classList.add("sa-exact-count-loading");
     const spinnerElement = Object.assign(document.createElement("span"), {

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -33,8 +33,12 @@ export default async function ({ addon, msg }) {
       }
       const page = (minPage + maxPage) / 2;
       const length = await getPageLength(url, page, cache);
-      if (length) minPage = page;
-      else maxPage = page;
+      if (length) {
+        minPage = page;
+        if (length < pageSize) return page * pageSize + length;
+      } else {
+        maxPage = page;
+      }
     }
   }
 

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -1,0 +1,80 @@
+export default async function ({ addon, msg }) {
+  const pageSize = 40;
+  const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + /[0-9]+/.exec(location.pathname)[0] + "/projects";
+  const countElement = await addon.tab.waitForElement(".studio-tab-nav > a:first-child .tab-count");
+  const originalText = countElement.innerText;
+  let counted = false;
+
+  // Do nothing if the count shown by Scratch isn't 100+
+  if (!originalText.includes("+")) return;
+
+  async function getPageLength(url, page, cache) {
+    if (Object.hasOwnProperty.call(cache, page)) return cache[page];
+    const res = await fetch(`${url}?limit=${pageSize}&offset=${page * pageSize}`);
+    if (res.status !== 200) throw res.status;
+    const length = (await res.json()).length;
+    cache[page] = length;
+    return length;
+  }
+
+  async function countProjects(url) {
+    let cache = {};
+    let minPage = 0;
+    let maxPage;
+    for (maxPage = 4; ; maxPage *= 2) {
+      const length = await getPageLength(url, maxPage, cache);
+      if (!length) break;
+      else if (length < pageSize) return maxPage * pageSize + length;
+      minPage = maxPage;
+    }
+    while (true) {
+      if (maxPage - minPage <= 1) {
+        return minPage * pageSize + (await getPageLength(url, minPage, cache));
+      }
+      const page = (minPage + maxPage) / 2;
+      const length = await getPageLength(url, page, cache);
+      if (length) minPage = page;
+      else maxPage = page;
+    }
+  }
+
+  addon.self.addEventListener("disabled", () => {
+    if (typeof counted === "number") {
+      countElement.innerText = originalText;
+    }
+  });
+  addon.self.addEventListener("reenabled", () => {
+    if (typeof counted === "number") {
+      countElement.innerText = `(${counted})`;
+    }
+  });
+
+  // Show tooltip when "(100+)" is hovered
+  const tooltip = Object.assign(document.createElement("span"), {
+    className: "validation-message validation-info sa-exact-count-tooltip",
+    textContent: msg("studio-tooltip"),
+  });
+  countElement.appendChild(tooltip);
+
+  // Show exact count when "(100+)" is clicked
+  async function onCountClick(e) {
+    if (addon.self.disabled) return;
+    e.stopPropagation(); // don't switch to Projects tab
+    e.preventDefault();
+    countElement.removeEventListener("click", onCountClick);
+    countElement.classList.add("sa-exact-count-loading");
+    const spinnerElement = Object.assign(document.createElement("span"), {
+      className: "sa-spinner",
+    });
+    countElement.appendChild(spinnerElement);
+    tooltip.remove();
+    try {
+      counted = await countProjects(apiUrlPrefix);
+      if (!addon.self.disabled) countElement.innerText = `(${counted})`;
+    } finally {
+      countElement.classList.remove("sa-exact-count-loading");
+      spinnerElement.remove();
+    }
+  }
+  countElement.addEventListener("click", onCountClick);
+}


### PR DESCRIPTION
### Changes

Adds the "exact count for studios" option (recently removed in #7617) back, but instead of loading the count (which sends a large number of requests to Scratch) every time a studio page is opened, the user has to click the "100+" first:
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/38572004-0fdc-4bad-8ef0-4aa03bbfc0fd)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/42850141-5c4d-4b65-9fd6-163f45a9e771)
![image](https://github.com/ScratchAddons/ScratchAddons/assets/51849865/a4040f59-827f-4b52-a4c5-68e15982b99f)

Also replaces the `countProjects` function with the updated one from the exactcount website, which is much more readable - no callbacks, only loops with `await`. It doesn't actually reduce the average number of requests per studio though - I tested it on various studios.

Comparison with the previous version of the addon: https://github.com/ScratchAddons/ScratchAddons/compare/27ed288c2d823284616aabddc53e6ea380f88b7e...mxmou:ScratchAddons:studio-exact-count

### Reason for changes

This feature was quite useful because vanilla Scratch doesn't provide a way to see the exact number of projects in a studio. The main issue with the previous implementation is solved in this PR.

### Tests

Tested on Edge and Firefox.