### PR TITLE
dark-www: remove styles for old Ideas page

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -358,6 +358,17 @@
       }
     },
     {
+      "name": "box-blackText",
+      "value": {
+        "type": "textColor",
+        "black": "#000000",
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
+    },
+    {
       "name": "box-filter",
       "value": {
         "type": "textColor",
@@ -620,17 +631,6 @@
       "value": {
         "type": "textColor",
         "black": "#666666",
-        "source": {
-          "type": "settingValue",
-          "settingId": "box"
-        }
-      }
-    },
-    {
-      "name": "box-scratchr2Caret",
-      "value": {
-        "type": "textColor",
-        "black": "#000000",
         "source": {
           "type": "settingValue",
           "settingId": "box"

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -120,9 +120,9 @@
           "type": "settingValue",
           "settingId": "page"
         },
-        "r": 0.99,
-        "g": 0.99,
-        "b": 0.99
+        "r": 0.98,
+        "g": 0.98,
+        "b": 0.98
       }
     },
     {
@@ -514,18 +514,6 @@
         "black": "rgba(0, 0, 0, 0.05)",
         "white": "rgba(255, 255, 255, 0.05)",
         "threshold": 32,
-        "source": {
-          "type": "settingValue",
-          "settingId": "box"
-        }
-      }
-    },
-    {
-      "name": "box-divider5",
-      "value": {
-        "type": "textColor",
-        "black": "rgba(0, 0, 0, 0.05)",
-        "white": "rgba(255, 255, 255, 0.05)",
         "source": {
           "type": "settingValue",
           "settingId": "box"

--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -192,7 +192,7 @@ span.small-text,
   color: var(--darkWww-box-scratchr2GrayText);
 }
 .dropdown span.dropdown-toggle.black span.caret {
-  border-top-color: var(--darkWww-box-scratchr2Caret);
+  border-top-color: var(--darkWww-box-blackText);
 }
 input::placeholder {
   color: var(--darkWww-box-scratchr2InputPlaceholder);

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -223,7 +223,6 @@ body:not(.sa-body-editor) .button.white,
 .tabs button:hover,
 .tabs button.active:hover,
 .grid .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
-.youtbe-video-button .video-info .video-title,
 .cards-modal-container .cards-modal-section-title,
 .unsupported-browser .faq-link-text,
 a.social-messages-profile-link:visited,
@@ -244,6 +243,9 @@ body:not(.sa-body-editor) .formik-input::placeholder,
 body:not(.sa-body-editor) .join-flow-privacy-message,
 .char-count {
   color: var(--darkWww-box-inputPlaceholder);
+}
+.youtbe-video-button .video-info .video-title {
+  color: var(--darkWww-box-blackText);
 }
 .comment .comment-body .comment-bubble.comment-bubble-reported,
 .comment .comment-body .comment-bubble.comment-bubble-reported::before,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -12,8 +12,6 @@ body {
   color-scheme: light;
 }
 #view,
-.tips,
-.physical-ideas,
 .crash-container,
 .semicolon {
   background-color: var(--darkWww-page);
@@ -24,8 +22,8 @@ body {
 .conf2019-description {
   color: var(--darkWww-page-text);
 }
-.tips-getting-started,
-.tips-activity-guides {
+.tips,
+.physical-ideas {
   background-color: var(--darkWww-page-ideas);
   color: var(--darkWww-page-text);
 }
@@ -139,7 +137,6 @@ body:not(.sa-body-editor) .formik-input,
 .studio-project-tile,
 .studio-member-tile,
 .studio-activity .studio-messages-list,
-.ttt-tile,
 .cards-modal-container,
 .about .body,
 .messages-social-list,
@@ -185,7 +182,6 @@ body:not(.sa-body-editor) .button.white,
 .feature-banner .feature-learn-more,
 .feature-banner .feature-banner-image,
 .outer .categories li,
-.banner-wrapper .banner-button /* Choose a tutorial */,
 .studio-selector-button,
 .onboarding button.go-back,
 .button.mod-2019-conf-maillist-button,
@@ -258,7 +254,6 @@ body:not(.sa-body-editor) .join-flow-privacy-message,
 .thumbnail .thumbnail-favorites::before,
 .thumbnail .thumbnail-remixes::before,
 .thumbnail .thumbnail-views::before,
-.ttt-item img,
 .playlist .spinner,
 .tabs button:not(.active) .tab-icon,
 body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
@@ -290,7 +285,6 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
   border-color: var(--darkWww-box-greenText);
 }
 .donate-banner .donate-container .donate-button,
-.banner-wrapper .banner-button /* Choose a tutorial */,
 .donate-section .donate-button {
   color: var(--darkWww-box-greenText);
 }
@@ -306,9 +300,6 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .transfer-host-modal .button:disabled {
   background-color: var(--darkWww-box-buttonDisabled);
   color: white;
-}
-.tips-divider {
-  border-color: var(--darkWww-box-divider5);
 }
 body:not(.sa-body-editor) .select .join-flow-select {
   background-image: var(--darkWww-box-caret);
@@ -499,9 +490,6 @@ body:not(.sa-body-editor) .select select:focus {
 .banner-outer:not(.banner-danger) .banner-button /* Share */ {
   background-color: #ffab1a;
 }
-a.ttt-try-tutorial-button > span {
-  color: var(--darkWww-button-text);
-}
 .row .col-sm-9 input[type="radio"]:checked::after {
   background-color: var(--darkWww-button-text);
 }
@@ -542,7 +530,6 @@ body:not(.sa-body-editor) input {
 #footer .inner .media li img {
   filter: var(--darkWww-button-filter);
 }
-.banner-wrapper .banner-button img /* "Choose a tutorial" icon */,
 .forms-close-button img,
 .os-chooser .button:not(.active) img {
   filter: none;
@@ -695,7 +682,6 @@ p.callout,
   border-color: var(--darkWww-border);
 }
 .grid .thumbnail,
-.ttt-tile,
 .thumbnail-column .thumbnail .thumbnail-image {
   box-shadow: 0 0 0 1px var(--darkWww-border);
 }
@@ -707,7 +693,6 @@ p.callout,
 .news li:nth-child(even),
 .thumbnail .thumbnail-image img,
 .video-player,
-.ttt-content-chunk + .ttt-content-chunk,
 .cards-modal-container .cards-modal-section-content .cards-modal-cards-list .card + .card,
 .messages-social-list,
 .social-message,


### PR DESCRIPTION
### Changes

Removes styles that have become unnecessary after the Ideas page update. Also makes the new page more similar to vanilla when the "Scratch's default colors" preset is used.

### Tests

Tested on Edge and Firefox.