### PR TITLE
Fix `hide-backpack` incompatibility with auto-hiding zoom controls in `custom-zoom`

### DIFF
--- a/addons/hide-backpack/button.css
+++ b/addons/hide-backpack/button.css
@@ -29,6 +29,7 @@
   border: 2px solid rgba(87, 94, 117, 0.5);
   border-radius: 50%;
   cursor: pointer;
+  z-index: 2;
 }
 
 [dir="ltr"] .sa-backpack-button {

--- a/addons/hide-backpack/button.css
+++ b/addons/hide-backpack/button.css
@@ -29,7 +29,7 @@
   border: 2px solid rgba(87, 94, 117, 0.5);
   border-radius: 50%;
   cursor: pointer;
-  z-index: 2;
+  z-index: 2; /* above custom zoom controls */
 }
 
 [dir="ltr"] .sa-backpack-button {


### PR DESCRIPTION
Resolves #8040

### Changes

Added `z-index: 2` to stylesheet in hide-backpack to fix layering issue.

### Tests

Tested on Chrome 131.0.6778.205.
