### PR TITLE
dark-www: style new links on teacher registration page

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -235,7 +235,8 @@ a.social-messages-profile-link:link,
 .studio-selector-button-text-unselected,
 .studio-project-tile .studio-project-username,
 .studio-member-tile .studio-member-role,
-body:not(.sa-body-editor) .join-flow-title {
+body:not(.sa-body-editor) .join-flow-title,
+.registration-step .bold-link {
   color: var(--darkWww-box-text);
 }
 .activity-li .social-message-date,


### PR DESCRIPTION
### Changes

Fixes the text color of the `no-reply@scratch.mit.edu` links in the following message:

![image](https://github.com/user-attachments/assets/9c9958a2-91e8-4e69-bff9-0fac12d9ccfb)

### Tests

Tested on Edge. I moved the `TeacherApprovalStep` to the beginning of the `Progression` in `src/views/teacherregistration/teacherregistration.jsx` and changed its attributes to the following:
```js
<Steps.TeacherApprovalStep
    confirmed={false}
    educator={permissions.educator}
    email={"example@example.com"}
    invited={permissions.educator_invitee}
/>
```