### PR TITLE
Add early return to 3.0 scratchblocks addon

### DIFF
--- a/addons/scratchblocks/userscript.js
+++ b/addons/scratchblocks/userscript.js
@@ -46,6 +46,9 @@ async function getLocales(addon) {
   return lang;
 }
 export default async function ({ addon, msg }) {
+  const newSB = !document.querySelector(`[src*="scratchblocks.js"]`);
+  if (newSB) return; // Return early for when Scratch bumps scratchblocks versions (it would use scratchblocks.min.js)
+
   window.scratchAddons._scratchblocks3Enabled = true;
 
   let languages = ["en"];


### PR DESCRIPTION
If Scratch updates to a newer scratchblocks plugin, it would use the filename scratchblocks.min.js (I know this because I implemented it), disable 3.0 scratchblocks addon with an early return as it would be redundant.