### PR TITLE
Remove scroll limits

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -158,6 +158,7 @@
   "workspace-dots",
   "asset-conflict-dialog",
   "remaining-replies",
+  "remove-editor-limits",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/remove-editor-limits/addon.json
+++ b/addons/remove-editor-limits/addon.json
@@ -1,0 +1,10 @@
+{
+  "name": "Remove code area limits",
+  "description": "Allows you to scroll as far away from existing code as you want.",
+  "credits": [{ "name": "Jazza", "link": "https://jazza.dev/" }],
+  "userscripts": [{ "url": "userscript.js", "matches": ["projects"] }],
+  "tags": ["codeEditor", "editor"],
+  "versionAdded": "1.39.0",
+  "dynamicDisable": true,
+  "dynamicEnable": true
+}

--- a/addons/remove-editor-limits/userscript.js
+++ b/addons/remove-editor-limits/userscript.js
@@ -1,0 +1,48 @@
+// To fix the scroll position resetting on zoom, I think we need something from
+// https://github.com/scratchfoundation/scratch-blocks/blob/8aa52c48393bfb91ef63f91bc1df4a030563237a/core/scrollbar.js#L87
+// or
+// https://github.com/scratchfoundation/scratch-blocks/blob/8aa52c48393bfb91ef63f91bc1df4a030563237a/core/scrollbar.js#L418
+// But I am not sure...
+
+export default async function ({ addon, console }) {
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+
+  console.log(ScratchBlocks);
+  console.log(addon.self.disabled);
+
+  const oldScroll = ScratchBlocks.WorkspaceSvg.prototype.scroll;
+  const oldDrag = ScratchBlocks.WorkspaceDragger.prototype.drag;
+
+  ScratchBlocks.WorkspaceSvg.prototype.scroll = function (x, y) {
+    if (addon.self.disabled) {
+      oldScroll.call(this, x, y);
+    } else {
+      var metrics = this.startDragMetrics; // Cached values
+
+      ScratchBlocks.WidgetDiv.hide(true);
+      ScratchBlocks.DropDownDiv.hideWithoutAnimation();
+      this.scrollbar.set(-x - metrics.contentLeft, -y - metrics.contentTop);
+    }
+  };
+
+  ScratchBlocks.WorkspaceDragger.prototype.drag = function (currentDragDeltaXY) {
+    if (addon.self.disabled) {
+      oldDrag.call(this, currentDragDeltaXY);
+    } else {
+      var metrics = this.startDragMetrics_;
+
+      var newXY = {
+        x: this.startScrollXY_.x + currentDragDeltaXY.x,
+        y: this.startScrollXY_.y + currentDragDeltaXY.y,
+      };
+
+      var x = newXY.x;
+      var y = newXY.y;
+
+      x = -x - metrics.contentLeft;
+      y = -y - metrics.contentTop;
+
+      this.updateScroll_(x, y);
+    }
+  };
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves: https://discord.com/channels/806602307750985799/1267516480614957218

### Changes

Added an addon that removes the bounds limit on the code area. This allows users to scroll as far as they want from their code. They can not get lost, as there is an existing button to center them on the code.

### Reason for changes

I often find myself wanting to scroll further away from code than scratch lets me. This situation gets worse when the bug with the collapsible block palette shows its head (which seems to be back)

### Tests

Works on brave. Dynamic enable and disable work. Allows scrolling as far as you want.

### More
Should handling of the scrollbars be different? Currently I don't touch them, and they eventually disappear. Maybe a better option is to not remove the fencing, but make the code area larger (through code? through shadow blocks?)
Zooming in (mouse scroll, mouse pinch, buttons) resets the view to the closest "normally allowed" point