### PR TITLE
scratch3to2: fix bugs

### DIFF
--- a/addons/player-thumb/addon.json
+++ b/addons/player-thumb/addon.json
@@ -15,6 +15,13 @@
     {
       "url": "userstyle.css",
       "matches": ["projects"]
+    },
+    {
+      "url": "scratch3to2.css",
+      "matches": ["projects"],
+      "if": {
+        "addonEnabled": ["scratch3to2"]
+      }
     }
   ],
   "userscripts": [

--- a/addons/player-thumb/scratch3to2.css
+++ b/addons/player-thumb/scratch3to2.css
@@ -1,0 +1,12 @@
+body:not(.sa-body-editor) [class*="stage-wrapper_stage-wrapper"] {
+  position: relative;
+}
+body:not(.sa-body-editor) div[class*="loader_background_"],
+body:not(.sa-body-editor) .sa-project-thumb {
+  border-radius: 0;
+}
+body:not(.sa-body-editor) :not([class*="stage-wrapper_full-screen_"]) > div[class*="loader_background_"],
+body:not(.sa-body-editor) .sa-project-thumb.loading {
+  top: 38px;
+  height: calc(100% - 39px);
+}

--- a/addons/scratch3to2/main.css
+++ b/addons/scratch3to2/main.css
@@ -1,6 +1,6 @@
 /* Page */
 html,
-body,
+body:not(.sa-body-editor, .scratchCommentBody),
 #view {
   background-color: var(--darkWww-page, #fcfcfc);
   background-image: var(
@@ -8,7 +8,7 @@ body,
     url("https://cdn.scratch.mit.edu/scratchr2/static/images/scratch-bg.png")
   );
 }
-body {
+body:not(.sa-body-editor, .scratchCommentBody) {
   color: var(--darkWww-page-scratchr2Text, #322f31);
 }
 p {

--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -302,20 +302,6 @@ body:not(.sa-body-editor) [class*="stage_green-flag-overlay_"] > img {
   display: none;
 }
 
-/* player-thumb compatibility */
-body:not(.sa-body-editor) [class*="stage-wrapper_stage-wrapper"] {
-  position: relative;
-}
-body:not(.sa-body-editor) div[class*="loader_background_"],
-body:not(.sa-body-editor) .sa-project-thumb {
-  border-radius: 0;
-}
-body:not(.sa-body-editor) :not([class*="stage-wrapper_full-screen_"]) > div[class*="loader_background_"],
-body:not(.sa-body-editor) .sa-project-thumb.loading {
-  top: 38px;
-  height: calc(100% - 39px);
-}
-
 /* Description */
 .preview .project-notes {
   margin: 0;


### PR DESCRIPTION
Resolves #8072

### Changes

* Fixes editor comments
* Moves styles for player-thumb compatibility into a separate file that's only loaded if player-thumb is enabled

### Tests

Tested on Edge and Firefox.