### PR TITLE
forum-toolbar: update link to Silk icon set

### DIFF
--- a/addons/forum-toolbar/addon.json
+++ b/addons/forum-toolbar/addon.json
@@ -6,7 +6,7 @@
       "name": "Silk",
       "note": "icons",
       "id": "icons",
-      "link": "http://www.famfamfam.com/lab/icons/silk/"
+      "link": "https://github.com/markjames/famfamfam-silk-icons"
     }
   ],
   "tags": ["community", "forums"],


### PR DESCRIPTION
### Changes

Changes the link to Silk ions in `forum-toolbar`'s credits.

### Reason for changes

The old link now shows a 404 error.

### Tests

Tested on Edge.