### PR TITLE
Include hidden files in packer action

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           name: Packed Extensions (zip)
           path: .dist/*.zip
+          include-hidden-files: true


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/pull/7134#issuecomment-2552137326

Tells upload-artifact to explicitly include dotfiles since it doesn't by default anymore. See https://github.com/actions/upload-artifact/issues/602.

### Tests

I successfully ran the action on my fork and loaded the extension into Chromium.
