### PR TITLE
Optimize `shouldCaptureComment`

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -788,12 +788,14 @@ if (isProfile || isStudio || isProject || isForums) {
       .split("")
       .filter((char, i, charArr) => (i === 0 ? true : charArr[i - 1] !== char))
       .join("");
-
   const shouldCaptureComment = (value) => {
-    const trimmedValue = value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, ""); // Trim like scratchr2
-    const limitedValue = removeReiteratedChars(trimmedValue.toLowerCase().replace(/[^a-z]+/g, ""));
-    const regex = /scratchadons/;
-    return regex.test(limitedValue);
+    const limitedValue = removeReiteratedChars(
+      value
+        .toLowerCase()
+        .match(/[a-z]+/g)
+        .join("")
+    );
+    return limitedValue.includes("scratchadon");
   };
   const extensionPolicyLink = document.createElement("a");
   extensionPolicyLink.href = "https://scratch.mit.edu/discuss/topic/284272/";

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -78,10 +78,13 @@ export default async ({ addon, msg, safeMsg }) => {
             .join("");
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js
-          const trimmedValue = value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, ""); // Trim like scratchr2
-          const limitedValue = removeReiteratedChars(trimmedValue.toLowerCase().replace(/[^a-z]+/g, ""));
-          const regex = /scratchadons/;
-          return regex.test(limitedValue);
+          const limitedValue = removeReiteratedChars(
+            value
+              .toLowerCase()
+              .match(/[a-z]+/g)
+              .join("")
+          );
+          return limitedValue.includes("scratchadon");
         };
         if (shouldCaptureComment(this.replyBoxValue)) {
           alert(chrome.i18n.getMessage("captureCommentError", [chrome.i18n.getMessage("captureCommentPolicy")]));


### PR DESCRIPTION
### Changes

Optimized the code that determines whether a user is trying to say "Scratch Addons".

**Performance improvements:**
- Skips whitespace trimming because all non-alphabetical characters are ignored anyway
- Changed `replace(regex, "")` to `match(regex).join("")`
- Replaced `regex.test(str)` with `str.includes(pattern)`

**Improved detection:**
- Matches "addon", singular

### Tests

I did not test the code on Scratch (I don't want to post something by accident), but I still made sure the updated code detects correctly.
