### PR TITLE
Add Scratch Addons identification to /csrf_token route

### DIFF
--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -9,7 +9,7 @@ const promisify =
 
 function getDefaultStoreId() {
   // Request Scratch to set the CSRF token.
-  return fetch("https://scratch.mit.edu/csrf_token/", {
+  return fetch("https://scratch.mit.edu/csrf_token/?sa=true", {
     credentials: "include",
   })
     .catch(() => {})

--- a/webpages/popup-loader.js
+++ b/webpages/popup-loader.js
@@ -53,7 +53,7 @@ async function getActualCookieStore() {
 async function refetchCookies(needsRequest = true) {
   if (needsRequest) {
     try {
-      await fetch("https://scratch.mit.edu/csrf_token/");
+      await fetch("https://scratch.mit.edu/csrf_token/?sa=true");
     } catch (e) {
       console.error(e);
       scratchAddons.cookieFetchingFailed = true;


### PR DESCRIPTION
At Scratch we're seeing some extremely high request rates to these endpoints (orders of magnitude higher than other endpoints), we would like to identify which requests are coming from Scratch Addons.

This change adds a `?sa=true` parameters to requests to these endpoints. It has no functional impact on Scratch Addons' use, it will help us diagnose the issue.

If possible, if we could get these changes in as soon as possible, that would be great!!