### PR TITLE
`blocks2image`: fix multiple reqs for same image

### DIFF
--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -125,18 +125,38 @@ export default async function ({ addon, console, msg }) {
       text.innerHTML = text.innerHTML.replace(/&nbsp;/g, " ");
     });
 
+    const groupBy = (arr, callback) => {
+      // This is a rough Object.groupBy polyfill
+      return arr.reduce((acc = {}, ...args) => {
+        const key = callback(...args);
+        acc[key] ??= [];
+        acc[key].push(args[0]);
+        return acc;
+      }, {});
+    };
+
+    const externalImages = /*Object.*/ groupBy(Array.from(svg.querySelectorAll("image")), (item) => {
+      const iconUrl = item.getAttribute("xlink:href");
+      if (iconUrl.startsWith("data:")) return "data:";
+      else return iconUrl;
+    });
+    delete externalImages["data:"];
+
+    // To help with testing this PR. Will be removed.
+    // To see  the logs, export as PNG or SVG.
+    console.log("Images (", svg.querySelectorAll("image").length, ")", Array.from(svg.querySelectorAll("image")));
+    console.log("Amount of different URLs to be fetched:", Object.keys(externalImages).length);
+
     // replace external images with data URIs
     await Promise.all(
-      Array.from(svg.querySelectorAll("image")).map(async (item) => {
-        const iconUrl = item.getAttribute("xlink:href");
-        if (iconUrl.startsWith("data:")) return;
+      Object.keys(externalImages).map(async (iconUrl) => {
         const blob = await (await fetch(iconUrl)).blob();
         const reader = new FileReader();
         const dataUri = await new Promise((resolve) => {
           reader.addEventListener("load", () => resolve(reader.result));
           reader.readAsDataURL(blob);
         });
-        item.setAttribute("xlink:href", dataUri);
+        externalImages[iconUrl].forEach((item) => item.setAttribute("xlink:href", dataUri));
       })
     );
     if (!isExportPNG) {

--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -142,11 +142,6 @@ export default async function ({ addon, console, msg }) {
     });
     delete externalImages["data:"];
 
-    // To help with testing this PR. Will be removed.
-    // To see  the logs, export as PNG or SVG.
-    console.log("Images (", svg.querySelectorAll("image").length, ")", Array.from(svg.querySelectorAll("image")));
-    console.log("Amount of different URLs to be fetched:", Object.keys(externalImages).length);
-
     // replace external images with data URIs
     await Promise.all(
       Object.keys(externalImages).map(async (iconUrl) => {


### PR DESCRIPTION
Resolves #7681

### Changes

Identical image URLs are only fetched once.

I used the new(ish) `Object.groupBy()` function to group icons by their image URLs.

I added logs when exporting blocks as image to facilitate testing this PR. See #7681 for repro steps and an example project and sprite. These logs will be removed before merging.

### Tests

Tested in Chromium.

Make sure that `editor-theme3` is off when testing this. If it is on, everything will be a data: url anyway.