### PR TITLE
Add some addon tags

### DIFF
--- a/addons/blocks2image/addon.json
+++ b/addons/blocks2image/addon.json
@@ -1,7 +1,7 @@
 {
   "name": "Save blocks as image",
   "description": "Right click on the code area or a stack of blocks to copy it to the clipboard or save it as a PNG or SVG file.",
-  "tags": ["editor", "codeEditor"],
+  "tags": ["editor", "codeEditor", "featured"],
   "credits": [
     {
       "name": "summerscar",

--- a/addons/editor-random-direction-block/addon.json
+++ b/addons/editor-random-direction-block/addon.json
@@ -8,7 +8,7 @@
     }
   ],
   "versionAdded": "1.35.0",
-  "tags": ["editor"],
+  "tags": ["editor", "codeEditor"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true,

--- a/addons/rename-broadcasts/addon.json
+++ b/addons/rename-broadcasts/addon.json
@@ -10,7 +10,7 @@
       "name": "GarboMuffin"
     }
   ],
-  "tags": ["editor", "featured"],
+  "tags": ["editor", "codeEditor", "featured"],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/search-sprites/addon.json
+++ b/addons/search-sprites/addon.json
@@ -33,6 +33,6 @@
     "version": "1.40.0",
     "temporaryNotice": "The search bar is now below the sprite list, next to the add button."
   },
-  "tags": ["editor"],
+  "tags": ["editor", "recommended"],
   "enabledByDefault": false
 }


### PR DESCRIPTION
### Changes

- Adds the `codeEditor` tag to `rename-broadcasts` and `editor-random-direction-block`.
- Adds recommended tag to `search-sprites`.
- Adds the featured tag to `blocks2image`.

### Tests

Tested on Chromium