### PR TITLE
dark-www: Compatibility with old download page

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -288,6 +288,7 @@ button:hover,
   color: var(--darkWww-gray-scratchr2Text);
   text-shadow: var(--darkWww-gray-scratchr2TextShadow);
 }
+.three-column-band,
 .djangobb blockquote,
 .nvtooltip h3 /* statistics */ {
   background-color: var(--darkWww-gray-scratchr2);


### PR DESCRIPTION
### Changes

Fixes a dark mode compatibility issue with the [old Scratch 2.0 download page](https://scratch.mit.edu/help/scratch2download/).

### Reason for changes

Someone submitted feedback about this.

### Tests

Tested on Chromium with and without `scratchr2`.