### PR TITLE
block-palette-icons: Fix on modern Blockly

### DIFF
--- a/addons/block-palette-icons/userstyle.css
+++ b/addons/block-palette-icons/userstyle.css
@@ -1,7 +1,9 @@
+.categoryBubble,
 .scratchCategoryItemBubble {
   position: relative;
 }
 
+.categoryBubble::after,
 .scratchCategoryItemBubble::after {
   content: "";
   position: absolute;
@@ -14,42 +16,52 @@
   background-size: cover;
 }
 
+.blocklyToolboxCategory#motion .categoryBubble::after,
 .scratchCategoryId-motion .scratchCategoryItemBubble::after {
   background-image: url(icons/motion_icon.svg);
 }
 
+.blocklyToolboxCategory#looks .categoryBubble::after,
 .scratchCategoryId-looks .scratchCategoryItemBubble::after {
   background-image: url(icons/looks_icon.svg);
 }
 
+.blocklyToolboxCategory#sound .categoryBubble::after,
 .scratchCategoryId-sound .scratchCategoryItemBubble::after {
   background-image: url(icons/sound_icon.svg);
 }
 
+.blocklyToolboxCategory#events .categoryBubble::after,
 .scratchCategoryId-events .scratchCategoryItemBubble::after {
   background-image: url(icons/events_icon.svg);
 }
 
+.blocklyToolboxCategory#control .categoryBubble::after,
 .scratchCategoryId-control .scratchCategoryItemBubble::after {
   background-image: url(icons/control_icon.svg);
 }
 
+.blocklyToolboxCategory#sensing .categoryBubble::after,
 .scratchCategoryId-sensing .scratchCategoryItemBubble::after {
   background-image: url(icons/sensing_icon.svg);
 }
 
+.blocklyToolboxCategory#operators .categoryBubble::after,
 .scratchCategoryId-operators .scratchCategoryItemBubble::after {
   background-image: url(icons/operators_icon.svg);
 }
 
+.blocklyToolboxCategory#variables .categoryBubble::after,
 .scratchCategoryId-variables .scratchCategoryItemBubble::after {
   background-image: url(icons/variables_icon.svg);
 }
 
+.blocklyToolboxCategory#lists .categoryBubble::after,
 .scratchCategoryId-lists .scratchCategoryItemBubble::after {
   background-image: url(icons/list_icon.svg);
 }
 
+.blocklyToolboxCategory#myBlocks .categoryBubble::after,
 .scratchCategoryId-myBlocks .scratchCategoryItemBubble::after {
   background-image: url(icons/block_icon.svg);
 }


### PR DESCRIPTION
### Changes

Fixes the block palette category icons on the new Blockly editor.

### Tests

Tested on Chromium.