### PR TITLE
editor-dark-mode: style category titles in Tutorials library

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -117,7 +117,8 @@
   background-color: var(--editorDarkMode-selector);
   color-scheme: var(--editorDarkMode-selector-colorScheme);
 }
-[class*="sprite-selector-item_sprite-info_"] {
+[class*="sprite-selector-item_sprite-info_"],
+[class*="library_library-category-title_"] {
   color: var(--editorDarkMode-selector-text);
 }
 [class*="card_card_"] {


### PR DESCRIPTION
### Changes

Scratch recently added categories to the Tutorials library. This PR adds the necessary styles to editor dark mode.
![image](https://github.com/user-attachments/assets/8d252bfe-5bd2-4483-8caf-512b74fa4235)

### Reason for changes

It looks like this on v1.39.1:
![image](https://github.com/user-attachments/assets/1ee254f4-0db7-4eaf-8fec-1483ad90ba01)

### Tests

Tested on Edge and Firefox.