### PR TITLE
debugger, editor-stepping, find-bar, jump-to-def: new Blockly

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -166,7 +166,7 @@ const injectWorkspace = (ScratchBlocks) => {
         }
       }
       return oldApplyColour.call(this, ...args);
-    }
+    };
   } else {
     const oldUpdateColour = BlockSvg.prototype.updateColour;
     BlockSvg.prototype.updateColour = function (...args) {
@@ -247,17 +247,18 @@ const injectWorkspace = (ScratchBlocks) => {
     };
   }
 
-  const newCreateAllInputs = (originalCreateAllInputs) => function (...args) {
-    const blockData = getCustomBlock(this.procCode_);
-    if (blockData) {
-      const originalProcCode = this.procCode_;
-      this.procCode_ = blockData.displayName;
-      const ret = originalCreateAllInputs.call(this, ...args);
-      this.procCode_ = originalProcCode;
-      return ret;
-    }
-    return originalCreateAllInputs.call(this, ...args);
-  };
+  const newCreateAllInputs = (originalCreateAllInputs) =>
+    function (...args) {
+      const blockData = getCustomBlock(this.procCode_);
+      if (blockData) {
+        const originalProcCode = this.procCode_;
+        this.procCode_ = blockData.displayName;
+        const ret = originalCreateAllInputs.call(this, ...args);
+        this.procCode_ = originalProcCode;
+        return ret;
+      }
+      return originalCreateAllInputs.call(this, ...args);
+    };
   if (ScratchBlocks.registry) {
     // new Blockly
     const originalBlockDoInit = ScratchBlocks.Block.prototype.doInit_;
@@ -268,7 +269,7 @@ const injectWorkspace = (ScratchBlocks) => {
         this.createAllInputs_ = newCreateAllInputs(originalCreateAllInputs);
         return result;
       }
-    }
+    };
   } else {
     const originalCreateAllInputs = ScratchBlocks.Blocks["procedures_call"].createAllInputs_;
     ScratchBlocks.Blocks["procedures_call"].createAllInputs_ = newCreateAllInputs(originalCreateAllInputs);

--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -140,22 +140,50 @@ const generateBlockXML = () => {
 };
 
 const injectWorkspace = (ScratchBlocks) => {
-  const BlockSvg = ScratchBlocks.BlockSvg;
-  const oldUpdateColour = BlockSvg.prototype.updateColour;
-  BlockSvg.prototype.updateColour = function (...args) {
-    // procedures_prototype also have a procedure code but we do not want to color them.
-    if (!this.isInsertionMarker() && this.type === "procedures_call") {
-      const block = this.procCode_ && getCustomBlock(this.procCode_);
-      const color = ScratchBlocks.Colours.text === "#000000" ? highContrastColor : defaultColor;
-      if (block) {
-        this.colour_ = customColor.color || color.color;
-        this.colourSecondary_ = customColor.secondaryColor || color.secondaryColor;
-        this.colourTertiary_ = customColor.tertiaryColor || color.tertiaryColor;
-        this.customContextMenu = null;
-      }
-    }
-    return oldUpdateColour.call(this, ...args);
+  const isHighContrast = (workspace) => {
+    if (ScratchBlocks.registry) return workspace.getTheme().name === "high-contrast"; // new Blockly
+    else return ScratchBlocks.Colours.text === "#000000";
   };
+
+  const BlockSvg = ScratchBlocks.BlockSvg;
+  if (ScratchBlocks.registry) {
+    // new Blockly
+    const oldApplyColour = BlockSvg.prototype.applyColour;
+    BlockSvg.prototype.applyColour = function (...args) {
+      // procedures_prototype also have a procedure code but we do not want to color them.
+      if (!this.isInsertionMarker() && this.type === "procedures_call") {
+        const block = this.procCode_ && getCustomBlock(this.procCode_);
+        const color = isHighContrast(this.workspace) ? highContrastColor : defaultColor;
+        if (block) {
+          this.style = {
+            ...this.style,
+            colourPrimary: customColor.color || color.color,
+            colourSecondary: customColor.secondaryColor || color.secondaryColor,
+            colourTertiary: customColor.tertiaryColor || color.tertiaryColor,
+          };
+          this.pathObject.setStyle(this.style);
+          this.customContextMenu = null;
+        }
+      }
+      return oldApplyColour.call(this, ...args);
+    }
+  } else {
+    const oldUpdateColour = BlockSvg.prototype.updateColour;
+    BlockSvg.prototype.updateColour = function (...args) {
+      // procedures_prototype also have a procedure code but we do not want to color them.
+      if (!this.isInsertionMarker() && this.type === "procedures_call") {
+        const block = this.procCode_ && getCustomBlock(this.procCode_);
+        const color = ScratchBlocks.Colours.text === "#000000" ? highContrastColor : defaultColor;
+        if (block) {
+          this.colour_ = customColor.color || color.color;
+          this.colourSecondary_ = customColor.secondaryColor || color.secondaryColor;
+          this.colourTertiary_ = customColor.tertiaryColor || color.tertiaryColor;
+          this.customContextMenu = null;
+        }
+      }
+      return oldUpdateColour.call(this, ...args);
+    };
+  }
 
   // We use Scratch's extension category mechanism to create a new category.
   // https://github.com/scratchfoundation/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
@@ -163,53 +191,63 @@ const injectWorkspace = (ScratchBlocks) => {
   const originalGetBlocksXML = vm.runtime.getBlocksXML;
   vm.runtime.getBlocksXML = function (target) {
     const result = originalGetBlocksXML.call(this, target);
+    let workspace;
+    if (ScratchBlocks.registry) {
+      // New Blockly: we need a workspace (it doesn't matter which one) to get the theme name.
+      // tabAPI.traps.getWorkspace() sometimes throws an error if called inside this function.
+      workspace = ScratchBlocks.common.getMainWorkspace();
+    }
     result.unshift({
       id: "sa-blocks",
       xml:
         "<category" +
         ` name="${escapeHTML(scratchAddons.l10n.get("debugger/@name", null, "Debugger"))}"` +
-        ' id="sa-blocks"' +
+        ` ${ScratchBlocks.registry ? "toolboxitemid" : "id"}="sa-blocks"` +
         ' colour="#ff7b26"' +
         ' secondaryColour="#ff7b26"' +
-        ` iconURI="${ScratchBlocks.Colours.text === "#000000" ? HIGH_CONTRAST_ICON : DEFAULT_ICON}"` +
+        ` iconURI="${isHighContrast(workspace) ? HIGH_CONTRAST_ICON : DEFAULT_ICON}"` +
         `>${generateBlockXML()}</category>`,
     });
     return result;
   };
 
-  // Trick Scratch into thinking addon blocks are defined somewhere.
-  // This makes Scratch's "is this procedure used anywhere" check work when addon blocks exist.
-  // getDefineBlock is used in https://github.com/scratchfoundation/scratch-blocks/blob/37f12ae3e342480f4d8e7b6ba783c46e29e77988/core/block_dragger.js#L275-L297
-  // and https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/procedures.js
-  // Only block_dragger.js should be able to reference addon blocks, but if procedures.js does
-  // somehow, we shim enough of the API that things shouldn't break.
-  const originalGetDefineBlock = ScratchBlocks.Procedures.getDefineBlock;
-  ScratchBlocks.Procedures.getDefineBlock = function (procCode, workspace) {
-    // If an actual definition with this code exists, return that instead of our shim.
-    const result = originalGetDefineBlock.call(this, procCode, workspace);
-    if (result) {
-      return result;
-    }
-    const block = getCustomBlock(procCode);
-    if (block) {
-      return {
-        workspace,
-        getInput() {
-          return {
-            connection: {
-              targetBlock() {
-                return null;
+  if (!ScratchBlocks.registry) {
+    // We can't override this function on new Blockly because it's a not exported.
+    // It isn't referenced anywhere outside procedures.js, so this shouldn't cause issues.
+    // ---
+    // Trick Scratch into thinking addon blocks are defined somewhere.
+    // This makes Scratch's "is this procedure used anywhere" check work when addon blocks exist.
+    // getDefineBlock is used in https://github.com/scratchfoundation/scratch-blocks/blob/37f12ae3e342480f4d8e7b6ba783c46e29e77988/core/block_dragger.js#L275-L297
+    // and https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/procedures.js
+    // Only block_dragger.js should be able to reference addon blocks, but if procedures.js does
+    // somehow, we shim enough of the API that things shouldn't break.
+    const originalGetDefineBlock = ScratchBlocks.Procedures.getDefineBlock;
+    ScratchBlocks.Procedures.getDefineBlock = function (procCode, workspace) {
+      // If an actual definition with this code exists, return that instead of our shim.
+      const result = originalGetDefineBlock.call(this, procCode, workspace);
+      if (result) {
+        return result;
+      }
+      const block = getCustomBlock(procCode);
+      if (block) {
+        return {
+          workspace,
+          getInput() {
+            return {
+              connection: {
+                targetBlock() {
+                  return null;
+                },
               },
-            },
-          };
-        },
-      };
-    }
-    return result;
-  };
+            };
+          },
+        };
+      }
+      return result;
+    };
+  }
 
-  const originalCreateAllInputs = ScratchBlocks.Blocks["procedures_call"].createAllInputs_;
-  ScratchBlocks.Blocks["procedures_call"].createAllInputs_ = function (...args) {
+  const newCreateAllInputs = (originalCreateAllInputs) => function (...args) {
     const blockData = getCustomBlock(this.procCode_);
     if (blockData) {
       const originalProcCode = this.procCode_;
@@ -220,6 +258,21 @@ const injectWorkspace = (ScratchBlocks) => {
     }
     return originalCreateAllInputs.call(this, ...args);
   };
+  if (ScratchBlocks.registry) {
+    // new Blockly
+    const originalBlockDoInit = ScratchBlocks.Block.prototype.doInit_;
+    ScratchBlocks.Block.prototype.doInit_ = function (...args) {
+      const result = originalBlockDoInit.call(this, args);
+      if (this.type === "procedures_call") {
+        const originalCreateAllInputs = this.createAllInputs_;
+        this.createAllInputs_ = newCreateAllInputs(originalCreateAllInputs);
+        return result;
+      }
+    }
+  } else {
+    const originalCreateAllInputs = ScratchBlocks.Blocks["procedures_call"].createAllInputs_;
+    ScratchBlocks.Blocks["procedures_call"].createAllInputs_ = newCreateAllInputs(originalCreateAllInputs);
+  }
 
   // Toolbox update may be required to make category appear in flyout
   queueToolboxUpdate();

--- a/addons/debugger/threads.js
+++ b/addons/debugger/threads.js
@@ -21,7 +21,7 @@ export default async function createThreadsTab({ debug, addon, console, msg }) {
   logView.outerElement.classList.add("sa-debugger-threads");
   logView.placeholderElement.textContent = msg("no-threads-running");
 
-  const highlighter = new Highlighter(10, "#ff0000");
+  const highlighter = new Highlighter(addon, 10, "#ff0000");
 
   logView.generateRow = (row) => {
     const root = document.createElement("div");

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -161,6 +161,7 @@ export default async function ({ addon, console, msg }) {
   interfaceHeader.append(tabListElement, buttonContainerElement);
   interfaceContainer.append(interfaceHeader, tabContentContainer);
   document.body.append(interfaceContainer);
+  moveInterface(0, 0); // necessary to initialize position if running scratch-gui locally
 
   const createHeaderButton = ({ text, icon, description }) => {
     const button = Object.assign(document.createElement("div"), {
@@ -300,7 +301,7 @@ export default async function ({ addon, console, msg }) {
   };
 
   const goToBlock = (blockId) => {
-    const workspace = Blockly.getMainWorkspace();
+    const workspace = addon.tab.traps.getWorkspace();
     const block = workspace.getBlockById(blockId);
     if (!block) return;
 
@@ -428,6 +429,7 @@ export default async function ({ addon, console, msg }) {
       // Try to call things like https://github.com/scratchfoundation/scratch-blocks/blob/0bd1a17e66a779ec5d11f4a00c43784e3ac7a7b8/blocks_vertical/operators.js#L36
       var jsonData;
       const fakeBlock = {
+        workspace: addon.tab.traps.getWorkspace(),
         jsonInit(data) {
           jsonData = data;
         },

--- a/addons/editor-stepping/highlighter.js
+++ b/addons/editor-stepping/highlighter.js
@@ -46,7 +46,8 @@ const removeHighlight = (element, highlighter) => {
 };
 
 class Highlighter {
-  constructor(priority, color) {
+  constructor(addon, priority, color) {
+    this.addon = addon;
     this.priority = priority;
 
     const id = `sa_glower_filter${nextGlowerId++}`;
@@ -104,7 +105,7 @@ class Highlighter {
 
   setGlowingThreads(threads) {
     const elementsToHighlight = new Set();
-    const workspace = Blockly.getMainWorkspace();
+    const workspace = this.addon.tab.traps.getWorkspace();
 
     if (workspace) {
       for (const thread of threads) {
@@ -121,9 +122,11 @@ class Highlighter {
             }
             return false;
           });
-          if (!childblock && block.svgPath_) {
-            const svgPath = block.svgPath_;
-            elementsToHighlight.add(svgPath);
+          if (!childblock) {
+            let svgPath;
+            if (block.pathObject) svgPath = block.pathObject.svgPath; // new Blockly
+            else svgPath = block.svgPath_;
+            if (svgPath) elementsToHighlight.add(svgPath);
           }
         });
       }

--- a/addons/editor-stepping/userscript.js
+++ b/addons/editor-stepping/userscript.js
@@ -4,7 +4,7 @@ import Highlighter from "./highlighter.js";
 export default async function ({ addon, console }) {
   const vm = addon.tab.traps.vm;
 
-  const highlighter = new Highlighter(0, addon.settings.get("highlight-color"));
+  const highlighter = new Highlighter(addon, 0, addon.settings.get("highlight-color"));
   addon.settings.addEventListener("change", () => {
     highlighter.setColor(addon.settings.get("highlight-color"));
   });

--- a/addons/find-bar/blockly/BlockFlasher.js
+++ b/addons/find-bar/blockly/BlockFlasher.js
@@ -11,7 +11,7 @@ export default class BlockFlasher {
       if (!block) return null;
       if (block.pathObject) return block.pathObject.svgPath; // new Blockly
       return block.svgPath_;
-    }
+    };
 
     if (myFlash.timerID > 0) {
       clearTimeout(myFlash.timerID);

--- a/addons/find-bar/blockly/BlockFlasher.js
+++ b/addons/find-bar/blockly/BlockFlasher.js
@@ -7,10 +7,16 @@ export default class BlockFlasher {
    * @param block the block to flash
    */
   static flash(block) {
+    const getSvgPath = (block) => {
+      if (!block) return null;
+      if (block.pathObject) return block.pathObject.svgPath; // new Blockly
+      return block.svgPath_;
+    }
+
     if (myFlash.timerID > 0) {
       clearTimeout(myFlash.timerID);
-      if (myFlash.block.svgPath_) {
-        myFlash.block.svgPath_.style.fill = "";
+      if (getSvgPath(myFlash.block)) {
+        getSvgPath(myFlash.block).style.fill = "";
       }
     }
 
@@ -23,8 +29,8 @@ export default class BlockFlasher {
      * @private
      */
     function _flash() {
-      if (myFlash.block.svgPath_) {
-        myFlash.block.svgPath_.style.fill = flashOn ? "#ffff80" : "";
+      if (getSvgPath(myFlash.block)) {
+        getSvgPath(myFlash.block).style.fill = flashOn ? "#ffff80" : "";
       }
       flashOn = !flashOn;
       count--;

--- a/addons/find-bar/blockly/Utils.js
+++ b/addons/find-bar/blockly/Utils.js
@@ -92,10 +92,13 @@ export default class Utils {
       y < s.viewTop + this.offsetY - 4 ||
       yy > s.viewTop + s.viewHeight
     ) {
-      let { sx, sy } = this.navigationHistory.scrollPosFromOffset({
-        left: x - this.offsetX,
-        top: y - this.offsetY,
-      }, s);
+      let { sx, sy } = this.navigationHistory.scrollPosFromOffset(
+        {
+          left: x - this.offsetX,
+          top: y - this.offsetY,
+        },
+        s
+      );
 
       this.navigationHistory.storeView(this.navigationHistory.peek(), 64);
 

--- a/addons/find-bar/blockly/Utils.js
+++ b/addons/find-bar/blockly/Utils.js
@@ -18,7 +18,7 @@ export default class Utils {
     // this._myFlash = { block: null, timerID: null, colour: null };
     this.offsetX = 32;
     this.offsetY = 32;
-    this.navigationHistory = new NavigationHistory();
+    this.navigationHistory = new NavigationHistory(this.addon);
     /**
      * The workspace
      */
@@ -48,13 +48,7 @@ export default class Utils {
    * @returns !Blockly.Workspace
    */
   getWorkspace() {
-    const currentWorkspace = Blockly.getMainWorkspace();
-    if (currentWorkspace.getToolbox()) {
-      // Sadly get get workspace does not always return the 'real' workspace... Not sure how to get that at the moment,
-      //  but we can work out whether it's the right one by whether it has a toolbox.
-      this._workspace = currentWorkspace;
-    }
-    return this._workspace;
+    return this.addon.tab.traps.getWorkspace();
   }
 
   /**
@@ -98,10 +92,10 @@ export default class Utils {
       y < s.viewTop + this.offsetY - 4 ||
       yy > s.viewTop + s.viewHeight
     ) {
-      // sx = s.contentLeft + s.viewWidth / 2 - x,
-      let sx = x - s.contentLeft - this.offsetX,
-        // sy = s.contentTop - y + Math.max(Math.min(32, 32 * scale), (s.viewHeight - yh) / 2);
-        sy = y - s.contentTop - this.offsetY;
+      let { sx, sy } = this.navigationHistory.scrollPosFromOffset({
+        left: x - this.offsetX,
+        top: y - this.offsetY,
+      }, s);
 
       this.navigationHistory.storeView(this.navigationHistory.peek(), 64);
 
@@ -128,12 +122,26 @@ export default class Utils {
 }
 
 class NavigationHistory {
+  constructor(addon) {
+    this.addon = addon;
+  }
+
+  scrollPosFromOffset({ left, top }, metrics) {
+    // New Blockly uses "scrollLeft" and "scrollTop" instead of "contentLeft" and "contentTop"
+    let scrollLeft = metrics.scrollLeft ?? metrics.contentLeft;
+    let scrollTop = metrics.scrollTop ?? metrics.contentTop;
+    return {
+      sx: left - scrollLeft,
+      sy: top - scrollTop,
+    };
+  }
+
   /**
    * Keep a record of the scroll and zoom position
    */
   storeView(next, dist) {
     forward = [];
-    let workspace = Blockly.getMainWorkspace(),
+    let workspace = this.addon.tab.traps.getWorkspace(),
       s = workspace.getMetrics();
 
     let pos = { left: s.viewLeft, top: s.viewTop };
@@ -147,7 +155,7 @@ class NavigationHistory {
   }
 
   goBack() {
-    const workspace = Blockly.getMainWorkspace(),
+    const workspace = this.addon.tab.traps.getWorkspace(),
       s = workspace.getMetrics();
 
     let pos = { left: s.viewLeft, top: s.viewTop };
@@ -168,8 +176,7 @@ class NavigationHistory {
       return;
     }
 
-    let sx = view.left - s.contentLeft,
-      sy = view.top - s.contentTop;
+    let { sx, sy } = this.scrollPosFromOffset(view, s);
 
     // transform.setTranslate(-600,0);
 
@@ -199,11 +206,10 @@ class NavigationHistory {
     }
     views.push(view);
 
-    let workspace = Blockly.getMainWorkspace(),
+    let workspace = this.addon.tab.traps.getWorkspace(),
       s = workspace.getMetrics();
 
-    let sx = view.left - s.contentLeft,
-      sy = view.top - s.contentTop;
+    let { sx, sy } = this.scrollPosFromOffset(view, s);
 
     workspace.scrollbar.set(sx, sy);
   }

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -28,7 +28,7 @@ export default async function ({ addon, msg, console }) {
     }
 
     get workspace() {
-      return Blockly.getMainWorkspace();
+      return addon.tab.traps.getWorkspace();
     }
 
     createDom(root) {
@@ -181,9 +181,14 @@ export default async function ({ addon, msg, console }) {
       // Call preventDefault() to make sure that the event only goes to scratch-blocks or scratch-paint.
       // Blockly.onKeyDown_:
       // https://github.com/scratchfoundation/scratch-blocks/blob/1421093/core/blockly.js#L185
+      // onKeyDown() in Blockly.inject module:
+      // https://github.com/google/blockly/blob/089179b/core/inject.ts#L294
       // KeyboardShortcutsHOC.handleKeyPress:
       // https://github.com/scratchfoundation/scratch-paint/blob/8119055/src/hocs/keyboard-shortcuts-hoc.jsx#L29
-      if (!Blockly.utils.isTargetInput(e) && addon.tab.redux.state?.scratchPaint.textEditTarget === null) {
+      let isTargetInput = false;
+      if (Blockly.registry) isTargetInput = Blockly.browserEvents.isTargetInput(e); // new Blockly
+      else isTargetInput = Blockly.utils.isTargetInput(e);
+      if (!isTargetInput && addon.tab.redux.state?.scratchPaint.textEditTarget === null) {
         if (
           (ctrlKey || e.altKey) &&
           (e.keyCode === 90 || e.key === "z" || (e.shiftKey && e.key.toLowerCase() === "z"))
@@ -271,7 +276,7 @@ export default async function ({ addon, msg, console }) {
         let desc;
         for (const fieldRow of fields.fieldRow) {
           desc = desc ? desc + " " : "";
-          if (fieldRow instanceof Blockly.FieldImage && fieldRow.src_.endsWith("green-flag.svg")) {
+          if (fieldRow instanceof Blockly.FieldImage && fieldRow.getValue().endsWith("green-flag.svg")) {
             desc += msg("/_general/blocks/green-flag");
           } else {
             desc += fieldRow.getText();
@@ -436,7 +441,7 @@ export default async function ({ addon, msg, console }) {
     }
 
     get workspace() {
-      return Blockly.getMainWorkspace();
+      return addon.tab.traps.getWorkspace();
     }
 
     createDom() {
@@ -796,12 +801,14 @@ export default async function ({ addon, msg, console }) {
 
   const findBar = new FindBar();
 
-  const _doBlockClick_ = Blockly.Gesture.prototype.doBlockClick_;
-  Blockly.Gesture.prototype.doBlockClick_ = function () {
-    if (!addon.self.disabled && (this.mostRecentEvent_.button === 1 || this.mostRecentEvent_.shiftKey)) {
+  const doBlockClickMethodName = Blockly.registry ? "doBlockClick" : "doBlockClick_";
+  const _doBlockClick_ = Blockly.Gesture.prototype[doBlockClickMethodName];
+  Blockly.Gesture.prototype[doBlockClickMethodName] = function () {
+    const event = Blockly.registry ? this.mostRecentEvent : this.mostRecentEvent_;
+    if (!addon.self.disabled && (event.button === 1 || event.shiftKey)) {
       // Wheel button...
       // Intercept clicks to allow jump to...?
-      let block = this.startBlock_;
+      let block = Blockly.registry ? this.startBlock : this.startBlock_;
       for (; block; block = block.getSurroundParent()) {
         if (block.type === "procedures_definition" || (!this.jumpToDef && block.type === "procedures_call")) {
           let id = block.id ? block.id : block.getId ? block.getId() : null;

--- a/addons/jump-to-def/userscript.js
+++ b/addons/jump-to-def/userscript.js
@@ -17,12 +17,14 @@ export default async function ({ addon, msg, console }) {
     },
   });
 
-  const _doBlockClick_ = Blockly.Gesture.prototype.doBlockClick_;
-  Blockly.Gesture.prototype.doBlockClick_ = function () {
-    if (!addon.self.disabled && (this.mostRecentEvent_.button === 1 || this.mostRecentEvent_.shiftKey)) {
+  const doBlockClickMethodName = Blockly.registry ? "doBlockClick" : "doBlockClick_";
+  const _doBlockClick_ = Blockly.Gesture.prototype[doBlockClickMethodName];
+  Blockly.Gesture.prototype[doBlockClickMethodName] = function () {
+    const event = Blockly.registry ? this.mostRecentEvent : this.mostRecentEvent_;
+    if (!addon.self.disabled && (event.button === 1 || event.shiftKey)) {
       // Wheel button...
       // Intercept clicks to allow jump to...?
-      let block = this.startBlock_;
+      let block = Blockly.registry ? this.startBlock : this.startBlock_;
       for (; block; block = block.getSurroundParent()) {
         if (block.type === "procedures_call") {
           let findProcCode = block.getProcCode();


### PR DESCRIPTION
### Changes

Updates "debugger" (including the `addon.tab.addBlock()` API), "running block border", "find bar", and "jump to custom block definition" to work with the new version of Blockly. Includes some changes from #7892.

### Tests

Tested both Scratch versions on Edge and Firefox.