### PR TITLE
Cloud variable kill switch

### DIFF
--- a/addons-l10n/en/cloud-off.json
+++ b/addons-l10n/en/cloud-off.json
@@ -1,0 +1,6 @@
+{
+  "cloud-off/reenable": "Re-enable Cloud Variables",
+  "cloud-off/reloadRequired": "You must reload the page to reconnect Cloud variables.",
+  "cloud-off/confirm": "Reload",
+  "cloud-off/cancel": "Cancel"
+}

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -157,6 +157,7 @@
   "asset-conflict-dialog",
   "remaining-replies",
   "forum-user-agent",
+  "cloud-off",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/cloud-off/addon.json
+++ b/addons/cloud-off/addon.json
@@ -1,0 +1,29 @@
+{
+  "name": "Cloud variable kill switch",
+  "description": "Allows you to cut the connection to the Cloud Data server when running projects with Cloud variables by flicking a switch, making them act as normal variables.",
+  "credits": [
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
+    }
+  ],
+  "info": [
+    {
+      "type": "notice",
+      "id": "reloadToReconnect",
+      "text": "Once disconnected, a page reload is required to reconnect to Cloud Data."
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"],
+      "runAtComplete": true
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "tags": ["editor", "projectPlayer"],
+  "versionAdded": "1.40.0",
+  "enabledByDefault": false
+}

--- a/addons/cloud-off/userscript.js
+++ b/addons/cloud-off/userscript.js
@@ -1,0 +1,85 @@
+export default async function ({ addon, console, msg }) {
+  const cloud = addon.tab.traps.vm.runtime.ioDevices.cloud;
+  /** Disconnects the Cloud variables, in response to the user turning off the switch. */
+  function disableCloud() {
+    if (cloud.provider.connection.readyState === WebSocket.OPEN) {
+      // First override the events that trigger a connection retry, then close the connection
+      cloud.provider.connection.onclose = () => {};
+      cloud.provider.connection.onerror = () => {};
+      cloud.provider.connection.close();
+      connected = false;
+    } else {
+      // WebSocket isn't open, we're not going to try to stop it now
+      console.warn("Not disconnecting because WebSocket is closed");
+      setCheckbox(true);
+    }
+  }
+  /** Opens a confirmation dialog to reload the page and reconnect, in response to the user turning on the switch. */
+  function reloadPrompt() {
+    setCheckbox(false);
+    addon.tab.scratchClassReady().then(() => {
+      addon.tab
+        .confirm(msg("reenable"), msg("reloadRequired"), {
+          okButtonLabel: msg("confirm"),
+          cancelButtonLabel: msg("cancel"),
+          useEditorClasses: false, // The toggle switch that opens this dialog is outside the editor
+        })
+        .then((confirmed) => {
+          if (confirmed) {
+            location.reload();
+          }
+        });
+    });
+  }
+
+  function addToggleSwitch() {
+    const sliderContainer = Object.assign(document.createElement("div"), {
+      className: "sa-toggle-cloud-off",
+    });
+    const label = Object.assign(document.createElement("label"), {
+      className: "toggle-switch",
+    });
+    const checkbox = Object.assign(document.createElement("input"), {
+      type: "checkbox",
+      checked: connected && !addon.tab.redux.state.scratchGui.mode.hasEverEnteredEditor,
+    });
+    const sliderSpan = Object.assign(document.createElement("span"), {
+      className: "slider",
+    });
+    label.append(checkbox, sliderSpan);
+    sliderContainer.append(label);
+    addon.tab.displayNoneWhileDisabled(sliderContainer);
+    const extChip = document.querySelector(".extension-content a[href^='/cloudmonitor']").parentElement.parentElement;
+    extChip.appendChild(sliderContainer);
+
+    checkbox.addEventListener("change", () => {
+      checkbox.checked ? reloadPrompt() : disableCloud();
+    });
+  }
+  /** Sets the state of the toggle switch. */
+  function setCheckbox(checked) {
+    document.querySelector(".sa-toggle-cloud-off input").checked = checked;
+  }
+
+  let connected = true;
+
+  await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState.startsWith("SHOWING"));
+
+  if (addon.tab.traps.vm.runtime.hasCloudData()) {
+    let checkCnt = 0;
+    while (cloud.provider?.connection.readyState !== WebSocket.OPEN) {
+      checkCnt++;
+      // Check at an interval of 200ms for 5 seconds, then 2s
+      await new Promise((resolve) => setTimeout(resolve, checkCnt > 25 ? 2000 : 200));
+    }
+
+    while (true) {
+      await addon.tab.waitForElement(".extension-content a[href^='/cloudmonitor']", {
+        markAsSeen: true,
+        reduxCondition: (state) => !state.scratchGui.mode.hasEverEnteredEditor,
+      });
+
+      addToggleSwitch();
+    }
+  }
+}


### PR DESCRIPTION
Resolves #5111

### Changes

Added a new addon called "Cloud variable kill switch". This addon adds an on/off switch next to the Cloud Variables extension chip.

![A toggle button on the Cloud Variables extension chip](https://github.com/user-attachments/assets/c42e3477-eec2-4757-82e1-0eb61adc5214)

Clicking it to turn it off disconnects Cloud variables from the Cloud Data server, making them act like normal variables.

To turn them on again, the page must be reloaded. This is because you could exploit the ability to re-enable Cloud variables dynamically to do things you wouldn't normally be able to do like claim occupied player slots in multiplayer games.

### Reason for changes

There are a few reasons a user may want to opt out of Cloud variables on a specific project:
- **Debugging:** Sometimes you want to check for behavior when not connected to Cloud Data.
- **Single player:** Sometimes you might not want to join multiplayer games.
- **Privacy:** Some people don't like Cloud variables that purely record your activity.

Most users also want to still be able to use Cloud variables in general, so the switch is on by default.

### Tests

I have tested this on scratch.mit.edu with Edge 130 / Windows 11.

#### Things to check

- The toggle appears after the Cloud provider has connected
- The toggle does not appear if Cloud Data is unavailable (e.g., you're signed out)
- The toggle is OFF after entering the editor
  - (I think in its current state it just doesn't appear after leaving the editor, close enough)
- Cloud variables work when the switch is ON and don't work when the switch is OFF