### PR TITLE
dark-www: style Community Guidelines modal

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -191,6 +191,12 @@ body:not(.sa-body-editor) .button.white,
 .initiatives-section .initiatives-subsection-content .bubble.inverted {
   background-color: var(--darkWww-box);
 }
+.ReactModal__Content[style*="background: rgb(255, 255, 255)"] {
+  /* Community Guidelines modal */
+  background-color: var(--darkWww-box) !important;
+  border-color: transparent !important;
+  color: var(--darkWww-box-text);
+}
 .expect .keynote .card {
   background-color: transparent;
 }


### PR DESCRIPTION
### Changes

Scratch now shows a full-screen popup with the Community Guidelines (similar to the Scratcher promotion page) to new users after joining. This PR adds the necessary dark mode CSS:

![image](https://github.com/user-attachments/assets/54427bc8-1fb8-4dd5-a45b-9c69794b082a)

### Tests

Tested on Edge and Firefox. The easiest way to test this is to set the localStorage key `shouldReviewCommunityGuidelines` to `true` and reload the Scratch homepage.