### PR TITLE
`scratch3to2`: Style invites

### DIFF
--- a/addons/scratch3to2/studio.css
+++ b/addons/scratch3to2/studio.css
@@ -346,6 +346,27 @@
 #sa-studio-followers-button + .button:hover {
   background-color: var(--darkWww-button-scratchr2Hover, #7854c0);
 }
+.studio-invitation {
+  display: block;
+  min-height: 0px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.studio-invitation-msg {
+  display: inline;
+  font-size: 13px;
+}
+.studio-invitation-button {
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+  margin-left: 3px;
+  box-shadow: none;
+  color: var(--darkWww-link-scratchr2, #855cd6);
+}
+.studio-invitation-button:hover {
+  text-decoration: underline;
+}
 
 /* Activity */
 .studio-activity .studio-messages-list {


### PR DESCRIPTION
### Changes

Makes `scratch3to2` style the invite panel a bit more like scratchr2 did.

![invite](https://github.com/user-attachments/assets/2b5e97e2-bf6f-4f87-acac-8b9bec8b8512)
![congrats](https://github.com/user-attachments/assets/6894cf63-5dd4-4f01-ab34-7ce344eeba01)


### Reason for changes

Pretty minor, but makes the addon closer to Scratchr2

### Tests

Tested on Edge