### PR TITLE
Add new item to `editor-theme3` credits

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -17,6 +17,7 @@
       "name": "Shock59",
       "link": "https://github.com/shock59"
     },
+    { "name": "0znzw", "link": "https://scratch.mit.edu/users/0znzw" },
     { "name": "Jazza", "link": "https://scratch.mit.edu/users/greeny--231" }
   ],
   "info": [


### PR DESCRIPTION
This does not resolve any issues, its just a change the editor-them3/addon.json, the link used in https://github.com/ScratchAddons/ScratchAddons/pull/7509/files#r1685494153 was dead because I changed my github account to what it is now so I am just adding a working link as it was in the original pr, nothing other than that :P