### PR TITLE
`msg-count-badge`: disable by default & some existing users

### DIFF
--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -2,7 +2,7 @@
   "name": "Message count on extension icon",
   "description": "Adds the current message count in the Scratch Addons icon.",
   "tags": ["popup", "recommended"],
-  "enabledByDefault": true,
+  "enabledByDefault": false,
   "versionAdded": "1.0.0",
   "info": [
     {
@@ -70,6 +70,11 @@
       "link": "https://scratch.mit.edu/users/lisa_wolfgang/"
     }
   ],
+  "latestUpdate": {
+    "isMajor": true,
+    "version": "1.39.0",
+    "temporaryNotice": "This addon was automatically disabled for some users. You can reenable it to get it back."
+  },
   "dynamicEnable": true,
   "dynamicDisable": true
 }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -174,7 +174,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
     if (addonSettings["editor-theme3333"]?._version === 3) {
       // Detected update to v1.39 (code below will set the version to 4)
-      if (addonsEnabled["msg-count-badge"]) {
+      if (addonsEnabled["msg-count-badge"] && chrome.action.getUserSettings) {
         chrome.action
           .getUserSettings()
           .then((userSettings) => {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -1,4 +1,6 @@
 import minifySettings from "../libraries/common/minify-settings.js";
+import changeAddonState from "./imports/change-addon-state.js";
+import { onReady } from "./imports/on-ready.js";
 
 /**
  Since presets can change independently of others, we have to keep track of
@@ -168,6 +170,21 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
       addonsEnabled["workspace-dots"] = true;
       if (!addonSettings["workspace-dots"]) addonSettings["workspace-dots"] = {};
       addonSettings["workspace-dots"]["theme"] = "none";
+    }
+
+    if (addonSettings["editor-theme3333"]?._version === 3) {
+      // Detected update to v1.39 (code below will set the version to 4)
+      if (addonsEnabled["msg-count-badge"]) {
+        chrome.action
+          .getUserSettings()
+          .then((userSettings) => {
+            if (userSettings?.isOnToolbar === false) {
+              // Disable addon if extension not pinned to toolbar
+              onReady(() => changeAddonState("msg-count-badge", false));
+            }
+          })
+          .catch(() => {});
+      }
     }
 
     for (const { manifest, addonId } of scratchAddons.manifests) {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -172,7 +172,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
       addonSettings["workspace-dots"]["theme"] = "none";
     }
 
-    if (addonSettings["editor-theme3333"]?._version === 3) {
+    if (addonSettings["editor-theme3"]?._version === 3) {
       // Detected update to v1.39 (code below will set the version to 4)
       if (addonsEnabled["msg-count-badge"] && chrome.action.getUserSettings) {
         chrome.action

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -495,6 +495,11 @@ let fuse;
         }
       }
 
+      if (addonId === "msg-count-badge" && manifest._enabled) {
+        // v1.39: only feature msg-count-badge if it is disabled
+        manifest._groups = manifest._groups.filter((g) => g !== "featuredNew");
+      }
+
       // Sort tags to preserve consistent order
       const order = tags.map((obj) => obj.matchName);
       manifest.tags.sort((b, a) => order.indexOf(b) - order.indexOf(a));


### PR DESCRIPTION
Resolves comment https://github.com/ScratchAddons/ScratchAddons/pull/7651#issuecomment-2254267589

### Changes

- The addon `msg-count-badge` is no longer enabled by default.
- When updating to v1.39.0, existing users who do not have Scratch Addons pinned to their extension toolbar will have this addon automatically disabled.
- Users can easily reenable the addon as it will appear at the top of the settings page if disabled.

### Reason for changes

- Removes a historical default due to our Scratch Messaging roots that makes little sense now.
- Less data and battery usage wasted updating the extension badge when it is not visible to the user.
- Sending less requests to Scratch servers.

### Tests

Tested in Chromium