### PR TITLE
editor-compact: fix sprite search bar in small stage mode

### DIFF
--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -225,7 +225,7 @@ button[class*="action-menu_more-button"] {
 .sa-search-sprites-container:hover,
 .sa-search-sprites-container:focus-within,
 .sa-search-sprites-container:not(.sa-search-sprites-empty) {
-  width: calc(100% - 5rem);
+  width: max(12rem, calc(100% - 5rem));
 }
 input.sa-search-sprites-box {
   padding-inline-start: 2rem;


### PR DESCRIPTION
### Changes

See https://github.com/ScratchAddons/ScratchAddons/pull/7822#discussion_r1789215426
![image](https://github.com/user-attachments/assets/6220fbc0-d11b-4c75-bd24-a5c38469cb4f)

### Tests

Tested on Edge.