### PR TITLE
editor-stage-left: move delete confirmation to the right

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -56,6 +56,19 @@
   border-bottom-right-radius: 0.5rem;
 }
 
+/* Move delete button confirmation to the right side */
+.ReactModal__Content[style*="width: 300px"] {
+  /* 300px (popup width)
+   + 25px (padding)
+   + 70px (sprite selector item width)
+   + 25px (padding) */
+  margin-left: 420px !important;
+}
+[class*="delete-confirmation-prompt_arrow-container_"] {
+  order: -1;
+  transform: scaleX(-1);
+}
+
 .Popover {
   /* See hide-flyout */
   z-index: 51;


### PR DESCRIPTION
### Changes

Moves the new delete confirmation to the right side of the sprite tile if editor-stage-left is enabled.
![image](https://github.com/user-attachments/assets/6a8c5e0a-f02f-46b0-b3ce-f55246202d78)

### Reason for changes

https://github.com/ScratchAddons/ScratchAddons/issues/7869#issuecomment-2460312848

### Tests

Tested on Edge and Firefox.