### PR TITLE
Remove flip controls notice

### DIFF
--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -5,10 +5,6 @@
     {
       "text": "On macOS, use the Cmd key instead of the Ctrl key.",
       "id": "macContextDisabled"
-    },
-    {
-      "text": "If \"flip controls\" is enabled, grabbing blocks individually will be the default behavior. Hold Ctrl to drag the entire stack.",
-      "id": "flipControls"
     }
   ],
   "credits": [


### PR DESCRIPTION
The setting description added in #8078 for testing is working fine and has been translated into multiple languages, so the notice is redundant now.