### PR TITLE
`find-bar`: Don't prevent Ctrl+F outside editor

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -136,7 +136,7 @@ export default async function ({ addon, msg, console }) {
     }
 
     eventKeyDown(e) {
-      if (addon.self.disabled || !this.findBarOuter) return;
+      if (addon.self.disabled || !this.findBarOuter || addon.tab.editorMode !== "editor") return;
 
       let ctrlKey = e.ctrlKey || e.metaKey;
 


### PR DESCRIPTION
Resolves #7627

### Changes

Do not prevent the default behavior of pressing <kbd>Ctrl</kbd>+<kbd>F</kbd> when not in the editor.

### Reason for changes

The find bar can only be used in the editor, and <kbd>Ctrl</kbd>+<kbd>F</kbd> usually opens the browser's find bar.

### Tests

Tested in Edge 126 on Windows.
