### PR TITLE
better-quoter: support new scratchblocks

### DIFF
--- a/addons/better-quoter/module.js
+++ b/addons/better-quoter/module.js
@@ -164,7 +164,7 @@ function getSelectionBBCode(selection) {
   // scratchblocks
   const scratchBlocksPres = html.getElementsByClassName("blocks");
   for (const pre of scratchBlocksPres) {
-    pre.textContent = `[scratchblocks]\n${pre.getAttribute("data-original")}\n[/scratchblocks]`; // cs.js manages data-original because 3.0 scratchblocks
+    pre.textContent = `[scratchblocks]\n${pre.getAttribute("data-original")}\n[/scratchblocks]`; // cs.js manages data-original
   }
 
   // code blocks

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -565,7 +565,8 @@ if (location.pathname.startsWith("/discuss/")) {
   if (document.readyState !== "loading") {
     setTimeout(preserveBlocks, 0);
   } else {
-    window.addEventListener("DOMContentLoaded", preserveBlocks, { once: true });
+    // { capture: true } is needed to run before jQuery's listener
+    window.addEventListener("DOMContentLoaded", preserveBlocks, { once: true, capture: true });
   }
 }
 


### PR DESCRIPTION
### Changes

Updates the code in cs.js that remembers the original text of scratchblocks elements.

### Reason for changes

https://github.com/ScratchAddons/ScratchAddons/issues/7910#issuecomment-2460856196

### Tests

Tested on Edge and Firefox.