### PR TITLE
dark-www: fix fully transparent borders

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -76,6 +76,30 @@
       }
     },
     {
+      "name": "page-divider5",
+      "value": {
+        "type": "textColor",
+        "black": "rgba(0, 0, 0, 0.05)",
+        "white": "rgba(255, 255, 255, 0.05)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "page"
+        }
+      }
+    },
+    {
+      "name": "page-divider15",
+      "value": {
+        "type": "textColor",
+        "black": "rgba(0, 0, 0, 0.15)",
+        "white": "rgba(255, 255, 255, 0.15)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "page"
+        }
+      }
+    },
+    {
       "name": "page-colorScheme",
       "value": {
         "type": "textColor",
@@ -423,6 +447,18 @@
       }
     },
     {
+      "name": "box-tab15",
+      "value": {
+        "type": "textColor",
+        "black": "rgba(0, 0, 0, 0.15)",
+        "white": "rgba(255, 255, 255, 0.15)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
+    },
+    {
       "name": "box-tabHover",
       "value": {
         "type": "textColor",
@@ -478,6 +514,18 @@
         "black": "rgba(0, 0, 0, 0.05)",
         "white": "rgba(255, 255, 255, 0.05)",
         "threshold": 32,
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
+    },
+    {
+      "name": "box-divider5",
+      "value": {
+        "type": "textColor",
+        "black": "rgba(0, 0, 0, 0.05)",
+        "white": "rgba(255, 255, 255, 0.05)",
         "source": {
           "type": "settingValue",
           "settingId": "box"
@@ -764,19 +812,28 @@
     {
       "name": "box-scratchr2ButtonBorder",
       "value": {
-        "type": "alphaBlend",
-        "opaqueSource": {
+        "type": "alphaThreshold",
+        "source": {
           "type": "settingValue",
-          "settingId": "box"
+          "settingId": "border"
         },
-        "transparentSource": {
-          "type": "brighten",
-          "source": {
+        "opaque": {
+          "type": "alphaBlend",
+          "opaqueSource": {
             "type": "settingValue",
-            "settingId": "border"
+            "settingId": "box"
           },
-          "a": 0.67
-        }
+          "transparentSource": {
+            "type": "brighten",
+            "source": {
+              "type": "settingValue",
+              "settingId": "border"
+            },
+            "a": 0.67
+          }
+        },
+        "transparent": "transparent",
+        "threshold": 0.05
       }
     },
     {
@@ -859,6 +916,18 @@
         "type": "textColor",
         "black": "rgba(0, 0, 0, 0.1)",
         "white": "rgba(255, 255, 255, 0.1)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "gray"
+        }
+      }
+    },
+    {
+      "name": "gray-divider15",
+      "value": {
+        "type": "textColor",
+        "black": "rgba(0, 0, 0, 0.15)",
+        "white": "rgba(255, 255, 255, 0.15)",
         "source": {
           "type": "settingValue",
           "settingId": "gray"
@@ -1251,30 +1320,39 @@
     {
       "name": "blue-studioTextareaBorder",
       "value": {
-        "type": "makeHsv",
-        "h": {
+        "type": "alphaThreshold",
+        "source": {
           "type": "settingValue",
           "settingId": "border"
         },
-        "s": {
-          "type": "settingValue",
-          "settingId": "border"
-        },
-        "v": {
-          "type": "alphaBlend",
-          "opaqueSource": {
+        "opaque": {
+          "type": "makeHsv",
+          "h": {
             "type": "settingValue",
-            "settingId": "blue"
+            "settingId": "border"
           },
-          "transparentSource": {
-            "type": "brighten",
-            "source": {
+          "s": {
+            "type": "settingValue",
+            "settingId": "border"
+          },
+          "v": {
+            "type": "alphaBlend",
+            "opaqueSource": {
               "type": "settingValue",
-              "settingId": "border"
+              "settingId": "blue"
             },
-            "a": 0.79
+            "transparentSource": {
+              "type": "brighten",
+              "source": {
+                "type": "settingValue",
+                "settingId": "border"
+              },
+              "a": 0.79
+            }
           }
-        }
+        },
+        "transparent": "transparent",
+        "threshold": 0.05
       }
     },
     {
@@ -1769,6 +1847,18 @@
         "type": "textColor",
         "black": "none",
         "white": "brightness(0) invert(1)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "footer"
+        }
+      }
+    },
+    {
+      "name": "footer-divider10",
+      "value": {
+        "type": "textColor",
+        "black": "rgba(0, 0, 0, 0.1)",
+        "white": "rgba(255, 255, 255, 0.1)",
         "source": {
           "type": "settingValue",
           "settingId": "footer"

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -238,18 +238,33 @@ input::placeholder {
 .postfootright {
   box-shadow: 1px 0 inset var(--darkWww-box-scratchr2Border);
 }
+.modal-header {
+  border-color: var(--darkWww-box-divider5);
+}
+.nvd3 .nv-axis line /* statistics */ {
+  stroke: var(--darkWww-box-tab);
+}
+.djangobb hr /* signature divider */ {
+  background-color: var(--darkWww-box-tabHover);
+}
+.nvd3 line.nv-guideline /* statistics */ {
+  stroke: var(--darkWww-box-tabHover);
+}
 button,
 .button.grey {
+  background-color: transparent;
   background-image: linear-gradient(
     var(--darkWww-box-scratchr2ButtonGradientTop),
     var(--darkWww-box-scratchr2ButtonGradientBottom)
   );
+  background-clip: padding-box;
   border-color: var(--darkWww-box-scratchr2ButtonBorder);
   color: var(--darkWww-box-scratchr2ButtonText);
   text-shadow: 0 1px var(--darkWww-box);
 }
 button:hover,
 .button.grey:hover {
+  background-color: transparent;
   background-image: linear-gradient(var(--darkWww-box-scratchr2ButtonHover), var(--darkWww-box-scratchr2ButtonHover));
 }
 .dropdown .dropdown-menu li:hover {
@@ -317,6 +332,10 @@ button:hover,
 }
 .modal-footer {
   box-shadow: 0 1px inset var(--darkWww-gray-boxHighlight);
+}
+.header-text .profile-details .group,
+.profile-details span.sa-ocular-status {
+  border-color: var(--darkWww-gray-divider15);
 }
 .v-tabs li.active,
 .v-tabs li.active:hover {
@@ -443,7 +462,6 @@ input.link.black:active,
 }
 
 /* Border color */
-.modal-header,
 #profile-box .player,
 .nvtooltip h3 /* statistics */ {
   border-color: var(--darkWww-border-5);
@@ -457,15 +475,11 @@ input.link.black:active,
 #email-resend-box {
   border-color: var(--darkWww-border);
 }
-.nvd3 .nv-axis line /* statistics */ {
-  stroke: var(--darkWww-border);
-}
 .sa-collapse-footer #footer,
 .thumb img,
 .djangobb blockquote,
 .media-list li,
 .media-item-content .media-thumb img,
-.header-text .profile-details .group,
 .slider-carousel .thumb img,
 #comments #comments-enabled-box,
 .table td,
@@ -513,15 +527,9 @@ select,
   border-color: var(--darkWww-border-20);
   border-top-color: var(--darkWww-border-5);
 }
-.djangobb hr {
-  background-color: var(--darkWww-border-20);
-}
 .markItUpHeader ul .markItUpSeparator {
   background-color: var(--darkWww-border-20) !important;
   color: transparent;
-}
-.nvd3 line.nv-guideline /* statistics */ {
-  stroke: var(--darkWww-border-20);
 }
 .modal,
 .markItUpHeader ul ul {

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -43,6 +43,17 @@ body {
 .project-favorites.favorited::before {
   filter: none;
 }
+.about .masthead div li:nth-child(odd) {
+  border-color: var(--darkWww-page-divider5);
+}
+.developers #donate,
+.conf2021-panel,
+.conf2019-panel,
+.conf2017-panel,
+.plan section,
+.extension-landing hr {
+  border-color: var(--darkWww-page-divider15);
+}
 
 /* Navigation bar background */
 #navigation,
@@ -143,7 +154,6 @@ body:not(.sa-body-editor) .formik-input,
 body:not(.sa-body-editor) [class*="stage-header_stage-size-row_"] > *,
 body:not(.sa-body-editor) [class*="stage-header_stage-button_"],
 .studio-adder-section .studio-adder-row input,
-.studio-adder-section .studio-adder-row .studio-adder-vertical-divider,
 .avatar-item img,
 .join-flow-outer-content /* username change */,
 .conf2019-panel-flag,
@@ -252,6 +262,9 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .os-chooser .button {
   background-color: var(--darkWww-box-tab);
 }
+.navigation .dot {
+  background-color: var(--darkWww-box-tab15);
+}
 .sub-nav button:active {
   background-color: var(--darkWww-box-tabHover);
 }
@@ -279,6 +292,9 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .transfer-host-modal .button:disabled {
   background-color: var(--darkWww-box-buttonDisabled);
   color: white;
+}
+.tips-divider {
+  border-color: var(--darkWww-box-divider5);
 }
 body:not(.sa-body-editor) .select .join-flow-select {
   background-image: var(--darkWww-box-caret);
@@ -315,6 +331,9 @@ body:not(.sa-body-editor) .outer .sort-mode .select select:focus {
 .box .box-header {
   border-top-color: var(--darkWww-gray-boxHighlight);
 }
+.outer .sort-controls {
+  border-color: var(--darkWww-gray-tab);
+}
 .toggle-switch .slider {
   background-color: var(--darkWww-gray-darker);
 }
@@ -334,6 +353,7 @@ body:not(.sa-body-editor) .outer .sort-mode .select select:focus {
 .studio-list-outer-scrollbox,
 .social-form,
 .studio-page,
+.studio-adder-section .studio-adder-row .studio-adder-vertical-divider,
 .user-projects-modal .user-projects-modal-content,
 .congratulations-page .congratulations-image-layout,
 .credits #acknowledgements,
@@ -378,12 +398,15 @@ body:not(.sa-body-editor) .gender-radio-row:hover,
 .studio-info-box .studio-info-close-button {
   background-color: var(--darkWww-blue-tab);
 }
+.studio-adder-section .studio-adder-row .studio-adder-vertical-divider,
+.extension-landing .blue hr {
+  border-color: var(--darkWww-blue-tab);
+}
 .studio-list-inner-scrollbox::-webkit-scrollbar-thumb {
   background-color: var(--darkWww-blue-tabHover);
 }
 .studio-info textarea.studio-title:not(:focus),
-.studio-info textarea.studio-description:not(:focus),
-.extension-landing .blue hr {
+.studio-info textarea.studio-description:not(:focus) {
   border-color: var(--darkWww-blue-studioTextareaBorder);
 }
 .install-scratch .downloads-container .horizontal-divider::before,
@@ -616,10 +639,12 @@ a:hover {
 img.tips-icon {
   filter: var(--darkWww-footer-filter);
 }
+.developers #faq,
+#footer .inner .collaborators /* 2018 conference sponsors */ {
+  border-color: var(--darkWww-footer-divider10);
+}
 
 /* Border color */
-.tips-divider,
-.about .masthead div li:nth-child(odd),
 .about .body,
 .about .body img,
 .about .body iframe,
@@ -637,15 +662,12 @@ body:not(.sa-body-editor) .select select,
 .action-button.close-button,
 .sa-collapse-footer #footer,
 .empty,
-.outer .sort-controls,
 .preview .comments-container .comments-turned-off,
 .comment .comment-body .comment-bubble,
 .comment .comment-body .comment-bubble::before,
 .studio-tab-nav a.nav_link:hover > li,
 .studio-info-box,
-.developers #faq,
 p.callout,
-#footer .inner .collaborators,
 .input,
 .row .col-sm-9 input[type="radio"]:not(:checked),
 .extension-landing .tip-box {
@@ -677,26 +699,19 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button_"],
 .studio-tab-nav a.nav_link > li,
 .studio-project-tile,
 .studio-adder-section .studio-adder-row input,
-.studio-adder-section .studio-adder-row .studio-adder-vertical-divider,
 .user-projects-modal .user-projects-modal-nav button,
 .studio-member-tile,
 .studio-activity .studio-messages-list,
 .developers #projects h3,
 .developers #principles h3,
-.developers #donate,
 .information-page .info-outer nav,
-.conf2021-panel,
-.conf2019-panel,
 .conf2019-panel-flag,
-.conf2017-panel,
 .conf2017-panel-flag,
 .expect .schedule table th,
 .expect .schedule table td,
-.plan section,
 .plan .faq .short,
 .supporters-section .supporters-level hr,
 body:not(.sa-body-editor) input[type="radio"].formik-radio-button,
-.extension-landing hr,
 .extension-landing .screenshot,
 .extension-landing .project-card,
 .extension-landing .hardware-card,
@@ -707,9 +722,6 @@ body:not(.sa-body-editor) input[type="radio"].formik-radio-button,
 .studio-compose-container .sa-emoji-picker,
 .sa-emoji-picker-divider {
   border-color: var(--darkWww-border-15);
-}
-.navigation .dot {
-  background-color: var(--darkWww-border-15);
 }
 .navigation .dot.active {
   background-color: #4d97ff;

--- a/libraries/common/cs/text-color.js
+++ b/libraries/common/cs/text-color.js
@@ -100,7 +100,7 @@ function brighten(hex, c) {
     r: (1 - c.r) * 255 + c.r * r,
     g: (1 - c.g) * 255 + c.g * g,
     b: (1 - c.b) * 255 + c.b * b,
-    a: 1 - c.a + c.a * a,
+    a: a ? 1 - c.a + c.a * a : 0,
   });
 }
 


### PR DESCRIPTION
Resolves #5945

### Changes

Website dark mode generates variants of the border color with different opacity. This change makes those generated colors fully transparent if the selected border color is fully transparent. It also makes certain elements, such as grid lines on the Statistics page and some separators, unaffected by the border color.

### Reason for changes

To make completely removing borders (by setting the border color opacity to zero) possible. This will allow the user to create a theme similar to #7722.

### Tests

Tested on Edge and Firefox.