### PR TITLE
ctrl-enter-post: submit the right comment

### DIFF
--- a/addons/ctrl-enter-post/comments.js
+++ b/addons/ctrl-enter-post/comments.js
@@ -11,7 +11,7 @@ export default async function ({ addon, console, msg }) {
         return state.scratchGui.mode.isPlayerOnly;
       },
     });
-    var button;
+    let button;
     if (isScratchR2) {
       button = textbox.parentNode.parentNode.querySelector(".control-group:not(.tooltip) div[data-control='post'] a");
     } else {


### PR DESCRIPTION
Resolves #7585

### Changes

Changes a `var` declaration to `let`. This fixes the bug because `let` has block scope, which means that a new variable is created in every iteration.

### Tests

Tested on Edge and Firefox. This can be tested without posting anything - just click "reply" on two comment and press Ctrl+Enter in one of the text boxes. The error message should appear next to that text box.