### PR TITLE
download-button: fix wrong tag

### DIFF
--- a/addons/download-button/addon.json
+++ b/addons/download-button/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Project page download button",
   "description": "Allows you to download projects directly from the project page, without having to open the editor first. The Download button is added next to the Copy Link button.",
-  "tags": ["community", "projectPlayer", "featured"],
+  "tags": ["community", "projectPage", "featured"],
   "versionAdded": "1.37.0",
   "credits": [{ "name": "Jazza", "link": "https://scratch.mit.edu/users/greeny--231" }],
   "userscripts": [


### PR DESCRIPTION
### Changes

Replaces the `"projectPlayer"` tag in download-button's addon.json with `"projectPage"`.

### Reason for changes

This makes the addon appear in the "Project Pages" category on the settings page - it was previously under "Others". The `"projectPlayer"` tag is intended for editor addons.

### Tests

Tested on Firefox.