### PR TITLE
Better comment capturing

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -783,17 +783,16 @@ const isProject = pathArr[0] === "projects";
 const isForums = pathArr[0] === "discuss";
 
 if (isProfile || isStudio || isProject || isForums) {
-  const removeReiteratedChars = (string) =>
-    string
-      .split("")
-      .filter((char, i, charArr) => (i === 0 ? true : charArr[i - 1] !== char))
-      .join("");
-
   const shouldCaptureComment = (value) => {
-    const trimmedValue = value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, ""); // Trim like scratchr2
-    const limitedValue = removeReiteratedChars(trimmedValue.toLowerCase().replace(/[^a-z]+/g, ""));
-    const regex = /scratchadons/;
-    return regex.test(limitedValue);
+    // Catch references to Scratch Addons
+    const saRegex = /(scratc|cratc|sratc|scatc|scrac|scrat|scart|scarct)h\s*(ad{1,3}[-\s]*on)/i;
+    // Catch references to the Chrome Web Store
+    const storeRegex = /web\s*store/i;
+
+    for (const regex of [saRegex, storeRegex]) {
+      if (regex.test(value)) return true;
+    }
+    return false;
   };
   const extensionPolicyLink = document.createElement("a");
   extensionPolicyLink.href = "https://scratch.mit.edu/discuss/topic/284272/";

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -785,7 +785,7 @@ const isForums = pathArr[0] === "discuss";
 if (isProfile || isStudio || isProject || isForums) {
   const shouldCaptureComment = (value) => {
     // Catch references to Scratch Addons
-    const saRegex = /(scratc|cratc|sratc|scatc|scrac|scrat|scart|scarct)h\s*(ad{1,3}[-\s]*on)/i;
+    const saRegex = /(scratc|cratc|sratc|scatc|scrac|scrat|scart|scartc|scract)h\s*(ad{1,3}[-\s]*on)/i;
     // Catch references to the Chrome Web Store
     const storeRegex = /web\s*store/i;
 

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -73,7 +73,7 @@ export default async ({ addon, msg, safeMsg }) => {
       postComment() {
         const shouldCaptureComment = (value) => {
           // Catch references to Scratch Addons
-          const saRegex = /(scratc|cratc|sratc|scatc|scrac|scrat|scart|scarct)h\s*(ad{1,3}[-\s]*on)/i;
+          const saRegex = /(scratc|cratc|sratc|scatc|scrac|scrat|scart|scartc|scract)h\s*(ad{1,3}[-\s]*on)/i;
           // Catch references to the Chrome Web Store
           const storeRegex = /web\s*store/i;
 

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -71,17 +71,16 @@ export default async ({ addon, msg, safeMsg }) => {
     },
     methods: {
       postComment() {
-        const removeReiteratedChars = (string) =>
-          string
-            .split("")
-            .filter((char, i, charArr) => (i === 0 ? true : charArr[i - 1] !== char))
-            .join("");
         const shouldCaptureComment = (value) => {
-          // From content-scripts/cs.js
-          const trimmedValue = value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, ""); // Trim like scratchr2
-          const limitedValue = removeReiteratedChars(trimmedValue.toLowerCase().replace(/[^a-z]+/g, ""));
-          const regex = /scratchadons/;
-          return regex.test(limitedValue);
+          // Catch references to Scratch Addons
+          const saRegex = /(scratc|cratc|sratc|scatc|scrac|scrat|scart|scarct)h\s*(ad{1,3}[-\s]*on)/i;
+          // Catch references to the Chrome Web Store
+          const storeRegex = /web\s*store/i;
+
+          for (const regex of [saRegex, storeRegex]) {
+            if (regex.test(value)) return true;
+          }
+          return false;
         };
         if (shouldCaptureComment(this.replyBoxValue)) {
           alert(chrome.i18n.getMessage("captureCommentError", [chrome.i18n.getMessage("captureCommentPolicy")]));


### PR DESCRIPTION
### Changes

Improves the regular expressions that catch comments that include "Scratch Addons". It now catches a few different misspellings of "Scratch" and matches "add-on" without an "s" and/or with a hyphen or whitespace in the middle. There's also now a regex test for "web store" or "webstore" as in the Chrome Web Store.

### Tests

I did not test the code on Scratch (I don't want to post something by accident), but I still made sure the updated code works.

Is this good, @WorldLanguages?