### PR TITLE
dark-www: support new Welcome section

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -432,6 +432,9 @@ body:not(.sa-body-editor) .gender-radio-row:hover,
   background-color: var(--darkWww-blue-20);
   color-scheme: var(--darKWww-blue-colorScheme);
 }
+.welcome .box-content .welcome-options .welcome-option-button {
+  border-color: var(--darkWww-blue-20);
+}
 .join-flow-footer-message {
   background-color: var(--darkWww-blue-25);
 }


### PR DESCRIPTION
Marking as draft until the scratch-www PR is merged.

### Changes

Adds styles for the new "Welcome to Scratch" section on the front page:

![image](https://github.com/user-attachments/assets/60f4e5ce-7177-4992-ac2e-29989d86c3ab)

It will replace this one:

![image](https://github.com/user-attachments/assets/bd46d143-9e14-472b-a273-7c33aba87f65)

### Tests

Tested on Edge.