### PR TITLE
Fix colored context menus on modern Blockly

### DIFF
--- a/addons/editor-colored-context-menus/userscript.css
+++ b/addons/editor-colored-context-menus/userscript.css
@@ -2,14 +2,20 @@
   background-color: var(--sa-contextmenu-bg);
   border-color: var(--sa-contextmenu-border);
 }
+.sa-contextmenu-colored .blocklyContextMenu .blocklyMenuItem:hover,
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight,
 .sa-contextmenu-colored .s3dev-mi:hover {
   background-color: #0001;
   border-color: transparent !important;
 }
+.sa-contextmenu-colored .blocklyContextMenu .blocklyMenuItem[style*="border-top"],
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem[style*="border-top"] {
   border-top-color: var(--sa-contextmenu-border) !important;
 }
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem .goog-menuitem-content {
   color: var(--sa-contextmenu-text);
+}
+
+.sa-contextmenu-colored .blocklyContextMenu .blocklyMenuItem {
+  color: var(--colour-text);
 }

--- a/addons/editor-colored-context-menus/userscript.js
+++ b/addons/editor-colored-context-menus/userscript.js
@@ -4,38 +4,45 @@ export default async function ({ addon, console }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
 
   const applyContextMenuColor = (block) => {
-    const widgetDiv = ScratchBlocks.WidgetDiv.DIV;
-    if (!widgetDiv) {
-      return;
+    let widgetDiv;
+    let background;
+    if (ScratchBlocks.registry) {
+      // New Blockly
+      widgetDiv = ScratchBlocks.WidgetDiv.getDiv();
+      background = block.pathObject.svgPath;
+    } else {
+      widgetDiv = ScratchBlocks.WidgetDiv.DIV;
+      background = block.svgPath_;
     }
-    const background = block.svgPath_;
-    if (!background) {
+    if (!widgetDiv || !background) {
       return;
     }
     const fill = removeAlpha(background.getAttribute("fill"));
     const border = background.getAttribute("stroke") || "#0003";
-    const text = ScratchBlocks.Colours.text;
     widgetDiv.classList.add("sa-contextmenu-colored");
     widgetDiv.style.setProperty("--sa-contextmenu-bg", fill);
     widgetDiv.style.setProperty("--sa-contextmenu-border", border);
-    widgetDiv.style.setProperty("--sa-contextmenu-text", text);
+    if (!ScratchBlocks.registry) {
+      // Old Blockly
+      const text = ScratchBlocks.Colours.text;
+      widgetDiv.style.setProperty("--sa-contextmenu-text", text);
+    }
   };
 
   const originalHandleRightClick = ScratchBlocks.Gesture.prototype.handleRightClick;
   ScratchBlocks.Gesture.prototype.handleRightClick = function (...args) {
-    const block = this.targetBlock_;
+    const block = (ScratchBlocks.registry) ? this.targetBlock : this.targetBlock_;
     const ret = originalHandleRightClick.call(this, ...args);
     if (block) {
       applyContextMenuColor(block);
+    } else {
+      if (ScratchBlocks.registry) {
+        // New Blockly
+        ScratchBlocks.WidgetDiv.getDiv().classList.remove("sa-contextmenu-colored");
+      } else {
+        ScratchBlocks.WidgetDiv.DIV.classList.remove("sa-contextmenu-colored");
+      }
     }
     return ret;
-  };
-
-  const originalHide = ScratchBlocks.WidgetDiv.hide;
-  ScratchBlocks.WidgetDiv.hide = function (...args) {
-    if (ScratchBlocks.WidgetDiv.DIV) {
-      ScratchBlocks.WidgetDiv.DIV.classList.remove("sa-contextmenu-colored");
-    }
-    return originalHide.call(this, ...args);
   };
 }

--- a/addons/editor-colored-context-menus/userscript.js
+++ b/addons/editor-colored-context-menus/userscript.js
@@ -31,7 +31,7 @@ export default async function ({ addon, console }) {
 
   const originalHandleRightClick = ScratchBlocks.Gesture.prototype.handleRightClick;
   ScratchBlocks.Gesture.prototype.handleRightClick = function (...args) {
-    const block = (ScratchBlocks.registry) ? this.targetBlock : this.targetBlock_;
+    const block = ScratchBlocks.registry ? this.targetBlock : this.targetBlock_;
     const ret = originalHandleRightClick.call(this, ...args);
     if (block) {
       applyContextMenuColor(block);

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -35,7 +35,8 @@
 .blocklyDropDownDiv .goog-menuitem-highlight,
 .blocklyDropDownDiv .goog-menuitem-hover,
 .blocklyDropDownDiv .blocklyMenu .blocklyMenuItem:hover,
-.sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight {
+.sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight,
+.sa-contextmenu-colored .blocklyContextMenu .blocklyMenuItem:hover {
   background-color: var(--editorTheme3-hoveredItem, rgba(0, 0, 0, 0.2));
 }
 

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -545,9 +545,15 @@ export default async function ({ addon, console, msg }) {
     };
   }
 
-  if (!Blockly.registry) {
-    // editor-colored-context menus compatibility
-    // doesn't support new Blockly yet
+  if (Blockly.registry) {
+    // New Blockly
+    const oldBlockShowContextMenu = Blockly.BlockSvg.prototype.showContextMenu;
+    Blockly.BlockSvg.prototype.showContextMenu = function (e) {
+      const widgetDiv = Blockly.WidgetDiv.getDiv();
+      widgetDiv.style.setProperty("--editorTheme3-hoveredItem", fieldBackground(this));
+      return oldBlockShowContextMenu.call(this, e);
+    };
+  } else {
     const oldBlockShowContextMenu = Blockly.BlockSvg.prototype.showContextMenu_;
     Blockly.BlockSvg.prototype.showContextMenu_ = function (e) {
       Blockly.WidgetDiv.DIV.style.setProperty("--editorTheme3-hoveredItem", fieldBackground(this));
@@ -879,6 +885,8 @@ export default async function ({ addon, console, msg }) {
         )
       );
       workspace.refreshTheme();
+      // used by editor-colored-context-menus
+      document.body.style.setProperty("--colour-text", uncoloredTextColor())
     }
     addon.tab.setCustomBlockColor({
       color: primaryColor(saCategory),

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -886,7 +886,7 @@ export default async function ({ addon, console, msg }) {
       );
       workspace.refreshTheme();
       // used by editor-colored-context-menus
-      document.body.style.setProperty("--colour-text", uncoloredTextColor())
+      document.body.style.setProperty("--colour-text", uncoloredTextColor());
     }
     addon.tab.setCustomBlockColor({
       color: primaryColor(saCategory),


### PR DESCRIPTION
### Changes

Fixes `editor-colored-context-menus` compatibility the new Blockly editor.

### Tests

Tested on Chromium with separators, Scratch's high contrast mode and `editor-theme3`'s colored on black setting.