### PR TITLE
New addon: `svg-path-editor`

### DIFF
--- a/addons-l10n/en/svg-path-editor.json
+++ b/addons-l10n/en/svg-path-editor.json
@@ -1,0 +1,4 @@
+{
+    "svg-path-editor/save": "Save",
+    "svg-path-editor/label": "Edit Path"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -158,6 +158,7 @@
   "asset-conflict-dialog",
   "remaining-replies",
   "forum-user-agent",
+  "svg-path-editor",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/svg-path-editor/addon.json
+++ b/addons/svg-path-editor/addon.json
@@ -1,0 +1,31 @@
+{
+  "name": "SVG path editor",
+  "description": "Changing the path of a shape in the Costume Editor with text.",
+  "tags": ["editor", "costumeEditor"],
+  "info": [
+    {
+      "type": "info",
+      "text": "It is enabled only when one figure is selected.",
+      "id": "enablingValidity"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Masaabu-YT",
+      "link": "https://scratch.mit.edu/Masaabu-YT/"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "style.css",
+      "matches": ["projects"]
+    }
+  ],
+  "versionAdded": "1.40.0"
+}

--- a/addons/svg-path-editor/image.svg
+++ b/addons/svg-path-editor/image.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="20px" height="20px" >
+  <g stroke-width="0.75" stroke="#855CD6">
+    <circle cx="5" cy="5" r="3" fill="#FFFFFF"/>
+    <circle cx="15" cy="15" r="3" fill="#FFFFFF"/>
+    <path d="M7 7l6 6"/>
+  </g>
+</svg>

--- a/addons/svg-path-editor/style.css
+++ b/addons/svg-path-editor/style.css
@@ -1,0 +1,9 @@
+.sa-svg-path-editor-svg {
+    margin: 1rem;
+    padding: 1rem;
+    background-color: hsla(215, 100%, 95%, 1);
+    border-radius: 1rem;
+}
+.sa-svg-path-editor-input {
+    margin: 0 1rem;
+}

--- a/addons/svg-path-editor/userscript.js
+++ b/addons/svg-path-editor/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, console }) {
+export default async function ({ addon, console, msg }) {
   let button;
   let lastPaintMode;
 
@@ -21,12 +21,18 @@ export default async function ({ addon, console }) {
       const img = document.createElement("img");
       img.className = "labeled-icon-button_edit-field-icon_YEtkK";
       img.src = addon.self.dir + "/image.svg";
-      img.alt = "Edit Path";
-      img.title = "Edit Path";
+      img.alt = msg("label");
+      img.title = msg("label");
+      button.appendChild(img);
+
+      const label = document.createElement("span");
+      label.className = "labeled-icon-button_edit-field-title_0dBTI";
+      label.textContent = msg("label");
+      button.appendChild(label);
 
       button.addEventListener("click", async function () {
         if (button.classList.contains("button_mod-disabled_HvX8y")) return;
-        const { content, closeButton, remove } = addon.tab.createModal("Edit Path", {
+        const { content, closeButton, remove } = addon.tab.createModal(msg("label"), {
           isOpen: true
         })
         try {
@@ -65,13 +71,13 @@ export default async function ({ addon, console }) {
 
           const cancelButton = document.createElement("button");
           cancelButton.className = "button action-button close-button white";
-          cancelButton.textContent = "cancel";
+          cancelButton.textContent = addon.tab.scratchMessage("general.cancel");
           cancelButton.addEventListener("click", () => {remove()});
           footer.appendChild(cancelButton);
 
           const saveButton = document.createElement("button");
           saveButton.className = "button action-button submit-button";
-          saveButton.textContent = "save";
+          saveButton.textContent = msg("save");
           saveButton.addEventListener("click", () => {
             addon.tab.redux.state.scratchPaint.selectedItems[0].pathData = input.value;
             remove();
@@ -89,7 +95,6 @@ export default async function ({ addon, console }) {
       });
       if (addon.tab.redux.state.scratchPaint.selectedItems.length !== 1) button.classList.add("button_mod-disabled_HvX8y")
       else if (!addon.tab.redux.state.scratchPaint.selectedItems[0].pathData) button.classList.add("button_mod-disabled_HvX8y")
-      button.appendChild(img);
 
       await addon.tab.waitForElement("div.mode-tools_mode-tools_kuBCO")
       const toolbar = document.querySelector("div.mode-tools_mode-tools_kuBCO");

--- a/addons/svg-path-editor/userscript.js
+++ b/addons/svg-path-editor/userscript.js
@@ -1,0 +1,103 @@
+export default async function ({ addon, console }) {
+  let button;
+  let lastPaintMode;
+
+  await addon.tab.waitForElement("div.mode-tools_mode-tools_kuBCO", {  markAsSeen: true });
+  addon.tab.redux.initialize()
+  addon.tab.redux.addEventListener("statechanged", async function() {
+    button = document.querySelector(".sa-svg-path-editor-button")
+    const paintMode = addon.tab.redux.state.scratchPaint.mode;
+    if (lastPaintMode !== paintMode) { if (button) { button.remove() } };
+    lastPaintMode = paintMode;
+    if (
+      paintMode !== "SELECT" &&
+      paintMode !== "RESHAPE"
+    ) return;
+    if (!button) {
+      button = document.createElement("span")
+      button.className = "button_button_LhMbA labeled-icon-button_mod-edit-field_wieqn sa-svg-path-editor-button";
+      button.role = "button";
+
+      const img = document.createElement("img");
+      img.className = "labeled-icon-button_edit-field-icon_YEtkK";
+      img.src = addon.self.dir + "/image.svg";
+      img.alt = "Edit Path";
+      img.title = "Edit Path";
+
+      button.addEventListener("click", async function () {
+        if (button.classList.contains("button_mod-disabled_HvX8y")) return;
+        const { content, closeButton, remove } = addon.tab.createModal("Edit Path", {
+          isOpen: true
+        })
+        try {
+          const pathData = addon.tab.redux.state.scratchPaint.selectedItems[0].pathData;
+
+          const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+          svg.classList.add("sa-svg-path-editor-svg");
+          svg.setAttribute("height", "200px");
+
+          const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+          path.setAttribute("stroke", "#009dec");
+          path.setAttribute("stroke-width", "3");
+          path.setAttribute("fill", "none");
+
+          svg.appendChild(path)
+          content.appendChild(svg)
+
+          async function setPath(d) {
+            path.setAttribute("d", d)
+            const bbox = path.getBBox();
+            svg.setAttribute("viewBox", `${bbox.x-3} ${bbox.y-3} ${bbox.width+3} ${bbox.height+3}`);
+          }
+
+          const input = document.createElement("input");
+          input.className = "input_input-form_w8QAP sa-svg-path-editor-input";
+          input.value = pathData;
+          input.addEventListener("input", () => {
+            setPath(input.value)
+          });
+          content.appendChild(input);
+
+          setPath(input.value)
+
+          const footer = document.createElement("div");
+          footer.className = "action-buttons";
+
+          const cancelButton = document.createElement("button");
+          cancelButton.className = "button action-button close-button white";
+          cancelButton.textContent = "cancel";
+          cancelButton.addEventListener("click", () => {remove()});
+          footer.appendChild(cancelButton);
+
+          const saveButton = document.createElement("button");
+          saveButton.className = "button action-button submit-button";
+          saveButton.textContent = "save";
+          saveButton.addEventListener("click", () => {
+            addon.tab.redux.state.scratchPaint.selectedItems[0].pathData = input.value;
+            remove();
+          });
+          footer.appendChild(saveButton);
+
+          content.appendChild(footer)
+
+          closeButton.addEventListener("click", () => {
+            remove();
+          });
+        } catch (e) {
+          remove()
+        }
+      });
+      if (addon.tab.redux.state.scratchPaint.selectedItems.length !== 1) button.classList.add("button_mod-disabled_HvX8y")
+      else if (!addon.tab.redux.state.scratchPaint.selectedItems[0].pathData) button.classList.add("button_mod-disabled_HvX8y")
+      button.appendChild(img);
+
+      await addon.tab.waitForElement("div.mode-tools_mode-tools_kuBCO")
+      const toolbar = document.querySelector("div.mode-tools_mode-tools_kuBCO");
+      toolbar.appendChild(button);
+    } else {
+      if (addon.tab.redux.state.scratchPaint.selectedItems.length !== 1) button.classList.add("button_mod-disabled_HvX8y")
+      else if (!addon.tab.redux.state.scratchPaint.selectedItems[0].pathData) button.classList.add("button_mod-disabled_HvX8y")
+      else button.classList.remove("button_mod-disabled_HvX8y")
+    }
+  })
+}


### PR DESCRIPTION
### Changes
Created an addon to add a button to change the path of a shape with text in the Costume Editor.

https://github.com/user-attachments/assets/6ab6a290-9a24-43c0-b34b-7f83e1ab1486

### Reason for changes
I sometimes edit SVG path and have always had to export the costume, edit it, and upload it again, but I created this addon to make that easier.

### Tests
Tested with Chrome for Windows