### PR TITLE
editor-theme3, number-pad: new Blockly

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -163,6 +163,19 @@
         "g": 0.7,
         "b": 0.7
       }
+    },
+    {
+      "name": "commentTopBar",
+      "value": {
+        "type": "multiply",
+        "source": {
+          "type": "settingValue",
+          "settingId": "comment-color"
+        },
+        "r": 0.9,
+        "g": 0.9,
+        "b": 0.9
+      }
     }
   ],
   "dynamicEnable": true,

--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -1,9 +1,11 @@
+.categoryBubble::after,
 .scratchCategoryItemBubble::after {
   /* block-palette-icons */
   filter: brightness(0);
 }
 
-.blocklyEditableText > text {
+.blocklyEditableText > text,
+.scratch-renderer.default-theme .blocklyEditableField > text {
   fill: var(--editorTheme3-inputColor-blackText);
 }
 .sa-theme3-editable-label .blocklyHtmlInput {
@@ -12,15 +14,18 @@
 }
 
 .blocklyDropDownDiv .goog-menuitem,
+.blocklyDropDownDiv .blocklyMenuItem,
 .blocklyNumPadButton {
   color: black;
 }
-.blocklyDropDownDiv .blocklyText {
+.blocklyDropDownDiv .blocklyText,
+.blocklyDropDownDiv.scratch-renderer.default-theme .blocklyText {
   /* "Play note" dropdown */
   fill: black;
 }
 .blocklyDropDownDiv .goog-menuitem-highlight,
 .blocklyDropDownDiv .goog-menuitem-hover,
+.blocklyDropDownDiv .blocklyMenu .blocklyMenuItem:hover,
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight {
   background-color: var(--editorTheme3-hoveredItem, rgba(255, 255, 255, 0.3));
 }

--- a/addons/editor-theme3/color_on_black.css
+++ b/addons/editor-theme3/color_on_black.css
@@ -4,7 +4,7 @@
 .u-dropdown-searchbar:focus {
   background-color: var(--editorTheme3-hoveredItem);
 }
-.blocklyDropDownDiv .goog-menuitem-checkbox {
+.blocklyMenuItemSelected .blocklyMenuItemCheckbox {
   filter: brightness(0) invert(1);
 }
 
@@ -12,16 +12,25 @@
   fill: #282828;
 }
 .scratchCommentBody,
-.scratchCommentTextarea {
+.scratchCommentTextarea,
+.blocklyComment .blocklyTextarea {
   background-color: #282828;
 }
 .scratchWorkspaceCommentBorder {
   stroke: var(--editorTheme3-commentColor);
 }
-.scratchCommentTextarea::placeholder {
+.blocklyComment {
+  --colour-commentBorder: var(--editorTheme3-commentColor);
+}
+.blocklyCommentTopbarBackground {
+  fill: #202020;
+}
+.scratchCommentTextarea::placeholder,
+.blocklyCommentText::placeholder {
   color: rgba(255, 255, 255, 0.5);
 }
-.scratchCommentText {
+.scratchCommentText,
+.scratch-renderer.default-theme .blocklyComment .blocklyTextarea {
   fill: #ffffff;
   color: #ffffff;
 }

--- a/addons/editor-theme3/color_on_white.css
+++ b/addons/editor-theme3/color_on_white.css
@@ -1,3 +1,4 @@
+.categoryBubble::after,
 .scratchCategoryItemBubble::after {
   /* block-palette-icons */
   filter: brightness(0);
@@ -11,13 +12,28 @@
 .u-dropdown-searchbar,
 .u-dropdown-searchbar:focus,
 .blocklyDropDownDiv .goog-menuitem,
+.blocklyDropDownDiv .blocklyMenuItem,
 .blocklyNumPadButton {
   color: #575e75;
+}
+.blocklyDropDownDiv .blocklyText,
+.blocklyDropDownDiv.scratch-renderer.default-theme .blocklyText {
+  /* "Play note" dropdown */
+  fill: #575e75;
 }
 .u-dropdown-searchbar:focus {
   background-color: var(--editorTheme3-hoveredItem);
 }
 
+.blocklyAngleGauge,
+.blocklyAngleCenterPoint {
+  fill: black;
+}
+.blocklyAngleLine,
+.blocklyAngleMarks,
+.blocklyAngleCenterPoint {
+  stroke: black;
+}
 .blocklyAngleDragHandle {
   stroke: black;
   stroke-opacity: 0.15;
@@ -28,16 +44,24 @@
   fill: #feffff;
 }
 .scratchCommentBody,
-.scratchCommentTextarea {
+.scratchCommentTextarea,
+.blocklyComment .blocklyTextarea {
   background-color: #ffffff;
 }
 .scratchWorkspaceCommentBorder {
   stroke: var(--editorTheme3-commentColor);
 }
+.blocklyComment {
+  --colour-commentBorder: var(--editorTheme3-commentColor);
+}
+.blocklyCommentTopbarBackground {
+  fill: #e9eef2;
+}
 .scratchCommentTextarea::placeholder {
   color: rgba(0, 0, 0, 0.5);
 }
-.scratchCommentText {
+.scratchCommentText,
+.scratch-renderer.default-theme .blocklyComment .blocklyTextarea {
   fill: #575e75;
   color: #575e75;
 }

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -1,7 +1,12 @@
-.blocklyEditableText > text {
+/* Styles for .high-contrast-theme aren't necessary
+   because the addon sets the theme name to "default". */
+
+.blocklyEditableText > text,
+.scratch-renderer.default-theme .blocklyEditableField > text {
   fill: var(--editorTheme3-inputColor-text);
 }
-.blocklyHtmlInput {
+.blocklyHtmlInput,
+.scratch-renderer.default-theme .blocklyHtmlInput {
   /* Hide the HTML input so that only the SVG part is visible.
      This is needed for transparent inputs. */
   background-color: transparent;
@@ -9,9 +14,14 @@
   caret-color: var(--editorTheme3-inputColor-text);
 }
 .sa-theme3-editable-label .blocklyHtmlInput {
-  /* Labels in custom block editor */
+  /* Labels in custom block editor (focused state) */
   background-color: var(--editorTheme3-inputColor-editableLabel);
   color: var(--editorTheme3-inputColor-text);
+}
+.scratch-renderer.default-theme .blocklyEditableField > rect:not(.blocklyDropdownRect) {
+  /* Labels in custom block editor.
+     In the new Blockly version, they currently look like normal text inputs. */
+  fill: var(--editorTheme3-inputColor);
 }
 
 /* Override Scratch's high contrast theme */
@@ -24,6 +34,7 @@
 }
 .blocklyDropDownDiv .goog-menuitem-highlight,
 .blocklyDropDownDiv .goog-menuitem-hover,
+.blocklyDropDownDiv .blocklyMenu .blocklyMenuItem:hover,
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight {
   background-color: var(--editorTheme3-hoveredItem, rgba(0, 0, 0, 0.2));
 }
@@ -32,16 +43,25 @@
   fill: var(--editorTheme3-commentColor);
 }
 .scratchCommentBody,
-.scratchCommentTextarea {
+.scratchCommentTextarea,
+.blocklyComment .blocklyTextarea {
   background-color: var(--editorTheme3-commentColor);
 }
 .scratchWorkspaceCommentBorder {
   stroke: var(--editorTheme3-commentBorder);
 }
-.scratchCommentTextarea::placeholder {
+.blocklyComment {
+  --colour-commentBorder: var(--editorTheme3-commentBorder);
+}
+.blocklyCommentTopbarBackground {
+  fill: var(--editorTheme3-commentTopBar);
+}
+.scratchCommentTextarea::placeholder,
+.blocklyCommentText::placeholder {
   color: var(--editorTheme3-commentTextTransparent);
 }
-.scratchCommentText {
+.scratchCommentText,
+.scratch-renderer.default-theme .blocklyComment .blocklyTextarea {
   fill: var(--editorTheme3-commentText);
   color: var(--editorTheme3-commentText);
 }

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -149,6 +149,7 @@ const arrowShadowColor = "#231f20";
 export default async function ({ addon, console, msg }) {
   // Will be replaced with the current Scratch theme's colors when entering the editor
   let originalColors = defaultColors;
+  let originalConstants = {};
 
   const textMode = () => {
     if (addon.self.disabled) {
@@ -242,20 +243,52 @@ export default async function ({ addon, console, msg }) {
   // Code that needs to work on the project page must be above this line
   const Blockly = await addon.tab.traps.getBlockly();
 
-  originalColors = JSON.parse(JSON.stringify(Blockly.Colours));
+  const updateOriginalColors = (theme) => {
+    const styles = theme.blockStyles;
+    for (const [colorId, color] of Object.entries(styles)) {
+      if (colorId.endsWith("_selected")) continue;
+      if (!color.colourPrimary) {
+        // not a block color
+        originalColors[colorId] = color;
+        continue;
+      }
+      originalColors[colorId] = {
+        primary: color.colourPrimary,
+        secondary: color.colourSecondary,
+        tertiary: color.colourTertiary,
+        quaternary: color.colourQuaternary,
+      };
+      if (!categories.find((category) => category.colorId === colorId)) {
+        categories.push({
+          id: null,
+          settingId: extensionsCategory.settingId,
+          colorId,
+        });
+      }
+    }
+  };
+  if (Blockly.registry) updateOriginalColors(addon.tab.traps.getWorkspace().getTheme());
+  else originalColors = JSON.parse(JSON.stringify(Blockly.Colours));
   originalColors.sa = {
     primary: "#29beb8",
     secondary: "#3aa8a4",
     tertiary: "#3aa8a4",
   };
 
-  const originalNumpadDeleteIcon = Blockly.FieldNumber.NUMPAD_DELETE_ICON;
+  let FieldNumber;
+  if (Blockly.registry) FieldNumber = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_number");
+  else FieldNumber = Blockly.FieldNumber;
+  const originalNumpadDeleteIcon = FieldNumber.NUMPAD_DELETE_ICON;
+
+  // Method that needs to be overridden to change field colors
+  const fieldMethodName = Blockly.registry ? "applyColour" : "init";
 
   const fieldBackground = (category) => {
     // Background color for open dropdowns and (in some textModes) Boolean inputs
     // The argument can be a block, field, or category
     if (category instanceof Blockly.Block || category instanceof Blockly.Field) {
-      const block = category instanceof Blockly.Block ? category : category.sourceBlock_;
+      let block = category instanceof Blockly.Block ? category : category.sourceBlock_;
+      if (block.isShadow() && block.getParent()) block = block.getParent();
       if (isColoredTextMode() || textMode() === "black") {
         let primary;
         if (block.isShadow() && block.getParent()) primary = block.getParent().getColour();
@@ -274,7 +307,11 @@ export default async function ({ addon, console, msg }) {
     if (addon.self.disabled) return originalColors.text;
     if (textMode() === "white") return "#ffffff";
     if (textMode() === "black") return "#000000";
-    if (field) return field.sourceBlock_.getColourTertiary();
+    if (field) {
+      let block = field.sourceBlock_;
+      if (block.isShadow() && block.getParent()) block = block.getParent();
+      return block.getColourTertiary();
+    }
     return "#000000";
   };
   const otherColor = (settingId, colorId) => {
@@ -292,9 +329,12 @@ export default async function ({ addon, console, msg }) {
   const iconPath = () => `${addon.self.dir}/icons/${useBlackIcons() ? "black_text" : "white_text"}`;
 
   const makeDropdownArrow = (color) => {
-    const arrow = Blockly.utils.createSvgElement("g");
+    let createSvgElement;
+    if (Blockly.registry) createSvgElement = Blockly.utils.dom.createSvgElement;
+    else createSvgElement = Blockly.utils.createSvgElement;
+    const arrow = createSvgElement("g");
     arrow.appendChild(
-      Blockly.utils.createSvgElement("path", {
+      createSvgElement("path", {
         d: arrowShadowPath,
         fill: arrowShadowColor,
         "fill-opacity": 0.1,
@@ -302,7 +342,7 @@ export default async function ({ addon, console, msg }) {
       })
     );
     arrow.appendChild(
-      Blockly.utils.createSvgElement("path", {
+      createSvgElement("path", {
         d: arrowPath,
         fill: color,
         transform: "translate(0, 1.6)",
@@ -312,76 +352,176 @@ export default async function ({ addon, console, msg }) {
   };
 
   // Blockly doesn't handle colors with transparency
-  const oldBlockMakeColor = Blockly.Block.prototype.makeColour_;
-  Blockly.Block.prototype.makeColour_ = function (color) {
-    if (typeof color === "string" && /^#(?:[0-9A-Za-z]{2}){3,4}$/.test(color)) return color;
-    return oldBlockMakeColor(color);
-  };
+  if (Blockly.registry) {
+    // new Blockly
+    const oldValidatedBlockStyle = Blockly.blockRendering.ConstantProvider.prototype.validatedBlockStyle_;
+    Blockly.blockRendering.ConstantProvider.prototype.validatedBlockStyle_ = function (style) {
+      try {
+        return oldValidatedBlockStyle.call(this, style);
+      } catch {
+        return {
+          colourPrimary: style.colourPrimary || "#000",
+          colourSecondary: style.colourSecondary || "#000",
+          colourTertiary: style.colourTertiary || "#000",
+          colourQuaternary: style.colourQuaternary || "#000",
+          hat: style.hat || "",
+        };
+      }
+    };
+  } else {
+    const oldBlockMakeColor = Blockly.Block.prototype.makeColour_;
+    Blockly.Block.prototype.makeColour_ = function (color) {
+      if (typeof color === "string" && /^#(?:[0-9A-Za-z]{2}){3,4}$/.test(color)) return color;
+      return oldBlockMakeColor(color);
+    };
+  }
 
-  const oldCategoryCreateDom = Blockly.Toolbox.Category.prototype.createDom;
-  Blockly.Toolbox.Category.prototype.createDom = function () {
-    // Category bubbles
-    if (this.iconURI_) {
-      if (addon.self.disabled) return oldCategoryCreateDom.call(this);
-      if (!["sa-blocks", "videoSensing", "text2speech"].includes(this.id_)) return oldCategoryCreateDom.call(this);
+  const recolorExtensionIcon = (item) => {
+    if (addon.self.disabled) return;
+    const oldIconUri = Blockly.registry ? item.toolboxItemDef_.iconURI : item.iconURI_;
+    if (oldIconUri) {
+      const id = Blockly.registry ? item.getId() : item.id_;
+      if (!["sa-blocks", "videoSensing", "text2speech"].includes(id)) return oldIconUri;
 
-      const match = dataUriRegex.exec(this.iconURI_);
+      const match = dataUriRegex.exec(oldIconUri);
       if (match) {
         const oldSvg = atob(match[1]);
-        const category = this.id_ === "sa-blocks" ? saCategory : extensionsCategory;
+        const category = id === "sa-blocks" ? saCategory : extensionsCategory;
         const newColor = textMode() === "white" ? primaryColor(category) : tertiaryColor(category);
         if (newColor) {
           const newSvg = oldSvg.replace(/#29beb8|#229487|#0ebd8c/gi, newColor);
-          this.iconURI_ = `data:image/svg+xml;base64,${btoa(newSvg)}`;
-        }
-      }
-    }
-    oldCategoryCreateDom.call(this);
-    if (this.iconURI_) return;
-    const category = categories.find((item) => item.id === this.id_);
-    if (!category) return;
-    this.bubble_.style.backgroundColor = isColoredTextMode() ? fieldBackground(category) : primaryColor(category);
-    this.bubble_.style.borderColor = tertiaryColor(category);
-  };
-
-  const oldBlockSetColour = Blockly.Block.prototype.setColour;
-  Blockly.Block.prototype.setColour = function (colour, colourSecondary, colourTertiary) {
-    // Extension blocks (color is set by VM)
-    if (colour.toLowerCase() === originalColors.pen.primary.toLowerCase()) {
-      colour = primaryColor(extensionsCategory);
-      colourSecondary = secondaryColor(extensionsCategory);
-      colourTertiary = tertiaryColor(extensionsCategory);
-    }
-    return oldBlockSetColour.call(this, colour, colourSecondary, colourTertiary);
-  };
-
-  const oldBlockUpdateColour = Blockly.BlockSvg.prototype.updateColour;
-  Blockly.BlockSvg.prototype.updateColour = function () {
-    oldBlockUpdateColour.call(this);
-    // Boolean inputs
-    if (isColoredTextMode()) {
-      for (const input of this.inputList) {
-        if (input.outlinePath) {
-          input.outlinePath.setAttribute("fill", fieldBackground(this));
+          const newIconUri = `data:image/svg+xml;base64,${btoa(newSvg)}`;
+          if (Blockly.registry) item.toolboxItemDef_.iconURI = newIconUri;
+          else item.iconURI_ = newIconUri;
         }
       }
     }
   };
+  if (Blockly.registry) {
+    // new Blockly
+    const ScratchContinuousCategory = Blockly.registry.getClass(
+      Blockly.registry.Type.TOOLBOX_ITEM,
+      Blockly.ToolboxCategory.registrationName
+    );
+    const oldCategoryCreateIconDom = ScratchContinuousCategory.prototype.createIconDom_;
+    ScratchContinuousCategory.prototype.createIconDom_ = function () {
+      // Category bubbles
+      const oldIconUri = this.toolboxItemDef_.iconURI;
+      recolorExtensionIcon(this);
+      if (!oldIconUri) {
+        const category = categories.find((item) => item.id === this.getId());
+        if (category) {
+          this.colour_ = isColoredTextMode() ? fieldBackground(category) : primaryColor(category);
+          this.toolboxItemDef_.secondaryColour = tertiaryColor(category);
+        }
+      }
+      const iconElement = oldCategoryCreateIconDom.call(this);
+      this.toolboxItemDef_.iconURI = oldIconUri;
+      return iconElement;
+    };
+  } else {
+    const oldCategoryCreateDom = Blockly.Toolbox.Category.prototype.createDom;
+    Blockly.Toolbox.Category.prototype.createDom = function () {
+      // Category bubbles
+      if (addon.self.disabled) return oldCategoryCreateDom.call(this);
+      recolorExtensionIcon(this);
+      oldCategoryCreateDom.call(this);
+      if (this.iconURI_) return;
+      const category = categories.find((item) => item.id === this.id_);
+      if (!category) return;
+      this.bubble_.style.backgroundColor = isColoredTextMode() ? fieldBackground(category) : primaryColor(category);
+      this.bubble_.style.borderColor = tertiaryColor(category);
+    };
+  }
 
-  const oldInsertionMarkerCreateMarkerBlock = Blockly.InsertionMarkerManager.prototype.createMarkerBlock_;
-  Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function (originalBlock) {
-    const markerBlock = oldInsertionMarkerCreateMarkerBlock.call(this, originalBlock);
+  if (Blockly.registry) {
+    // new Blockly
+
+    const oldThemeSetBlockStyle = Blockly.Theme.prototype.setBlockStyle;
+    Blockly.Theme.prototype.setBlockStyle = function (colorId, colors) {
+      // Extension blocks (color is set when extension is added)
+      if (colors.colourPrimary && colors.colourPrimary.toLowerCase() === originalColors.pen.primary.toLowerCase()) {
+        originalColors[colorId] = {
+          primary: colors.colourPrimary,
+          secondary: colors.colourSecondary,
+          tertiary: colors.colourTertiary,
+        };
+        colors = {
+          colourPrimary: primaryColor(extensionsCategory),
+          colourSecondary: secondaryColor(extensionsCategory),
+          colourTertiary: tertiaryColor(extensionsCategory),
+          colourQuaternary: fieldBackground(extensionsCategory),
+        };
+        if (!categories.find((category) => category.colorId === colorId)) {
+          categories.push({
+            id: colorId,
+            settingId: extensionsCategory.settingId,
+            colorId,
+          });
+        }
+      }
+      return oldThemeSetBlockStyle.call(this, colorId, colors);
+    };
+
+    const oldPathObjectApplyColour = Blockly.zelos.PathObject.prototype.applyColour;
+    Blockly.zelos.PathObject.prototype.applyColour = function (block) {
+      // Boolean inputs (called when theme changes)
+      oldPathObjectApplyColour.call(this, block);
+      if (isColoredTextMode()) {
+        for (const outline of this.outlines.values()) {
+          outline.setAttribute("fill", this.style.colourSecondary);
+        }
+      }
+    };
+    const oldPathObjectSetOutlinePath = Blockly.zelos.PathObject.prototype.setOutlinePath;
+    Blockly.zelos.PathObject.prototype.setOutlinePath = function (name, pathString) {
+      // Boolean inputs (called when a new block is created)
+      oldPathObjectSetOutlinePath.call(this, name, pathString);
+      if (isColoredTextMode()) {
+        this.getOutlinePath(name).setAttribute("fill", this.style.colourSecondary);
+      }
+    };
+  } else {
+    const oldBlockSetColour = Blockly.Block.prototype.setColour;
+    Blockly.Block.prototype.setColour = function (colour, colourSecondary, colourTertiary) {
+      // Extension blocks (color is set by VM)
+      if (colour.toLowerCase() === originalColors.pen.primary.toLowerCase()) {
+        colour = primaryColor(extensionsCategory);
+        colourSecondary = secondaryColor(extensionsCategory);
+        colourTertiary = tertiaryColor(extensionsCategory);
+      }
+      return oldBlockSetColour.call(this, colour, colourSecondary, colourTertiary);
+    };
+
+    const oldBlockUpdateColour = Blockly.BlockSvg.prototype.updateColour;
+    Blockly.BlockSvg.prototype.updateColour = function () {
+      oldBlockUpdateColour.call(this);
+      // Boolean inputs
+      if (isColoredTextMode()) {
+        for (const input of this.inputList) {
+          if (input.outlinePath) {
+            input.outlinePath.setAttribute("fill", fieldBackground(this));
+          }
+        }
+      }
+    };
+  }
+
+  const recolorInsertionMarker = (originalBlock, markerBlock) => {
     if (!addon.self.disabled) {
       const styleColour = isColoredTextMode() ? originalBlock.getColourTertiary() : originalBlock.getColour();
       const fillStyle = addon.settings.get("fillStyle");
       const strokeStyle = addon.settings.get("strokeStyle");
 
-      markerBlock.svgPath_.style.fill = {
+      let svgPath;
+      if (Blockly.registry) svgPath = markerBlock.pathObject.svgPath; // new Blockly
+      else svgPath = markerBlock.svgPath_;
+      svgPath.style.fill = {
         none: "transparent",
         gray: "",
         colored: styleColour,
       }[fillStyle];
-      markerBlock.svgPath_.style.stroke = {
+      svgPath.style.stroke = {
         none: "",
         gray: "var(--editorDarkMode-workspace-insertionMarker, rgb(0, 0, 0))",
         colored: styleColour,
@@ -389,50 +529,104 @@ export default async function ({ addon, console, msg }) {
     }
     return markerBlock;
   };
+  if (Blockly.registry) {
+    // new Blockly
+    const oldCreateInsertionMarker = Blockly.InsertionMarkerPreviewer.prototype.createInsertionMarker;
+    Blockly.InsertionMarkerPreviewer.prototype.createInsertionMarker = function (originalBlock) {
+      const markerBlock = oldCreateInsertionMarker.call(this, originalBlock);
+      return recolorInsertionMarker(originalBlock, markerBlock);
+    };
+  } else {
+    const oldInsertionMarkerCreateMarkerBlock = Blockly.InsertionMarkerManager.prototype.createMarkerBlock_;
+    Blockly.InsertionMarkerManager.prototype.createMarkerBlock_ = function (originalBlock) {
+      const markerBlock = oldInsertionMarkerCreateMarkerBlock.call(this, originalBlock);
+      return recolorInsertionMarker(originalBlock, markerBlock);
+    };
+  }
 
-  const oldBlockShowContextMenu = Blockly.BlockSvg.prototype.showContextMenu_;
-  Blockly.BlockSvg.prototype.showContextMenu_ = function (e) {
-    Blockly.WidgetDiv.DIV.style.setProperty("--editorTheme3-hoveredItem", fieldBackground(this));
-    return oldBlockShowContextMenu.call(this, e);
-  };
+  if (!Blockly.registry) {
+    // editor-colored-context menus compatibility
+    // doesn't support new Blockly yet
+    const oldBlockShowContextMenu = Blockly.BlockSvg.prototype.showContextMenu_;
+    Blockly.BlockSvg.prototype.showContextMenu_ = function (e) {
+      Blockly.WidgetDiv.DIV.style.setProperty("--editorTheme3-hoveredItem", fieldBackground(this));
+      return oldBlockShowContextMenu.call(this, e);
+    };
+  }
 
-  const oldFieldLabelInit = Blockly.FieldLabel.prototype.init;
-  Blockly.FieldLabel.prototype.init = function () {
+  if (Blockly.registry) {
+    // new Blockly
+    const oldFieldGetConstants = Blockly.Field.prototype.getConstants;
+    Blockly.Field.prototype.getConstants = function () {
+      const constants = oldFieldGetConstants.call(this);
+      for (const [name, settingId] of [["FIELD_BORDER_RECT_COLOUR", "input-color"]]) {
+        if (!Object.prototype.hasOwnProperty.call(originalConstants, name)) originalConstants[name] = constants[name];
+        if (addon.self.disabled) constants[name] = originalConstants[name];
+        else constants[name] = addon.settings.get(settingId);
+      }
+      return constants;
+    };
+  }
+
+  const oldFieldLabelInit = Blockly.FieldLabel.prototype[fieldMethodName];
+  Blockly.FieldLabel.prototype[fieldMethodName] = function () {
     // Labels
     oldFieldLabelInit.call(this);
-    this.textElement_.style.fill = textColor(this);
+    if (this.textElement_) this.textElement_.style.fill = textColor(this);
   };
 
-  const oldFieldTextInputInit = Blockly.FieldTextInput.prototype.init;
-  Blockly.FieldTextInput.prototype.init = function () {
-    // Text inputs
-    oldFieldTextInputInit.call(this);
-    if (this.sourceBlock_.isShadow()) return;
-    // Labels in custom block editor
-    this.box_.setAttribute("fill", isColoredTextMode() ? fieldBackground(this) : this.sourceBlock_.getColourTertiary());
-  };
+  if (!Blockly.registry) {
+    // old Blockly
 
-  const oldFieldTextInputRemovableShowEditor = Blockly.FieldTextInputRemovable.prototype.showEditor_;
-  Blockly.FieldTextInputRemovable.prototype.showEditor_ = function () {
-    oldFieldTextInputRemovableShowEditor.call(this);
-    if (!this.sourceBlock_.isShadow()) {
+    const oldFieldTextInputInit = Blockly.FieldTextInput.prototype.init;
+    Blockly.FieldTextInput.prototype.init = function () {
+      // Text inputs
+      oldFieldTextInputInit.call(this);
+      if (this.sourceBlock_.isShadow()) return;
       // Labels in custom block editor
-      Blockly.WidgetDiv.DIV.classList.add("sa-theme3-editable-label");
-    }
-  };
+      this.box_.setAttribute(
+        "fill",
+        isColoredTextMode() ? fieldBackground(this) : this.sourceBlock_.getColourTertiary()
+      );
+    };
 
-  const oldFieldNumberUpdateDisplay = Blockly.FieldNumber.updateDisplay_;
-  Blockly.FieldNumber.updateDisplay_ = function (...args) {
-    /* Called when editing a number input using the numpad. Scratch's implementation
-       only updates the HTML input. The addon hides the HTML input, so the field itself
-       needs to be updated to make the change visible. */
-    oldFieldNumberUpdateDisplay.call(this, ...args);
-    Blockly.FieldNumber.activeField_.onHtmlInputChange_(new Event(""));
-  };
+    const oldFieldTextInputRemovableShowEditor = Blockly.FieldTextInputRemovable.prototype.showEditor_;
+    Blockly.FieldTextInputRemovable.prototype.showEditor_ = function () {
+      oldFieldTextInputRemovableShowEditor.call(this);
+      if (!this.sourceBlock_.isShadow()) {
+        // Labels in custom block editor
+        Blockly.WidgetDiv.DIV.classList.add("sa-theme3-editable-label");
+      }
+    };
+
+    const oldFieldNumberUpdateDisplay = Blockly.FieldNumber.updateDisplay_;
+    Blockly.FieldNumber.updateDisplay_ = function (...args) {
+      /* Called when editing a number input using the numpad. Scratch's implementation
+          only updates the HTML input. The addon hides the HTML input, so the field itself
+          needs to be updated to make the change visible. */
+      oldFieldNumberUpdateDisplay.call(this, ...args);
+      Blockly.FieldNumber.activeField_.onHtmlInputChange_(new Event(""));
+    };
+  }
+
+  if (Blockly.registry) {
+    // new Blockly
+    const oldFieldNUmberShowNumPad = FieldNumber.prototype.showNumPad_;
+    FieldNumber.prototype.showNumPad_ = function () {
+      // Number pad
+      oldFieldNUmberShowNumPad.call(this);
+      Blockly.DropDownDiv.setColour(
+        this.sourceBlock_.getParent().getColour(),
+        this.sourceBlock_.getParent().getColourTertiary()
+      );
+    };
+  }
 
   const oldFieldImageSetValue = Blockly.FieldImage.prototype.setValue;
   Blockly.FieldImage.prototype.setValue = function (src) {
     // Icons
+    if (this.saOriginalSrc) src = this.saOriginalSrc;
+    else this.saOriginalSrc = src;
     if ((src.startsWith("data:") || src.includes("static/assets")) && this.sourceBlock_) {
       // Extension icon
       const iconsToReplace = ["music", "pen", "text2speech", "translate", "videoSensing"];
@@ -451,38 +645,98 @@ export default async function ({ addon, console, msg }) {
     return oldFieldImageSetValue.call(this, src);
   };
 
-  const oldFieldDropdownInit = Blockly.FieldDropdown.prototype.init;
-  Blockly.FieldDropdown.prototype.init = function () {
-    // Dropdowns
-    oldFieldDropdownInit.call(this);
-    this.textElement_.style.setProperty("fill", textColor(this), "important");
-    this.arrow_.remove();
-    this.arrow_ = makeDropdownArrow(textColor(this));
-    // Redraw arrow
-    const text = this.text_;
-    this.text_ = null;
-    this.setText(text);
-  };
+  if (Blockly.registry) {
+    // new Blockly
+    const oldFieldImageApplyColour = Blockly.FieldImage.prototype.applyColour;
+    Blockly.FieldImage.prototype.applyColour = function () {
+      // Update icon
+      oldFieldImageApplyColour.call(this);
+      this.setValue(this.getValue()); // setValue() is overridden above
+    };
+  }
 
-  const oldFieldDropdownShowEditor = Blockly.FieldDropdown.prototype.showEditor_;
-  Blockly.FieldDropdown.prototype.showEditor_ = function () {
+  let FieldDropdown;
+  if (Blockly.registry) {
+    /* new Blockly: most dropdowns are instances of ScratchFieldDropdown,
+       which is a subclass of Blockly.FieldDropdown. */
+    const ScratchFieldDropdown = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_dropdown");
+    FieldDropdown = ScratchFieldDropdown;
+
+    const oldFieldDropdownApplyColour = Blockly.FieldDropdown.prototype.applyColour;
+    Blockly.FieldDropdown.prototype.applyColour = function () {
+      // Dropdowns
+      oldFieldDropdownApplyColour.call(this);
+      if (this.textElement_) this.textElement_.style.setProperty("fill", textColor(this), "important");
+      if (this.svgArrow) {
+        this.svgArrow.remove();
+        this.svgArrow = makeDropdownArrow(textColor(this));
+        this.fieldGroup_.appendChild(this.svgArrow);
+        // Reposition arrow
+        this.renderSelectedText();
+      }
+    };
+
+    // Force all instances of Blockly.Dropdown to behave like ScratchFieldDropdown
+    // This fixes some dropdowns using tertiary instead of quaternary color when open
+    const oldBlocklyFieldDropdownShowEditor = Blockly.FieldDropdown.prototype.showEditor_;
+    Blockly.FieldDropdown.prototype.showEditor_ = function (e) {
+      if (this instanceof ScratchFieldDropdown || this.saPreventInfiniteRecursion) {
+        oldBlocklyFieldDropdownShowEditor.call(this, e);
+        return;
+      }
+      this.saPreventInfiniteRecursion = true;
+      ScratchFieldDropdown.prototype.showEditor_.call(this, e);
+      delete this.saPreventInfiniteRecursion;
+    };
+    const oldBlocklyFieldDropdownDispose = Blockly.FieldDropdown.prototype.dropdownDispose_;
+    Blockly.FieldDropdown.prototype.dropdownDispose_ = function (e) {
+      if (this instanceof ScratchFieldDropdown || this.saPreventInfiniteRecursion) {
+        oldBlocklyFieldDropdownDispose.call(this, e);
+        return;
+      }
+      this.saPreventInfiniteRecursion = true;
+      ScratchFieldDropdown.prototype.dropdownDispose_.call(this, e);
+      delete this.saPreventInfiniteRecursion;
+    };
+  } else {
+    FieldDropdown = Blockly.FieldDropdown;
+
+    const oldFieldDropdownInit = Blockly.FieldDropdown.prototype.init;
+    Blockly.FieldDropdown.prototype.init = function () {
+      // Dropdowns
+      oldFieldDropdownInit.call(this);
+      this.textElement_.style.setProperty("fill", textColor(this), "important");
+      this.arrow_.remove();
+      this.arrow_ = makeDropdownArrow(textColor(this));
+      // Redraw arrow
+      const text = this.text_;
+      this.text_ = null;
+      this.setText(text);
+    };
+  }
+
+  const oldFieldDropdownShowEditor = FieldDropdown.prototype.showEditor_;
+  FieldDropdown.prototype.showEditor_ = function () {
     oldFieldDropdownShowEditor.call(this);
 
-    // Open dropdowns
-    if (!this.disableColourChange_) {
-      if (this.sourceBlock_.isShadow()) {
-        this.sourceBlock_.setShadowColour(fieldBackground(this));
-      } else if (this.box_) {
-        this.box_.setAttribute("fill", fieldBackground(this));
+    if (!Blockly.registry) {
+      // old Blockly
+      // Open dropdowns
+      if (!this.disableColourChange_) {
+        if (this.sourceBlock_.isShadow()) {
+          this.sourceBlock_.setShadowColour(fieldBackground(this));
+        } else if (this.box_) {
+          this.box_.setAttribute("fill", fieldBackground(this));
+        }
       }
-    }
 
-    // Dropdown menus
-    let primaryColor;
-    if (this.sourceBlock_.isShadow() && this.sourceBlock_.getParent())
-      primaryColor = this.sourceBlock_.getParent().getColour();
-    else primaryColor = this.sourceBlock_.getColour();
-    Blockly.DropDownDiv.DIV_.style.backgroundColor = removeAlpha(primaryColor);
+      // Dropdown menus
+      let primaryColor;
+      if (this.sourceBlock_.isShadow() && this.sourceBlock_.getParent())
+        primaryColor = this.sourceBlock_.getParent().getColour();
+      else primaryColor = this.sourceBlock_.getColour();
+      Blockly.DropDownDiv.DIV_.style.backgroundColor = removeAlpha(primaryColor);
+    }
     if (isColoredTextMode()) {
       Blockly.DropDownDiv.getContentDiv().style.setProperty("--editorTheme3-hoveredItem", fieldBackground(this));
     } else {
@@ -490,22 +744,28 @@ export default async function ({ addon, console, msg }) {
     }
   };
 
-  const oldFieldVariableInit = Blockly.FieldVariable.prototype.init;
-  Blockly.FieldVariable.prototype.init = function () {
-    // Variable dropdowns
-    oldFieldVariableInit.call(this);
-    this.textElement_.style.setProperty("fill", textColor(this), "important");
-  };
+  if (!Blockly.registry) {
+    // old Blockly
+    const oldFieldVariableInit = Blockly.FieldVariable.prototype.init;
+    Blockly.FieldVariable.prototype.init = function () {
+      // Variable dropdowns
+      oldFieldVariableInit.call(this);
+      this.textElement_.style.setProperty("fill", textColor(this), "important");
+    };
 
-  const oldFieldVariableGetterInit = Blockly.FieldVariableGetter.prototype.init;
-  Blockly.FieldVariableGetter.prototype.init = function () {
-    // Variable reporters
-    oldFieldVariableGetterInit.call(this);
-    this.textElement_.style.fill = textColor(this);
-  };
+    const oldFieldVariableGetterInit = Blockly.FieldVariableGetter.prototype.init;
+    Blockly.FieldVariableGetter.prototype.init = function () {
+      // Variable reporters
+      oldFieldVariableGetterInit.call(this);
+      this.textElement_.style.fill = textColor(this);
+    };
+  }
 
-  const oldFieldNoteAddOctaveButton = Blockly.FieldNote.prototype.addOctaveButton_;
-  Blockly.FieldNote.prototype.addOctaveButton_ = function (...args) {
+  let FieldNote;
+  if (Blockly.registry) FieldNote = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_note");
+  FieldNote = Blockly.FieldNote;
+  const oldFieldNoteAddOctaveButton = FieldNote.prototype.addOctaveButton_;
+  FieldNote.prototype.addOctaveButton_ = function (...args) {
     // Octave buttons in "play note" dropdown
     const group = oldFieldNoteAddOctaveButton.call(this, ...args);
     group
@@ -515,9 +775,14 @@ export default async function ({ addon, console, msg }) {
   };
 
   // Matrix inputs
-  const oldFieldMatrixInit = Blockly.FieldMatrix.prototype.init;
-  Blockly.FieldMatrix.prototype.init = function () {
+  let FieldMatrix;
+  if (Blockly.registry) FieldMatrix = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_matrix");
+  else FieldMatrix = Blockly.FieldMatrix;
+  const oldFieldMatrixInit = FieldMatrix.prototype[fieldMethodName];
+  FieldMatrix.prototype[fieldMethodName] = function () {
     oldFieldMatrixInit.call(this);
+    if (this.getValue()) this.updateMatrix_();
+    if (!this.arrow_) return;
     const arrowTransform = this.arrow_.getAttribute("transform");
     this.arrow_.remove();
     this.arrow_ = makeDropdownArrow(textColor(this));
@@ -525,40 +790,51 @@ export default async function ({ addon, console, msg }) {
     this.arrow_.style.cursor = "default";
     this.fieldGroup_.appendChild(this.arrow_);
   };
-  const oldFieldMatrixShowEditor = Blockly.FieldMatrix.prototype.showEditor_;
-  Blockly.FieldMatrix.prototype.showEditor_ = function () {
-    oldFieldMatrixShowEditor.call(this);
-    let primaryColor;
-    if (this.sourceBlock_.isShadow() && this.sourceBlock_.getParent())
-      primaryColor = this.sourceBlock_.getParent().getColour();
-    else primaryColor = this.sourceBlock_.getColour();
-    Blockly.DropDownDiv.DIV_.style.backgroundColor = removeAlpha(primaryColor);
-  };
-  const oldFieldMatrixUpdateMatrix = Blockly.FieldMatrix.prototype.updateMatrix_;
-  Blockly.FieldMatrix.prototype.updateMatrix_ = function () {
+  if (!Blockly.registry) {
+    // old Blockly
+    const oldFieldMatrixShowEditor = Blockly.FieldMatrix.prototype.showEditor_;
+    Blockly.FieldMatrix.prototype.showEditor_ = function () {
+      oldFieldMatrixShowEditor.call(this);
+      let primaryColor;
+      if (this.sourceBlock_.isShadow() && this.sourceBlock_.getParent())
+        primaryColor = this.sourceBlock_.getParent().getColour();
+      else primaryColor = this.sourceBlock_.getColour();
+      Blockly.DropDownDiv.DIV_.style.backgroundColor = removeAlpha(primaryColor);
+    };
+  }
+  const oldFieldMatrixUpdateMatrix = FieldMatrix.prototype.updateMatrix_;
+  FieldMatrix.prototype.updateMatrix_ = function () {
     oldFieldMatrixUpdateMatrix.call(this);
-    for (let i = 0; i < this.matrix_.length; i++) {
-      if (this.matrix_[i] !== "0") {
+    const matrix = this.getValue();
+    for (let i = 0; i < matrix.length; i++) {
+      if (matrix[i] !== "0") {
         this.fillMatrixNode_(this.ledButtons_, i, uncoloredTextColor());
         this.fillMatrixNode_(this.ledThumbNodes_, i, uncoloredTextColor());
       }
     }
   };
-  const oldFieldMatrixCreateButton = Blockly.FieldMatrix.prototype.createButton_;
-  Blockly.FieldMatrix.prototype.createButton_ = function (fill) {
+  const oldFieldMatrixCreateButton = FieldMatrix.prototype.createButton_;
+  FieldMatrix.prototype.createButton_ = function (fill) {
     if (fill === "#FFFFFF") fill = uncoloredTextColor();
     return oldFieldMatrixCreateButton.call(this, fill);
   };
 
-  const oldFieldVerticalSeparatorInit = Blockly.FieldVerticalSeparator.prototype.init;
-  Blockly.FieldVerticalSeparator.prototype.init = function () {
+  let FieldVerticalSeparator;
+  if (Blockly.registry)
+    FieldVerticalSeparator = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_vertical_separator");
+  else FieldVerticalSeparator = Blockly.FieldVerticalSeparator;
+  const oldFieldVerticalSeparatorInit = FieldVerticalSeparator.prototype[fieldMethodName];
+  FieldVerticalSeparator.prototype[fieldMethodName] = function () {
     // Vertical line between extension icon and block label
     oldFieldVerticalSeparatorInit.call(this);
-    if (isColoredTextMode() || textMode() === "black")
-      this.lineElement_.setAttribute("stroke", this.sourceBlock_.getColourTertiary());
+    if (this.lineElement_) {
+      if (isColoredTextMode() || textMode() === "black")
+        this.lineElement_.setAttribute("stroke", this.sourceBlock_.getColourTertiary());
+      else this.lineElement_.setAttribute("stroke", this.sourceBlock_.getColourSecondary());
+    }
   };
 
-  const updateColors = () => {
+  const updateColors = (workspace) => {
     for (const category of categories) {
       // CSS variables are used for compatibility with other addons
       const prefix = `--editorTheme3-${category.colorId}`;
@@ -571,51 +847,105 @@ export default async function ({ addon, console, msg }) {
         document.documentElement.style.setProperty(`${prefix}-${name}`, value);
       }
 
-      // Update Blockly.Colours
-      if (!Blockly.Colours[category.colorId]) continue;
-      Blockly.Colours[category.colorId].primary = primaryColor(category);
-      Blockly.Colours[category.colorId].secondary = secondaryColor(category);
-      Blockly.Colours[category.colorId].tertiary = tertiaryColor(category);
+      if (!Blockly.registry) {
+        // old Blockly: update Blockly.Colours for categories
+        if (!Blockly.Colours[category.colorId]) continue;
+        Blockly.Colours[category.colorId].primary = primaryColor(category);
+        Blockly.Colours[category.colorId].secondary = secondaryColor(category);
+        Blockly.Colours[category.colorId].tertiary = tertiaryColor(category);
+      }
+    }
+    if (Blockly.registry) {
+      // new Blockly: update theme
+      if (!workspace) workspace = addon.tab.traps.getWorkspace();
+      workspace.setTheme(
+        new Blockly.Theme(
+          "default", // Scratch's CSS expects the name to be "default" or "high-contrast"
+          Object.fromEntries(
+            categories.map((category) => [
+              category.colorId,
+              {
+                colourPrimary: primaryColor(category),
+                colourSecondary: secondaryColor(category),
+                colourTertiary: tertiaryColor(category),
+                colourQuaternary: fieldBackground(category),
+              },
+            ])
+          )
+        )
+      );
+      workspace.refreshTheme();
     }
     addon.tab.setCustomBlockColor({
       color: primaryColor(saCategory),
       secondaryColor: secondaryColor(saCategory),
       tertiaryColor: tertiaryColor(saCategory),
     });
-    Blockly.Colours.textField = otherColor("input-color", "textField");
-    if (textMode() === "colorOnWhite") Blockly.Colours.fieldShadow = "rgba(0, 0, 0, 0.15)";
-    else Blockly.Colours.fieldShadow = originalColors.fieldShadow;
-    Blockly.Colours.text = uncoloredTextColor(); // used by editor-colored-context-menus
+    if (!Blockly.registry) {
+      // old Blockly: update Blockly.Colours for UI elements
+      Blockly.Colours.textField = otherColor("input-color", "textField");
+      if (textMode() === "colorOnWhite") Blockly.Colours.fieldShadow = "rgba(0, 0, 0, 0.15)";
+      else Blockly.Colours.fieldShadow = originalColors.fieldShadow;
+      Blockly.Colours.text = uncoloredTextColor(); // used by editor-colored-context-menus
+    }
 
     const safeTextColor = encodeURIComponent(uncoloredTextColor());
-    Blockly.FieldNumber.NUMPAD_DELETE_ICON = originalNumpadDeleteIcon.replace("white", safeTextColor);
+    FieldNumber.NUMPAD_DELETE_ICON = originalNumpadDeleteIcon.replace("white", safeTextColor);
 
-    updateAllBlocks(addon.tab, { updateCategories: true });
+    updateAllBlocks(addon.tab, {
+      updateMainWorkspace: !Blockly.registry,
+      updateFlyout: !Blockly.registry,
+      updateCategories: true,
+    });
   };
 
-  updateColors();
-  addon.settings.addEventListener("change", updateColors);
-  addon.self.addEventListener("disabled", updateColors);
-  addon.self.addEventListener("reenabled", updateColors);
+  if (Blockly.registry) {
+    const updateAllWorkspaces = () => {
+      for (const workspace of Blockly.common.getAllWorkspaces()) {
+        updateColors(workspace);
+      }
+    };
+    updateAllWorkspaces();
+    addon.settings.addEventListener("change", updateAllWorkspaces);
+    addon.self.addEventListener("disabled", updateAllWorkspaces);
+    addon.self.addEventListener("reenabled", updateAllWorkspaces);
+  } else {
+    updateColors();
+    addon.settings.addEventListener("change", updateColors);
+    addon.self.addEventListener("disabled", updateColors);
+    addon.self.addEventListener("reenabled", updateColors);
+  }
 
-  /* inject() and overrideColours() are called when a new Blockly instance is created,
-     which usually happens when changing the Scratch theme, language, or editor mode.
-     They will also be called when the Make a Block modal is opened. */
-  const oldInject = Blockly.inject;
-  Blockly.inject = function (...args) {
-    const workspace = oldInject.call(this, ...args);
-    /* Scratch doesn't pass color options to inject() when creating a custom block
-       editing workspace, so we don't need to call updateColors() in that case.
-       The custom block workspace doesn't have a toolbox. */
-    if (workspace.getToolbox()) updateColors();
-    return workspace;
-  };
-  Blockly.inject.bindDocumentEvents_ = oldInject.bindDocumentEvents_;
-  Blockly.inject.loadSounds_ = oldInject.loadSounds_;
-  Blockly.Colours.overrideColours = function (newColors) {
-    if (!newColors) return;
-    Object.assign(originalColors, newColors);
-  };
+  if (Blockly.registry) {
+    // new Blockly: ThemeManager.subscribeWorkspace() is called when a new workspace is created
+    const oldThemeManagerSubscribeWorkspace = Blockly.ThemeManager.prototype.subscribeWorkspace;
+    Blockly.ThemeManager.prototype.subscribeWorkspace = function (workspace) {
+      oldThemeManagerSubscribeWorkspace.call(this, workspace);
+      setTimeout(() => {
+        updateOriginalColors(workspace.getTheme());
+        updateColors(workspace);
+      }, 0);
+    };
+  } else {
+    /* old Blockly: inject() and overrideColours() are called when a new Blockly instance is created,
+      which usually happens when changing the Scratch theme, language, or editor mode.
+      They will also be called when the Make a Block modal is opened. */
+    const oldInject = Blockly.inject;
+    Blockly.inject = function (...args) {
+      const workspace = oldInject.call(this, ...args);
+      /* Scratch doesn't pass color options to inject() when creating a custom block
+        editing workspace, so we don't need to call updateColors() in that case.
+        The custom block workspace doesn't have a toolbox. */
+      if (workspace.getToolbox()) updateColors();
+      return workspace;
+    };
+    Blockly.inject.bindDocumentEvents_ = oldInject.bindDocumentEvents_;
+    Blockly.inject.loadSounds_ = oldInject.loadSounds_;
+    Blockly.Colours.overrideColours = function (newColors) {
+      if (!newColors) return;
+      Object.assign(originalColors, newColors);
+    };
+  }
 
   (async () => {
     // Custom colors for "Add an input/label" block icons in the "Make a block" popup menu, by pumpkinhasapatch

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -859,19 +859,22 @@ export default async function ({ addon, console, msg }) {
       // new Blockly: update theme
       if (!workspace) workspace = addon.tab.traps.getWorkspace();
       workspace.setTheme(
-        new Blockly.Theme(
+        Blockly.Theme.defineTheme(
           "default", // Scratch's CSS expects the name to be "default" or "high-contrast"
-          Object.fromEntries(
-            categories.map((category) => [
-              category.colorId,
-              {
-                colourPrimary: primaryColor(category),
-                colourSecondary: secondaryColor(category),
-                colourTertiary: tertiaryColor(category),
-                colourQuaternary: fieldBackground(category),
-              },
-            ])
-          )
+          {
+            blockStyles: Object.fromEntries(
+              categories.map((category) => [
+                category.colorId,
+                {
+                  colourPrimary: primaryColor(category),
+                  colourSecondary: secondaryColor(category),
+                  colourTertiary: tertiaryColor(category),
+                  colourQuaternary: fieldBackground(category),
+                },
+              ])
+            ),
+            startHats: true,
+          }
         )
       );
       workspace.refreshTheme();

--- a/addons/number-pad/userscript.js
+++ b/addons/number-pad/userscript.js
@@ -1,12 +1,23 @@
 export default async function ({ addon, msg, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
 
-  // https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/field_number.js#L165
-  const originalMouseDown = ScratchBlocks.FieldNumber.prototype.showEditor_;
-  ScratchBlocks.FieldNumber.prototype.showEditor_ = function (...args) {
+  // https://github.com/scratchfoundation/scratch-blocks/blob/2e3a31e/core/field_number.js#L165
+  // https://github.com/scratchfoundation/scratch-blocks/blob/638ee0f/src/fields/field_number.js#L135
+  let FieldNumber;
+  if (ScratchBlocks.registry) {
+    // new Blockly
+    FieldNumber = ScratchBlocks.registry.getClass(ScratchBlocks.registry.Type.FIELD, "field_number");
+  } else {
+    FieldNumber = ScratchBlocks.FieldNumber;
+  }
+  const originalMouseDown = FieldNumber.prototype.showEditor_;
+  FieldNumber.prototype.showEditor_ = function (e) {
     if (!addon.self.disabled) {
       this.useTouchInteraction_ = true;
+      if (typeof e !== "undefined") {
+        e = new PointerEvent(e.type, { ...e, pointerType: "touch" });
+      }
     }
-    return originalMouseDown.apply(this, args);
+    return originalMouseDown.call(this, e);
   };
 }


### PR DESCRIPTION
### Changes

Updates "customizable block colors" and "always show number pad" to work with the new version of Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox.