### PR TITLE
New addon: Jump to unread posts in discussion forums

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -157,6 +157,7 @@
   "remaining-replies",
   "forum-user-agent",
   "no-sprite-confirm",
+  "forums-jump-to-unread",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/forums-jump-to-unread/addon.json
+++ b/addons/forums-jump-to-unread/addon.json
@@ -1,0 +1,22 @@
+{
+  "name": "Jump to unread posts in discussion forums",
+  "description": "Makes topic links on the discuss page go to the first unread post rather than the first post of the topic.",
+  "tags": ["community", "forums"],
+  "versionAdded": "1.41.0",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["^https://scratch.mit.edu/discuss/(?:m/|)(?:search|1|3|4|6|7|9|11|49)/"]
+    }
+  ],
+  "userstyles": [{
+    "url": "userstyle.css",
+    "matches": ["^https://scratch.mit.edu/discuss/(?:m/|)(?:search|1|3|4|6|7|9|11|49)/"]
+  }],
+  "credits": [{
+    "name": "just-a-hriday",
+    "link": "https://scratch.mit.edu/users/just-a-hriday/"
+  }],
+  "dynamicDisable": true,
+  "dynamicEnable": true
+}

--- a/addons/forums-jump-to-unread/addon.json
+++ b/addons/forums-jump-to-unread/addon.json
@@ -9,14 +9,18 @@
       "matches": ["^https://scratch.mit.edu/discuss/(?:m/|)(?:search|1|3|4|6|7|9|11|49)/"]
     }
   ],
-  "userstyles": [{
-    "url": "userstyle.css",
-    "matches": ["^https://scratch.mit.edu/discuss/(?:m/|)(?:search|1|3|4|6|7|9|11|49)/"]
-  }],
-  "credits": [{
-    "name": "just-a-hriday",
-    "link": "https://scratch.mit.edu/users/just-a-hriday/"
-  }],
+  "userstyles": [
+    {
+      "url": "userstyle.css",
+      "matches": ["^https://scratch.mit.edu/discuss/(?:m/|)(?:search|1|3|4|6|7|9|11|49)/"]
+    }
+  ],
+  "credits": [
+    {
+      "name": "just-a-hriday",
+      "link": "https://scratch.mit.edu/users/just-a-hriday/"
+    }
+  ],
   "dynamicDisable": true,
   "dynamicEnable": true
 }

--- a/addons/forums-jump-to-unread/userscript.js
+++ b/addons/forums-jump-to-unread/userscript.js
@@ -1,0 +1,19 @@
+export default async function ({ addon, console }) {
+  addon.self.addEventListener("reenabled", () =>
+    document
+      .querySelectorAll(".tclcon>h3>a")
+      .forEach((link) => (link.href = link.href.replace(/(\d+)\/?$/, "$1/unread/")))
+  );
+  addon.self.addEventListener("disabled", () =>
+    document.querySelectorAll(".tclcon>h3>a").forEach((link) => (link.href = link.href.replace(/unread\/?$/, "")))
+  );
+
+  while (true) {
+    const link = await addon.tab.waitForElement(".tclcon>h3>a", {
+      markAsSeen: true,
+      condition: () => !addon.self.disabled,
+    });
+    console.log("found element");
+    link.href = link.href.replace(/(\d+)\/?$/, "$1/unread/");
+  }
+}

--- a/addons/forums-jump-to-unread/userstyle.css
+++ b/addons/forums-jump-to-unread/userstyle.css
@@ -1,0 +1,3 @@
+.tclcon > a {
+  display: none;
+}


### PR DESCRIPTION
Resolves #8055

### Changes

Makes topic links on the discuss page go to the first unread post rather than the first post of the topic. Also removes the new posts links (which also removes the _Necropost?_ links created by the necropost-highlighter addon).

The addon name and description could probably be worded better.

### Tests

Tested on Chrome 131.0.6778.205.
