### PR TITLE
middle-click-popup: new Blockly

### DIFF
--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -351,10 +351,11 @@ export class BlockTypeInfo {
     else if (block.type === "sensing_of") name = "sensing";
     else if (block.type === "event_whenbackdropswitchesto") name = "events";
     else name = block.styleName_ ?? block.category_;
-    name = {
-      event: "events",
-      data_lists: "data-lists",
-    }[name] || name;
+    name =
+      {
+        event: "events",
+        data_lists: "data-lists",
+      }[name] || name;
 
     return {
       name,
@@ -440,7 +441,7 @@ export class BlockTypeInfo {
         }
         if (
           field instanceof Blockly.FieldLabel ||
-          !Blockly.registry && field instanceof Blockly.FieldVariableGetter
+          (!Blockly.registry && field instanceof Blockly.FieldVariableGetter)
         ) {
           if (field.getText().trim().length !== 0) parts.push(field.getText());
         } else if (field instanceof FieldColour) {

--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -304,7 +304,7 @@ export class BlockShape {
       return BlockShape.Round;
     } else if (workspaceBlock.getOutputShape() === 1) {
       return BlockShape.Boolean;
-    } else if (workspaceBlock.hat ?? workspaceBlock.startHat_) {
+    } else if (!workspaceBlock.previousConnection) {
       return BlockShape.Hat;
     } else if (!workspaceBlock.nextConnection) {
       return BlockShape.End;

--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -300,11 +300,11 @@ export class BlockShape {
   static Stack = new BlockShape(true, true, false);
 
   static getBlockShape(workspaceBlock) {
-    if (workspaceBlock.edgeShape_ === 2) {
+    if (workspaceBlock.getOutputShape() === 2) {
       return BlockShape.Round;
-    } else if (workspaceBlock.edgeShape_ === 1) {
+    } else if (workspaceBlock.getOutputShape() === 1) {
       return BlockShape.Boolean;
-    } else if (workspaceBlock.startHat_) {
+    } else if (workspaceBlock.hat ?? workspaceBlock.startHat_) {
       return BlockShape.Hat;
     } else if (!workspaceBlock.nextConnection) {
       return BlockShape.End;
@@ -350,13 +350,17 @@ export class BlockTypeInfo {
     } else if (block.isScratchExtension) name = "pen";
     else if (block.type === "sensing_of") name = "sensing";
     else if (block.type === "event_whenbackdropswitchesto") name = "events";
-    else name = block.category_;
+    else name = block.styleName_ ?? block.category_;
+    name = {
+      event: "events",
+      data_lists: "data-lists",
+    }[name] || name;
 
     return {
       name,
-      colorPrimary: block.colour_,
-      colorSecondary: block.colourSecondary_,
-      colorTertiary: block.colourTertiary_,
+      colorPrimary: block.getColour(),
+      colorSecondary: block.getColourSecondary(),
+      colorTertiary: block.getColourTertiary(),
     };
   }
 
@@ -377,7 +381,7 @@ export class BlockTypeInfo {
     const flyoutDom = Blockly.Xml.workspaceToDom(flyoutWorkspace);
     const flyoutDomBlockMap = {};
     for (const blockDom of flyoutDom.children) {
-      if (blockDom.tagName === "BLOCK") {
+      if (blockDom.tagName.toUpperCase() === "BLOCK") {
         let id = blockDom.getAttribute("id");
         flyoutDomBlockMap[id] = blockDom;
       }
@@ -408,11 +412,11 @@ export class BlockTypeInfo {
     };
 
     const addFieldInputs = (field, inputIdx, fieldIdx) => {
-      if (field.className_ === "blocklyText blocklyDropdownText") {
+      if (field instanceof Blockly.FieldDropdown) {
         const options = field.getOptions();
         addInput(new BlockInputEnum(options, inputIdx, fieldIdx, fieldIdx === -1));
       } else if (field instanceof Blockly.FieldImage) {
-        switch (field.src_.split("/").pop()) {
+        switch (field.getValue().split("/").pop()) {
           case "green-flag.svg":
             parts.push(locale("/_general/blocks/green-flag"));
             break;
@@ -424,11 +428,24 @@ export class BlockTypeInfo {
             break;
         }
       } else {
-        if (!field.argType_) {
+        let FieldColour;
+        let FieldNumber;
+        if (Blockly.registry) {
+          // new Blockly
+          FieldColour = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_colour_slider");
+          FieldNumber = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_number");
+        } else {
+          FieldColour = Blockly.FieldColour;
+          FieldNumber = Blockly.FieldNumber;
+        }
+        if (
+          field instanceof Blockly.FieldLabel ||
+          !Blockly.registry && field instanceof Blockly.FieldVariableGetter
+        ) {
           if (field.getText().trim().length !== 0) parts.push(field.getText());
-        } else if (field.argType_[0] === "colour") {
+        } else if (field instanceof FieldColour) {
           addInput(new BlockInputColour(inputIdx, fieldIdx));
-        } else if (field.argType_[1] === "number") {
+        } else if (field instanceof FieldNumber) {
           addInput(new BlockInputNumber(inputIdx, fieldIdx, field.text_));
         } else {
           addInput(new BlockInputString(inputIdx, fieldIdx, field.text_));
@@ -450,7 +467,7 @@ export class BlockTypeInfo {
           let innerField = innerBlock.inputList[0].fieldRow[0];
           addFieldInputs(innerField, inputIdx, -1);
         } else {
-          if (input.outlinePath) {
+          if (input.type === Blockly.INPUT_VALUE) {
             addInput(new BlockInputBoolean(inputIdx, -1));
           } else {
             addInput(new BlockInputBlock(inputIdx, -1));
@@ -459,7 +476,7 @@ export class BlockTypeInfo {
       }
     }
 
-    if (workspaceForm.id === "of") {
+    if (workspaceForm.type === "sensing_of") {
       let blocks = [];
 
       let baseVarInputIdx, baseTargetInputIdx;
@@ -527,7 +544,7 @@ export class BlockTypeInfo {
       }
 
       return blocks;
-    } else if (workspaceForm.id === "control_stop") {
+    } else if (workspaceForm.type === "control_stop") {
       // This block is special because when "other scripts in sprite" is selected the block
       //  needs to be BlockShape.End.
       const oldInput = inputs[0];
@@ -554,7 +571,7 @@ export class BlockTypeInfo {
 
   constructor(workspace, Blockly, vm, workspaceForm, domForm, parts, inputs, shape) {
     /** @type {string} */
-    this.id = workspaceForm.id;
+    this.id = workspaceForm.type;
     this.workspaceForm = workspaceForm;
     this.domForm = domForm;
     /** @type {BlockShape} */

--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -447,9 +447,9 @@ export class BlockTypeInfo {
         } else if (field instanceof FieldColour) {
           addInput(new BlockInputColour(inputIdx, fieldIdx));
         } else if (field instanceof FieldNumber) {
-          addInput(new BlockInputNumber(inputIdx, fieldIdx, field.text_));
+          addInput(new BlockInputNumber(inputIdx, fieldIdx, field.getText()));
         } else {
-          addInput(new BlockInputString(inputIdx, fieldIdx, field.text_));
+          addInput(new BlockInputString(inputIdx, fieldIdx, field.getText()));
         }
       }
     };

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -111,10 +111,16 @@ export default async function ({ addon, msg, console }) {
 
     Blockly.hideChaff();
 
-    blockTypes = BlockTypeInfo.getBlocks(Blockly, vm, Blockly.getMainWorkspace(), msg);
+    const workspace = addon.tab.traps.getWorkspace();
+    blockTypes = BlockTypeInfo.getBlocks(Blockly, vm, workspace, msg);
     querier.indexWorkspace([...blockTypes]);
     blockTypes.sort((a, b) => {
-      const prio = (block) => ["operators", "data"].indexOf(block.category.name) - block.id.startsWith("data_");
+      // Block order:
+      // 1. variable reporters
+      // 2. operators
+      // 3. other variable blocks
+      // 4. everything else
+      const prio = (block) => ["operators", "data"].indexOf(block.category.name) - (block.id.startsWith("data_") && block.id !== "data_variable");
       return prio(b) - prio(a);
     });
 
@@ -129,6 +135,25 @@ export default async function ({ addon, msg, console }) {
     popupInput.value = "";
     popupInput.focus();
     updateInput();
+
+    if (Blockly.registry) {
+      // new Blockly: register delete area
+      const component = new Blockly.DeleteArea();
+      component.id = "saMiddleClickPopup";
+      component.getClientRect = () => {
+        const rect = popupContainer.getBoundingClientRect();
+        return new Blockly.utils.Rect(rect.top, rect.bottom, rect.left, rect.right);
+      };
+      workspace.getComponentManager().addComponent({
+        component,
+        weight: 1,
+        capabilities: [
+          Blockly.ComponentManager.Capability.DELETE_AREA,
+          Blockly.ComponentManager.Capability.DRAG_TARGET,
+        ]
+      });
+      workspace.recordDragTargets();
+    }
   }
 
   function closePopup() {
@@ -138,6 +163,12 @@ export default async function ({ addon, msg, console }) {
       popupRoot.style.display = "none";
       blockTypes = null;
       querier.clearWorkspaceIndex();
+      if (Blockly.registry) {
+        // new Blockly: unregister delete area
+        const workspace = addon.tab.traps.getWorkspace();
+        workspace.getComponentManager().removeComponent("saMiddleClickPopup");
+        workspace.recordDragTargets();
+      }
     }
   }
 
@@ -196,7 +227,7 @@ export default async function ({ addon, msg, console }) {
         e.preventDefault();
         updateSelection(resultIdx);
         allowMenuClose = !e.shiftKey;
-        selectBlock();
+        selectBlock(e);
         allowMenuClose = true;
         if (e.shiftKey) popupInput.focus();
       };
@@ -210,11 +241,13 @@ export default async function ({ addon, msg, console }) {
       svgBackground.setAttribute("height", height * previewScale + "px");
       svgBackground.classList.add("sa-mcp-preview-block-bg");
       svgBackground.addEventListener("mousemove", mouseMoveListener);
-      svgBackground.addEventListener("mousedown", mouseDownListener);
+      if (Blockly.registry) svgBackground.addEventListener("pointerdown", mouseDownListener); // new Blockly
+      else svgBackground.addEventListener("mousedown", mouseDownListener);
 
       const svgBlock = popupPreviewBlocks.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "g"));
       svgBlock.addEventListener("mousemove", mouseMoveListener);
-      svgBlock.addEventListener("mousedown", mouseDownListener);
+      if (Blockly.registry) svgBlock.addEventListener("pointerdown", mouseDownListener); // new Blockly
+      else svgBlock.addEventListener("mousedown", mouseDownListener);
       svgBlock.classList.add("sa-mcp-preview-block");
 
       const renderedBlock = renderBlock(result.block, svgBlock);
@@ -257,6 +290,12 @@ export default async function ({ addon, msg, console }) {
     updateSelection(0);
     updateCursor();
     updateScrollbar();
+
+    if (Blockly.registry) {
+      // new Blockly: update delete area after resizing popup
+      const workspace = addon.tab.traps.getWorkspace();
+      workspace.recordDragTargets();
+    }
   }
 
   function updateSelection(newIdx) {
@@ -336,7 +375,7 @@ export default async function ({ addon, msg, console }) {
     popupPreviewScrollbarHandle.setAttribute("y", "" + scrollbarY);
   }
 
-  function selectBlock() {
+  function selectBlock(e) {
     const selectedPreview = queryPreviews[selectedPreviewIdx];
     if (!selectedPreview) return;
 
@@ -349,14 +388,21 @@ export default async function ({ addon, msg, console }) {
     Blockly.Events.disable();
     try {
       newBlock = selectedPreview.block.createWorkspaceForm();
-      Blockly.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
+      if (!Blockly.registry) {
+        // New Blockly doesn't currently change shadow IDs when copying blocks,
+        // so the addon only does this on old Blockly.
+        Blockly.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
+      }
 
       var svgRootNew = newBlock.getSvgRoot();
       if (!svgRootNew) {
         throw new Error("newBlock is not rendered.");
       }
 
-      let blockBounds = newBlock.svgPath_.getBoundingClientRect();
+      let svgPath;
+      if (newBlock.pathObject) svgPath = newBlock.pathObject.svgPath; // new Blockly
+      else svgPath = newBlock.svgPath_;
+      let blockBounds = svgPath.getBoundingClientRect();
       let newBlockX = Math.floor((mousePosition.x - (blockBounds.left + blockBounds.right) / 2) / workspace.scale);
       let newBlockY = Math.floor((mousePosition.y - (blockBounds.top + blockBounds.bottom) / 2) / workspace.scale);
       newBlock.moveBy(newBlockX, newBlockY);
@@ -375,8 +421,30 @@ export default async function ({ addon, msg, console }) {
       preventDefault: function () {},
       target: selectedPreview.svgBlock,
     };
-    if (workspace.getGesture(fakeEvent)) {
-      workspace.startDragWithFakeEvent(fakeEvent, newBlock);
+    if (Blockly.registry) {
+      // new Blockly expects a pointerdown event
+      fakeEvent.type = "pointerdown";
+      fakeEvent.pointerType = "mouse";
+      // If the block is being dragged using the mouse or touch, the correct pointerId
+      // needs to be set so that Blockly recognizes the associated pointerup event.
+      // If the block is selected using the keyboard, pointerId will be undefined and a
+      // click will be necessary to end the "drag".
+      fakeEvent.pointerId = e.pointerId;
+      // Start dragging the block
+      // Based on old Blockly's WorkspaceSvg.startDragWithFakeEvent() and Gesture.forceStartBlockDrag()
+      Blockly.Touch.clearTouchIdentifier();
+      Blockly.Touch.checkTouchIdentifier(fakeEvent);
+      const gesture = workspace.getGesture(fakeEvent);
+      gesture.handleBlockStart(fakeEvent, newBlock);
+      gesture.handleWsStart(fakeEvent, workspace);
+      gesture.dragging = true;
+      gesture.hasExceededDragRadius = true;
+      gesture.dragger = gesture.createDragger(newBlock, workspace);
+      gesture.dragger.onDragStart(fakeEvent);
+    } else {
+      if (workspace.getGesture(fakeEvent)) {
+        workspace.startDragWithFakeEvent(fakeEvent, newBlock);
+      }
     }
   }
 
@@ -411,7 +479,7 @@ export default async function ({ addon, msg, console }) {
         e.preventDefault();
         break;
       case "Enter":
-        selectBlock();
+        selectBlock(e);
         closePopup();
         e.stopPropagation();
         e.preventDefault();
@@ -443,26 +511,31 @@ export default async function ({ addon, msg, console }) {
   });
 
   // Open on mouse wheel button
-  const _doWorkspaceClick_ = Blockly.Gesture.prototype.doWorkspaceClick_;
-  Blockly.Gesture.prototype.doWorkspaceClick_ = function () {
-    if (this.mostRecentEvent_.button === 1 || this.mostRecentEvent_.shiftKey) openPopup();
-    mousePosition = { x: this.mostRecentEvent_.clientX, y: this.mostRecentEvent_.clientY };
+  const doWorkspaceClickMethodName = Blockly.registry ? "doWorkspaceClick" : "doWorkspaceClick_";
+  const _doWorkspaceClick_ = Blockly.Gesture.prototype[doWorkspaceClickMethodName];
+  Blockly.Gesture.prototype[doWorkspaceClickMethodName] = function () {
+    const event = Blockly.registry ? this.mostRecentEvent : this.mostRecentEvent_;
+    if (event.button === 1 || event.shiftKey) openPopup();
+    mousePosition = { x: event.clientX, y: event.clientY };
     _doWorkspaceClick_.call(this);
   };
 
-  // The popup should delete blocks dragged ontop of it
-  const _isDeleteArea = Blockly.WorkspaceSvg.prototype.isDeleteArea;
-  Blockly.WorkspaceSvg.prototype.isDeleteArea = function (e) {
-    if (popupPosition) {
-      if (
-        e.clientX > popupPosition.x &&
-        e.clientX < popupPosition.x + previewWidth &&
-        e.clientY > popupPosition.y &&
-        e.clientY < popupPosition.y + previewHeight
-      ) {
-        return Blockly.DELETE_AREA_TOOLBOX;
+  if (!Blockly.registry) {
+    // The popup should delete blocks dragged ontop of it
+    // For new Blockly, this is implemented using Blockly.ComponentManager instead
+    const _isDeleteArea = Blockly.WorkspaceSvg.prototype.isDeleteArea;
+    Blockly.WorkspaceSvg.prototype.isDeleteArea = function (e) {
+      if (popupPosition) {
+        if (
+          e.clientX > popupPosition.x &&
+          e.clientX < popupPosition.x + previewWidth &&
+          e.clientY > popupPosition.y &&
+          e.clientY < popupPosition.y + previewHeight
+        ) {
+          return Blockly.DELETE_AREA_TOOLBOX;
+        }
       }
-    }
-    return _isDeleteArea.call(this, e);
-  };
+      return _isDeleteArea.call(this, e);
+    };
+  }
 }

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -120,7 +120,9 @@ export default async function ({ addon, msg, console }) {
       // 2. operators
       // 3. other variable blocks
       // 4. everything else
-      const prio = (block) => ["operators", "data"].indexOf(block.category.name) - (block.id.startsWith("data_") && block.id !== "data_variable");
+      const prio = (block) =>
+        ["operators", "data"].indexOf(block.category.name) -
+        (block.id.startsWith("data_") && block.id !== "data_variable");
       return prio(b) - prio(a);
     });
 
@@ -150,7 +152,7 @@ export default async function ({ addon, msg, console }) {
         capabilities: [
           Blockly.ComponentManager.Capability.DELETE_AREA,
           Blockly.ComponentManager.Capability.DRAG_TARGET,
-        ]
+        ],
       });
       workspace.recordDragTargets();
     }

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -426,7 +426,7 @@ export default async function ({ addon, msg, console }) {
     if (Blockly.registry) {
       // new Blockly expects a pointerdown event
       fakeEvent.type = "pointerdown";
-      fakeEvent.pointerType = "mouse";
+      fakeEvent.pointerType = e.pointerType ?? "mouse";
       // If the block is being dragged using the mouse or touch, the correct pointerId
       // needs to be set so that Blockly recognizes the associated pointerup event.
       // If the block is selected using the keyboard, pointerId will be undefined and a

--- a/addons/middle-click-popup/userstyle.css
+++ b/addons/middle-click-popup/userstyle.css
@@ -113,3 +113,8 @@
 .sa-mcp-preview-block-bg-selection {
   fill: #7774;
 }
+
+.blocklyAnimationLayer {
+  /* show delete animation above the popup */
+  z-index: 1000;
+}


### PR DESCRIPTION
### Changes

Makes "insert blocks by name" compatible with modern Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox. The addon still works correctly and is still compatible with theme3.
