### PR TITLE
Tweak list of enabled by default addons

### DIFF
--- a/addons/animated-thumb/addon.json
+++ b/addons/animated-thumb/addon.json
@@ -16,6 +16,5 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "tags": ["community", "projectPage", "recommended"],
-  "versionAdded": "1.3.0",
-  "enabledByDefault": true
+  "versionAdded": "1.3.0"
 }

--- a/addons/disable-sprite-wobble/addon.json
+++ b/addons/disable-sprite-wobble/addon.json
@@ -49,7 +49,7 @@
     }
   ],
   "tags": ["editor", "recommended"],
-  "enabledByDefault": false,
+  "enabledByDefault": true,
   "versionAdded": "1.24.0",
   "latestUpdate": {
     "version": "1.35.0",


### PR DESCRIPTION
Resolves #7708
Resolves #7830

### Changes

Disables `animated-thumb` by default and enables `disable-sprite-wobble` by default keeping the number the same as before.