### PR TITLE
Added date created to "last-edit-tooltip" addon

### DIFF
--- a/addons-l10n/en/last-edit-tooltip.json
+++ b/addons-l10n/en/last-edit-tooltip.json
@@ -1,4 +1,5 @@
 {
   "last-edit-tooltip/modified": "Modified: {date}",
-  "last-edit-tooltip/shared": "Shared: {date}"
+  "last-edit-tooltip/shared": "Shared: {date}",
+  "last-edit-tooltip/created": "Created: {date}"
 }

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Shared/edited dates tooltip",
-  "description": "Hover over a project's share date for information on when exactly it was shared and last edited.",
+  "description": "Hover over a project's share date for information on when exactly it was shared, last edited and created.",
   "credits": [
     {
       "name": "TheColaber",
@@ -9,6 +9,10 @@
     {
       "name": "Weredime (9gr)",
       "link": "https://scratch.mit.edu/users/9gr/"
+    },
+    {
+      "name": "AeroKoder",
+      "link": "https://scratch.mit.edu/users/AeroKoder/"
     }
   ],
   "dynamicEnable": true,

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -24,6 +24,10 @@
     }
   ],
   "versionAdded": "1.2.0",
+  "latestUpdate": {
+    "version": "1.40.0",
+    "temporaryNotice": "Added the project creation date to the tooltip."
+  },
   "tags": ["community", "projectPage"],
   "enabledByDefault": false
 }

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shared/edited dates tooltip",
+  "name": "Additional Project Info",
   "description": "Hover over a project's share date for information on when exactly it was created, shared and last edited.",
   "credits": [
     {
@@ -25,7 +25,7 @@
   ],
   "versionAdded": "1.2.0",
   "latestUpdate": {
-    "version": "1.40.0",
+    "version": "1.42.0",
     "temporaryNotice": "Added the project creation date to the tooltip."
   },
   "tags": ["community", "projectPage"],

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Additional Project Info",
+  "name": "Additional project dates",
   "description": "Hover over a project's share date for information on when exactly it was created, shared and last edited.",
   "credits": [
     {

--- a/addons/last-edit-tooltip/addon.json
+++ b/addons/last-edit-tooltip/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Shared/edited dates tooltip",
-  "description": "Hover over a project's share date for information on when exactly it was shared, last edited and created.",
+  "description": "Hover over a project's share date for information on when exactly it was created, shared and last edited.",
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -26,8 +26,10 @@ export default async function ({ addon, console, msg }) {
     });
     let dateMod = data.history.modified ? dateFormatterWithMonthName.format(new Date(data.history.modified)) : "?";
     let dateShared = data.history.shared ? dateFormatterWithMonthName.format(new Date(data.history.shared)) : "?";
+    let dateCreated = data.history.created ? dateFormatterWithMonthName.format(new Date(data.history.created)) : "?";
     let dataTitle = `${msg("shared", { date: dateShared })}
-${msg("modified", { date: dateMod })}`;
+${msg("modified", { date: dateMod })}
+${msg("created", { date: dateCreated })}`;
     element.setAttribute("title", dataTitle);
 
     addon.self.addEventListener("disabled", () => {

--- a/addons/last-edit-tooltip/userscript.js
+++ b/addons/last-edit-tooltip/userscript.js
@@ -27,9 +27,9 @@ export default async function ({ addon, console, msg }) {
     let dateMod = data.history.modified ? dateFormatterWithMonthName.format(new Date(data.history.modified)) : "?";
     let dateShared = data.history.shared ? dateFormatterWithMonthName.format(new Date(data.history.shared)) : "?";
     let dateCreated = data.history.created ? dateFormatterWithMonthName.format(new Date(data.history.created)) : "?";
-    let dataTitle = `${msg("shared", { date: dateShared })}
-${msg("modified", { date: dateMod })}
-${msg("created", { date: dateCreated })}`;
+    let dataTitle = `${msg("created", { date: dateCreated })}
+${msg("shared", { date: dateShared })}
+${msg("modified", { date: dateMod })}`;
     element.setAttribute("title", dataTitle);
 
     addon.self.addEventListener("disabled", () => {


### PR DESCRIPTION
Resolves [#7974](https://github.com/ScratchAddons/ScratchAddons/issues/7974)

### Changes

Added the creation date of the project to the tool tip.

### Reason for changes

This addon would be helpful when wanting to know the creation date, of a project.

### Tests

Tested on Edge.
