### PR TITLE
New addon: `hidden-blocks`

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -158,6 +158,7 @@
   "forum-user-agent",
   "no-sprite-confirm",
   "costume-editor-shortcuts",
+  "hidden-blocks",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/hidden-blocks/addon.json
+++ b/addons/hidden-blocks/addon.json
@@ -1,0 +1,35 @@
+{
+  "name": "Hidden blocks",
+  "description": "Shows working hidden blocks in the block palette.",
+  "tags": ["editor", "codeEditor"],
+  "versionAdded": "1.42.0",
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "settings": [
+    {
+      "name": "Add sprites to menu in block \"when this sprite touches\"",
+      "id": "addSpritesToMenu",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+  "credits": [
+    {
+      "name": "Mikhail Zuenko",
+      "link": "https://scratch.mit.edu/users/zuenko-michail"
+    }
+  ],
+  "info": [
+    {
+      "type": "notice",
+      "text": "When using hidden blocks, there's no guarantee that they will work with future updates to Scratch. The project that used the hidden blocks might be marked as NFE (Not For Everyone).",
+      "id": "hiddenBlocksCanBeRemoved"
+    }
+  ],
+  "dynamicDisable": true,
+  "dynamicEnable": true
+}

--- a/addons/hidden-blocks/userscript.js
+++ b/addons/hidden-blocks/userscript.js
@@ -1,0 +1,74 @@
+export default async function({ addon }) {
+  const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const { vm } = addon.tab.traps;
+
+  const oldTouchingMenuInit = ScratchBlocks.Blocks.event_touchingobjectmenu.init;
+  ScratchBlocks.Blocks.event_touchingobjectmenu.init = function() {
+    if (addon.self.disabled || !addon.settings.get('addSpritesToMenu')) return oldTouchingMenuInit.call(this);
+    this.jsonInit({
+      message0: '%1',
+      args0: [
+        {
+          type: 'field_dropdown',
+          name: 'TOUCHINGOBJECTMENU',
+          options: [
+            [ScratchBlocks.Msg.SENSING_TOUCHINGOBJECT_POINTER, '_mouse_'],
+            [ScratchBlocks.Msg.SENSING_TOUCHINGOBJECT_EDGE, '_edge_'],
+            ...Object.values(vm.runtime.targets)
+              .filter(target => target.isOriginal && !target.isStage && target !== vm.editingTarget)
+              .map(target => [target.sprite.name, target.sprite.name])
+          ]
+        }
+      ],
+      extensions: ['colours_event', 'output_string']
+    });
+  };
+
+  const oldShow = ScratchBlocks.Flyout.prototype.show;
+  ScratchBlocks.Flyout.prototype.show = function(xmlList) {
+    if (!addon.self.disabled) {
+      function addAfter(type, xml) {
+        const index = xmlList.findIndex(i => i.getAttribute?.('type') === type);
+        if (index > -1) {
+          xmlList.splice(index + 1, 0, ScratchBlocks.Xml.textToDom(xml));
+        }
+      }
+
+      const whenTouchingObject = '<block type="event_whentouchingobject"><value name="TOUCHINGOBJECTMENU"><shadow type="event_touchingobjectmenu"/></value></block>';
+      addAfter('event_whenthisspriteclicked', whenTouchingObject);
+      addAfter('event_whenstageclicked', whenTouchingObject);
+
+      addAfter('control_wait_until', '<block type="control_while"/>');
+      addAfter('control_repeat_until', '<block type="control_for_each"><value name="VALUE"><shadow type="math_whole_number"><field name="NUM">10</field></shadow></value></block>');
+
+      addAfter('control_delete_this_clone', '<block type="control_incr_counter"/>');
+      addAfter('control_incr_counter', '<block type="control_clear_counter"/>');
+      addAfter('control_clear_counter', '<block type="control_get_counter"/>');
+      addAfter('control_delete_this_clone', '<sep gap="36"/>');
+
+      addAfter('sensing_loudness', '<block type="sensing_loud"/>');
+    }
+    return oldShow.call(this, xmlList);
+  };
+
+  let addSpritesToMenu = false;
+  function updateBlocks() {
+    const needAddSpritesToMenu = !addon.self.disabled && addon.settings.get('addSpritesToMenu');
+    if (needAddSpritesToMenu !== addSpritesToMenu) {
+      if (vm.editingTarget) vm.emitWorkspaceUpdate();
+      addSpritesToMenu = needAddSpritesToMenu;
+    }
+  }
+
+  function updateWorkspace() {
+    const workspace = addon.tab.traps.getWorkspace();
+    if (!workspace) return;
+    updateBlocks();
+    workspace.getToolbox().refreshSelection();
+  }
+
+  updateWorkspace();
+  addon.self.addEventListener('disabled', updateWorkspace);
+  addon.self.addEventListener('reenabled', updateWorkspace);
+  addon.settings.addEventListener('change', updateBlocks);
+}


### PR DESCRIPTION
### Changes
This addon shows following hidden blocks in the block pallete:
* when this sprite touches
* while
* for each
* increment counter
* clear couner
* counter
* loud?

It also allows you to add a list of sprites to menu in block "when this sprite touches".

### Tests
Tested on Chrome 131.0.6778.267.
