### PR TITLE
Improve efficiency in `copy-message-link` on profiles

### DIFF
--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -4,8 +4,8 @@ export default async function ({ addon, console, msg }) {
   while (true) {
     const comment = await addon.tab.waitForElement("div.comment:not(.sa-copy-link)", {
       markAsSeen: true,
-    })
-    comment.classList.add("sa-copy-link")
+    });
+    comment.classList.add("sa-copy-link");
 
     const newElem = document.createElement("span");
     addon.tab.displayNoneWhileDisabled(newElem);

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -1,6 +1,4 @@
 export default async function ({ addon, console, msg }) {
-  let amtOfComments = 0;
-  let pass = 0;
   while (true) {
     const comment = await addon.tab.waitForElement("div.comment:not(.sa-copy-link)", {
       markAsSeen: true,

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -5,7 +5,7 @@ export default async function ({ addon, console, msg }) {
     // See https://github.com/ScratchAddons/ScratchAddons/pull/7657#pullrequestreview-2190078414
     if (this.get(0).querySelector(".sa-copy-link-btn")) return;
     return oldJQueryHtml.call(this, ...args);
-  }
+  };
 
   while (true) {
     const comment = await addon.tab.waitForElement("div.comment:not(.sa-copy-link)", {

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -1,4 +1,12 @@
 export default async function ({ addon, console, msg }) {
+  const oldJQueryHtml = $.fn.html;
+  $.fn.html = function (...args) {
+    // Prevent Scratch from changing the action row of existing comments after loading a new page
+    // See https://github.com/ScratchAddons/ScratchAddons/pull/7657#pullrequestreview-2190078414
+    if (this.get(0).querySelector(".sa-copy-link-btn")) return;
+    return oldJQueryHtml.call(this, ...args);
+  }
+
   while (true) {
     const comment = await addon.tab.waitForElement("div.comment:not(.sa-copy-link)", {
       markAsSeen: true,

--- a/addons/copy-message-link/profile.js
+++ b/addons/copy-message-link/profile.js
@@ -2,19 +2,11 @@ export default async function ({ addon, console, msg }) {
   let amtOfComments = 0;
   let pass = 0;
   while (true) {
-    const newAmtOfComments = document.querySelectorAll("div.comment").length;
-    if (amtOfComments !== newAmtOfComments) {
-      pass++;
-      amtOfComments = newAmtOfComments;
-    }
-    const comment = await addon.tab.waitForElement(`div.comment:not([data-sa-copy-link-pass='${pass}'])`);
-    comment.dataset.saCopyLinkPass = pass;
-    if (comment.querySelector(".sa-copy-link-btn")) {
-      // This will to all comments after posting a new one,
-      // and to the first comment on every loaded page.
-      // Do not readd button if we already added it
-      continue;
-    }
+    const comment = await addon.tab.waitForElement("div.comment:not(.sa-copy-link)", {
+      markAsSeen: true,
+    })
+    comment.classList.add("sa-copy-link")
+
     const newElem = document.createElement("span");
     addon.tab.displayNoneWhileDisabled(newElem);
     newElem.className = "actions report sa-copy-link-btn";


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #7656 

### Changes

Used `markAsSeen` and added a new class to comments that have already had the button added. This ensures that comments don't get used twice and also improves efficiency by not having the waitForElement API read over the comment again.

### Reason for changes

Lag can become pretty noticeable on profiles (as the project/studio one worked differently) when you have a lot of comments on the page.

### Tests

macOS Sonoma 14.5
Chrome Version 126.0.6478.36 (Official Build) beta (arm64)
