### PR TITLE
cloud-games: fix add button position

### DIFF
--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -106,6 +106,10 @@ body {
   padding-top: 0.5rem;
 }
 
+.add-button .large-button {
+  display: inline-flex;
+}
+
 .opened {
   border: 1px solid var(--blue-variant);
 }


### PR DESCRIPTION
Resolves #7515

### Changes

Makes the "Add this project" button in the cloud games popup centered.

### Tests

Tested on Edge and Firefox.