### PR TITLE
Make 'More Settings' linkable

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -175,10 +175,10 @@
           <img src="../../images/icons/comment.svg" draggable="false" />
           <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
         </a>
-        <div v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
+        <a v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" href="#moresettings">
           <img src="../../images/icons/wrench.svg" draggable="false" />
           <span>{{ msg("moreSettings") }}</span>
-        </div>
+        </a>
       </div>
       <div v-show="!isIframe && smallMode === false" class="categories-shrink" @click="sidebarToggle()">
         <img

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -175,10 +175,10 @@
           <img src="../../images/icons/comment.svg" draggable="false" />
           <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
         </a>
-        <a v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" href="#moresettings">
+        <div v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
           <img src="../../images/icons/wrench.svg" draggable="false" />
           <span>{{ msg("moreSettings") }}</span>
-        </a>
+        </div>
       </div>
       <div v-show="!isIframe && smallMode === false" class="categories-shrink" @click="sidebarToggle()">
         <img

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -84,7 +84,7 @@ let fuse;
         forceEnglishSetting: null,
         forceEnglishSettingInitial: null,
         switchPath: "../../images/icons/switch.svg",
-        moreSettingsOpen: false,
+        moreSettingsOpen: location.hash.toLocaleLowerCase() === "#moresettings",
         categoryOpen: true,
         loaded: false,
         searchLoaded: false,
@@ -344,6 +344,9 @@ let fuse;
       forceEnglishSetting(newValue, oldValue) {
         if (oldValue !== null) chrome.storage.local.set({ forceEnglish: this.forceEnglishSetting });
       },
+      moreSettingsOpen(newValue) {
+        if (!newValue) location.hash = "#";
+      }
     },
     ready() {
       // Autofocus search bar in iframe mode for both browsers
@@ -380,15 +383,19 @@ let fuse;
       window.addEventListener(
         "hashchange",
         (e) => {
-          const addonId = location.hash.replace(/^#addon-/, "");
-          const groupWithAddon = this.addonGroups.find((group) => group.addonIds.includes(addonId));
-          if (!groupWithAddon) return; //Don't run if hash is invalid
-          const addon = this.manifestsById[addonId];
+          if (location.hash.toLocaleLowerCase() === "#moresettings") {
+            vue.openMoreSettings();
+          } else {
+            const addonId = location.hash.replace(/^#addon-/, "");
+            const groupWithAddon = this.addonGroups.find((group) => group.addonIds.includes(addonId));
+            if (!groupWithAddon) return; //Don't run if hash is invalid
+            const addon = this.manifestsById[addonId];
 
-          groupWithAddon.expanded = true;
-          this.selectedCategory = addon?.tags.includes("easterEgg") ? "easterEgg" : "all";
-          this.clearSearch();
-          setTimeout(() => document.getElementById("addon-" + addonId)?.scrollIntoView(), 0);
+            groupWithAddon.expanded = true;
+            this.selectedCategory = addon?.tags.includes("easterEgg") ? "easterEgg" : "all";
+            this.clearSearch();
+            setTimeout(() => document.getElementById("addon-" + addonId)?.scrollIntoView(), 0);
+          }
         },
         { capture: false }
       );

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -381,7 +381,7 @@ let fuse;
       window.addEventListener(
         "hashchange",
         (e) => {
-          if (location.hash.toLocaleLowerCase() === "#moresettings") {
+          if (location.hash === "#moresettings") {
             vue.openMoreSettings();
           } else {
             const addonId = location.hash.replace(/^#addon-/, "");
@@ -597,7 +597,7 @@ let fuse;
     vue.loaded = true;
     setTimeout(() => {
       const hash = window.location.hash;
-      if (location.hash.toLocaleLowerCase() === "#moresettings") {
+      if (location.hash === "#moresettings") {
         vue.openMoreSettings();
       } else if (hash.startsWith("#addon-")) {
         const addonId = hash.substring(7);

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -346,7 +346,7 @@ let fuse;
       },
       moreSettingsOpen(newValue) {
         if (!newValue) location.hash = "#";
-      }
+      },
     },
     ready() {
       // Autofocus search bar in iframe mode for both browsers

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -84,7 +84,7 @@ let fuse;
         forceEnglishSetting: null,
         forceEnglishSettingInitial: null,
         switchPath: "../../images/icons/switch.svg",
-        moreSettingsOpen: location.hash.toLocaleLowerCase() === "#moresettings",
+        moreSettingsOpen: false,
         categoryOpen: true,
         loaded: false,
         searchLoaded: false,
@@ -179,6 +179,7 @@ let fuse;
         if (vue.smallMode) {
           vue.sidebarToggle();
         }
+        location.hash = "";
       },
       sidebarToggle: function () {
         this.categoryOpen = !this.categoryOpen;
@@ -343,9 +344,6 @@ let fuse;
       },
       forceEnglishSetting(newValue, oldValue) {
         if (oldValue !== null) chrome.storage.local.set({ forceEnglish: this.forceEnglishSetting });
-      },
-      moreSettingsOpen(newValue) {
-        if (!newValue) location.hash = "#";
       },
     },
     ready() {
@@ -599,7 +597,9 @@ let fuse;
     vue.loaded = true;
     setTimeout(() => {
       const hash = window.location.hash;
-      if (hash.startsWith("#addon-")) {
+      if (location.hash.toLocaleLowerCase() === "#moresettings") {
+        vue.openMoreSettings();
+      } else if (hash.startsWith("#addon-")) {
         const addonId = hash.substring(7);
         const groupWithAddon = vue.addonGroups.find((group) => group.addonIds.includes(addonId));
         if (!groupWithAddon) return;


### PR DESCRIPTION
Resolves #5422

### Changes

Makes more settings linkable and replaces the more settings button with a link. Right now more settings stays open after a page reload but I can change that if it's too annoying.

### Reason for changes

So more settings can be linked to directly.

### Tests

Tested on Chromium. Addon linking still works.