### PR TITLE
editor-dark-mode: new Blockly

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -166,6 +166,7 @@
 [class*="stage-selector_header_"],
 [class*="drag-layer_image_"],
 .blocklyDropDownDiv .goog-slider-horizontal .goog-slider-thumb,
+.scratchColourSlider::-webkit-slider-thumb,
 [class*="asset-panel_wrapper_"],
 [class*="color-button_outline-swatch_"]::after,
 [class*="slider_handle_"],
@@ -205,7 +206,9 @@
 .blocklyFlyoutButton:hover {
   fill: var(--editorDarkMode-accent);
 }
-.blocklyFlyoutButton:hover .blocklyText {
+.blocklyFlyoutButton:hover .blocklyText,
+.scratch-renderer.default-theme .blocklyFlyoutButton:hover .blocklyText,
+.scratch-renderer.high-contrast-theme .blocklyFlyoutButton:hover .blocklyText {
   fill: var(--editorDarkMode-accent-text);
 }
 [class*="selector_new-buttons_"]::before {
@@ -281,6 +284,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="input_input-form_"],
 [class*="context-menu_context-menu_"],
 .blocklyWidgetDiv .goog-menu,
+.blocklyWidgetDiv .blocklyMenu,
 [class*="filter_filter_"],
 [class*="prompt_button-row_"] button,
 [class*="prompt_variable-name-text-input_"],
@@ -306,7 +310,9 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="filter_filter-input_"],
 [class*="filter_filter-input_"]::placeholder,
 .blocklyWidgetDiv .goog-menuitem,
-.scratchColourPickerLabel {
+.blocklyMenuItem,
+.scratchColourPickerLabel,
+.valueReportBox {
   color: var(--editorDarkMode-input-text);
 }
 .Popover-tipShape,
@@ -315,7 +321,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 .blocklyFlyoutCheckbox {
   fill: var(--editorDarkMode-input);
 }
-.blocklyBlockCanvas g:not(.checked) .blocklyFlyoutCheckboxPath {
+.blocklyBlockCanvas g:not(.checked) .blocklyFlyoutCheckboxPath,
+.blocklyBubbleCanvas > g:not(.checked) .blocklyFlyoutCheckboxPath {
   stroke: var(--editorDarkMode-input);
 }
 .blocklyDropDownDiv[style*="background-color: rgb(255, 255, 255)"] {
@@ -335,14 +342,19 @@ img[class*="tool-select-base_tool-select-icon_"],
 .blocklyWidgetDiv .goog-menuitem-disabled .goog-menuitem-content {
   color: var(--editorDarkMode-input-transparentText) !important;
 }
+.blocklyMenuItemDisabled {
+  color: var(--editorDarkMode-input-transparentText);
+}
 .blocklyDropDownDiv .goog-slider-horizontal .goog-slider-thumb,
+.scratchColourSlider::-webkit-slider-thumb,
 [class*="slider_handle_"] {
   box-shadow: 0 0 0 4px var(--editorDarkMode-input-foregroundShadow);
 }
 [class*="context-menu_menu-item-bordered_"] {
   border-color: var(--editorDarkMode-input-divider);
 }
-.blocklyWidgetDiv .goog-menuitem {
+.blocklyWidgetDiv .goog-menuitem,
+.blocklyMenuItem {
   border-color: var(--editorDarkMode-input-divider) !important;
 }
 [class*="question_question-input_"] [class*="input_input-form_"] {
@@ -373,6 +385,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 .scratchCategoryMenu {
   background: var(--editorDarkMode-categoryMenu);
   color: var(--editorDarkMode-categoryMenu-text);
+  --colour-toolboxSelected: var(--editorDarkMode-categoryMenu-selection);
+  --colour-toolboxText: var(--editorDarkMode-categoryMenu-text);
 }
 .scratchCategoryMenuItem.categorySelected {
   background-color: var(--editorDarkMode-categoryMenu-selection);
@@ -381,6 +395,9 @@ img[class*="tool-select-base_tool-select-icon_"],
 .scratchCategoryMenuItem:hover {
   color: var(--editorDarkMode-categoryMenu-hoverText) !important;
 }
+.blocklyToolboxCategory:hover {
+  color: var(--editorDarkMode-categoryMenu-hoverText);
+}
 
 /* Block palette background */
 .blocklyFlyoutBackground {
@@ -388,7 +405,11 @@ img[class*="tool-select-base_tool-select-icon_"],
   fill-opacity: 1;
 }
 .blocklyFlyoutLabelText,
-.blocklyFlyoutButton .blocklyText {
+.scratch-renderer.default-theme .blocklyFlyoutLabelText,
+.scratch-renderer.high-contrast-theme .blocklyFlyoutLabelText,
+.blocklyFlyoutButton .blocklyText,
+.scratch-renderer.default-theme .blocklyFlyoutButton .blocklyText,
+.scratch-renderer.high-contrast-theme .blocklyFlyoutButton .blocklyText {
   fill: var(--editorDarkMode-palette-text);
 }
 .blocklyFlyoutScrollbar .blocklyScrollbarHandle,
@@ -458,6 +479,9 @@ img[class*="tool-select-base_tool-select-icon_"],
 .blocklyWidgetDiv .goog-menuitem-highlight,
 .blocklyWidgetDiv .goog-menuitem-hover {
   background-color: var(--editorDarkMode-primary-transparent15);
+}
+:root {
+  --colour-contextualMenuHover: var(--editorDarkMode-primary-transparent15);
 }
 [class*="library_filter-bar_"],
 .sa-body-editor [class*="stage-header_stage-button_"]:active,
@@ -615,6 +639,7 @@ img[src*="c3RvcC1wbGF5YmFjayI+CiAgICAgICAgICAgICAgICAgICAgICAgIDx1c2UgZmlsbD0iYm
 [class*="library-item_library-item_"],
 [class*="context-menu_context-menu_"],
 .blocklyWidgetDiv .goog-menu,
+.blocklyWidgetDiv .blocklyMenu,
 .scratchEyedropper,
 .Popover-body,
 .sa-onion-settings,
@@ -660,6 +685,10 @@ img[src*="c3RvcC1wbGF5YmFjayI+CiAgICAgICAgICAgICAgICAgICAgICAgIDx1c2UgZmlsbD0iYm
   /* Make backpack items have a white background,
   otherwise they would be too dark in dark mode. */
   mix-blend-mode: normal;
+}
+.blocklyToolboxCategory:not(.blocklyToolboxSelected):hover {
+  /* Remove Blockly's default hover highlight from categories. */
+  background-color: transparent;
 }
 .blocklyWidgetDiv .goog-menuitem-highlight {
   border: none;

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -207,9 +207,11 @@
   fill: var(--editorDarkMode-accent);
 }
 .blocklyFlyoutButton:hover .blocklyText,
-.scratch-renderer.default-theme .blocklyFlyoutButton:hover .blocklyText,
-.scratch-renderer.high-contrast-theme .blocklyFlyoutButton:hover .blocklyText {
+.scratch-renderer.default-theme .blocklyFlyoutButton:hover .blocklyText {
   fill: var(--editorDarkMode-accent-text);
+}
+.scratch-renderer.high-contrast-theme .blocklyFlyoutButton:hover .blocklyText {
+  fill: var(--editorDarkMode-accent-text) !important;
 }
 [class*="selector_new-buttons_"]::before {
   background: linear-gradient(var(--editorDarkMode-accent-gradient-opacity0), var(--editorDarkMode-accent-gradient));
@@ -408,9 +410,11 @@ img[class*="tool-select-base_tool-select-icon_"],
 .scratch-renderer.default-theme .blocklyFlyoutLabelText,
 .scratch-renderer.high-contrast-theme .blocklyFlyoutLabelText,
 .blocklyFlyoutButton .blocklyText,
-.scratch-renderer.default-theme .blocklyFlyoutButton .blocklyText,
-.scratch-renderer.high-contrast-theme .blocklyFlyoutButton .blocklyText {
+.scratch-renderer.default-theme .blocklyFlyoutButton .blocklyText {
   fill: var(--editorDarkMode-palette-text);
+}
+.scratch-renderer.high-contrast-theme .blocklyFlyoutButton .blocklyText {
+  fill: var(--editorDarkMode-palette-text) !important;
 }
 .blocklyFlyoutScrollbar .blocklyScrollbarHandle,
 .blocklyFlyoutScrollbar .blocklyScrollbarBackground:hover + .blocklyScrollbarHandle,

--- a/addons/editor-dark-mode/extension_icons.js
+++ b/addons/editor-dark-mode/extension_icons.js
@@ -6,23 +6,42 @@ const dataUriRegex = new RegExp("^data:image/svg\\+xml;base64,([A-Za-z0-9+/=]*)$
 export default async function ({ addon, console }) {
   const Blockly = await addon.tab.traps.getBlockly();
 
-  const oldCategoryCreateDom = Blockly.Toolbox.Category.prototype.createDom;
-  Blockly.Toolbox.Category.prototype.createDom = function () {
-    if (addon.self.disabled) return oldCategoryCreateDom.call(this);
-    if (!this.iconURI_ || !["music", "videoSensing", "text2speech"].includes(this.id_))
-      return oldCategoryCreateDom.call(this);
+  const recolorIcon = (iconUri, extensionId) => {
+    if (addon.self.disabled) return iconUri;
+    if (!iconUri || !["music", "videoSensing", "text2speech"].includes(extensionId)) return iconUri;
 
-    const match = dataUriRegex.exec(this.iconURI_);
+    const match = dataUriRegex.exec(iconUri);
     if (match) {
       const oldSvg = atob(match[1]);
       const newColor = textColor(addon.settings.get("categoryMenu"), null, "#ffffff");
       if (newColor) {
         const newSvg = oldSvg.replace(/#575e75|#4d4d4d/gi, newColor);
-        this.iconURI_ = `data:image/svg+xml;base64,${btoa(newSvg)}`;
+        return `data:image/svg+xml;base64,${btoa(newSvg)}`;
       }
     }
-    oldCategoryCreateDom.call(this);
   };
+
+  if (Blockly.registry) {
+    // new Blockly
+    const ScratchContinuousCategory = Blockly.registry.getClass(
+      Blockly.registry.Type.TOOLBOX_ITEM,
+      Blockly.ToolboxCategory.registrationName
+    );
+    const oldCategoryCreateIconDom = ScratchContinuousCategory.prototype.createIconDom_;
+    ScratchContinuousCategory.prototype.createIconDom_ = function () {
+      const oldIconUri = this.toolboxItemDef_.iconURI;
+      this.toolboxItemDef_.iconURI = recolorIcon(oldIconUri, this.getId());
+      const iconElement = oldCategoryCreateIconDom.call(this);
+      this.toolboxItemDef_.iconURI = oldIconUri;
+      return iconElement;
+    };
+  } else {
+    const oldCategoryCreateDom = Blockly.Toolbox.Category.prototype.createDom;
+    Blockly.Toolbox.Category.prototype.createDom = function () {
+      this.iconURI_ = recolorIcon(this.iconURI_, this.id_);
+      oldCategoryCreateDom.call(this);
+    };
+  }
 
   const reloadToolbox = () => {
     updateAllBlocks(addon.tab, {

--- a/libraries/common/cs/update-all-blocks.js
+++ b/libraries/common/cs/update-all-blocks.js
@@ -24,8 +24,17 @@ export async function updateAllBlocks(
       }
       if (updateCategories) {
         const selectedItemId = toolbox.getSelectedItem().id_;
-        toolbox.categoryMenu_.populate(workspace.options.languageTree);
-        toolbox.selectCategoryById(selectedItemId, false);
+        if (blockly.registry) {
+          // new Blockly
+          toolbox.render(workspace.options.languageTree);
+          toolbox.selectItem_(
+            null,
+            toolbox.contents_.find((item) => item.id_ === selectedItemId)
+          );
+        } else {
+          toolbox.categoryMenu_.populate(workspace.options.languageTree);
+          toolbox.selectCategoryById(selectedItemId, false);
+        }
       }
       toolbox.refreshSelection();
     }


### PR DESCRIPTION
### Changes

Makes the necessary changes to editor-dark-mode to support the new Blockly version. This PR doesn't update the code for zoom icons yet - scratch-blocks currently uses Blockly's default icons, which will probably be replaced with Scratch's ones before the new version is released.

### Tests

Tested on Edge and Firefox using both the current version of scratch-gui and the spork branch.