### PR TITLE
New addon: `no-sprite-confirm`

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -156,6 +156,7 @@
   "asset-conflict-dialog",
   "remaining-replies",
   "forum-user-agent",
+  "no-sprite-confirm",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Remove sprite deletion confirmation",
+  "name": "Delete sprites without confirmation",
   "description": "Removes the confirmation prompt that asks if you are sure you want to delete a project sprite.",
   "info": [
     {

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -3,7 +3,7 @@
   "description": "Removes the confirmation prompt that asks if you are sure you want to delete a project sprite.",
   "info": [
     {
-      "text": "Tip: If you accidentally delete a sprite, you can undo the deletion by clicking Edit in the menu bar then Restore.",
+      "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore.",
       "id": "restoretip"
     }
   ],

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "Remove sprite deletion confirmation",
+  "description": "Removes the confirmation prompt that asks if you are sure you want to delete a project sprite.",
+  "info": [
+    {
+      "text": "Tip: If you accidentally delete a sprite, you can undo the deletion by clicking Edit in the menu bar then Restore.",
+      "id": "restoretip"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.40.0",
+  "tags": ["editor", "danger"]
+}

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -13,6 +13,12 @@
       "matches": ["projects"]
     }
   ],
+  "userstyles": [
+    {
+      "url": "hide.css",
+      "matches": ["projects"]
+    }
+  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.40.0",

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Delete sprites without confirmation",
-  "description": "Removes the confirmation prompt that asks if you are sure you want to delete a project sprite.",
+  "description": "Removes the confirmation prompt that asks if you are sure you want to delete a sprite.",
   "info": [
     {
       "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore.",

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -22,5 +22,5 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.40.0",
-  "tags": ["editor", "danger"]
+  "tags": ["editor", "danger", "featured"]
 }

--- a/addons/no-sprite-confirm/hide.css
+++ b/addons/no-sprite-confirm/hide.css
@@ -1,0 +1,3 @@
+[class^="delete-confirmation-prompt_"] {
+  visibility: hidden;
+}

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,8 +1,8 @@
 export default async ({ addon, console }) => {
-  while (true) {
-    const confirmButton = await addon.tab.waitForElement("[class^='delete-confirmation-prompt_ok-button_']", {
-      markAsSeen: true,
-    });
-    if (!addon.self.disabled) confirmButton.click();
-  }
+  document.body.addEventListener("click", () => {
+    setTimeout(() => {
+      const confirmButton = document.querySelector("[class^='delete-confirmation-prompt_ok-button_']");
+      if (!addon.self.disabled && confirmButton) confirmButton.click();
+    }, 0)
+  })
 };

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -3,6 +3,6 @@ export default async ({ addon, console }) => {
     setTimeout(() => {
       const confirmButton = document.querySelector("[class^='delete-confirmation-prompt_ok-button_']");
       if (!addon.self.disabled && confirmButton) confirmButton.click();
-    }, 0)
-  })
+    }, 0);
+  });
 };

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,0 +1,7 @@
+export default async ({ addon, console }) => {
+  while (true) {
+    const confirmButton = await addon.tab.waitForElement("[class^='delete-confirmation-prompt_ok-button_']", { markAsSeen: true });
+    if (!addon.self.disabled) confirmButton.click();
+  }
+};
+

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,7 +1,8 @@
 export default async ({ addon, console }) => {
   while (true) {
-    const confirmButton = await addon.tab.waitForElement("[class^='delete-confirmation-prompt_ok-button_']", { markAsSeen: true });
+    const confirmButton = await addon.tab.waitForElement("[class^='delete-confirmation-prompt_ok-button_']", {
+      markAsSeen: true,
+    });
     if (!addon.self.disabled) confirmButton.click();
   }
 };
-


### PR DESCRIPTION
Resolves #7966

### Changes

Adds an addon to remove Scratch's sprite deletion confirmation. It has the danger tag but whether it's necessary is debatable since edit  > restore can still be used.

### Reason for changes

Some users really don't like the confirmation.

### Tests

Tested on Chromium and Firefox.
