### PR TITLE
Fix tooltip CSS

### DIFF
--- a/addons/better-img-uploads/style.css
+++ b/addons/better-img-uploads/style.css
@@ -1,3 +1,5 @@
+@import url("../../libraries/common/cs/react-tooltip.css");
+
 [data-for*="HD Upload"]:hover + .__react_component_tooltip {
   visibility: visible;
 }

--- a/addons/paint-by-default/addon.json
+++ b/addons/paint-by-default/addon.json
@@ -12,6 +12,12 @@
       "matches": ["projects"]
     }
   ],
+  "userstyles": [
+    {
+      "url": "../../libraries/common/cs/react-tooltip.css",
+      "matches": ["projects"]
+    }
+  ],
   "settings": [
     {
       "id": "sprite",

--- a/libraries/common/cs/react-tooltip.css
+++ b/libraries/common/cs/react-tooltip.css
@@ -1,0 +1,16 @@
+.__react_component_tooltip {
+  padding: 8px 21px;
+  color: white;
+}
+
+.__react_component_tooltip.place-left {
+  margin-left: -10px;
+}
+
+.__react_component_tooltip.place-right {
+  margin-left: 10px;
+}
+
+.__react_component_tooltip::after {
+  top: 50%;
+}


### PR DESCRIPTION
Resolves #7805

### Changes

Fixes the CSS of tooltips added/changed by `better-img-uploads` and `paint-by-default`. #7808 fixes the HD upload button.

### Tests

Tested on Edge and Firefox.