### PR TITLE
`mediarecorder`: Add "Video scale" option

### DIFF
--- a/addons-l10n/en/mediarecorder.json
+++ b/addons-l10n/en/mediarecorder.json
@@ -4,6 +4,7 @@
   "mediarecorder/option-title": "Record Options",
   "mediarecorder/record-duration": "End recording after:",
   "mediarecorder/start-delay": "Start recording after:",
+  "mediarecorder/stage-scale": "Video scale:",
   "mediarecorder/seconds": "seconds",
   "mediarecorder/starting-in": "Starting in {secs}...",
   "mediarecorder/record-audio": "Record project audio",

--- a/addons/mediarecorder/addon.json
+++ b/addons/mediarecorder/addon.json
@@ -15,8 +15,8 @@
     }
   ],
   "latestUpdate": {
-    "version": "1.35.0",
-    "temporaryNotice": "The maximum recording time has been increased to 10 minutes (600 seconds)."
+    "version": "1.41.0",
+    "temporaryNotice": "A new \"Video scale\" option has been added, to allow making high resolution recordings."
   },
   "versionAdded": "1.6.0",
   "enabledByDefault": false

--- a/addons/mediarecorder/style.css
+++ b/addons/mediarecorder/style.css
@@ -50,9 +50,14 @@ p.mediaRecorderPopupOption {
 }
 
 #recordOptionSecondsInput,
-#recordOptionDelayInput {
+#recordOptionDelayInput,
+#recordOptionScaleInput {
   width: 5rem;
   margin-bottom: 0.25rem;
+}
+
+#recordOptionScaleInput {
+  width: 6rem;
 }
 
 .mediaRecorderSeparator {

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -31,6 +31,8 @@ export default async ({ addon, console, msg }) => {
 
   const getStoredOptions = () => {
     try {
+      // If any new properties get added to DEFAULT_SETTINGS,
+      // this makes sure that they are individually applied to the saved settings too
       return Object.assign(
         structuredClone(DEFAULT_SETTINGS),
         JSON.parse(localStorage.getItem(LOCALSTORAGE_ENTRY)) ?? DEFAULT_SETTINGS

--- a/addons/mediarecorder/userscript.js
+++ b/addons/mediarecorder/userscript.js
@@ -31,7 +31,10 @@ export default async ({ addon, console, msg }) => {
 
   const getStoredOptions = () => {
     try {
-      return Object.assign(structuredClone(DEFAULT_SETTINGS), JSON.parse(localStorage.getItem(LOCALSTORAGE_ENTRY)) ?? DEFAULT_SETTINGS);
+      return Object.assign(
+        structuredClone(DEFAULT_SETTINGS),
+        JSON.parse(localStorage.getItem(LOCALSTORAGE_ENTRY)) ?? DEFAULT_SETTINGS
+      );
     } catch {
       return DEFAULT_SETTINGS;
     }
@@ -53,7 +56,7 @@ export default async ({ addon, console, msg }) => {
     const runtime = vm.runtime;
     return [
       runtime?.stageWidth ?? runtime.constructor.STAGE_WIDTH,
-      runtime?.stageHeight ?? runtime.constructor.STAGE_HEIGHT
+      runtime?.stageHeight ?? runtime.constructor.STAGE_HEIGHT,
     ];
   }
 
@@ -62,17 +65,13 @@ export default async ({ addon, console, msg }) => {
   const initialStageSize = getStageSize();
   let actualWidth = vm.runtime.renderer.gl?.canvas?.width ?? initialStageSize[0];
   let actualHeight = vm.runtime.renderer.gl?.canvas?.height ?? initialStageSize[1];
-  vm.runtime.renderer.constructor.prototype.resize = function(pixelsWide, pixelsTall) {
+  vm.runtime.renderer.constructor.prototype.resize = function (pixelsWide, pixelsTall) {
     actualWidth = pixelsWide;
     actualHeight = pixelsTall;
     if (!isRecording) return oldResize.call(this, pixelsWide, pixelsTall);
     const stageSize = getStageSize();
     const scale = Math.max(MIN_SCALE, stageScale);
-    return oldResize.call(
-      this,
-      Math.ceil(stageSize[0] * scale),
-      Math.ceil(stageSize[1] * scale)
-    );
+    return oldResize.call(this, Math.ceil(stageSize[0] * scale), Math.ceil(stageSize[1] * scale));
   };
   function forceRendererResize() {
     vm.runtime.renderer.resize(actualWidth, actualHeight);
@@ -255,8 +254,7 @@ export default async ({ addon, console, msg }) => {
         recordOptionScaleInput.value = scale;
 
         const [stageWidth, stageHeight] = getStageSize();
-        recordOptionScalePreview.textContent =
-          `(${Math.ceil(stageWidth * scale)}x${Math.ceil(stageHeight * scale)})`;
+        recordOptionScalePreview.textContent = `(${Math.ceil(stageWidth * scale)}x${Math.ceil(stageHeight * scale)})`;
       };
       recordOptionScaleInput.addEventListener("change", onScaleInputChange);
       onScaleInputChange();


### PR DESCRIPTION
Resolves [this suggestion posted in the TurboWarp Discord server](https://discord.com/channels/837024174865776680/1321234454710321174)

### Changes

Adds a "Video scale" option in the project video recorder addon's dialog. This option forces the stage canvas' (and thus the video's) scale to be whatever the option is set to while recording; for example, if you have a 480x360 stage and set the video scale to 2, the canvas will be forced to 960x720; therefore, the outputted video file will be 960x720.
![image](https://github.com/user-attachments/assets/2be74eaf-fc26-49da-ad25-5de425989bde)

This option has a range from 0.01-15x, which is probably a bit too much, but should be more than enough for anyone. (Maybe if someone is, say, making a game with an 8x8 stage or something?)

### Reason for changes

Allows making higher (or lower, I guess)-resolution recordings. It also prevents the canvas from resizing during recording, which at least prevents Firefox from outputting corrupted 0-byte WEBMs.

### Tests

Only tested on Firefox.
