### PR TITLE
dark-www: support new Starter Projects page

### DIFF
--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -515,6 +515,18 @@
       }
     },
     {
+      "name": "box-strongBlueText",
+      "value": {
+        "type": "textColor",
+        "black": "#056dff",
+        "white": "#80b5ff",
+        "source": {
+          "type": "settingValue",
+          "settingId": "box"
+        }
+      }
+    },
+    {
       "name": "box-greenText",
       "value": {
         "type": "textColor",

--- a/addons/dark-www/banners/darker.css
+++ b/addons/dark-www/banners/darker.css
@@ -53,6 +53,8 @@
 .initiatives-section .initiatives-subsection-content .teacher-quote .comment-text::after {
   border-color: #3d2966;
 }
+.starter-projects-page .page-header,
+.projects-carousel .header,
 .boost .extension-header,
 .ev3 .extension-header,
 .wedo2 .extension-header {

--- a/addons/dark-www/banners/desaturated.css
+++ b/addons/dark-www/banners/desaturated.css
@@ -53,6 +53,8 @@
 .initiatives-section .initiatives-subsection-content .teacher-quote .comment-text::after {
   border-color: #473e59;
 }
+.starter-projects-page .page-header,
+.projects-carousel .header,
 .boost .extension-header,
 .ev3 .extension-header,
 .wedo2 .extension-header {

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -138,6 +138,7 @@ body:not(.sa-body-editor) .formik-input,
 .studio-member-tile,
 .studio-activity .studio-messages-list,
 .cards-modal-container,
+.projects-carousel .content .slick-track .thumbnail,
 .about .body,
 .messages-social-list,
 .comment-text,
@@ -224,6 +225,7 @@ body:not(.sa-body-editor) .button.white,
 .tabs button.active:hover,
 .grid .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .cards-modal-container .cards-modal-section-title,
+.projects-carousel .content .slick-track .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .unsupported-browser .faq-link-text,
 a.social-messages-profile-link:visited,
 a.social-messages-profile-link:link,
@@ -289,6 +291,9 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"],
 .donate-banner .donate-container .donate-button,
 .donate-section .donate-button {
   color: var(--darkWww-box-greenText);
+}
+.projects-carousel .content .slick-track .thumbnail .thumbnail-info .thumbnail-title a {
+  color: var(--darkWww-box-strongBlueText);
 }
 .social-message-icon {
   opacity: var(--darkWww-box-messageIconOpacity);
@@ -496,6 +501,7 @@ body:not(.sa-body-editor) .select select:focus {
   background-color: var(--darkWww-button-text);
 }
 .preview .remix-button,
+.starter-projects-page .surprise .surprise-button,
 .os-chooser .button:not(.active),
 .card .card-button,
 .initiatives-section .video-background.abhi .button,
@@ -533,6 +539,7 @@ body:not(.sa-body-editor) input {
   filter: var(--darkWww-button-filter);
 }
 .forms-close-button img,
+.starter-projects-page .surprise .surprise-button img,
 .os-chooser .button:not(.active) img {
   filter: none;
 }
@@ -638,6 +645,7 @@ a:hover {
 #footer,
 #donor,
 .gray-area,
+.starter-projects-page .getting-started,
 .parents .title-banner.faq-banner,
 .developers .title-banner.faq-banner {
   background-color: var(--darkWww-footer);


### PR DESCRIPTION
### Changes

This PR adds dark mode styles for the redesigned Starter Projects page. I might add 3.0 → 2.0 support later.

### Tests

Tested locally on Edge.

![image](https://github.com/user-attachments/assets/e6953683-a958-4c25-85b1-891fcebf277b)