### PR TITLE
Update clipboardWrite permission logic for Firefox 127+

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -238,7 +238,7 @@ export default class Tab extends Listenable {
   copyImage(dataURL) {
     if (!dataURL.startsWith(DATA_PNG)) return Promise.reject(new TypeError("Expected PNG data URL"));
     if (typeof Clipboard.prototype.write === "function") {
-      // Chrome
+      // Chrome or Firefox 127+
       const blob = dataURLToBlob(dataURL);
       const items = [
         new ClipboardItem({
@@ -247,7 +247,8 @@ export default class Tab extends Listenable {
       ];
       return navigator.clipboard.write(items);
     } else {
-      // Firefox needs Content Script
+      // Firefox 109-126 only
+      // The image is sent to the background event page where it is copied with extension APIs
       return scratchAddons.methods.copyImage(dataURL).catch((err) => {
         return Promise.reject(new Error(`Error inside clipboard handler: ${err}`));
       });

--- a/background/imports/util.js
+++ b/background/imports/util.js
@@ -2,7 +2,7 @@
 const browserLevelPermissions = ["notifications"];
 if (typeof browser !== "undefined") {
   // Firefox only
-  if (typeof Clipboard.prototype.write === "function") {
+  if (typeof Clipboard.prototype.write !== "function") {
     // Firefox 109-126 only
     browserLevelPermissions.push("clipboardWrite");
   }

--- a/background/imports/util.js
+++ b/background/imports/util.js
@@ -1,5 +1,12 @@
+// REMINDER: update similar code at /webpages/settings/index.js
 const browserLevelPermissions = ["notifications"];
-if (typeof browser !== "undefined") browserLevelPermissions.push("clipboardWrite");
+if (typeof browser !== "undefined") {
+  // Firefox only
+  if (typeof Clipboard.prototype.write === "function") {
+    // Firefox 109-126 only
+    browserLevelPermissions.push("clipboardWrite");
+  }
+}
 
 export const getMissingOptionalPermissions = () => {
   return new Promise((resolve) => {

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -100,8 +100,11 @@ const cs = {
     csUrlObserver.dispatchEvent(new CustomEvent("change", { detail: { newUrl } }));
   },
   copyImage(dataURL) {
-    // Firefox only
+    // Firefox 109-126 only
     return new Promise((resolve, reject) => {
+      if (typeof Clipboard.prototype.write === "function") {
+        reject("Use browser API instead");
+      }
       browser.runtime.sendMessage({ clipboardDataURL: dataURL }).then(
         (res) => {
           resolve();

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -104,6 +104,7 @@ const cs = {
     return new Promise((resolve, reject) => {
       if (typeof Clipboard.prototype.write === "function") {
         reject("Use browser API instead");
+        return;
       }
       browser.runtime.sendMessage({ clipboardDataURL: dataURL }).then(
         (res) => {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -56,8 +56,15 @@ let fuse;
     },
   });
 
+  // REMINDER: update similar code at /background/imports/util.js
   const browserLevelPermissions = ["notifications"];
-  if (typeof browser !== "undefined") browserLevelPermissions.push("clipboardWrite");
+  if (typeof browser !== "undefined") {
+    // Firefox only
+    if (typeof Clipboard.prototype.write === "function") {
+      // Firefox 109-126 only
+      browserLevelPermissions.push("clipboardWrite");
+    }
+  }
   let grantedOptionalPermissions = [];
   const updateGrantedPermissions = () =>
     chrome.permissions.getAll(({ permissions }) => {

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -60,7 +60,7 @@ let fuse;
   const browserLevelPermissions = ["notifications"];
   if (typeof browser !== "undefined") {
     // Firefox only
-    if (typeof Clipboard.prototype.write === "function") {
+    if (typeof Clipboard.prototype.write !== "function") {
       // Firefox 109-126 only
       browserLevelPermissions.push("clipboardWrite");
     }


### PR DESCRIPTION
Resolves #7625

This affects addons that request the "clipboardWrite" addon permission in order to copy PNG images into the clipboard. The extension then requests the "clipboardWrite" **extension permission** if necessary, after the user tries to enable an addon that requests it. This extension permission is deprecated in Chrome, but not in Firefox.

The only addon that uses this permission is currently `bitmap-copy`, and soon `blocks2image`.

### Changes

Firefox 127+ will behave exactly like Chrome always had, in respect to this permission, in order to avoid unnecessary permission prompts.
- A permission prompt will not appear when enabling an addon that requires this permission.
- Existing addons that get this permission added with an update, won't get disabled automatically if the permission is missing.

Firefox versions 126 and below (less than 15% of users) are not affected by these changes.

### Reason for changes

`Clipboard.prototype.write` was implemented in Firefox 127.
See MDN: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write#browser_compatibility

### Tests

Both Chrome and Firefox only allow the clipboard to be modified if there's a "transient activation", such as a gesture, key press, or click. The behavior may not be identical, but we always copy in response to a user gesture, so this is not a problem.