### PR TITLE
Add beta tag to Scratch Notifier

### DIFF
--- a/addons/scratch-notifier/addon.json
+++ b/addons/scratch-notifier/addon.json
@@ -117,7 +117,7 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "tags": ["community", "recommended"],
+  "tags": ["community", "beta"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true


### PR DESCRIPTION
### Changes

Replaces Scratch Notifier's recommended tag with the beta tag.

### Reason for changes

The addon has been unreliable  since the MV3 transition and it doesn't seem like it's going to be fixed soon.

- #3877
- #7839

### Tests

Tested on Chromium.
