### PR TITLE
Update context menu code

### DIFF
--- a/addons/block-switching/userscript.js
+++ b/addons/block-switching/userscript.js
@@ -1,3 +1,5 @@
+import { enableContextMenuSeparators, addSeparator } from "../../libraries/common/cs/blockly-context-menu.js";
+
 export default async function ({ addon, console, msg }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
   const vm = addon.tab.traps.vm;
@@ -939,6 +941,7 @@ export default async function ({ addon, console, msg }) {
 
   const uniques = (array) => [...new Set(array)];
 
+  enableContextMenuSeparators(addon.tab);
   addon.tab.createBlockContextMenu(
     (items, block) => {
       if (!addon.self.disabled) {
@@ -1007,12 +1010,14 @@ export default async function ({ addon, console, msg }) {
               : // If there's no such button, insert at end
                 items.length;
           const text = opcodeData.msg ? opcodeData.msg : opcodeData.opcode ? msg(opcodeData.opcode) : msg(block.type);
-          items.splice(insertBeforeIndex, 0, {
+          const item = {
             enabled: true,
             text,
             callback: menuCallbackFactory(block, opcodeData),
             separator: i === 0,
-          });
+          };
+          if (i === 0) addSeparator(item);
+          items.splice(insertBeforeIndex, 0, item);
         });
 
         if (block.type === "data_variable" || block.type === "data_listcontents") {
@@ -1021,7 +1026,10 @@ export default async function ({ addon, console, msg }) {
           // firstVariableItem might be undefined, a variable to switch to,
           // or an item added by editor-devtools (or any addon before this one)
           const firstVariableItem = items[delBlockIndex + 1];
-          if (firstVariableItem) firstVariableItem.separator = true;
+          if (firstVariableItem) {
+            firstVariableItem.separator = true;
+            addSeparator(firstVariableItem);
+          }
         }
       }
       return items;

--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -1,3 +1,5 @@
+import { enableContextMenuSeparators, addSeparator } from "../../libraries/common/cs/blockly-context-menu.js";
+
 export default async function ({ addon, console, msg }) {
   const Blockly = await addon.tab.traps.getBlockly();
 
@@ -39,32 +41,55 @@ export default async function ({ addon, console, msg }) {
   exSVG.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
   exSVG.setAttribute("version", "1.1");
 
-  addon.tab.createBlockContextMenu(
-    (items) => {
-      if (addon.self.disabled) return items;
-      let svgchild = document.querySelector("svg.blocklySvg g.blocklyBlockCanvas");
+  enableContextMenuSeparators(addon.tab);
 
-      const pasteItemIndex = items.findIndex((obj) => obj._isDevtoolsFirstItem);
-      const insertBeforeIndex =
-        pasteItemIndex !== -1
-          ? // If "paste" button exists, add own items before it
-            pasteItemIndex
-          : // If there's no such button, insert at end
-            items.length;
-
-      items.splice(insertBeforeIndex, 0, {
-        enabled: !!svgchild?.childNodes?.length,
-        text: msg("saveAll"),
+  if (Blockly.registry) {
+    // new Blockly
+    Blockly.ContextMenuRegistry.registry.register(
+      addSeparator({
+        displayText: msg("saveAll"),
+        preconditionFn: () => {
+          if (addon.self.disabled) return "hidden";
+          if (document.querySelector("svg.blocklySvg g.blocklyBlockCanvas > g.blocklyBlock")) return "enabled";
+          return "disabled";
+        },
         callback: () => {
           exportPopup();
         },
-        separator: true,
-      });
+        scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+        id: "saSaveAllAsImage",
+        weight: 9, // after Add Comment
+      })
+    );
+  } else {
+    addon.tab.createBlockContextMenu(
+      (items) => {
+        if (addon.self.disabled) return items;
+        let svgchild = document.querySelector("svg.blocklySvg g.blocklyBlockCanvas");
 
-      return items;
-    },
-    { workspace: true }
-  );
+        const pasteItemIndex = items.findIndex((obj) => obj._isDevtoolsFirstItem);
+        const insertBeforeIndex =
+          pasteItemIndex !== -1
+            ? // If "paste" button exists, add own items before it
+              pasteItemIndex
+            : // If there's no such button, insert at end
+              items.length;
+
+        items.splice(insertBeforeIndex, 0, {
+          enabled: !!svgchild?.childNodes?.length,
+          text: msg("saveAll"),
+          callback: () => {
+            exportPopup();
+          },
+          separator: true,
+        });
+
+        return items;
+      },
+      { workspace: true }
+    );
+  }
+
   addon.tab.createBlockContextMenu(
     (items, block) => {
       if (addon.self.disabled) return items;
@@ -76,14 +101,18 @@ export default async function ({ addon, console, msg }) {
           : // If there's no such button, insert at end
             items.length;
 
-      items.splice(insertBeforeIndex, 0, {
-        enabled: true,
-        text: msg("save"),
-        callback: () => {
-          exportPopup(block);
-        },
-        separator: true,
-      });
+      items.splice(
+        insertBeforeIndex,
+        0,
+        addSeparator({
+          enabled: true,
+          text: msg("save"),
+          callback: () => {
+            exportPopup(block);
+          },
+          separator: true,
+        })
+      );
 
       return items;
     },

--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -1,3 +1,5 @@
+import { enableContextMenuSeparators, addSeparator } from "../../libraries/common/cs/blockly-context-menu.js";
+
 export default async function ({ addon, msg, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
   const vm = addon.tab.traps.vm;
@@ -366,6 +368,7 @@ export default async function ({ addon, msg, console }) {
     return ret;
   };
 
+  enableContextMenuSeparators(addon.tab);
   addon.tab.createBlockContextMenu(
     (items, block) => {
       if (!addon.self.disabled && (block.getCategory() === "data" || block.getCategory() === "data-lists")) {
@@ -378,12 +381,14 @@ export default async function ({ addon, msg, console }) {
               items[0].text = msg("edit-list-option");
             }
           }
-          items.push({
-            enabled: true,
-            separator: true,
-            text: msg(`to-${variable.isLocal ? "global" : "local"}`),
-            callback: () => convertVariable(variable, !variable.isLocal, variable.isCloud),
-          });
+          items.push(
+            addSeparator({
+              enabled: true,
+              separator: true,
+              text: msg(`to-${variable.isLocal ? "global" : "local"}`),
+              callback: () => convertVariable(variable, !variable.isLocal, variable.isCloud),
+            })
+          );
         }
       }
       return items;

--- a/libraries/common/cs/blockly-context-menu.js
+++ b/libraries/common/cs/blockly-context-menu.js
@@ -1,0 +1,41 @@
+let separatorsEnabled = false;
+
+export async function enableContextMenuSeparators(tab) {
+  if (separatorsEnabled) return;
+  separatorsEnabled = true;
+  const Blockly = await tab.traps.getBlockly();
+  if (!Blockly.registry) return;
+
+  const oldMenuItemCreateDom = Blockly.MenuItem.prototype.createDom;
+  Blockly.MenuItem.prototype.createDom = function (...args) {
+    const element = oldMenuItemCreateDom.call(this, ...args);
+    if (this.content.saSeparator) {
+      element.style.borderTop = "1px solid hsla(0, 0%, 0%, 0.15)";
+      element.style.backgroundClip = "padding-box";
+    }
+    return element;
+  };
+}
+
+export function addSeparator(item) {
+  /* Store .saSeparator as a property of text/displayText so that MenuItem.createDom()
+       (overridden in enableSeparators() above) can receive it */
+  if (item.saSeparator) return; // addSeparator() was already called for this item
+  item.saSeparator = true;
+  if (typeof item.displayText === "function") {
+    const oldDisplayText = item.displayText;
+    item.displayText = (scope) => {
+      let text = oldDisplayText(scope);
+      text = document.createTextNode(text);
+      text.saSeparator = true;
+      return text;
+    };
+  } else if (typeof item.displayText === "string") {
+    item.displayText = document.createTextNode(item.displayText);
+    item.displayText.saSeparator = true;
+  } else {
+    item.text = document.createTextNode(item.text);
+    item.text.saSeparator = true;
+  }
+  return item;
+}


### PR DESCRIPTION
### Changes

Updates the context menu API to work with the new version of Blockly. The updated API only supports block context menus - for workspace and comment menus, addons can call `Blockly.ContextMenuRegistry.registry.register()` directly.

### Tests

Tested block switching, blocks2image and devtools on Edge and Firefox. The menu items they add appear correctly, but most of them don't work - I'll fix them in a later PR. swap-local-global's menu callback currently throws an error in new Blockly - this will also be fixed later.