### PR TITLE
Check if chrome.scripting exists before using it

### DIFF
--- a/background/firefox-localhost-support.js
+++ b/background/firefox-localhost-support.js
@@ -1,4 +1,4 @@
-if (typeof browser === "object") {
+if (typeof browser === "object" && chrome.scripting) {
   const manifest = chrome.runtime.getManifest();
   const manifestScripts = manifest.content_scripts.filter((script) =>
     script.matches.includes("http://localhost:8602/*")


### PR DESCRIPTION
Tries to address #7761, not sure if this will fix it or not.

### Changes

Checks for the `chrome.scripting` API being available before using it in firefox-local-support.js, as it does not exist on Firefox for release builds (which do not have the `scripting` permission).

### Reason for changes

Without this, the extension completely breaks on Firefox.

### Tests

I think this is a Firefox-specific bug, so I only tested there. I tested by manually removing the `scripting` permission from manifest.json, and it seems to make the extension work.
