### PR TITLE
`discuss-button`: Add en to scratch wiki link

### DIFF
--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -86,7 +86,7 @@
         },
         {
           "name": "Wiki",
-          "values": { "name": "Wiki", "url": "https://scratch-wiki.info/" }
+          "values": { "name": "Wiki", "url": "https://en.scratch-wiki.info/" }
         }
       ]
     },


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #7700

### Changes

Changes `scratch-wiki.info` to `en.scratch-wiki.info`.

### Reason for changes

#7700

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->

I couldn't test it because of a firefox glitch, but it's a *really* minor change and pretty much doesn't need testing. (Reading manifest: Warning processing version_name: An unexpected property was found in the WebExtension manifest.)