### PR TITLE
Use new `resizeEvent` option in more addons

### DIFF
--- a/addons/download-button/style.css
+++ b/addons/download-button/style.css
@@ -48,8 +48,7 @@
   animation-iteration-count: 1, infinite;
 }
 
-@media (max-width: 767px) {
-  /* $tablet-portrait - 1px */
+@media (max-width: 767px) /* $tablet-portrait - 1px */ {
   #sa-download-button {
     display: none;
   }

--- a/addons/download-button/style.css
+++ b/addons/download-button/style.css
@@ -48,7 +48,8 @@
   animation-iteration-count: 1, infinite;
 }
 
-@media (max-width: 767px) { /* $tablet-portrait - 1px */
+@media (max-width: 767px) {
+  /* $tablet-portrait - 1px */
   #sa-download-button {
     display: none;
   }

--- a/addons/download-button/style.css
+++ b/addons/download-button/style.css
@@ -47,3 +47,9 @@
   animation-delay: 0s, 0.25s;
   animation-iteration-count: 1, infinite;
 }
+
+@media (max-width: 767px) { /* $tablet-portrait - 1px */
+  #sa-download-button {
+    display: none;
+  }
+}

--- a/addons/download-button/userscript.js
+++ b/addons/download-button/userscript.js
@@ -52,6 +52,8 @@ export default async function ({ addon, console, msg }) {
   while (true) {
     await addon.tab.waitForElement(".flex-row.subactions > .flex-row.action-buttons", {
       markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      resizeEvent: true,
       reduxCondition: (state) => state.scratchGui.mode.isPlayerOnly,
     });
     addbutton();

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -13,6 +13,7 @@ export default async function ({ addon, console, msg }) {
     const element = await addon.tab.waitForElement(".share-date", {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      resizeEvent: true,
       reduxCondition: (state) => state.scratchGui.mode.isPlayerOnly,
     });
 

--- a/addons/remix-tree-button/addon.json
+++ b/addons/remix-tree-button/addon.json
@@ -11,8 +11,7 @@
   "userscripts": [
     {
       "url": "main.js",
-      "matches": ["projects"],
-      "runAtComplete": false
+      "matches": ["projects"]
     }
   ],
   "userstyles": [

--- a/addons/remix-tree-button/button.css
+++ b/addons/remix-tree-button/button.css
@@ -11,7 +11,8 @@
   content: "";
 }
 
-@media (max-width: 767px) { /* $tablet-portrait - 1px */
+@media (max-width: 767px) {
+  /* $tablet-portrait - 1px */
   .remixtree-button {
     display: none;
   }

--- a/addons/remix-tree-button/button.css
+++ b/addons/remix-tree-button/button.css
@@ -10,3 +10,9 @@
   vertical-align: bottom;
   content: "";
 }
+
+@media (max-width: 767px) { /* $tablet-portrait - 1px */
+  .remixtree-button {
+    display: none;
+  }
+}

--- a/addons/remix-tree-button/button.css
+++ b/addons/remix-tree-button/button.css
@@ -11,8 +11,7 @@
   content: "";
 }
 
-@media (max-width: 767px) {
-  /* $tablet-portrait - 1px */
+@media (max-width: 767px) /* $tablet-portrait - 1px */ {
   .remixtree-button {
     display: none;
   }

--- a/addons/remix-tree-button/main.js
+++ b/addons/remix-tree-button/main.js
@@ -1,35 +1,25 @@
 export default async function ({ addon, console, msg }) {
   //define remix tree button elements
-  function loadRemixButton() {
-    if (document.querySelector("#scratchAddonsRemixTreeBtn")) return;
-    if (addon.tab.editorMode === "projectpage") {
-      addon.tab
-        .waitForElement(".flex-row.subactions", {
-          reduxCondition: (state) => state.scratchGui.mode.isPlayerOnly,
-        })
-        .then(() => {
-          if (!document.querySelector(".copy-link-button")) return;
-          if (document.querySelector("#scratchAddonsRemixTreeBtn")) return; // Check again because we're inside a promise
-          const remixtree = document.createElement("button");
+  while (true) {
+    await addon.tab.waitForElement(".flex-row.subactions > .flex-row.action-buttons", {
+      markAsSeen: true,
+      reduxEvents: ["SET_PROJECT_INFO", "scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      resizeEvent: true,
+      reduxCondition: (state) => state.scratchGui.mode.isPlayerOnly,
+    });
+    const remixtree = document.createElement("button");
 
-          const remixtreeSpan = document.createElement("span");
-          remixtreeSpan.innerText = msg("remix-tree");
-          addon.tab.displayNoneWhileDisabled(remixtree);
-          remixtree.className = "button action-button remixtree-button";
-          remixtree.id = "scratchAddonsRemixTreeBtn";
-          remixtree.appendChild(remixtreeSpan);
-          remixtree.addEventListener("click", () => {
-            window.location.href = `https://scratch.mit.edu/projects/${
-              window.location.href.split("projects")[1].split("/")[1]
-            }/remixtree`;
-          });
-          addon.tab.appendToSharedSpace({ space: "afterCopyLinkButton", element: remixtree, order: 0 });
-        });
-    }
+    const remixtreeSpan = document.createElement("span");
+    remixtreeSpan.innerText = msg("remix-tree");
+    addon.tab.displayNoneWhileDisabled(remixtree);
+    remixtree.className = "button action-button remixtree-button";
+    remixtree.id = "scratchAddonsRemixTreeBtn";
+    remixtree.appendChild(remixtreeSpan);
+    remixtree.addEventListener("click", () => {
+      window.location.href = `https://scratch.mit.edu/projects/${
+        window.location.href.split("projects")[1].split("/")[1]
+      }/remixtree`;
+    });
+    addon.tab.appendToSharedSpace({ space: "afterCopyLinkButton", element: remixtree, order: 0 });
   }
-
-  loadRemixButton();
-  addon.tab.addEventListener("urlChange", () => {
-    loadRemixButton();
-  });
 }

--- a/addons/remix-tree-button/main.js
+++ b/addons/remix-tree-button/main.js
@@ -3,7 +3,12 @@ export default async function ({ addon, console, msg }) {
   while (true) {
     await addon.tab.waitForElement(".flex-row.subactions > .flex-row.action-buttons", {
       markAsSeen: true,
-      reduxEvents: ["SET_PROJECT_INFO", "scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+      reduxEvents: [
+        "SET_PROJECT_INFO",
+        "scratch-gui/mode/SET_PLAYER",
+        "fontsLoaded/SET_FONTS_LOADED",
+        "scratch-gui/locales/SELECT_LOCALE",
+      ],
       resizeEvent: true,
       reduxCondition: (state) => state.scratchGui.mode.isPlayerOnly,
     });


### PR DESCRIPTION
Resolves #6956

### Changes

The tooltip added by `last-edit-tooltip` now remains after resizing the window. The Download and Remix Tree buttons are still hidden when the window is narrow enough that the page switches to the vertical layout, but they now appear again when switching back to a larger window size.

### Tests

Tested on Edge and Firefox.