### PR TITLE
New addon: Hold to delete sprites

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -156,6 +156,7 @@
   "asset-conflict-dialog",
   "remaining-replies",
   "forum-user-agent",
+  "hold-delete",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/hold-delete/addon.json
+++ b/addons/hold-delete/addon.json
@@ -1,0 +1,42 @@
+{
+  "name": "Hold to delete sprites",
+  "description": "Require the delete button to be held down in order to delete a sprite.",
+  "tags": ["editor"],
+  "credits": [
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
+    },
+    {
+      "name": "Samq64",
+      "link": "https://github.com/Samq64"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "hide-confirmation.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": { "noConfirm": true }
+      }
+    }
+  ],
+  "settings": [
+    {
+      "name": "Skip confirmation",
+      "id": "noConfirm",
+      "type": "boolean",
+      "default": false
+    }
+  ],
+  "versionAdded": "1.40.0",
+  "dynamicDisable": true,
+  "dynamicEnable": true,
+  "updateUserstylesOnSettingsChange": true
+}

--- a/addons/hold-delete/hide-confirmation.css
+++ b/addons/hold-delete/hide-confirmation.css
@@ -1,0 +1,3 @@
+[class^="delete-confirmation-prompt_"] {
+  visibility: hidden;
+}

--- a/addons/hold-delete/userscript.js
+++ b/addons/hold-delete/userscript.js
@@ -1,0 +1,71 @@
+export default async function ({ addon, console }) {
+  const DELETE_BUTTON_SELECTOR =
+    "[class^='sprite-selector_items-wrapper_'] [class*='sprite-selector-item_delete-button']";
+  let deleteButton;
+  let holding = false;
+
+  document.body.addEventListener("mousedown", async (e) => {
+    if (addon.self.disabled) return;
+
+    const potentialDeleteButton = e.target.closest(DELETE_BUTTON_SELECTOR);
+    // If we haven't already, then...
+    if (e.target !== deleteButton && potentialDeleteButton) {
+      e.stopImmediatePropagation();
+      deleteButton = potentialDeleteButton;
+      setUpPressAndHold(); // ...set up this delete button.
+    }
+  });
+
+  /** Do a one-time setup for the press-and-hold logic per delete button. */
+  const setUpPressAndHold = () => {
+    startHold(deleteButton);
+
+    // Prevent the user from activating the delete button
+    deleteButton.addEventListener("click", (e) => {
+      if (addon.self.disabled) return;
+
+      if (e.isTrusted) {
+        e.stopImmediatePropagation();
+      } else if (addon.settings.get("noConfirm")) {
+        setTimeout(() => {
+          const confirmButton = document.querySelector("[class^='delete-confirmation-prompt_ok-button_']");
+          if (confirmButton) confirmButton.click();
+        }, 0);
+      }
+    });
+
+    deleteButton.addEventListener("mousedown", async (e) => {
+      if (addon.self.disabled) return;
+
+      e.stopImmediatePropagation();
+      startHold(deleteButton);
+    });
+
+    async function startHold(deleteButton) {
+      holding = true;
+
+      // Wait out the hold delay
+      for (let i = 0; i < 100; i += 2) {
+        if (!holding) break;
+        deleteButton.firstElementChild.style.background = `linear-gradient(0deg, #ff8c1a, #ff8c1a ${i}%, var(--editorDarkMode-primary, #855cd6) ${i}%)`;
+        await new Promise((resolve) => setTimeout(resolve, 17));
+      }
+
+      deleteButton.firstElementChild.style.transition = "none";
+      deleteButton.firstElementChild.style.removeProperty("background");
+      setTimeout(() => deleteButton.firstElementChild.style.removeProperty("transition"), 10);
+
+      // Then delete the sprite
+      if (holding) deleteButton.click();
+    }
+  };
+
+  // Cancel if released
+  document.body.addEventListener("mouseup", async () => {
+    holding = false;
+  });
+  // Cancel if image dragged
+  document.body.addEventListener("dragstart", async () => {
+    holding = false;
+  });
+}


### PR DESCRIPTION
Sorta resolves #7966

### Changes

This new addon makes it so you have to press and hold the delete icon next to a sprite to delete it. The addon also has an option to skip the confirmation that would appear after pressing and holding the delete button.

As you hold the button, it will gradually fill up with the color orange until it's completely orange then the delete function is activated.

https://github.com/user-attachments/assets/6a7d783e-15ee-425f-b69f-750ee81f113c

### Reason for changes

Mainly to allow people to delete their sprites without having to confirm while still making it harder to delete by accident.

### Tests and Notes

Tested in Edge 131.
Tested alongside `editor-dark-mode` and `compact-editor`.
Should "skip confirmation" disable the deletion confirmation on right click > delete? It doesn't currently.
