### PR TITLE
exact-count: explain that a click is required in studios

### DIFF
--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -16,6 +16,10 @@
   ],
   "info": [
     {
+      "id": "studioClick",
+      "text": "To see the exact number of projects in a studio, click the \"100+\" on the Projects tab. The \"exact count for studios\" setting below needs to be enabled."
+    },
+    {
       "id": "setting-removal",
       "text": "The forum setting has been removed since the ScratchDB database used by it is offline."
     }

--- a/addons/exact-count/addon.json
+++ b/addons/exact-count/addon.json
@@ -17,7 +17,7 @@
   "info": [
     {
       "id": "studioClick",
-      "text": "To see the exact number of projects in a studio, click the \"100+\" on the Projects tab. The \"exact count for studios\" setting below needs to be enabled."
+      "text": "To see the exact number of projects in a studio, enable the \"exact count for studios\" setting below and click the \"100+\" label on the studio's Projects tab."
     },
     {
       "id": "setting-removal",


### PR DESCRIPTION
### Changes

Adds the following info to the exact count addon:
![image](https://github.com/user-attachments/assets/d09ea452-5e69-4beb-a23e-8d1ca3a588e5)

### Reason for changes

https://github.com/ScratchAddons/ScratchAddons/issues/7577#issuecomment-2317063674

### Tests

Tested on Edge.