### PR TITLE
Message count in tooltip

### DIFF
--- a/addons/msg-count-badge/addon.json
+++ b/addons/msg-count-badge/addon.json
@@ -9,6 +9,11 @@
       "type": "info",
       "text": "You can use Do Not Disturb (right click extension icon \u2192 Do not disturb) to temporarily hide the message count.",
       "id": "dndtohide"
+    },
+    {
+      "type": "info",
+      "text": "If you disable this addon, you can still hover over the extension icon to show the message count.",
+      "id": "hoverfortooltip"
     }
   ],
   "settings": [

--- a/background/message-cache.js
+++ b/background/message-cache.js
@@ -7,8 +7,8 @@ let duringBadgeUpdate = false;
 
 const promisify =
   (callbackFn) =>
-    (...args) =>
-      new Promise((resolve) => callbackFn(...args, resolve));
+  (...args) =>
+    new Promise((resolve) => callbackFn(...args, resolve));
 
 const ALARM_NAME = "fetchMessages";
 const BADGE_ALARM_NAME = "updateBadge";
@@ -37,10 +37,7 @@ export async function updateBadge(defaultStoreId) {
       chrome.action.setTitle({
         title: `${chrome.i18n.getMessage("extensionName")}${tooltipCount}`,
       });
-      if (
-        scratchAddons.localState.addonsEnabled["msg-count-badge"] &&
-        !scratchAddons.muted
-      ) {
+      if (scratchAddons.localState.addonsEnabled["msg-count-badge"] && !scratchAddons.muted) {
         // Do not show 0, unless that 0 means logged out
         if (count || !isLoggedIn) {
           const color = isLoggedIn ? badgeSettings.color : "#dd2222";


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/pull/7317#issuecomment-2045141524

### Changes

This Pull Request adds the Extension badge status (exact message count/offline) to the Extension icon's tooltip.
- No unread messages, online: *Scratch Addons*
- x unread messages: *Scratch Addons (x)*
- Offline: *Scratch Addons (?)*

### Reason for changes

This feature provides a quick way to check the exact message count when the Extension badge is hidden or the message count is cut off or shortened (#7317).

### Tests

**Tested on Chromium 126.0 and Firefox 125.0**