### PR TITLE
`download-button`: include proj. ID in filename if Shift

### DIFF
--- a/addons/download-button/userscript.js
+++ b/addons/download-button/userscript.js
@@ -12,13 +12,15 @@ export default async function ({ addon, console, msg }) {
   const isOwn = username === projectAuthor;
   const shared = addon.tab.redux.state.preview.projectInfo.is_published;
 
-  async function download() {
+  async function download(beginFilenameWithId) {
     const downloadButton = document.querySelector(".sa-download-button");
     downloadButton.classList.add("loading");
     try {
       const project = await vm.saveProjectSb3();
       const title = isOwn ? document.querySelector(".project-title input") : document.querySelector(".project-title");
-      downloadBlob(`${isOwn ? title.value : title.innerText}.sb3`, project);
+      const titleStr = isOwn ? title.value : title.innerText;
+      const projectId = window.location.pathname.split("/")[2];
+      downloadBlob((beginFilenameWithId ? `${projectId} ` : "") + titleStr + ".sb3", project);
     } finally {
       downloadButton.classList.remove("loading");
     }
@@ -26,7 +28,9 @@ export default async function ({ addon, console, msg }) {
 
   const downloadButton = document.createElement("button");
   downloadButton.innerText = msg("download");
-  downloadButton.onclick = download;
+  downloadButton.onclick = (e) => {
+    download(e.shiftKey);
+  };
   downloadButton.classList = "button action-button sa-download-button waiting";
   downloadButton.id = "sa-download-button";
 


### PR DESCRIPTION
Resolves #7695

### Changes

Example project: https://scratch.mit.edu/projects/504994642/

When clicking the "download" button normally, the default name for the file is: `Happy Dango day (April 1)`

New: when shift+clicking the "download" button, the default name of the file is: `504994642 Happy Dango day (April 1)`

### Reason for changes

Small change that helps sfederici.
We shouldn't document this, if we ever want to change Shift+click to do something else we can.

### Tests

Tested in Chromium