### PR TITLE
Fix `addon.tab.scratchClass()` not supporting classes with "+"

### DIFF
--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -284,9 +284,10 @@ function loadClasses() {
         .flat()
         .map((e) => e.selectorText)
         .filter((e) => e)
-        .map((e) => e.match(/(([\w-]+?)_([\w-]+)_([\w\d-]+))/g))
+        .map((e) => e.match(/(([\w-]+?)_([\w-]+)_(([\w\d-]|\\\+)+))/g))
         .filter((e) => e)
         .flat()
+        .map((e) => e.replace(/\\\+/g, "+"))
     ),
   ];
   scratchAddons.classNames.loaded = true;


### PR DESCRIPTION
Resolves #7786

### Changes

Changes `addon.tab.scratchClass()` to handle classes containing a plus sign correctly.

### Reason for changes

The hashes at the end of some class names now contain a plus sign. This broke the `echo-effect` addon because it uses one of those classes.

### Tests

Tested on Edge and Firefox.