### PR TITLE
`jump-to-def` bugfix

### DIFF
--- a/addons/jump-to-def/userscript.js
+++ b/addons/jump-to-def/userscript.js
@@ -29,7 +29,7 @@ export default async function ({ addon, msg, console }) {
         if (block.type === "procedures_call") {
           let findProcCode = block.getProcCode();
 
-          let topBlocks = utils.getWorkspace().getTopBlocks();
+          let topBlocks = addon.tab.traps.getWorkspace().getTopBlocks();
           for (const root of topBlocks) {
             if (root.type === "procedures_definition") {
               let label = root.getChildren()[0];


### PR DESCRIPTION
Resolves #8026

### Changes

Replaces `utils.getWorkspace` in jump-to-def's userscript with `addon.tab.traps.getWorkspace` (#7892 deleted the former but didn't update the usage in jump-to-def).

### Tests

Works on chrome 131.0.6778.205.
