### PR TITLE
Fix script-snap & no-script-bumping on new Blockly

### DIFF
--- a/addons/no-script-bumping/userscript.js
+++ b/addons/no-script-bumping/userscript.js
@@ -1,9 +1,17 @@
 export default async function ({ addon, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
-  const originalBumpNeighbors = ScratchBlocks.BlockSvg.prototype.bumpNeighbours_;
-  ScratchBlocks.BlockSvg.prototype.bumpNeighbours_ = function () {
-    if (addon.self.disabled) {
-      originalBumpNeighbors.call(this);
+  if (ScratchBlocks.registry) {
+    // New Blockly
+    const originalBumpNeighbors = ScratchBlocks.BlockSvg.prototype.bumpNeighbours;
+    ScratchBlocks.BlockSvg.prototype.bumpNeighbours = function () {
+      if (addon.self.disabled) originalBumpNeighbors.call(this);
     }
-  };
+  } else {
+    const originalBumpNeighbors = ScratchBlocks.BlockSvg.prototype.bumpNeighbours_;
+    ScratchBlocks.BlockSvg.prototype.bumpNeighbours_ = function () {
+      if (addon.self.disabled) {
+        originalBumpNeighbors.call(this);
+      }
+    };
+  }
 }

--- a/addons/no-script-bumping/userscript.js
+++ b/addons/no-script-bumping/userscript.js
@@ -5,7 +5,7 @@ export default async function ({ addon, console }) {
     const originalBumpNeighbors = ScratchBlocks.BlockSvg.prototype.bumpNeighbours;
     ScratchBlocks.BlockSvg.prototype.bumpNeighbours = function () {
       if (addon.self.disabled) originalBumpNeighbors.call(this);
-    }
+    };
   } else {
     const originalBumpNeighbors = ScratchBlocks.BlockSvg.prototype.bumpNeighbours_;
     ScratchBlocks.BlockSvg.prototype.bumpNeighbours_ = function () {

--- a/addons/script-snap/userscript.js
+++ b/addons/script-snap/userscript.js
@@ -16,9 +16,17 @@ export default async function ({ addon, console }) {
   addon.self.addEventListener("reenabled", () => setGrid(true));
 
   function setGrid(enabled) {
-    workspace.grid_.snapToGrid_ = enabled;
-    if (enabled) workspace.grid_.spacing_ = addon.settings.get("grid");
-    else workspace.grid_.spacing_ = 40;
-    workspace.grid_.update(workspace.scale);
+    if (Blockly.registry) {
+      // New Blockly
+      workspace.grid.snapToGrid = enabled;
+      if (enabled) workspace.grid.spacing = addon.settings.get("grid");
+      else workspace.grid.spacing = 40;
+      workspace.grid.update(workspace.scale);
+    } else {
+      workspace.grid_.snapToGrid_ = enabled;
+      if (enabled) workspace.grid_.spacing_ = addon.settings.get("grid");
+      else workspace.grid_.spacing_ = 40;
+      workspace.grid_.update(workspace.scale);
+    }
   }
 }


### PR DESCRIPTION
### Changes

Fixes `script-snap` and `no-script-bumping` on the modern Blockly editor by calling the non-underscore functions there. The changes are easier to see with hide whitespace.

### Tests

Tested on Chromium on thew website and modern Blockly locally.