### PR TITLE
editor-dark-mode: support delete confirmation

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -233,6 +233,16 @@
       }
     },
     {
+      "name": "primary-iconFilter",
+      "value": {
+        "type": "recolorFilter",
+        "source": {
+          "type": "settingValue",
+          "settingId": "primary"
+        }
+      }
+    },
+    {
       "name": "primary-transparent35",
       "value": {
         "type": "multiply",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -162,6 +162,7 @@
 .sa-body-editor [class*="stage-header_stage-size-row_"] > *,
 .sa-body-editor [class*="stage-header_unselect-wrapper_"],
 [class*="sprite-info_sprite-info_"],
+div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="delete-confirmation-prompt_button-row_"] button,
 [class*="stage-selector_stage-selector_"],
 [class*="stage-selector_header_"],
 [class*="drag-layer_image_"],
@@ -436,6 +437,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="backpack_more_"],
 [class*="sprite-selector-item_is-selected_"] [class*="sprite-selector-item_sprite-info_"],
 [class*="delete-button_delete-button-visible_"],
+[class*="delete-confirmation-prompt_body_"],
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header_"],
 [class*="font-dropdown_mod-menu-item_"]:hover:not(:active),
 [class*="tool-select-base_mod-tool-select_"][class*="tool-select-base_is-selected_"],
@@ -451,6 +453,7 @@ img[class*="tool-select-base_tool-select-icon_"],
   background-color: var(--editorDarkMode-primary);
   color: var(--editorDarkMode-primary-text);
 }
+[class*="delete-button_delete-button-clicked_"],
 [class*="context-menu_menu-item-danger_"]:hover {
   background-color: hsla(30, 100%, 55%, 1);
 }
@@ -535,6 +538,7 @@ img[class*="tool-select-base_tool-select-icon_"],
   fill: var(--editorDarkMode-primary-transparent35);
   stroke: var(--editorDarkMode-primary);
 }
+[class*="delete-confirmation-prompt_label_"],
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header-title_"],
 [class*="prompt_button-row_"] button[class*="prompt_ok-button_"],
 [class*="record-modal_button-row_"] button[class*="record-modal_ok-button_"] {
@@ -552,6 +556,9 @@ img[class*="tool-select-base_tool-select-icon_"],
 .sa-paint-snap-button[data-enabled="true"] .sa-paint-snap-image,
 .sa-onion-button[data-enabled="true"] .sa-onion-image {
   filter: var(--editorDarkMode-primary-filter2);
+}
+[class*="delete-confirmation-prompt_arrow-container_"] [class*="delete-confirmation-prompt_delete-icon_"] {
+  filter: var(--editorDarkMode-primary-iconFilter);
 }
 [class*="action-menu_more-buttons-outer_"],
 [class*="action-menu_more-button_"] {
@@ -572,6 +579,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 /* Text and icon highlight color */
 .sa-body-editor a:link,
 [class*="gui_tab_"][class*="gui_is-selected_"],
+div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="delete-confirmation-prompt_button-row_"] button,
 [class*="dropdown_dropdown_"],
 [class*="record-modal_playing-text_"],
 [class*="record-modal_button-row_"] button,
@@ -581,6 +589,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="gui_tab_"][class*="gui_is-selected_"] img,
 [class*="toggle-buttons_button_"][aria-pressed="true"] > img,
 [class*="sprite-info_is-active_"] [class*="sprite-info_icon_"],
+[class*="delete-confirmation-prompt_button-row_"] [class*="delete-confirmation-prompt_delete-icon_"],
 [class*="fixed-tools_button-group-button-icon_"],
 [class*="color-picker_swap-button_"] [class*="labeled-icon-button_edit-field-icon_"],
 [class*="dropdown_dropdown-icon_"],
@@ -615,6 +624,7 @@ img[src*="c3RvcC1wbGF5YmFjayI+CiAgICAgICAgICAgICAgICAgICAgICAgIDx1c2UgZmlsbD0iYm
 [class*="input_input-form_"],
 [class*="sprite-info_sprite-info_"],
 [class*="sprite-selector-item_sprite-selector-item_"],
+div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="delete-confirmation-prompt_button-row_"] button,
 [class*="stage-selector_stage-selector_"],
 [class*="stage-selector_header_"],
 [class*="stage-selector_costume-canvas_"],


### PR DESCRIPTION
### Changes

Adds styles for Scratch's confirmation popup that appears when deleting a sprite (#7869) to editor-dark-mode.

### Tests

Tested on scratchfoundation.github.io in Edge and Firefox.