### PR TITLE
`mediarecorder`: prefer mp4 over webm

### DIFF
--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -32,13 +32,13 @@ export default async ({ addon, console, msg }) => {
   };
 
   const mimeType = [
-    // Chrome and Firefox only support encoding as webm
+    // Prefer mp4 format over webm (Chrome and Safari)
+    "video/mp4",
+    // Chrome 125 and below and Firefox only support encoding as webm
     // VP9 is preferred as its playback is better supported across platforms
     "video/webm; codecs=vp9",
     // Firefox only supports encoding VP8
     "video/webm",
-    // Safari only supports encoding H264 as mp4
-    "video/mp4",
   ].find((i) => MediaRecorder.isTypeSupported(i));
   const fileExtension = mimeType.split(";")[0].split("/")[1];
 


### PR DESCRIPTION
Resolves comment https://github.com/ScratchAddons/ScratchAddons/pull/7058#discussion_r1760364692

### Changes

Downloads video files as mp4 on modern Chrome

### Reason for changes

It is a frequent request by users, and it's been supported since Chrome 126 (released June 2024)

### Tests

Not tested