### PR TITLE
Mute for 4 hours and until tomorrow options

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -36,7 +36,7 @@
     "message": "Until tomorrow"
   },
   "untilEnabled": {
-    "message": "Until I turn it off"
+    "message": "Until turned off"
   },
   "muteFor": {
     "message": "Do not disturb"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -26,8 +26,11 @@
   "1hour": {
     "message": "For 1 hour"
   },
-  "nhours": {
-    "message": "For $1 hours"
+  "4hours": {
+    "message": "For 4 hours"
+  },
+  "8hours": {
+    "message": "For 8 hours"
   },
   "untilTomorrow": {
     "message": "Until tomorrow"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -26,14 +26,14 @@
   "1hour": {
     "message": "For 1 hour"
   },
-  "8hours": {
-    "message": "For 8 hours"
+  "nhours": {
+    "message": "For $1 hours"
   },
-  "24hours": {
-    "message": "For 24 hours"
+  "untilTomorrow": {
+    "message": "Until tomorrow"
   },
   "untilEnabled": {
-    "message": "Until I turn it back on"
+    "message": "Until I turn it off"
   },
   "muteFor": {
     "message": "Do not disturb"

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -23,7 +23,7 @@ const periods = [
     mins: "tomorrow",
   },
   {
-    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("untilEnabled")) || "Until I turn it off",
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("untilEnabled")) || "Until turned off",
     mins: Infinity,
   },
 ];

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -11,15 +11,19 @@ const periods = [
     mins: 60,
   },
   {
-    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("8hours")) || "8 hours",
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("nhours", "4")) || "4 hours",
+    mins: 240,
+  },
+  {
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("nhours", "8")) || "8 hours",
     mins: 480,
   },
   {
-    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("24hours")) || "24 hours",
-    mins: 1440,
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("untilTomorrow")) || "Until tomorrow",
+    mins: "tomorrow",
   },
   {
-    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("untilEnabled")) || "Until I turn it back on",
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("untilEnabled")) || "Until I turn it off",
     mins: Infinity,
   },
 ];
@@ -37,9 +41,18 @@ let currentMenuItem = null;
 
 chrome.contextMenus?.onClicked.addListener(({ parentMenuItemId, menuItemId }) => {
   if (parentMenuItemId === "mute") {
-    const mins = Number(menuItemId.split("_")[1]);
+    const mins = menuItemId.split("_")[1];
     contextMenuMuted();
-    muteForMins(mins);
+    if (mins === "tomorrow") {
+      const now = new Date();
+      const tomorrow = new Date();
+      tomorrow.setDate(now.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+      const differenceinMins = Math.ceil(tomorrow.getTime() / 60000 - now.getTime() / 60000);
+      muteForMins(differenceinMins);
+    } else {
+      muteForMins(Number(mins));
+    }
   } else if (menuItemId === "unmute") {
     contextMenuUnmuted();
     unmute();

--- a/background/handle-notifications.js
+++ b/background/handle-notifications.js
@@ -11,11 +11,11 @@ const periods = [
     mins: 60,
   },
   {
-    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("nhours", "4")) || "4 hours",
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("4hours")) || "4 hours",
     mins: 240,
   },
   {
-    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("nhours", "8")) || "8 hours",
+    name: (chrome.i18n.getMessage && chrome.i18n.getMessage("8hours")) || "8 hours",
     mins: 480,
   },
   {


### PR DESCRIPTION
### Changes

Changes the "Do not disturb" context submenu:
- Removes the "24 hours" option and replaces it with "until tomorrow", which lasts until midnight the next day.
- Also adds a "4 hours" option.

![Scratch Addons extension action dropdown with "Do not disturb" selection submenu with options "For 15 minutes", "For 1 hour", "For 4 hours", "For 8 hours", "Until tomorrow", and "Until turned off"](https://github.com/user-attachments/assets/a3095faa-8fe6-4b0f-81e3-98ac128ad93a)

### Reason for changes

24 hours would most often be used to prevent distractions for an entire day, but that could have the potential to extend several hours into the following day.

### Tests

Tested in Edge 128.
