### PR TITLE
dark-www: support new Ideas and Community Guidelines page designs

### DIFF
--- a/addons/dark-www/banners/darker.css
+++ b/addons/dark-www/banners/darker.css
@@ -23,6 +23,7 @@
   border-color: #004099;
 }
 .parents .title-banner.masthead,
+.guidelines-page header,
 .download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,
 .gdxfor .extension-header,
 .blue-background,

--- a/addons/dark-www/banners/desaturated.css
+++ b/addons/dark-www/banners/desaturated.css
@@ -23,6 +23,7 @@
   border-color: #334766;
 }
 .parents .title-banner.masthead,
+.guidelines-page header,
 .download .title-banner.masthead /* Scratch 2.0 and 1.4 download */,
 .gdxfor .extension-header,
 .blue-background,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -18,6 +18,7 @@ body {
   color: var(--darkWww-page-text);
 }
 .subactions .share-date,
+.guidelines-page .navigation .navigation-buttons a,
 .conf2019-description {
   color: var(--darkWww-page-text);
 }
@@ -357,6 +358,7 @@ body:not(.sa-body-editor) .outer .sort-mode .select select:focus {
 .user-projects-modal .user-projects-modal-content,
 .congratulations-page .congratulations-image-layout,
 .credits #acknowledgements,
+.guidelines-page .navigation .navigation-buttons a:hover,
 .download .blue,
 p.callout,
 .mission-section,
@@ -707,6 +709,7 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button_"],
 .studio-activity .studio-messages-list,
 .developers #projects h3,
 .developers #principles h3,
+.guidelines-page .navigation .navigation-buttons a,
 .information-page .info-outer nav,
 .conf2019-panel-flag,
 .conf2017-panel-flag,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -12,6 +12,8 @@ body {
   color-scheme: light;
 }
 #view,
+.tips,
+.physical-ideas,
 .crash-container,
 .semicolon {
   background-color: var(--darkWww-page);


### PR DESCRIPTION
### Changes

Adds styles for the updated Ideas and Community Guidelines pages to website dark mode.

![image](https://github.com/user-attachments/assets/796b8878-c822-44f1-93dc-c67198214f6f)

![image](https://github.com/user-attachments/assets/74a83ed3-c2bb-4456-a95e-581d9d91eeeb)

### Tests

Tested locally on Edge and Firefox.