### PR TITLE
Packer: Change folder path `.dist` → `dist`

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Packed Extensions (zip)
-          path: .dist/*.zip
+          path: dist/*.zip


### PR DESCRIPTION
The other half of ScratchAddons/packer-script#2

### Changes

Updates the "pack extensions" workflow to upload artifacts from:
```diff
- .dist/*.zip
+ dist/*.zip
```

### Reason for changes

upload-artifact no longer uploads hidden files because of the risk of uploading confidential information.