### PR TITLE
`find-bar`: Only override CTRL+F shortcut when find bar is not in focus

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -140,7 +140,7 @@ export default async function ({ addon, msg, console }) {
 
       let ctrlKey = e.ctrlKey || e.metaKey;
 
-      if (e.key.toLowerCase() === "f" && ctrlKey && !e.shiftKey) {
+      if (e.key.toLowerCase() === "f" && ctrlKey && !e.shiftKey && !document.activeElement.closest(".sa-find-bar")) {
         // Ctrl + F (Override default Ctrl+F find)
         this.findInput.focus();
         this.findInput.select();
@@ -206,10 +206,10 @@ export default async function ({ addon, msg, console }) {
         this.selectedTab === 0
           ? this.getScratchBlocks()
           : this.selectedTab === 1
-            ? this.getScratchCostumes()
-            : this.selectedTab === 2
-              ? this.getScratchSounds()
-              : [];
+          ? this.getScratchCostumes()
+          : this.selectedTab === 2
+          ? this.getScratchSounds()
+          : [];
 
       this.dropdown.empty();
 

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -206,10 +206,10 @@ export default async function ({ addon, msg, console }) {
         this.selectedTab === 0
           ? this.getScratchBlocks()
           : this.selectedTab === 1
-          ? this.getScratchCostumes()
-          : this.selectedTab === 2
-          ? this.getScratchSounds()
-          : [];
+            ? this.getScratchCostumes()
+            : this.selectedTab === 2
+              ? this.getScratchSounds()
+              : [];
 
       this.dropdown.empty();
 


### PR DESCRIPTION
Resolves #7635

### Changes

Made `find-bar`'s CTRL+F shortcut only focus the find bar when it's not already focused.

### Reason for changes

Opens up easy access to the browser's own find bar.

### Tests

Tested with Edge.
