### PR TITLE
Popups: Always load ./popup.html and ./popup.js

### DIFF
--- a/addons/cloud-games/addon.json
+++ b/addons/cloud-games/addon.json
@@ -18,9 +18,7 @@
   "popup": {
     "icon": "../../images/icons/cloud.svg",
     "name": "Games",
-    "fullscreen": true,
-    "script": "popup.js",
-    "html": "popup.html"
+    "fullscreen": true
   },
   "settings": [
     {

--- a/addons/scratch-messaging/addon.json
+++ b/addons/scratch-messaging/addon.json
@@ -12,9 +12,7 @@
   "popup": {
     "icon": "../../images/icons/envelope.svg",
     "name": "Messaging",
-    "fullscreen": true,
-    "script": "popup.js",
-    "html": "popup.html"
+    "fullscreen": true
   },
   "versionAdded": "1.0.0",
   "tags": ["popup", "recommended"],

--- a/webpages/popup-loader.js
+++ b/webpages/popup-loader.js
@@ -156,8 +156,7 @@ async function refetchSession(addon) {
     scratchAddons.l10n.get(key.startsWith("/") ? key.slice(1) : `${addonId}/${key}`, placeholders);
   msg.locale = scratchAddons.l10n.locale;
 
-  const fileName = popupData.popup.script;
-  const module = await import(chrome.runtime.getURL(`/popups/${addonId}/${fileName}`));
+  const module = await import(chrome.runtime.getURL(`/popups/${addonId}/popup.js`));
   module.default({
     addon: addon,
     console,

--- a/webpages/popup/index.js
+++ b/webpages/popup/index.js
@@ -82,7 +82,7 @@ chrome.runtime.sendMessage("getSettingsInfo", (res) => {
       ({ addonId, manifest }) =>
         (manifest.popup._addonId = addonId) &&
         Object.assign(manifest.popup, {
-          html: `../../popups/${addonId}/${manifest.popup.html}`,
+          html: `../../popups/${addonId}/popup.html`,
         })
     );
   popupObjects.push({
@@ -114,7 +114,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (newState === true) {
       manifest.popup._addonId = addonId;
       Object.assign(manifest.popup, {
-        html: `../../popups/${addonId}/${manifest.popup.html}`,
+        html: `../../popups/${addonId}/popup.html`,
       });
 
       vue.popups.push(manifest.popup);


### PR DESCRIPTION
Changes the addon manifest structure. Remember to update documentation and schema.

### Changes

Removes the addon manifest keys `popup.html` and `popup.script` and defaults their values to `./popup.html` and `./popup.js` respectively.

### Reason for changes

Popups can only have one HTML and one JS file, and using the filenames `./popup.html` and `./popup.js` is the standard way.

### Tests

Tested in Edge 131 / Windows 11.
