### PR TITLE
find-bar: show correct index of first result

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -709,7 +709,6 @@ export default async function ({ addon, msg, console }) {
       } else {
         this.remove();
         this.blocks = blocks;
-        item.appendChild(this.createDom());
 
         this.idx = 0;
         if (instanceBlock) {
@@ -721,6 +720,7 @@ export default async function ({ addon, msg, console }) {
             }
           }
         }
+        item.appendChild(this.createDom());
 
         if (this.idx < this.blocks.length) {
           this.utils.scrollBlockIntoView(this.blocks[this.idx]);


### PR DESCRIPTION
Resolves #7717

### Changes

Shows the index of the first result in the sprite when clicking an item in the find bar dropdown.

### Tests

Tested on Edge and Firefox.

https://github.com/user-attachments/assets/2fedff68-7f26-493d-89e2-b0d0852bf125