### PR TITLE
old-studio-layout: fix Browse Followers button

### DIFF
--- a/addons/old-studio-layout/classes.js
+++ b/addons/old-studio-layout/classes.js
@@ -26,7 +26,7 @@ export default async function ({ addon, console }) {
     addon.tab.appendToSharedSpace({ space: "studioCuratorsTab", element: button, order: 0.5 });
     addon.tab.addEventListener("urlChange", (e) => {
       if (location.pathname.split("/")[3] === "curators") {
-        addon.tab.displayNoneWhileDisabled(button);
+        button.style.display = "";
       } else {
         button.style.display = "none";
       }

--- a/addons/old-studio-layout/classes.js
+++ b/addons/old-studio-layout/classes.js
@@ -23,7 +23,7 @@ export default async function ({ addon, console }) {
     button.appendChild(span);
     button.onclick = () => setTimeout(() => realButton.click(), 0);
     addon.tab.displayNoneWhileDisabled(button);
-    addon.tab.appendToSharedSpace({ space: "studioCuratorsTab", element: button, order: 0.5 });
+    document.querySelector(".sa-oldstudio-browse-followers").appendChild(button);
     addon.tab.addEventListener("urlChange", (e) => {
       if (location.pathname.split("/")[3] === "curators") {
         button.style.display = "";

--- a/addons/studio-followers/userscript.js
+++ b/addons/studio-followers/userscript.js
@@ -204,7 +204,13 @@ export default async function ({ addon, console, msg }) {
         }
       });
 
+      // old-studio-layout adds a second button, which should be hidden if this addon is disabled
+      const oldStudioButtonContainer = document.createElement("div");
+      oldStudioButtonContainer.className = "sa-oldstudio-browse-followers";
+      addon.tab.displayNoneWhileDisabled(oldStudioButtonContainer);
+
       addon.tab.appendToSharedSpace({ space: "studioCuratorsTab", element: button, order: 0 });
+      addon.tab.appendToSharedSpace({ space: "studioCuratorsTab", element: oldStudioButtonContainer, order: 0.5 });
     }
   }
   async function addCurator(username) {


### PR DESCRIPTION
### Changes

* Fixes #8119. The code that adds a second Browse Followers button was written for the old implementation of `displayNoneWhileDisabled`.
* Fixes the button not being hidden when `studio-followers` is disabled.

### Tests

Tested on Edge and Firefox.