### PR TITLE
Full area updates

### DIFF
--- a/addons/full-signature/addon.json
+++ b/addons/full-signature/addon.json
@@ -19,26 +19,32 @@
   ],
   "settings": [
     {
-      "name": "Show scroll for \"What I've been doing\"",
+      "name": "What I've been doing",
       "id": "whatworkingon",
       "type": "boolean",
       "default": true
     },
     {
-      "name": "Show scroll for \"What's Happening?\"",
+      "name": "What's Happening?",
       "id": "whathappen",
       "type": "boolean",
       "default": true
     },
     {
-      "name": "Show scroll for forum signatures",
+      "name": "Forum signatures",
       "id": "signature",
       "type": "boolean",
       "default": true
     },
     {
-      "name": "Show scroll for forum Scratchblocks",
+      "name": "Forum Scratchblocks",
       "id": "blocks",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Project titles",
+      "id": "titles",
       "type": "boolean",
       "default": true
     }
@@ -55,6 +61,10 @@
       "url": "happen.js",
       "matches": ["https://scratch.mit.edu/"],
       "runAtComplete": false
+    },
+    {
+      "url": "disable.js",
+      "matches": ["projects", "profiles", "topics"]
     }
   ],
   "userstyles": [
@@ -84,6 +94,13 @@
       "matches": ["https://scratch.mit.edu/"],
       "if": {
         "settings": { "whathappen": true }
+      }
+    },
+    {
+      "url": "titles.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": { "titles": true }
       }
     }
   ],

--- a/addons/full-signature/disable.js
+++ b/addons/full-signature/disable.js
@@ -1,0 +1,8 @@
+export default async function ({ addon, console }) {
+  addon.self.addEventListener("disabled", () => {
+    document.querySelectorAll(".activity-stream, .activity-ul, .postsignature, .project-title.no-edit, .scratchblocks, .blocks3").forEach((el) => {
+      el.scrollTop = 0;
+      el.scrollLeft = 0;
+    });
+  });
+}

--- a/addons/full-signature/disable.js
+++ b/addons/full-signature/disable.js
@@ -1,8 +1,12 @@
 export default async function ({ addon, console }) {
   addon.self.addEventListener("disabled", () => {
-    document.querySelectorAll(".activity-stream, .activity-ul, .postsignature, .project-title.no-edit, .scratchblocks, .blocks3").forEach((el) => {
-      el.scrollTop = 0;
-      el.scrollLeft = 0;
-    });
+    document
+      .querySelectorAll(
+        ".activity-stream, .activity-ul, .postsignature, .project-title.no-edit, .scratchblocks, .blocks3"
+      )
+      .forEach((el) => {
+        el.scrollTop = 0;
+        el.scrollLeft = 0;
+      });
   });
 }

--- a/addons/full-signature/signature.css
+++ b/addons/full-signature/signature.css
@@ -1,4 +1,5 @@
 .postsignature {
   overflow-y: auto !important;
   max-height: 168px;
+  scrollbar-width: thin;
 }

--- a/addons/full-signature/titles.css
+++ b/addons/full-signature/titles.css
@@ -1,0 +1,4 @@
+.preview .project-title.no-edit {
+  overflow-x: auto;
+  text-overflow: clip;
+}


### PR DESCRIPTION
Mostly Resolves #3858
Closes #5609

### Changes

- Scrolls to the top-left when dynamically disabled
- Uses thin scrollbars on signatures
- Adds the option to scroll project titles
- Shortens the setting names

### Reason for changes

Being able to scroll other's project titles is nice and leaving half-scrolled areas when disabling isn't ideal.

### Tests

Tested on Chromium
