### PR TITLE
editor-theme3: Apply block colors to icons in "Make a block" popup

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -622,7 +622,7 @@ export default async function ({ addon, console, msg }) {
     while (true) {
       // Wait until "Make a block" popup is opened and icon elements are created
       const iconElement = await addon.tab.waitForElement("[class^=custom-procedures_option-icon_]", {
-          markAsSeen: true,
+        markAsSeen: true,
       });
       // Get img.src, remove data:image... header, then atob() decodes base64 to get the actual <svg> tags.
       let svg = atob(iconElement.src.replace(uriHeader, ""));

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -629,14 +629,15 @@ export default async function ({ addon, console, msg }) {
 
       // Find and replace the default color codes in the svg with our custom ones
       // Placeholder values are used to prevent hex codes replacing each other (see PR #7545 changes)
-      svg = svg.replace("#ff6680", "%primary%") // Primary block color
-      .replace("#ff4d6a", "%inner%") // Inside empty boolean/reporter input slots
-      .replace("#f35", "%outline%") // Border around edges of block
-      .replace("#fff", "%labeltext%") // Text color for "Add a label" icon
-      .replace("%primary%", primaryColor(myBlocksCategory))
-      .replace("%inner%", isColoredTextMode() ? fieldBackground(myBlocksCategory) : tertiaryColor(myBlocksCategory))
-      .replace("%outline%", tertiaryColor(myBlocksCategory))
-      .replace("%labeltext%", isColoredTextMode() ? tertiaryColor(myBlocksCategory) : uncoloredTextColor());
+      svg = svg
+        .replace("#ff6680", "%primary%") // Primary block color
+        .replace("#ff4d6a", "%inner%") // Inside empty boolean/reporter input slots
+        .replace("#f35", "%outline%") // Border around edges of block
+        .replace("#fff", "%labeltext%") // Text color for "Add a label" icon
+        .replace("%primary%", primaryColor(myBlocksCategory))
+        .replace("%inner%", isColoredTextMode() ? fieldBackground(myBlocksCategory) : tertiaryColor(myBlocksCategory))
+        .replace("%outline%", tertiaryColor(myBlocksCategory))
+        .replace("%labeltext%", isColoredTextMode() ? tertiaryColor(myBlocksCategory) : uncoloredTextColor());
 
       //console.log(svg);
       iconElement.src = uriHeader + btoa(svg); // Re-encode image to base64 and replace img.src

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -615,6 +615,29 @@ export default async function ({ addon, console, msg }) {
     Object.assign(originalColors, newColors);
   };
 
+  (async () => {
+    // Custom colors for "Add an input/label" block icons in the "Make a block" popup menu, by pumpkinhasapatch
+    const uriHeader = "data:image/svg+xml;base64,";
+    const myBlocksCategory = categories[9];
+    while (true) {
+      // Wait until "Make a block" popup is opened and icon elements are created
+      const iconElement = await addon.tab.waitForElement("[class^=custom-procedures_option-icon_]", {
+          markAsSeen: true,
+      });
+      // Get img.src, remove data:image... header, then atob() decodes base64 to get the actual <svg> tags.
+      let svg = atob(iconElement.src.replace(uriHeader, ""));
+
+      // Find and replace the default color codes in the svg with our custom ones
+      svg = svg.replace("#ff6680", primaryColor(myBlocksCategory));
+      svg = svg.replace("#ff4d6a", secondaryColor(myBlocksCategory));
+      svg = svg.replace("#f35", tertiaryColor(myBlocksCategory));
+      svg = svg.replace("#fff", uncoloredTextColor()); // Text color for "Add a label" icon
+
+      //console.log(svg);
+      iconElement.src = uriHeader + btoa(svg); // Re-encode image to base64 and replace img.src
+    }
+  })();
+
   while (true) {
     const colorModeSubmenu = await addon.tab.waitForElement(
       "[class*=menu-bar_menu-bar-menu_] > ul > li:nth-child(2) ul",

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -634,9 +634,9 @@ export default async function ({ addon, console, msg }) {
       .replace("#f35", "%outline%") // Border around edges of block
       .replace("#fff", "%labeltext%") // Text color for "Add a label" icon
       .replace("%primary%", primaryColor(myBlocksCategory))
-      .replace("%inner%", secondaryColor(myBlocksCategory))
+      .replace("%inner%", isColoredTextMode() ? fieldBackground(myBlocksCategory) : tertiaryColor(myBlocksCategory))
       .replace("%outline%", tertiaryColor(myBlocksCategory))
-      .replace("%labeltext%", uncoloredTextColor());
+      .replace("%labeltext%", isColoredTextMode() ? tertiaryColor(myBlocksCategory) : uncoloredTextColor());
 
       //console.log(svg);
       iconElement.src = uriHeader + btoa(svg); // Re-encode image to base64 and replace img.src

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -624,7 +624,8 @@ export default async function ({ addon, console, msg }) {
       const iconElement = await addon.tab.waitForElement("[class^=custom-procedures_option-icon_]", {
         markAsSeen: true,
         reduxEvents: ["scratch-gui/custom-procedures/ACTIVATE_CUSTOM_PROCEDURES"],
-        reduxCondition: (state) => state.scratchGui.editorTab.activeTabIndex === 0 && !state.scratchGui.mode.isPlayerOnly,
+        reduxCondition: (state) =>
+          state.scratchGui.editorTab.activeTabIndex === 0 && !state.scratchGui.mode.isPlayerOnly,
       });
       // Get img.src, remove data:image... header, then atob() decodes base64 to get the actual <svg> tags.
       let svg = atob(iconElement.src.replace(uriHeader, ""));

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -2,6 +2,12 @@ import { removeAlpha, multiply, brighten, alphaBlend } from "../../libraries/com
 import { updateAllBlocks } from "../../libraries/common/cs/update-all-blocks.js";
 
 const dataUriRegex = new RegExp("^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$");
+const uriHeader = "data:image/svg+xml;base64,";
+const myBlocksCategory = {
+  id: "myBlocks",
+  settingId: "custom-color",
+  colorId: "more",
+};
 const extensionsCategory = {
   id: null,
   settingId: "Pen-color",
@@ -57,11 +63,7 @@ const categories = [
     settingId: "data-lists-color",
     colorId: "data_lists",
   },
-  {
-    id: "myBlocks",
-    settingId: "custom-color",
-    colorId: "more",
-  },
+  myBlocksCategory,
   extensionsCategory,
   saCategory,
 ];
@@ -617,8 +619,6 @@ export default async function ({ addon, console, msg }) {
 
   (async () => {
     // Custom colors for "Add an input/label" block icons in the "Make a block" popup menu, by pumpkinhasapatch
-    const uriHeader = "data:image/svg+xml;base64,";
-    const myBlocksCategory = categories[9];
     while (true) {
       // Wait until "Make a block" popup is opened and icon elements are created
       const iconElement = await addon.tab.waitForElement("[class^=custom-procedures_option-icon_]", {

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -628,10 +628,15 @@ export default async function ({ addon, console, msg }) {
       let svg = atob(iconElement.src.replace(uriHeader, ""));
 
       // Find and replace the default color codes in the svg with our custom ones
-      svg = svg.replace("#ff6680", primaryColor(myBlocksCategory));
-      svg = svg.replace("#ff4d6a", secondaryColor(myBlocksCategory));
-      svg = svg.replace("#f35", tertiaryColor(myBlocksCategory));
-      svg = svg.replace("#fff", uncoloredTextColor()); // Text color for "Add a label" icon
+      // Placeholder values are used to prevent hex codes replacing each other (see PR #7545 changes)
+      svg = svg.replace("#ff6680", "%primary%") // Primary block color
+      .replace("#ff4d6a", "%inner%") // Inside empty boolean/reporter input slots
+      .replace("#f35", "%outline%") // Border around edges of block
+      .replace("#fff", "%labeltext%") // Text color for "Add a label" icon
+      .replace("%primary%", primaryColor(myBlocksCategory))
+      .replace("%inner%", secondaryColor(myBlocksCategory))
+      .replace("%outline%", tertiaryColor(myBlocksCategory))
+      .replace("%labeltext%", uncoloredTextColor());
 
       //console.log(svg);
       iconElement.src = uriHeader + btoa(svg); // Re-encode image to base64 and replace img.src

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -623,6 +623,8 @@ export default async function ({ addon, console, msg }) {
       // Wait until "Make a block" popup is opened and icon elements are created
       const iconElement = await addon.tab.waitForElement("[class^=custom-procedures_option-icon_]", {
         markAsSeen: true,
+        reduxEvents: ["scratch-gui/custom-procedures/ACTIVATE_CUSTOM_PROCEDURES"],
+        reduxCondition: (state) => state.scratchGui.editorTab.activeTabIndex === 0 && !state.scratchGui.mode.isPlayerOnly,
       });
       // Get img.src, remove data:image... header, then atob() decodes base64 to get the actual <svg> tags.
       let svg = atob(iconElement.src.replace(uriHeader, ""));


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #4036
Resolves [Scratch Addons Discord -> #bug-reports -> Custom block color not applied at make a block prompt buttons](https://discord.com/channels/806602307750985799/1213678804203995206)

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->

This is a small change to the Customizable block colors (editor-theme3) addon. It applies custom block colors to the "Add a input/label" button block-like icons in the "Make a block" popup modal by editing the icon's vector svg data.

### Reason for changes

<!-- Why should these changes be made? -->

In the latest version of Scratch Addons as of writing, custom block colors do not affect these icons in the "Make a block" modal and they appear in Scratch's default pink custom block color which is inconsistent. This pull request changes the colors of the icons to make them match the actual rendered blocks.

| Make a block popup currently | Make a block popup with this fix |
| - | - |
| <img src="https://github.com/user-attachments/assets/9acc30e4-71e0-4334-a98c-73679fc0ba63"> | ![Screenshot from 2024-10-19 06-08-46](https://github.com/user-attachments/assets/08a6083d-da55-4dee-b40d-6d4e06c42a4f) |


### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->

Tested on Chromium 129 with Scratch Addons v1.40.0-pre.

Try it yourself: [Download addon fork](https://github.com/pumpkinhasapatch/ScratchAddons/archive/refs/heads/make-a-block-icon-colors.zip) -> [Installation instructions](https://github.com/ScratchAddons/ScratchAddons#installation)

This has been tested with different block colors and the "Text Color" addon options like "Black" or "Colored on white/black background", like the color presets below.

| High Contrast blocks preset | Editor dark mode + Black preset |
| - | - |
![Screenshot from 2024-10-19 06-06-14](https://github.com/user-attachments/assets/0356b5ef-7232-4cc5-8d98-618211dc0059) | ![Screenshot from 2024-10-19 06-07-45](https://github.com/user-attachments/assets/28092ee3-0d18-4ef3-9805-20870a5110ae) |

