### PR TITLE
New addon: "Save now" button when updating variables

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -157,6 +157,7 @@
   "asset-conflict-dialog",
   "remaining-replies",
   "forum-user-agent",
+  "save-updating-variables",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/save-updating-variables/addon.json
+++ b/addons/save-updating-variables/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "\"Save now\" button when updating variables",
+  "description": "Shows the \"Save now\" button when a variable or list is being edited on the stage.",
+  "tags": ["editor"],
+  "versionAdded": "1.40.0",
+  "userscripts": [
+    {
+      "matches": ["projects"],
+      "url": "userscript.js"
+    }
+  ],
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/save-updating-variables/userscript.js
+++ b/addons/save-updating-variables/userscript.js
@@ -1,0 +1,31 @@
+export default async function ({ addon, console }) {
+  // https://github.com/scratchfoundation/scratch-vm/blob/6ea3f2198b29ec2b6e66b74e919cd8f14982acef/src/engine/runtime.js#L2573
+  // The argument `monitor` is sometimes an immutable.Map and sometimes a
+  // vanilla JavaScript map.
+  // this._monitorState is an immutable.Map.
+  // immutable.Map comes from https://www.npmjs.com/package/immutable.
+  const _requestUpdateMonitor = addon.tab.traps.vm.runtime.requestUpdateMonitor;
+  addon.tab.traps.vm.runtime.requestUpdateMonitor = function (monitor) {
+    const id = monitor.get("id");
+    const currentMonitor = this._monitorState.get(id);
+    const monitorValue = monitor.get("value");
+    const currentMonitorValue = currentMonitor?.get("value");
+    if (
+      !addon.self.disabled &&
+      currentMonitor &&
+      !currentMonitor.isSuperset(monitor) &&
+      !(
+        Array.isArray(monitorValue) &&
+        Array.isArray(currentMonitorValue) &&
+        monitorValue.length === currentMonitorValue.length &&
+        monitorValue.every((mvi, i) => mvi === currentMonitorValue[i])
+      )
+    ) {
+      addon.tab.redux.dispatch({
+        type: "scratch-gui/project-changed/SET_PROJECT_CHANGED",
+        changed: true,
+      });
+    }
+    return _requestUpdateMonitor.call(this, monitor);
+  };
+}


### PR DESCRIPTION
Resolves #7735

### Changes

Adds a new addon that makes monitor updates trigger a project change.

### Reason for changes

Making sure people don't lose changes.

### Tests

Tested with Edge. It works with:

- Dragging monitors
- Showing/hiding monitors
- Changing a variable's display type
- Changing a variable's value via the slider
- Changing a slider's range
- Adding items to lists
- Removing items from lists
- Editing list items
- Resizing lists
- Importing to a list
