### PR TITLE
`mediarecorder`: Specify audio codec

### DIFF
--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -33,6 +33,7 @@ export default async ({ addon, console, msg }) => {
 
   const mimeType = [
     // Prefer mp4 format over webm (Chrome and Safari)
+    "video/mp4; codecs=mp4a.40.2",
     "video/mp4",
     // Chrome 125 and below and Firefox only support encoding as webm
     // VP9 is preferred as its playback is better supported across platforms


### PR DESCRIPTION
### Changes

I figured out how to get audio recording to work on MP4 recordings! You need to set mimeType to `"video/mp4; codecs=mp4a.40.2"`.

### Tests

Tested with Edge 131 on Windows 11.