### PR TITLE
hide-backpack: new Blockly

### DIFF
--- a/addons/hide-backpack/button.css
+++ b/addons/hide-backpack/button.css
@@ -39,6 +39,14 @@
   left: 24px;
 }
 
+[dir="ltr"] .sa-backpack-button.sa-new-blockly {
+  right: 28px;
+}
+
+[dir="rtl"] .sa-backpack-button.sa-new-blockly {
+  left: 29px;
+}
+
 .sa-backpack-open .sa-backpack-button {
   background-color: #0b8e69;
   border-color: rgba(11, 142, 105, 0.35);

--- a/addons/hide-backpack/userscript.js
+++ b/addons/hide-backpack/userscript.js
@@ -4,7 +4,7 @@ export default async function ({ addon, console }) {
   // Event listeners that add dynamic enable/disable
   addon.self.addEventListener("reenabled", () => changeBackpackVisibility());
   addon.self.addEventListener("disabled", () => {
-    moveResizeButtons(0);
+    moveResizeButtons(addon, 0);
     originalBackpack.style.display = "block";
     window.dispatchEvent(new Event("resize"));
   });
@@ -21,7 +21,7 @@ export default async function ({ addon, console }) {
     originalBackpack.style.display = "none";
     let backpackEl = document.querySelector(".sa-backpack-button");
     if (backpackEl) {
-      moveResizeButtons(36);
+      moveResizeButtons(addon, 36);
     } else {
       createBackpackButton(addon);
     }
@@ -38,6 +38,10 @@ function isBackpackOpen() {
 function createBackpackButton(addon) {
   let backpackButton = document.createElement("div");
   backpackButton.classList.add("sa-backpack-button");
+  if (document.querySelector(".blocklyToolboxCategoryGroup")) {
+    // new Blockly
+    backpackButton.classList.add("sa-new-blockly");
+  }
   // Can't use displayNoneWhileDisabled because it updates after the resize event
   backpackButton.style.display = "none"; // overridden by userstyle if the addon is enabled
   backpackButton.title = addon.tab.scratchMessage("gui.backpack.header");
@@ -48,7 +52,7 @@ function createBackpackButton(addon) {
       alt: "",
     })
   );
-  moveResizeButtons(36);
+  moveResizeButtons(addon, 36);
 
   document.querySelector("[class*='gui_tabs_']").appendChild(backpackButton);
 }
@@ -67,9 +71,15 @@ function toggleBackpack() {
 }
 
 // Move resize buttons to top
-function moveResizeButtons(distance) {
+function moveResizeButtons(addon, distance) {
   const resizeElements = document.querySelectorAll(".blocklyZoom > image");
-  resizeElements[0].setAttribute("y", (44 - distance).toString());
-  resizeElements[1].setAttribute("y", (0 - distance).toString());
-  resizeElements[2].setAttribute("y", (88 - distance).toString());
+  if (document.querySelector(".blocklyToolboxCategoryGroup")) {
+    // new Blockly
+    const workspace = addon.tab.traps.getWorkspace();
+    workspace.zoomControls_.MARGIN_VERTICAL = 20 + distance;
+  } else {
+    resizeElements[0].setAttribute("y", (44 - distance).toString());
+    resizeElements[1].setAttribute("y", (0 - distance).toString());
+    resizeElements[2].setAttribute("y", (88 - distance).toString());
+  }
 }


### PR DESCRIPTION
### Changes

Updates the code in hide-backpack that changes the position of zoom buttons to work with modern Blockly.

![image](https://github.com/user-attachments/assets/e9434481-ceb5-4d72-8313-50460137a398)

### Tests

Tested both Scratch versions on Edge and Firefox.