### PR TITLE
Conditional addon notices

### DIFF
--- a/addons/cat-blocks/addon.json
+++ b/addons/cat-blocks/addon.json
@@ -20,7 +20,10 @@
     {
       "type": "notice",
       "text": "The \"watch mouse cursor\" setting may impact performance when the editor is open.",
-      "id": "watch"
+      "id": "watch",
+      "if": {
+        "settings": { "watch": true }
+      }
     }
   ],
   "settings": [

--- a/addons/fullscreen/addon.json
+++ b/addons/fullscreen/addon.json
@@ -10,8 +10,11 @@
   "info": [
     {
       "type": "notice",
-      "text": "If you choose to never show the toolbar, remember that you can use the Esc key to exit the project player's full screen mode.",
-      "id": "hideToolbarNotice"
+      "text": "Remember that you can use the Esc key to exit the project player's full screen mode.",
+      "id": "hideToolbarNotice",
+      "if": {
+        "settings": { "toolbar": "hide" }
+      }
     }
   ],
   "settings": [

--- a/addons/hide-flyout/addon.json
+++ b/addons/hide-flyout/addon.json
@@ -14,7 +14,10 @@
   "info": [
     {
       "text": "\"Palette area hover\" mode only extends the viewing area. If you want to be able to drag blocks into that area without them getting trashed, use one of the other modes.",
-      "id": "hoverExplanation"
+      "id": "hoverExplanation",
+      "if": {
+        "settings": { "toggle": "hover" }
+      }
     }
   ],
   "dynamicEnable": true,

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -32,18 +32,12 @@
         <addon-tag tag="new"></addon-tag>
         {{ addon.latestUpdate.temporaryNotice }}
       </div>
-      <div id="info" v-for="info of addon.info">
-        <div :class="['addon-message', 'addon-' + (info.type || 'info')]">
-          <img
-            :src="'../../images/icons/' + {
-              'warning': 'warning.svg',
-              'notice': 'notice.svg',
-              'info': 'help.svg',
-            }[info.type || 'info']"
-            draggable="false"
-          />{{ info.text }}
-        </div>
-      </div>
+      <addon-notice
+        v-for="info of addon.info"
+        v-show="shouldShow"
+        :info="info"
+        :addon-settings="addonSettings"
+      ></addon-notice>
       <div class="addon-credits" v-if="addon.credits">
         <span>{{ msg("creditTo") }}</span>
         <span v-for="credit of addon.credits">

--- a/webpages/settings/components/addon-notice.html
+++ b/webpages/settings/components/addon-notice.html
@@ -1,0 +1,12 @@
+<template>
+  <div :class="['addon-message', 'addon-' + (info.type || 'info')]" v-show="shouldShow">
+    <img
+      :src="'../../images/icons/' + {
+            'warning': 'warning.svg',
+            'notice': 'notice.svg',
+            'info': 'help.svg',
+          }[info.type || 'info']"
+      draggable="false"
+    />{{ info.text }}
+  </div>
+</template>

--- a/webpages/settings/components/addon-notice.js
+++ b/webpages/settings/components/addon-notice.js
@@ -1,0 +1,36 @@
+export default async function ({ template }) {
+  const addonNotice = Vue.extend({
+    props: ["info", "addon-settings"],
+    template,
+    computed: {
+      shouldShow() {
+        // Same logic as addon-setting
+        if (!this.info.if) return true;
+
+        if (this.info.if.addonEnabled) {
+          const arr = Array.isArray(this.info.if.addonEnabled)
+            ? this.info.if.addonEnabled
+            : [this.info.if.addonEnabled];
+          if (arr.some((addon) => this.$root.manifestsById[addon]._enabled === true)) return true;
+        }
+
+        if (this.info.if.settings) {
+          const anyMatches = Object.keys(this.info.if.settings).some((settingName) => {
+            const arr = Array.isArray(this.info.if.settings[settingName])
+              ? this.info.if.settings[settingName]
+              : [this.info.if.settings[settingName]];
+            return arr.some(
+              (possibleValue) =>
+                this.addonSettings[settingName] === possibleValue ||
+                this.$parent?.addonSettings?.[settingName] === possibleValue
+            );
+          });
+          if (anyMatches === true) return true;
+        }
+
+        return false;
+      },
+    },
+  });
+  Vue.component("addon-notice", addonNotice);
+}

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -27,6 +27,7 @@ let fuse;
     "webpages/settings/components/picker-component",
     "webpages/settings/components/reset-dropdown",
     "webpages/settings/components/addon-setting",
+    "webpages/settings/components/addon-notice",
     "webpages/settings/components/addon-tag",
     "webpages/settings/components/addon-group-header",
     "webpages/settings/components/addon-body",


### PR DESCRIPTION
Resolves #3930

### Changes

Adds the ability to hide notices using the same structure/logic as `setting.if` and moves them into a component (but not update notices for now). The styles are still in `addon-body` but they can be moved if needed.

### Reason for changes

To hide notices when they aren't relevant while keeping them clearly visible when they are.

### Tests

Tested on Chromium.