### PR TITLE
editor-theme3: fix comment text in the forums

### DIFF
--- a/addons/editor-theme3/forums/base.css
+++ b/addons/editor-theme3/forums/base.css
@@ -129,8 +129,7 @@ svg[class*="scratchblocks-style-scratch3"] .sb3-label,
   fill: var(--editorTheme3-commentColor);
   stroke: var(--editorTheme3-commentBorder);
 }
-.sb3-comment-label,
-.sb3-label.sb3-comment-label {
+svg[class*="scratchblocks-style-scratch3"] .sb3-label.sb3-comment-label {
   fill: var(--editorTheme3-commentText);
 }
 

--- a/addons/editor-theme3/forums/color_on_black.css
+++ b/addons/editor-theme3/forums/color_on_black.css
@@ -23,7 +23,7 @@ svg[class*="scratchblocks-style-scratch3"] .sb3-obsolete {
 }
 
 svg[class*="scratchblocks-style-scratch3"] .sb3-label,
-.sb3-label.sb3-comment-label {
+svg[class*="scratchblocks-style-scratch3"] .sb3-label.sb3-comment-label {
   fill: white;
 }
 

--- a/addons/editor-theme3/forums/color_on_white.css
+++ b/addons/editor-theme3/forums/color_on_white.css
@@ -22,6 +22,7 @@ svg[class*="scratchblocks-style-scratch3"] .sb3-obsolete {
   stroke: var(--editorTheme3-commentColor);
 }
 svg[class*="scratchblocks-style-scratch3"] .sb3-label,
+svg[class*="scratchblocks-style-scratch3"] .sb3-label.sb3-comment-label,
 #sb3-dropdownArrow path,
 #sb3-loopArrow path[fill="#fff"],
 #sb3-turnLeft path[fill="#fff"],


### PR DESCRIPTION
Resolves #8018

### Changes

Uses a more specific selector for comment text.

### Reason for changes

This fixes the text being unreadable in the default and Scratch 2.0 presets.

### Tests

Tested on Edge and Firefox with different combinations of the "comments" and "text color" settings. Example post that contains a scratchblocks comment: https://scratch.mit.edu/discuss/post/7975899/