### PR TITLE
scratch3to2: fix gamepad compatibility

### DIFF
--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -249,12 +249,14 @@ body:not(.sa-body-editor) [class*="stage-header_stage-size-row_"] > * {
 }
 body:not(.sa-body-editor) [class*="stage-header_stage-button_"] {
   background-color: transparent;
+  border: none;
+}
+body:not(.sa-body-editor) [class*="stage-header_stage-button_"]:not(.sa-gamepad-container *) {
   background-image: url("%addon-self-dir%/assets/full_screen.png");
   background-repeat: no-repeat;
   background-position: center center;
-  border: none;
 }
-body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"] {
+body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"]:not(.sa-gamepad-container *) {
   display: none;
 }
 [class*="stage-header_embed-scratch-logo_"] img {


### PR DESCRIPTION
Fixes this:

![image](https://github.com/user-attachments/assets/2a60b440-5e84-44ad-92dd-652335c64672)