### PR TITLE
README: Add badge for Discord online users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![](https://img.shields.io/github/v/release/ScratchAddons/ScratchAddons?style=flat-square&logo=github&logoColor=white&label=GitHub&color=181717)](https://github.com/ScratchAddons/ScratchAddons/releases)
 
 [![](https://img.shields.io/github/license/ScratchAddons/ScratchAddons?style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/blob/master/LICENSE)
-[![](https://img.shields.io/badge/chat-on_discord-7289da.svg?style=flat-square)](https://discord.gg/R5NBqwMjNc)
+[![](https://img.shields.io/discord/806602307750985799?style=flat-square&color=7289da)](https://discord.gg/R5NBqwMjNc)
 [![](https://img.shields.io/badge/website-scratchaddons.com-ff7b26.svg?style=flat-square)](https://scratchaddons.com)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![](https://img.shields.io/github/v/release/ScratchAddons/ScratchAddons?style=flat-square&logo=github&logoColor=white&label=GitHub&color=181717)](https://github.com/ScratchAddons/ScratchAddons/releases)
 
 [![](https://img.shields.io/github/license/ScratchAddons/ScratchAddons?style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/blob/master/LICENSE)
-[![](https://img.shields.io/discord/806602307750985799?style=flat-square&color=7289da)](https://discord.gg/R5NBqwMjNc)
+[![](https://img.shields.io/discord/806602307750985799?style=flat-square&logo=discord&logoColor=white&color=7289da)](https://discord.gg/R5NBqwMjNc)
 [![](https://img.shields.io/badge/website-scratchaddons.com-ff7b26.svg?style=flat-square)](https://scratchaddons.com)
 
 ## About


### PR DESCRIPTION
Resolves #7676

### Changes

Changes the static "chat on discord" badge to a dynamic badge that displays the number of users on our Discord server who are online.

### Reason for changes

It's a great opportunity to display the statistic.
