### PR TITLE
custom-menu-bar: Add hide debug button setting

### DIFF
--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -59,6 +59,12 @@
       "default": false
     },
     {
+      "name": "Hide Debug button",
+      "id": "hide-debug-button",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "Hide My Stuff button",
       "id": "my-stuff",
       "type": "boolean",
@@ -122,11 +128,34 @@
           "hide-tutorials-button": true
         }
       }
+    },
+    {
+      "url": "debug-hide.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": {
+          "hide-debug-button": true
+        }
+      }
+    },
+    {
+      "url": "divider-hide.css",
+      "matches": ["projects"],
+      "if": {
+        "settings": {
+          "hide-tutorials-button": true,
+          "hide-debug-button": true
+        }
+      }
     }
   ],
   "dynamicDisable": true,
   "dynamicEnable": true,
   "updateUserstylesOnSettingsChange": true,
   "enabledByDefault": false,
-  "versionAdded": "1.36.0"
+  "versionAdded": "1.36.0",
+  "latestUpdate": {
+    "version": "1.40.0",
+    "newSettings": ["hide-debug-button"]
+  }
 }

--- a/addons/custom-menu-bar/addon.json
+++ b/addons/custom-menu-bar/addon.json
@@ -156,6 +156,7 @@
   "versionAdded": "1.36.0",
   "latestUpdate": {
     "version": "1.40.0",
-    "newSettings": ["hide-debug-button"]
+    "newSettings": ["hide-debug-button"],
+    "isMajor": true
   }
 }

--- a/addons/custom-menu-bar/debug-hide.css
+++ b/addons/custom-menu-bar/debug-hide.css
@@ -1,0 +1,3 @@
+.tutorials-button + div {
+  display: none;
+}

--- a/addons/custom-menu-bar/divider-hide.css
+++ b/addons/custom-menu-bar/divider-hide.css
@@ -1,0 +1,3 @@
+[class*="menu-bar_divider"] {
+  display: none;
+}

--- a/addons/custom-menu-bar/tutorials-hide.css
+++ b/addons/custom-menu-bar/tutorials-hide.css
@@ -1,8 +1,3 @@
-/*
-  file-group is either the left section or the tutorials section.
-  The left section starts with the Scratch logo, which is not hoverable.
-*/
-[class*="menu-bar_file-group_"] > [class*="menu-bar_hoverable_"]:first-child,
-[class*="menu-bar_divider"] {
+.tutorials-button {
   display: none;
 }


### PR DESCRIPTION
Resolves #7950

### Changes

Adds a setting to the customizable editor menu bar addon to hide the debug button.

### Reason for changes

Some users will never use it and removing it saves some menu bar space.

### Tests

Tested on Chromium. The divider is only removed when both the tutorial and and debug buttons are hidden.