### PR TITLE
Created "Additional Stats" addon

### DIFF
--- a/addons-l10n/en/additonal-stats.json
+++ b/addons-l10n/en/additonal-stats.json
@@ -1,0 +1,5 @@
+{
+    "additonal-stats/date-modifed": "Last modifed on {date}",
+    "additonal-stats/date-created": "Created on {date}",
+    "additonal-stats/followers-per-day": "{followers} followers per day"
+}

--- a/addons/additonal-stats/addon.json
+++ b/addons/additonal-stats/addon.json
@@ -1,0 +1,49 @@
+{
+    "name": "Additonal Stats",
+    "description": "Displays additonal stats on the project and studio pages.",
+    "credits": [
+      {
+        "name": "AeroKoder",
+        "link": "https://scratch.mit.edu/users/AeroKoder/"
+      }
+    ],
+    "settings": [
+      {
+        "name": "Adds the date of when the project was created and last modifed on the project page.",
+        "type": "boolean",
+        "default": true,
+        "id": "projectDates"
+      },
+      {
+        "name": "Adds the date of when the studio was created in the studio page.",
+        "type": "boolean",
+        "default": true,
+        "id": "studioDates"
+      },
+      {
+        "name": "Tells the avarage amount of followers per day in the studio page.",
+        "type": "boolean",
+        "default": false,
+        "id": "studioFollowers"
+      }
+    ],
+    "userscripts": [
+      {
+        "url": "project.js",
+        "matches": ["projects"],
+        "if": { "settings": { "projectDates": true } }
+      },
+      {
+        "url": "studioDates.js",
+        "matches": ["https://scratch.mit.edu/studios/*"],
+        "if": { "settings": { "studioDates": true } }
+      },
+      {
+        "url": "studioFollowers.js",
+        "matches": ["https://scratch.mit.edu/studios/*"],
+        "if": { "settings": { "studioFollowers": true } }
+      }
+    ],
+    "tags": ["community", "studios", "projectPage"],
+    "versionAdded": "1.40.0"
+  }

--- a/addons/additonal-stats/project.js
+++ b/addons/additonal-stats/project.js
@@ -1,0 +1,32 @@
+export default async function ({ addon, console, msg }) {
+    while (addon.tab.redux.state.preview.projectInfo.id == undefined) {}
+
+    let project = await (
+      await fetch(`https://api.scratch.mit.edu/projects/${addon.tab.redux.state.preview.projectInfo.id}`)
+    ).json();
+
+    const dateCreatedText = new Date(project.history.created).toLocaleString(msg.locale, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+
+    const dateModifiedText = new Date(project.history.modified).toLocaleString(msg.locale, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+
+    let dateStats = document.getElementsByClassName("subactions")[0];
+    let end = dateStats.children[1];
+
+    let dateCreatedStat = document.createElement("span");
+    dateCreatedStat.classList.add("share-date");
+    dateCreatedStat.innerHTML = msg("date-created", { date: dateCreatedText });
+    dateStats.insertBefore(dateCreatedStat, end);
+
+    let dateModifiedStat = document.createElement("span");
+    dateModifiedStat.classList.add("share-date");
+    dateModifiedStat.innerHTML = msg("date-modifed", { date: dateModifiedText });
+    dateStats.insertBefore(dateModifiedStat, end);
+  }

--- a/addons/additonal-stats/studioDates.js
+++ b/addons/additonal-stats/studioDates.js
@@ -1,0 +1,17 @@
+export default async function ({ addon, console, msg }) {
+    let studio = await (await fetch(`https://api.scratch.mit.edu/studios/${addon.tab.redux.state.studio.id}`)).json();
+
+    const dateCreatedText = new Date(studio.history.created).toLocaleString(msg.locale, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+
+    let footerStats = document.getElementsByClassName("studio-info-footer-stats")[0];
+    let dateCreatedStat = document.createElement("div");
+    dateCreatedStat.innerHTML = footerStats.children[0].innerHTML;
+
+    let dateCreatedStatText = dateCreatedStat.getElementsByTagName("span")[0];
+    dateCreatedStatText.innerHTML = msg("date-created", { date: dateCreatedText });
+    footerStats.prepend(dateCreatedStat);
+  }

--- a/addons/additonal-stats/studioFollowers.js
+++ b/addons/additonal-stats/studioFollowers.js
@@ -1,0 +1,14 @@
+export default async function ({ addon, console, msg }) {
+    let studio = await (await fetch(`https://api.scratch.mit.edu/studios/${addon.tab.redux.state.studio.id}`)).json();
+
+    const timeSinceCreated = (Date.now() - Date.parse(studio.history.created)) / 86400000;
+    const followersPerDay = studio.stats.followers / timeSinceCreated;
+
+    let footerStats = document.getElementsByClassName("studio-info-footer-stats")[0];
+    let followersPerDayStat = document.createElement("div");
+    followersPerDayStat.innerHTML = footerStats.children[2].innerHTML
+
+    let followersPerDayStatText = followersPerDayStat.getElementsByTagName("span")[0];
+    followersPerDayStatText.innerHTML = msg("followers-per-day", {"followers": Math.round(followersPerDay)});
+    footerStats.append(followersPerDayStat);
+  }

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -156,6 +156,7 @@
   "asset-conflict-dialog",
   "remaining-replies",
   "forum-user-agent",
+  "additonal-stats",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",


### PR DESCRIPTION
Resolves [#7974](https://github.com/ScratchAddons/ScratchAddons/issues/7974)

### Changes

Added an addon that will display additional stats on the project and studio pages.
![Screenshot 2024-12-01 165935](https://github.com/user-attachments/assets/d22d75dd-418d-49ab-9443-9f99de7c816f)

### Reason for changes

This addon would be helpful when wanting to know the creation date, and other additional stats, of a studio or project.

### Tests

Tested on Edge.
