### PR TITLE
[v1.38.x] Stop fetching scratch.mit.edu/csrf_token and more optimizations

### DIFF
--- a/addons-l10n/en/exact-count.json
+++ b/addons-l10n/en/exact-count.json
@@ -1,0 +1,3 @@
+{
+  "exact-count/studio-tooltip": "Click to show exact count"
+}

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -44,18 +44,19 @@
     },
     {
       "url": "studio.js",
-      "matches": ["https://scratch.mit.edu/studios/*"],
+      "matches": ["studios"],
       "if": {
         "settings": { "studio": true }
       }
-    },
+    }
+  ],
+  "userstyles": [
     {
-      "url": "forum.js",
-      "matches": ["https://scratch.mit.edu/discuss/topic/*"],
+      "url": "studio.css",
+      "matches": ["studios"],
       "if": {
-        "settings": { "forumuser": true }
-      },
-      "runAtComplete": false
+        "settings": { "studio": true }
+      }
     }
   ],
   "dynamicEnable": true,

--- a/addons/exact-count/studio.css
+++ b/addons/exact-count/studio.css
@@ -1,0 +1,45 @@
+@import url("../../libraries/common/cs/spinner.css");
+
+.studio-tab-nav li .tab-count {
+  position: relative;
+}
+
+.studio-tab-nav li .tab-count .sa-exact-count-tooltip {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin: 0;
+  margin-top: 1rem;
+  transform: translate(-50%, 0);
+  width: max-content;
+  pointer-events: none;
+}
+
+.studio-tab-nav li .tab-count:hover .sa-exact-count-tooltip {
+  display: block;
+}
+
+.studio-tab-nav li .tab-count .sa-exact-count-tooltip::before {
+  display: block;
+  top: -0.5rem;
+  left: 50%;
+  margin-left: -0.5rem;
+  transform: rotate(135deg);
+}
+
+.studio-tab-nav li .tab-count.sa-exact-count-loading {
+  position: relative;
+  color: color-mix(in srgb, currentcolor, transparent);
+}
+
+.studio-tab-nav li .tab-count .sa-spinner {
+  position: absolute;
+  top: calc(50% - 11.4px);
+  left: calc(50% - 11.4px);
+}
+
+.studio-tab-nav .active > li .tab-count .sa-spinner {
+  background-image: url(https://scratch.mit.edu/svgs/modal/spinner-white.svg);
+  filter: var(--darkWww-button-filter, none);
+}

--- a/addons/exact-count/studio.js
+++ b/addons/exact-count/studio.js
@@ -1,27 +1,59 @@
-export default async function ({ addon }) {
-  async function countProjects(url, page, delta) {
-    const res = await fetch(url + 40 * page);
-    const data = await res.json();
-    let pageLen = data.length;
-    if (pageLen === 40) {
-      return countProjects(url, page + delta, delta);
-    } else if (pageLen > 0) {
-      let count = 40 * page + pageLen;
-      return count;
-    } else if (pageLen === 0 && page === 0) {
-      return 0;
-    } else {
-      page -= delta;
-      delta /= 10;
-      return countProjects(url, page + delta, delta);
-    }
-  }
-  const apiUrlPrefix =
-    "https://api.scratch.mit.edu/studios/" + /[0-9]+/.exec(location.pathname)[0] + "/projects/?limit=40&offset=";
-  const initialDelta = 100;
+export default async function ({ addon, msg }) {
+  const pageSize = 40;
+  const apiUrlPrefix = "https://api.scratch.mit.edu/studios/" + /[0-9]+/.exec(location.pathname)[0] + "/projects";
+
   const countElement = await addon.tab.waitForElement(".studio-tab-nav > a:first-child .tab-count");
   const originalText = countElement.innerText;
   let counted = false;
+
+  const maxRequestsPerSecond = 5;
+  const minRequestDelay = 1000 / maxRequestsPerSecond;
+  let lastRequestTime = 0;
+
+  // Do nothing if the count shown by Scratch isn't 100+
+  if (!originalText.includes("+")) return;
+
+  async function getPageLength(url, page, cache) {
+    if (Object.hasOwnProperty.call(cache, page)) return cache[page];
+    const timeSinceLastRequest = Date.now() - lastRequestTime;
+    if (timeSinceLastRequest < minRequestDelay) {
+      await new Promise((resolve) => {
+        setTimeout(() => resolve(), minRequestDelay - timeSinceLastRequest);
+      });
+    }
+    lastRequestTime = Date.now();
+    const res = await fetch(`${url}?limit=${pageSize}&offset=${page * pageSize}`);
+    if (res.status !== 200) throw res.status;
+    const length = (await res.json()).length;
+    cache[page] = length;
+    return length;
+  }
+
+  async function countProjects(url) {
+    let cache = {};
+    let minPage = 0;
+    let maxPage;
+    for (maxPage = 4; ; maxPage *= 2) {
+      const length = await getPageLength(url, maxPage, cache);
+      if (!length) break;
+      else if (length < pageSize) return maxPage * pageSize + length;
+      minPage = maxPage;
+    }
+    while (true) {
+      if (maxPage - minPage <= 1) {
+        return minPage * pageSize + (await getPageLength(url, minPage, cache));
+      }
+      const page = (minPage + maxPage) / 2;
+      const length = await getPageLength(url, page, cache);
+      if (length) {
+        minPage = page;
+        if (length < pageSize) return page * pageSize + length;
+      } else {
+        maxPage = page;
+      }
+    }
+  }
+
   addon.self.addEventListener("disabled", () => {
     if (typeof counted === "number") {
       countElement.innerText = originalText;
@@ -33,6 +65,30 @@ export default async function ({ addon }) {
     }
   });
 
-  counted = await countProjects(apiUrlPrefix, 0, initialDelta);
-  if (!addon.self.disabled) countElement.innerText = `(${counted})`;
+  // Show tooltip when "(100+)" is hovered
+  const tooltip = Object.assign(document.createElement("span"), {
+    className: "validation-message validation-info sa-exact-count-tooltip",
+    textContent: msg("studio-tooltip"),
+  });
+  countElement.appendChild(tooltip);
+
+  // Show exact count when "(100+)" is clicked
+  async function onCountClick(e) {
+    if (addon.self.disabled) return;
+    countElement.removeEventListener("click", onCountClick);
+    countElement.classList.add("sa-exact-count-loading");
+    const spinnerElement = Object.assign(document.createElement("span"), {
+      className: "sa-spinner",
+    });
+    countElement.appendChild(spinnerElement);
+    tooltip.remove();
+    try {
+      counted = await countProjects(apiUrlPrefix);
+      if (!addon.self.disabled) countElement.innerText = `(${counted})`;
+    } finally {
+      countElement.classList.remove("sa-exact-count-loading");
+      spinnerElement.remove();
+    }
+  }
+  countElement.addEventListener("click", onCountClick);
 }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,5 +1,6 @@
 import changeAddonState from "./imports/change-addon-state.js";
 import { getMissingOptionalPermissions } from "./imports/util.js";
+import { setUserAsActive } from "./imports/inactivity.js";
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.replaceTabWithUrl) chrome.tabs.update(sender.tab.id, { url: request.replaceTabWithUrl });
@@ -223,6 +224,7 @@ const csInfoCache = new Map();
 // (example: on browser startup, with a Scratch page opening on startup).
 chrome.webRequest.onBeforeRequest.addListener(
   async (request) => {
+    setUserAsActive();
     if (!scratchAddons.localState.allReady) return;
     const identity = createCsIdentity({ tabId: request.tabId, frameId: request.frameId, url: request.url });
     const loadingObj = { loading: true };
@@ -246,26 +248,20 @@ chrome.webRequest.onBeforeRequest.addListener(
 // Example: going to https://scratch.mit.edu/studios/104 (no slash after 104)
 // will redirect to /studios/104/ (with a slash)
 // If a cache entry is too old, remove it
-const alarmFrequency =
-  typeof browser !== "undefined"
-    ? // ↓ Firefox (event page)
-      1
-    : // ↓ Chromium (service worker)
-      5;
-chrome.alarms.create("cleanCsInfoCache", { periodInMinutes: alarmFrequency });
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === "cleanCsInfoCache") {
-    csInfoCache.forEach((obj, key) => {
-      if (!obj.loading) {
-        const currentTimestamp = Date.now();
-        const objTimestamp = obj.timestamp;
-        if (currentTimestamp - objTimestamp > 45000) {
-          csInfoCache.delete(key);
-        }
+setInterval(() => {
+  csInfoCache.forEach((obj, key) => {
+    if (!obj.loading) {
+      const currentTimestamp = Date.now();
+      const objTimestamp = obj.timestamp;
+      if (currentTimestamp - objTimestamp > 45000) {
+        csInfoCache.delete(key);
       }
-    });
-  }
-});
+    }
+  });
+}, 30000);
+// This interval may possibly be missed if the background context gets
+// killed or stopped - but at that point, the csInfoCache no longer
+// exists, so we have nothing to clear anyway.
 
 chrome.webRequest.onResponseStarted.addListener(
   (request) => {

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -7,21 +7,20 @@ const promisify =
   (...args) =>
     new Promise((resolve) => callbackFn(...args, resolve));
 
-function getDefaultStoreId() {
-  // Request Scratch to set the CSRF token.
-  return fetch("https://scratch.mit.edu/csrf_token/", {
-    credentials: "include",
-  })
-    .catch(() => {})
-    .then(() =>
-      promisify(chrome.cookies.get)({
-        url: "https://scratch.mit.edu/",
-        name: "scratchcsrftoken",
-      })
-    )
-    .then((cookie) => {
-      return (scratchAddons.cookieStoreId = cookie.storeId);
-    });
+async function getDefaultStoreId() {
+  const CHROME_DEFAULT = "0";
+  const FIFEFOX_DEFAULT = "firefox-default";
+  const cookieStores = await chrome.cookies.getAllCookieStores();
+  if (cookieStores.length === 0) throw "";
+  if (cookieStores.some((store) => store.id === CHROME_DEFAULT)) {
+    // Chrome
+    return CHROME_DEFAULT;
+  }
+  if (cookieStores.some((store) => store.id === FIFEFOX_DEFAULT)) {
+    // Firefox
+    return FIFEFOX_DEFAULT;
+  }
+  return cookieStores[0].id;
 }
 
 (async function () {

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -56,7 +56,7 @@ const onCookiesChanged = ({ cookie, cause, removed }) => {
   notify(cookie);
 };
 
-const COOKIE_CHANGE_RATE_LIMIT = 1500; // (ms) First events get processed immediately, then rate-limit is used.
+const COOKIE_CHANGE_RATE_LIMIT = 5000; // (ms) First events get processed immediately, then rate-limit is used.
 const queue = []; // We store cookies.onChanged events here. We'll try to process them all, but there's no guarantee.
 let timer = null; // The integer ID returned by setInterval.
 let n = 0; // Resets to 0 after each "burst" ends. If number is low, the event is processed with no delay.
@@ -91,8 +91,8 @@ const addToQueue = (item) => {
     // Process first 5 events immediately (gets reset after receiving 0 events for `COOKIE_CHANGE_RATE_LIMIT` milliseconds)
     process({ clearIntervalIfQueueEmpty: false });
   }
-  if (queue.length > 15) {
-    // If queue has more than 15 items, remove the oldest one.
+  if (queue.length > 8) {
+    // If queue has more than 8 items, remove the oldest one.
     queue.shift();
   }
 };

--- a/background/handle-settings-page.js
+++ b/background/handle-settings-page.js
@@ -2,10 +2,12 @@ import changeAddonState from "./imports/change-addon-state.js";
 import minifySettings from "../libraries/common/minify-settings.js";
 import { updateBadge } from "./message-cache.js";
 import { onReady } from "./imports/on-ready.js";
+import { setUserAsActive } from "./imports/inactivity.js";
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   // Message used to load popups as well
   if (request === "getSettingsInfo") {
+    setUserAsActive(); // User opened the popup or the settings page, consider them active.
     return onReady(() => {
       sendResponse({
         manifests: scratchAddons.manifests,

--- a/background/imports/inactivity.js
+++ b/background/imports/inactivity.js
@@ -1,0 +1,37 @@
+import { handleBadgeAlarm } from "../message-cache.js";
+
+const INACTIVITY_DELAY_MINS = 10;
+const INACTIVITY_ALARM = "inactivityAlarm";
+
+// This function should be called each time the user interacts with scratch.mit.edu or with the extension.
+// We consider the user inactive if it's been some minutes since this function was last called.
+export function setUserAsActive() {
+  chrome.alarms.clear(INACTIVITY_ALARM);
+  chrome.storage.session?.set({ inactivity: false });
+
+  chrome.alarms.create(INACTIVITY_ALARM, {
+    delayInMinutes: INACTIVITY_DELAY_MINS,
+  });
+
+  handleBadgeAlarm();
+}
+
+chrome.storage.session?.get("inactivity", (o) => {
+  if (o.inactivity === undefined) {
+    setUserAsActive(); // Consider user active on startup
+  }
+});
+
+chrome.alarms.onAlarm.addListener(async (al) => {
+  if (al.name === INACTIVITY_ALARM) {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true, url: "https://scratch.mit.edu/*" });
+    if (tabs.length > 0) setUserAsActive();
+    else {
+      // Consider user inactive starting now.
+      chrome.storage.session?.set({ inactivity: true });
+
+      // Adjust other alarms to run less often until user is active again.
+      handleBadgeAlarm();
+    }
+  }
+});

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -87,8 +87,8 @@ export async function startCache(defaultStoreId, forceClear) {
 }
 
 async function calculateBadgeAlarmInterval() {
-  const DEFAULT_MINS = 1;
-  const INACTIVITY_MINS = 2.5;
+  const DEFAULT_MINS = 1.5;
+  const INACTIVITY_MINS = 3.5;
   if (!chrome.storage.session) return DEFAULT_MINS;
   const o = await chrome.storage.session.get("inactivity");
   return o.inactivity ? INACTIVITY_MINS : DEFAULT_MINS;

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -86,23 +86,36 @@ export async function startCache(defaultStoreId, forceClear) {
   });
 }
 
+async function calculateBadgeAlarmInterval() {
+  const DEFAULT_MINS = 1;
+  const INACTIVITY_MINS = 2.5;
+  if (!chrome.storage.session) return DEFAULT_MINS;
+  const o = await chrome.storage.session.get("inactivity");
+  return o.inactivity ? INACTIVITY_MINS : DEFAULT_MINS;
+}
+
 // Update badge without fetching messages
 export function handleBadgeAlarm() {
-  chrome.alarms.get(BADGE_ALARM_NAME, (a) => {
-    const alarmExists = a !== undefined;
-    const badgeAddonEnabled = scratchAddons.localState.addonsEnabled["msg-count-badge"];
-    if (badgeAddonEnabled && !alarmExists) {
-      chrome.alarms.create(BADGE_ALARM_NAME, {
-        periodInMinutes: 1,
-      });
-    }
-    if (!badgeAddonEnabled && alarmExists) {
-      // Remove unnecessary alarm
-      chrome.alarms.clear(BADGE_ALARM_NAME);
-    }
+  onReady(() => {
+    chrome.alarms.get(BADGE_ALARM_NAME, (currentAlarm) => {
+      const alarmExists = currentAlarm !== undefined;
+      const badgeAddonEnabled = scratchAddons.localState.addonsEnabled["msg-count-badge"];
+      if (badgeAddonEnabled) {
+        calculateBadgeAlarmInterval().then((newPeriod) => {
+          if (!alarmExists || currentAlarm.periodInMinutes !== newPeriod)
+            chrome.alarms.create(BADGE_ALARM_NAME, {
+              periodInMinutes: newPeriod,
+            });
+        });
+      }
+      if (!badgeAddonEnabled && alarmExists) {
+        // Remove unnecessary alarm
+        chrome.alarms.clear(BADGE_ALARM_NAME);
+      }
+    });
   });
 }
-onReady(handleBadgeAlarm);
+handleBadgeAlarm();
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (!ready) return;

--- a/webpages/popup-loader.js
+++ b/webpages/popup-loader.js
@@ -50,7 +50,7 @@ async function getActualCookieStore() {
   return current?.cookieStoreId || undefined;
 }
 
-async function refetchCookies(needsRequest = true) {
+async function refetchCookies(needsRequest = false) {
   if (needsRequest) {
     try {
       await fetch("https://scratch.mit.edu/csrf_token/");


### PR DESCRIPTION
Resolves #7646

### Changes

- [x] Uses an appropriate API to get the ID of the default cookie store. (See PR #2976 which added support for multiple cookie stores)
- [x] Check whether the popup needs to fetch /csrf_token at all
- [x] Possibly enforce stronger rate limits. Currently 1500ms on handle-auth.js
- [x] Would like to cherrypick #7505 into this branch as well.
- [x] Cherrypick parts of #7621

### Reason for changes

See PR description: #7646