### PR TITLE
Rephrase some confirmation messages

### DIFF
--- a/addons-l10n/en/confirm-actions.json
+++ b/addons-l10n/en/confirm-actions.json
@@ -1,7 +1,7 @@
 {
   "confirm-actions/yes": "Yes",
   "confirm-actions/no": "No",
-  "confirm-actions/share": "Are you sure you want to share?",
+  "confirm-actions/share": "Are you ready to share your project?",
   "confirm-actions/unshare": "Are you sure you want to unshare?",
   "confirm-actions/follow": "Are you sure you want to follow this user?",
   "confirm-actions/unfollow": "Are you sure you want to unfollow this user?",

--- a/addons-l10n/en/scratch-messaging.json
+++ b/addons-l10n/en/scratch-messaging.json
@@ -15,7 +15,7 @@
   "scratch-messaging/chars-left": "{num, plural, one {1 character left} other {# characters left}}",
   "scratch-messaging/follows": "Follows",
   "scratch-messaging/stMessages": "Messages from the Scratch Team",
-  "scratch-messaging/stMessagesConfirm": "Dismiss this message?",
+  "scratch-messaging/stMessagesConfirm": "Delete this message permanently?",
   "scratch-messaging/studio-invites": "Studio invites",
   "scratch-messaging/curate-invite": "{actor} invited you to curate {title}",
   "scratch-messaging/forum": "Forum activity",

--- a/addons-l10n/en/scratch-messaging.json
+++ b/addons-l10n/en/scratch-messaging.json
@@ -15,7 +15,7 @@
   "scratch-messaging/chars-left": "{num, plural, one {1 character left} other {# characters left}}",
   "scratch-messaging/follows": "Follows",
   "scratch-messaging/stMessages": "Messages from the Scratch Team",
-  "scratch-messaging/stMessagesConfirm": "Are you sure you want to dismiss this message from the Scratch Team? It cannot be recovered.",
+  "scratch-messaging/stMessagesConfirm": "Dismiss this message?",
   "scratch-messaging/studio-invites": "Studio invites",
   "scratch-messaging/curate-invite": "{actor} invited you to curate {title}",
   "scratch-messaging/forum": "Forum activity",


### PR DESCRIPTION
### Changes and reasons for changes

```diff
- Are you sure you want to dismiss this message from the Scratch Team? It cannot be recovered.
+ Delete this message permanently?
```
This isn't as destructive as other actions.
```diff
- Are you sure you want to share?
+ Are you ready to share your project?
```
This is more encouraging.