### PR TITLE
middle-click-popup: fix color inputs

### DIFF
--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -429,14 +429,14 @@ export class BlockTypeInfo {
             break;
         }
       } else {
-        let FieldColour;
+        let FieldColourSlider;
         let FieldNumber;
         if (Blockly.registry) {
           // new Blockly
-          FieldColour = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_colour_slider");
+          FieldColourSlider = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_colour_slider");
           FieldNumber = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_number");
         } else {
-          FieldColour = Blockly.FieldColour;
+          FieldColourSlider = Blockly.FieldColourSlider;
           FieldNumber = Blockly.FieldNumber;
         }
         if (
@@ -444,7 +444,7 @@ export class BlockTypeInfo {
           (!Blockly.registry && field instanceof Blockly.FieldVariableGetter)
         ) {
           if (field.getText().trim().length !== 0) parts.push(field.getText());
-        } else if (field instanceof FieldColour) {
+        } else if (field instanceof FieldColourSlider) {
           addInput(new BlockInputColour(inputIdx, fieldIdx));
         } else if (field instanceof FieldNumber) {
           addInput(new BlockInputNumber(inputIdx, fieldIdx, field.getText()));

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -603,7 +603,7 @@ class TokenTypeColor extends TokenType {
   }
 
   createText(token, query, endOnly) {
-    return query.query.substring(token.start, token.end);
+    return query.str.substring(token.start, token.end);
   }
 }
 


### PR DESCRIPTION
### Changes

Makes middle-click-popup correctly recognize color inputs. In v1.40, they work like text inputs, so it's possible to type things like "touching color apple". Now they only accept colors (for example "touching color #abcdef").

### Tests

Tested on Edge (current Scratch version and Spork).