### PR TITLE
player-thumb: Fix fullscreen bugs

### DIFF
--- a/addons/fullscreen/hideToolbar.css
+++ b/addons/fullscreen/hideToolbar.css
@@ -10,7 +10,8 @@
 }
 
 [class*="stage-wrapper_full-screen"] div[class*="loader_background_"] {
-  top: 0; /* Override removeBorder.css */
+  height: 100%;
+  top: 0;
 }
 
 .phantom-header {

--- a/addons/fullscreen/hideToolbar.css
+++ b/addons/fullscreen/hideToolbar.css
@@ -9,6 +9,10 @@
   transition: transform 0.3s;
 }
 
+[class*="stage-wrapper_full-screen"] div[class*="loader_background_"] {
+  top: 0; /* Override removeBorder.css */
+}
+
 .phantom-header {
   position: absolute;
   top: 0px;
@@ -16,7 +20,7 @@
   right: 0px;
   height: 8px;
   display: block;
-  z-index: 5000;
+  z-index: 5001; /* 1 above loader_background */
 }
 
 .stage-header-hover {

--- a/addons/fullscreen/hideToolbar.css
+++ b/addons/fullscreen/hideToolbar.css
@@ -9,7 +9,7 @@
   transition: transform 0.3s;
 }
 
-[class*="stage-wrapper_full-screen"] div[class*="loader_background_"] {
+[class*="stage-wrapper_full-screen"] .sa-loader-background {
   height: 100%;
   top: 0;
 }
@@ -21,7 +21,7 @@
   right: 0px;
   height: 8px;
   display: block;
-  z-index: 5001; /* 1 above loader_background */
+  z-index: 5000;
 }
 
 .stage-header-hover {

--- a/addons/fullscreen/removeBorder.css
+++ b/addons/fullscreen/removeBorder.css
@@ -12,6 +12,16 @@
 }
 
 [class*="stage-wrapper_full-screen"] .sa-project-thumb {
-  width: 100%;
   height: 100%;
+  top: 0;
+}
+
+[class*="stage-wrapper_full-screen"] .sa-project-thumb.loading {
+  top: 0;
+  height: min(100%, 100vw * 0.75);
+}
+
+[class*="stage-wrapper_full-screen"] div[class*="loader_background_"] {
+  top: 2.75rem;
+  height: min(100% - 2.75rem, 100vw * 0.75);
 }

--- a/addons/fullscreen/removeBorder.css
+++ b/addons/fullscreen/removeBorder.css
@@ -20,7 +20,7 @@
   height: min(100%, 100vw * 0.75);
 }
 
-[class*="stage-wrapper_full-screen"] div[class*="loader_background_"] {
+[class*="stage-wrapper_full-screen"] .sa-loader-background {
   top: 2.75rem;
   height: min(100% - 2.75rem, 100vw * 0.75);
 }

--- a/addons/fullscreen/removeBorder.css
+++ b/addons/fullscreen/removeBorder.css
@@ -13,7 +13,6 @@
 
 [class*="stage-wrapper_full-screen"] .sa-project-thumb {
   height: 100%;
-  top: 0;
 }
 
 [class*="stage-wrapper_full-screen"] .sa-project-thumb.loading {

--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -7,6 +7,11 @@ export default async function ({ addon, console }) {
   thumb.classList = "sa-project-thumb loading";
 
   const stageWrapper = await addon.tab.waitForElement('div[class*="stage-wrapper_stage-wrapper_"]');
+  addon.tab.redux.initialize();
+
+  // It's possible this runs after the project loads even without dynamic enable
+  if (addon.tab.redux.state?.scratchGui?.vmStatus?.started) return;
+
   const alerts = document.querySelector(".project-info-alerts");
   const controls = stageWrapper.querySelector('div[class^="controls_controls-container_"]');
   controls.classList.add("sa-controls-disabled");
@@ -20,7 +25,6 @@ export default async function ({ addon, console }) {
     loaderBackground.classList.add("sa-loader-background");
   });
 
-  addon.tab.redux.initialize();
 
   function handleStateChange(e) {
     if (e.detail.action.type === "scratch-gui/project-changed/SET_PROJECT_CHANGED") {

--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -25,7 +25,6 @@ export default async function ({ addon, console }) {
     loaderBackground.classList.add("sa-loader-background");
   });
 
-
   function handleStateChange(e) {
     if (e.detail.action.type === "scratch-gui/project-changed/SET_PROJECT_CHANGED") {
       // Move the thumbnail after the project loads

--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -10,7 +10,7 @@ export default async function ({ addon, console }) {
   addon.tab.redux.initialize();
 
   // It's possible this runs after the project loads even without dynamic enable
-  if (addon.tab.redux.state?.scratchGui?.vmStatus?.started) return;
+  if (addon.tab.redux.state?.scratchGui?.projectState?.loadingState === "SHOWING_WITH_ID") return;
 
   const alerts = document.querySelector(".project-info-alerts");
   const controls = stageWrapper.querySelector('div[class^="controls_controls-container_"]');

--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -14,8 +14,11 @@ export default async function ({ addon, console }) {
   const loaderBackground = stageWrapper.querySelector('[class*="loader_background_"]');
   stageWrapper.insertBefore(thumb, loaderBackground);
   alerts.style.display = "none";
-  // Ensure thumbnail is injected before adding transparency
-  loaderBackground.style.backgroundColor = "rgba(0, 0, 0, 0.25)";
+  loaderBackground.classList.add("sa-loader-background");
+
+  addon.tab.addEventListener("urlChange", () => {
+    loaderBackground.classList.add("sa-loader-background");
+  });
 
   addon.tab.redux.initialize();
 

--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -18,7 +18,8 @@ export default async function ({ addon, console }) {
   loaderBackground.style.backgroundColor = "rgba(0, 0, 0, 0.25)";
 
   addon.tab.redux.initialize();
-  addon.tab.redux.addEventListener("statechanged", (e) => {
+
+  function handleStateChange(e) {
     if (e.detail.action.type === "scratch-gui/project-changed/SET_PROJECT_CHANGED") {
       // Move the thumbnail after the project loads
       thumb.classList.remove("loading");
@@ -28,6 +29,11 @@ export default async function ({ addon, console }) {
       stage.insertBefore(thumb, greenFlagOverlay);
       alerts.style.display = "flex";
     }
-    if (e.detail.action.type === "scratch-gui/vm-status/SET_STARTED_STATE") thumb.remove();
-  });
+    if (e.detail.action.type === "scratch-gui/vm-status/SET_STARTED_STATE") {
+      thumb.remove();
+      addon.tab.redux.removeEventListener("statechanged", handleStateChange);
+    }
+  }
+
+  addon.tab.redux.addEventListener("statechanged", handleStateChange);
 }

--- a/addons/player-thumb/userstyle.css
+++ b/addons/player-thumb/userstyle.css
@@ -2,6 +2,7 @@
   display: inline;
   position: absolute;
   background-color: var(--darkWww-page, #fcfcfc);
+  aspect-ratio: 4 / 3;
 }
 
 .sa-controls-disabled > img {
@@ -12,7 +13,6 @@
 body:not(.sa-body-editor) .sa-project-thumb {
   top: 1px;
   left: 1px;
-  width: calc(100% - 2px);
   height: calc(100% - 2px);
   border-radius: calc(0.5rem - 1px);
 }

--- a/addons/player-thumb/userstyle.css
+++ b/addons/player-thumb/userstyle.css
@@ -5,6 +5,11 @@
   aspect-ratio: 4 / 3;
 }
 
+.sa-loader-background {
+  background-color: rgba(0, 0, 0, 0.25);
+  z-index: 4999;
+}
+
 .sa-controls-disabled > img {
   pointer-events: none;
   opacity: 0.5;
@@ -17,11 +22,11 @@ body:not(.sa-body-editor) .sa-project-thumb {
   border-radius: calc(0.5rem - 1px);
 }
 
-body:not(.sa-body-editor) div[class*="loader_background_"] {
+body:not(.sa-body-editor) .sa-loader-background {
   border-radius: calc(0.5rem - 1px);
 }
 
-body:not(.sa-body-editor) div[class*="loader_background_"],
+body:not(.sa-body-editor) .sa-loader-background,
 body:not(.sa-body-editor) .sa-project-thumb.loading {
   top: calc(2.75rem + 1px);
   height: calc(100% - 2.75rem - 2px);
@@ -40,7 +45,7 @@ body:not(.sa-body-editor) .sa-project-thumb.loading {
   height: min(100% - 12px, 100vw * 0.75);
 }
 
-[class*="stage-wrapper_full-screen"] div[class*="loader_background_"] {
+[class*="stage-wrapper_full-screen"] .sa-loader-background {
   top: calc(2.75rem + 6px);
   left: auto;
   width: auto;

--- a/addons/player-thumb/userstyle.css
+++ b/addons/player-thumb/userstyle.css
@@ -1,5 +1,5 @@
 .sa-project-thumb {
-  display: none; /* For editor only, not fullscreen */
+  display: inline;
   position: absolute;
   background-color: var(--darkWww-page, #fcfcfc);
 }
@@ -10,7 +10,6 @@
 }
 
 body:not(.sa-body-editor) .sa-project-thumb {
-  display: inline;
   top: 1px;
   left: 1px;
   width: calc(100% - 2px);
@@ -29,7 +28,6 @@ body:not(.sa-body-editor) .sa-project-thumb.loading {
 }
 
 [class*="stage-wrapper_full-screen"] .sa-project-thumb {
-  display: inline;
   top: 3px;
   left: 3px;
   height: calc(100% - 6px);


### PR DESCRIPTION
Resolves #8027
Resolves #8033
Properly fixes #7928

### Changes

Removes the event listener instead of hiding the thumbnail in the editor and fixes enhanced fullscreen compatibility.

### Reason for changes

To fix bugs such as one from feedback where the thumbnail gets stuck when going fullscreen from the editor.

### Tests

Tested on Chromium.
