### PR TITLE
stage-monitor: Run on embeds

### DIFF
--- a/addons/stage-monitor/addon.json
+++ b/addons/stage-monitor/addon.json
@@ -14,11 +14,11 @@
   "userstyles": [
     {
       "url": "monitors.css",
-      "matches": ["projects"]
+      "matches": ["projects", "projectEmbeds"]
     },
     {
       "url": "monitor-values.css",
-      "matches": ["projects"],
+      "matches": ["projects", "projectEmbeds"],
       "if": {
         "settings": { "customValueColor": true }
       }


### PR DESCRIPTION
### Changes

Allows the customizable stage monitors addon to run on project embeds.

### Tests

Tested on Chromium on the new ideas page.
