### PR TITLE
middle-click-popup: fix extension blocks

### DIFF
--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -431,16 +431,20 @@ export class BlockTypeInfo {
       } else {
         let FieldColour;
         let FieldNumber;
+        let FieldVerticalSeparator;
         if (Blockly.registry) {
           // new Blockly
           FieldColour = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_colour_slider");
           FieldNumber = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_number");
+          FieldVerticalSeparator = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_vertical_separator");
         } else {
           FieldColour = Blockly.FieldColour;
           FieldNumber = Blockly.FieldNumber;
+          FieldVerticalSeparator = Blockly.FieldVerticalSeparator;
         }
         if (
           field instanceof Blockly.FieldLabel ||
+          field instanceof FieldVerticalSeparator ||
           (!Blockly.registry && field instanceof Blockly.FieldVariableGetter)
         ) {
           if (field.getText().trim().length !== 0) parts.push(field.getText());


### PR DESCRIPTION
Resolves #8042

### Changes

Ignores vertical separators when adding inputs to blocks.

(Before #7949, the addon used the `argType_` attribute to determine which fields aren't inputs. This attribute doesn't exist in modern Blockly.)

### Tests

Tested on Edge (current Scratch version and spork) and Firefox (current Scratch version).

![image](https://github.com/user-attachments/assets/11d8e670-450d-4ab0-9d32-2a10981c718c)

As the screenshot shows, color inputs are also currently broken. I'll make a separate PR to fix those.