### PR TITLE
Don't include dist/ in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@
 *.md export-ignore
 LICENSE export-ignore
 .* export-ignore
+dist export-ignore
 typedef.js export-ignore
 
 libraries/README.md -export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,7 @@
 
 *.md export-ignore
 LICENSE export-ignore
+eslint.config.mjs export-ignore
 .* export-ignore
 dist export-ignore
 typedef.js export-ignore


### PR DESCRIPTION
Fixes https://github.com/ScratchAddons/ScratchAddons/pull/8012#issuecomment-2555750817

> That didn't quite work, the "dist" folder is being included inside the chrome zip now.

This should fix the problem. Previously we were `git archive`-ing every non-dot folder including `dist`.