### PR TITLE
Don't run costume editor shortcuts with modifier keys

### DIFF
--- a/addons/costume-editor-shortcuts/userscript.js
+++ b/addons/costume-editor-shortcuts/userscript.js
@@ -85,7 +85,7 @@ export default async function ({ addon, console }) {
    * Switch costume editor tool if a valid shortcut was pressed.
    */
   function handleKeyDown(event) {
-    if (isUserTyping) return;
+    if (isUserTyping || event.ctrlKey || event.altKey || event.metaKey) return;
 
     const localizationId = shortcutToToolLocalizationId[event.key.toLowerCase()];
     if (!localizationId) return;


### PR DESCRIPTION
From feedback:

> I found a bug in Costume editor keyboard shortcuts addon. When i press ctrl + a to select all, it works but it also selects reshape tool. so better to make to selects tools when key ctrl || shift || alt isn't pressed

### Tests

Tested on Firefox. Ctrl+A switches to the select tool as expected.