### PR TITLE
disable-auto-save: don't show confirmation twice

### DIFF
--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -6,11 +6,6 @@ export default async ({ addon, console, msg }) => {
     console.log("Pending autosave prevented.");
   });
 
-  // If the addon is enable late, don't use the `waitForElement` below
-  // because the `waitForElement` below only runs on certain redux events
-  if (addon.self.enabledLate) {
-    addListener(document.querySelector('[class*="community-button_community-button_"]'));
-  }
   while (true) {
     const btn = await addon.tab.waitForElement('[class*="community-button_community-button_"]', {
       markAsSeen: true,


### PR DESCRIPTION
### Changes

See https://github.com/ScratchAddons/ScratchAddons/issues/6139#issuecomment-1964662287. The previous code would add two event listeners if the addon was enabled late, which caused the confirmation popup for leaving the editor to be shown twice.

### Tests

Tested on Edge and Firefox.