### PR TITLE
[v1.38.x] Send less requests to `scratch.mit.edu/session` etc.

### DIFF
--- a/addon-api/common/FetchableAuth.js
+++ b/addon-api/common/FetchableAuth.js
@@ -29,11 +29,12 @@ export default class FetchableAuth extends AuthCommon {
    * @private
    */
   _waitUntilFetched() {
+    const prom = new Promise((resolve) => this.addEventListener("session", resolve, { once: true }));
     if (this._requestFetchFn) {
       this._requestFetchFn();
       this._requestFetchFn = undefined;
     }
-    return new Promise((resolve) => this.addEventListener("session", resolve, { once: true }));
+    return prom;
   }
 
   /**

--- a/addon-api/common/FetchableAuth.js
+++ b/addon-api/common/FetchableAuth.js
@@ -9,11 +9,12 @@ export default class FetchableAuth extends AuthCommon {
   /**
    * @private
    */
-  _refresh() {
+  _refresh(requestFetchFn) {
     this._lastUsername = undefined;
     this._lastUserId = undefined;
     this._lastIsLoggedIn = undefined;
     this._lastXToken = undefined;
+    if (requestFetchFn) this.requestFetchFn = requestFetchFn; // A function to call when data is requested
   }
 
   /**
@@ -28,6 +29,10 @@ export default class FetchableAuth extends AuthCommon {
    * @private
    */
   _waitUntilFetched() {
+    if (this.requestFetchFn) {
+      this.requestFetchFn();
+      this.requestFetchFn = undefined;
+    }
     return new Promise((resolve) => this.addEventListener("session", resolve, { once: true }));
   }
 

--- a/addon-api/common/FetchableAuth.js
+++ b/addon-api/common/FetchableAuth.js
@@ -14,7 +14,7 @@ export default class FetchableAuth extends AuthCommon {
     this._lastUserId = undefined;
     this._lastIsLoggedIn = undefined;
     this._lastXToken = undefined;
-    if (requestFetchFn) this.requestFetchFn = requestFetchFn; // A function to call when data is requested
+    if (requestFetchFn) this._requestFetchFn = requestFetchFn; // A function to call when data is requested
   }
 
   /**
@@ -29,9 +29,9 @@ export default class FetchableAuth extends AuthCommon {
    * @private
    */
   _waitUntilFetched() {
-    if (this.requestFetchFn) {
-      this.requestFetchFn();
-      this.requestFetchFn = undefined;
+    if (this._requestFetchFn) {
+      this._requestFetchFn();
+      this._requestFetchFn = undefined;
     }
     return new Promise((resolve) => this.addEventListener("session", resolve, { once: true }));
   }

--- a/addons/animated-thumb/persistent-thumb.js
+++ b/addons/animated-thumb/persistent-thumb.js
@@ -8,6 +8,7 @@ export const init = (console) => {
     if (!isDisabled() && method === "POST" && String(path).startsWith("/internalapi/project/thumbnail/")) {
       console.log("Blocked overwriting thumbnails.");
       method = "OPTIONS"; // This makes sure thumbnail request errors.
+      // TODO: avoid sending the request
     }
     return xhrOpen.call(this, method, path, ...args);
   };

--- a/addons/animated-thumb/persistent-thumb.js
+++ b/addons/animated-thumb/persistent-thumb.js
@@ -8,7 +8,6 @@ export const init = (console) => {
     if (!isDisabled() && method === "POST" && String(path).startsWith("/internalapi/project/thumbnail/")) {
       console.log("Blocked overwriting thumbnails.");
       method = "OPTIONS"; // This makes sure thumbnail request errors.
-      // TODO: avoid sending the request
     }
     return xhrOpen.call(this, method, path, ...args);
   };

--- a/addons/exact-count/user.js
+++ b/addons/exact-count/user.js
@@ -1,11 +1,11 @@
 export default async function ({ addon }) {
   const CACHE = {
     projects: null,
-    favorites: null,
+    // favorites: null,
     followers: null,
     following: null,
-    studios: null,
-    studios_following: null,
+    // studios: null,
+    // studios_following: null,
   };
   const details = Object.keys(CACHE);
   const username = Scratch.INIT_DATA.PROFILE.model.username;
@@ -29,6 +29,15 @@ export default async function ({ addon }) {
   });
 
   for (const detail of details) {
+    if (detail === "projects") {
+      const boxheadName = getBoxHead("projects")?.querySelector("h4");
+      if (!boxheadName) continue;
+      if (!boxheadName.innerText.endsWith("100+)")) {
+        // Page already shows exact project count!
+        continue;
+      }
+    }
+
     fetch(`https://scratch.mit.edu/users/${username}/${detail}/`, { credentials: "omit" })
       .then((res) => res.text())
       .then((html) => {

--- a/addons/forum-post-countdown/userscript.js
+++ b/addons/forum-post-countdown/userscript.js
@@ -17,9 +17,7 @@ export default async function ({ addon, msg }) {
     localStorage.removeItem("sa-forum-post-countdown");
     return;
   }
-  const secondCount = scratchAddons.session.permissions.new_scratcher
-    ? 120
-    : 60;
+  const secondCount = scratchAddons.session.permissions.new_scratcher ? 120 : 60;
 
   const elt = document.createElement("span");
   elt.id = "sa-forum-post-countdown";

--- a/addons/forum-post-countdown/userscript.js
+++ b/addons/forum-post-countdown/userscript.js
@@ -17,9 +17,7 @@ export default async function ({ addon, msg }) {
     localStorage.removeItem("sa-forum-post-countdown");
     return;
   }
-  const secondCount = (
-    await fetch("/session", { headers: { "x-requested-with": "XMLHttpRequest" } }).then((resp) => resp.json())
-  ).permissions.new_scratcher
+  const secondCount = scratchAddons.session.permissions.new_scratcher
     ? 120
     : 60;
 

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -126,7 +126,6 @@ async function checkSession(firstTime = false) {
   isChecking = true;
   const { scratchSession } = (await chrome.storage.session?.get("scratchSession")) ?? {};
   if (firstTime && scratchSession) {
-    // We didn't wake up due to a cookie change
     console.log("Used cached /session info.");
     json = scratchSession;
   } else {

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -26,7 +26,7 @@ async function getDefaultStoreId() {
 (async function () {
   const defaultStoreId = await getDefaultStoreId();
   console.log("Default cookie store ID: ", defaultStoreId);
-  await checkSession();
+  await checkSession(true);
   startCache(defaultStoreId);
 })();
 
@@ -123,13 +123,13 @@ async function setLanguage() {
 
 let isChecking = false;
 
-async function checkSession() {
+async function checkSession(firstTime = false) {
   let res;
   let json;
   if (isChecking) return;
   isChecking = true;
   const { scratchSession } = (await chrome.storage.session?.get("scratchSession")) ?? {};
-  if (scratchSession && canUseCachedSession) {
+  if (firstTime && scratchSession && canUseCachedSession) {
     // We didn't wake up due to a cookie change
     console.log("Used cached /session info.");
     json = scratchSession;

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -96,11 +96,7 @@ const addToQueue = (item) => {
     queue.shift();
   }
 };
-let canUseCachedSession = true;
-chrome.cookies.onChanged.addListener((e) => {
-  canUseCachedSession = false;
-  addToQueue(e);
-});
+chrome.cookies.onChanged.addListener((e) => addToQueue(e));
 
 function getCookieValue(name) {
   return new Promise((resolve) => {
@@ -129,7 +125,7 @@ async function checkSession(firstTime = false) {
   if (isChecking) return;
   isChecking = true;
   const { scratchSession } = (await chrome.storage.session?.get("scratchSession")) ?? {};
-  if (firstTime && scratchSession && canUseCachedSession) {
+  if (firstTime && scratchSession) {
     // We didn't wake up due to a cookie change
     console.log("Used cached /session info.");
     json = scratchSession;

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -128,7 +128,7 @@ async function checkSession() {
   let json;
   if (isChecking) return;
   isChecking = true;
-  const { scratchSession } = await chrome.storage.session?.get("scratchSession"); // TODO sesionnn
+  const { scratchSession } = (await chrome.storage.session?.get("scratchSession")) ?? {};
   if (scratchSession && canUseCachedSession) {
     // We didn't wake up due to a cookie change
     console.log("Used cached /session info.");

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -131,7 +131,7 @@ async function checkSession() {
   const { scratchSession } = await chrome.storage.session?.get("scratchSession"); // TODO sesionnn
   if (scratchSession && canUseCachedSession) {
     // We didn't wake up due to a cookie change
-    console.log("Used cached /session info.")
+    console.log("Used cached /session info.");
     json = scratchSession;
   } else {
     try {
@@ -141,7 +141,7 @@ async function checkSession() {
         },
       });
       json = await res.json();
-      chrome.storage.session?.set({scratchSession: json}); // TODO sesionnn
+      chrome.storage.session?.set({ scratchSession: json }); // TODO sesionnn
     } catch (err) {
       console.warn(err);
       json = {};

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -141,7 +141,7 @@ async function checkSession() {
         },
       });
       json = await res.json();
-      chrome.storage.session?.set({ scratchSession: json }); // TODO sesionnn
+      chrome.storage.session?.set({ scratchSession: json });
     } catch (err) {
       console.warn(err);
       json = {};

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -93,6 +93,7 @@ const page = {
       !document.querySelector("meta[name='format-detection']") &&
       document.querySelector("script[type='text/javascript']");
     if (!firstTime && isScratchR2) {
+      // We assume this function always gets called with firstTime:true at least once.
       // scratchr2 pages do not support logging in/out without a page reload.
       // Why even bother to check auth again?
       return;

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -88,8 +88,7 @@ const page = {
   },
   isFetching: false,
   async refetchSession(firstTime = false) {
-    if (isScratchGui) return;
-
+    if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601") return;
     const isScratchR2 =
       !document.querySelector("meta[name='format-detection']") &&
       document.querySelector("script[type='text/javascript']");

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -56,7 +56,7 @@ const page = {
   set dataReady(val) {
     this._dataReady = val;
     onDataReady(); // Assume set to true
-    this.refetchSession();
+    this.refetchSession(true);
   },
 
   runAddonUserscripts, // Gets called by cs.js when addon enabled late
@@ -87,28 +87,45 @@ const page = {
     }
   },
   isFetching: false,
-  async refetchSession() {
-    if (location.origin === "https://scratchfoundation.github.io" || location.port === "8601") return;
-    let res;
-    let d;
-    if (this.isFetching) return;
-    this.isFetching = true;
-    scratchAddons.eventTargets.auth.forEach((auth) => auth._refresh());
-    try {
-      res = await fetch("/session/", {
-        headers: {
-          "X-Requested-With": "XMLHttpRequest",
-        },
-      });
-      d = await res.json();
-    } catch (e) {
-      d = {};
-      scratchAddons.console.warn("Session fetch failed: ", e);
-      if ((res && !res.ok) || !res) setTimeout(() => this.refetchSession(), 60000);
+  async refetchSession(firstTime = false) {
+    if (isScratchGui) return;
+
+    const isScratchR2 =
+      !document.querySelector("meta[name='format-detection']") &&
+      document.querySelector("script[type='text/javascript']");
+    if (!firstTime && isScratchR2) {
+      // scratchr2 pages do not support logging in/out without a page reload.
+      // Why even bother to check auth again?
+      return;
     }
-    scratchAddons.session = d;
-    scratchAddons.eventTargets.auth.forEach((auth) => auth._update(d));
-    this.isFetching = false;
+
+    const refreshFn = async () => {
+      let res;
+      let d;
+      if (this.isFetching) return;
+      this.isFetching = true;
+      if (firstTime && window.__scratchAddonsSessionRes?.loaded) {
+        d = window.__scratchAddonsSessionRes.session;
+      } else {
+        try {
+          res = await fetch("/session/", {
+            headers: {
+              "X-Requested-With": "XMLHttpRequest",
+            },
+          });
+          d = await res.json();
+        } catch (e) {
+          d = {};
+          scratchAddons.console.warn("Session fetch failed: ", e);
+          if ((res && !res.ok) || !res) setTimeout(() => this.refetchSession(), 60000);
+        }
+      }
+      scratchAddons.session = d;
+      scratchAddons.eventTargets.auth.forEach((auth) => auth._update(d));
+      this.isFetching = false;
+    };
+
+    scratchAddons.eventTargets.auth.forEach((auth) => auth._refresh(refreshFn));
   },
 };
 Comlink.expose(page, Comlink.windowEndpoint(comlinkIframe4.contentWindow, comlinkIframe3.contentWindow));

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -125,7 +125,15 @@ const page = {
       this.isFetching = false;
     };
 
-    scratchAddons.eventTargets.auth.forEach((auth) => auth._refresh(refreshFn));
+    let calledFn = false;
+    const refreshFnOnce = () => {
+      if (!calledFn) {
+        calledFn = true;
+        refreshFn();
+      }
+    };
+
+    scratchAddons.eventTargets.auth.forEach((auth) => auth._refresh(refreshFnOnce));
   },
 };
 Comlink.expose(page, Comlink.windowEndpoint(comlinkIframe4.contentWindow, comlinkIframe3.contentWindow));

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -44,7 +44,6 @@ immediatelyRunFunctionInMainWorld(() => {
 
   const originalXhrOpen = XMLHttpRequest.prototype.open;
   XMLHttpRequest.prototype.open = function (method, path, ...args) {
-    console.log(method, path);
     if (method === "GET" && path === "/session/") {
       this.addEventListener(
         "load",

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -38,3 +38,24 @@ if ((!(document.documentElement instanceof SVGElement) && location.pathname.spli
     };
   });
 }
+
+immediatelyRunFunctionInMainWorld(() => {
+  window.__scratchAddonsSessionRes = { loaded: false, session: null };
+
+  const originalXhrOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (method, path, ...args) {
+    console.log(method, path);
+    if (method === "GET" && path === "/session/") {
+      this.addEventListener(
+        "load",
+        () => {
+          if (this.responseType !== "json") return;
+          window.__scratchAddonsSessionRes.session = this.response;
+          window.__scratchAddonsSessionRes.loaded = true;
+        },
+        { once: true }
+      );
+    }
+    return originalXhrOpen.call(this, method, path, ...args);
+  };
+});


### PR DESCRIPTION
Resolves comment https://github.com/ScratchAddons/ScratchAddons/pull/7651#issuecomment-2239953482
Related: #7648

When viewing the diff, I recommend you enable "hide whitespace".

### Changes

This PR intends to make very small changes/optimizations to reduce the load on Scratch servers. It should also slightly help with battery and data usage.

These are small code changes. Big restructurings are intentionally not made.
The changes are made in such a way that anyone can clearly see that, after the changes, it's impossible that the extension sends more than requests than before.

#### Background process (service worker / event page)

The amount of requests to `/session` will decrease significantly. This is strongly related to the Manifest V3 lifecycle and using `chrome.storage.session` to cache data.

- Previously, `/session` would be fetched each time the service worker wakes up.
- Now, the response to `/session` is cached through `chrome.storage.session` and the amount of background requests to that endpoint should be similar to our old Manifest V2 versions.
- The function that previously caused an infinite loop (`addToQueue`) remains intentionally unchanged. It may still request `/session` if Scratch cookies changed.

#### Non-addon code running in Scratch tabs (content scripts in both worlds)

The amount of requests to `/session` will decrease significantly.

- In `scratch-www` pages, such as the front page, projects, and studios, we don't need to fetch `/session` ourselves on page load, as Scratch will do this automatically. We can obtain the response data either by polluting XHR or by looking at Redux. (In this PR I fetch XHR as it's the easiest and more reliable option).
- If no addon calls `addon.auth.fetchX` (X can be "Username", "IsLoggedIn", "UserId" or "XToken") there is no need to fetch `/session`. In fact, in non-www pages (that is, "scratchr2" pages) no requests to `/session` will be sent at all, until one of the running userscripts calls one of these methods.
- In non-www pages (that is, "scratchr2" pages) there is no need to fetch `/session` more than once. Only in some www pages the user can log in or out without a reload. This may mean data gets out of sync if the user logs in to a different account, but that's what already happens on vanilla Scratch, and what tricks like "follow yourself" rely on.

#### Addons

- The `forum-post-countdown` addon reuses the session data fetched by the `isLoggedIn()` call, so overall 1 request is sent instead of two.
- `exact-count`: Do not fetch exact project count if it does not exceed 100. Do not fetch exact favorites and studio counts. (May revert this last decision if there's user feedback about it, see issue #7623)

#### Extension popup

No changes

### Tests

Have to test