### PR TITLE
editor-dark-mode: update debugger performance charts if they already exist

### DIFF
--- a/addons/editor-dark-mode/debugger.js
+++ b/addons/editor-dark-mode/debugger.js
@@ -20,6 +20,7 @@ export default async function ({ addon, console }) {
     }
   };
 
+  if (document.querySelector(".sa-debugger-chart")) updateCharts();
   window.addEventListener("saDebuggerPerformanceTabShown", updateCharts);
   addon.settings.addEventListener("change", updateCharts);
   addon.self.addEventListener("disabled", updateCharts);


### PR DESCRIPTION
### Changes

https://github.com/ScratchAddons/ScratchAddons/pull/7815#discussion_r1797843704

### Reason for changes

This fixes dynamically enabling dark mode when the performance tab is open.

### Tests

Tested on Edge and Firefox.