### PR TITLE
Fix custom-menu-bar icons only mode

### DIFF
--- a/addons/custom-menu-bar/menu-icons.css
+++ b/addons/custom-menu-bar/menu-icons.css
@@ -1,5 +1,14 @@
 [class*="settings-menu_dropdown-label"],
 [class*="menu-bar_collapsible-label"],
-[class*="menu-bar_tutorials-label"] {
+[class*="menu-bar_tutorials-label"],
+[class*="menu-bar_debug-label_"] {
   display: none;
+}
+
+[class*="menu-bar_help-icon_"] {
+  margin: 0;
+}
+
+[class*="menu-bar_file-group_"] [class*="menu-bar_no-offset_"] {
+  padding: 0 0.75rem;
 }

--- a/addons/custom-menu-bar/menu-icons.css
+++ b/addons/custom-menu-bar/menu-icons.css
@@ -8,7 +8,3 @@
 [class*="menu-bar_help-icon_"] {
   margin: 0;
 }
-
-[class*="menu-bar_file-group_"] [class*="menu-bar_no-offset_"] {
-  padding: 0 0.75rem;
-}


### PR DESCRIPTION
Hides the debug label and removes the right margin from both help buttons in the icon only mode of the customizable editor menu bar.

Someone sent feedback about the label on 1.39.2 but it also applies to the latest version.