### PR TITLE
"Instant read indicators on forum category pages" addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -157,6 +157,7 @@
   "forum-user-agent",
   "no-sprite-confirm",
   "costume-editor-shortcuts",
+  "live-read-topics",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/live-read-topics/addon.json
+++ b/addons/live-read-topics/addon.json
@@ -1,0 +1,24 @@
+{
+  "name": "Instant read indicators on forum category pages",
+  "description": "Automatically shows a topic as read when clicking on it on a forum category's page without requiring a reload.",
+  "versionAdded": "1.42.0",
+  "tags": ["community", "forums"],
+  "credits": [
+    {
+      "link": "https://scratch.mit.edu/mybearworld",
+      "name": "mybearworld"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "subforums.js",
+      "matches": ["https://scratch.mit.edu/discuss/*/"]
+    },
+    {
+      "url": "topics.js",
+      "matches": ["topics"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/live-read-topics/addon.json
+++ b/addons/live-read-topics/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Instant read indicators on forum category pages",
+  "name": "Instant forum read indicators",
   "description": "Automatically shows a topic as read when clicking on it on a forum category's page without requiring a reload.",
   "versionAdded": "1.42.0",
   "tags": ["community", "forums"],

--- a/addons/live-read-topics/addon.json
+++ b/addons/live-read-topics/addon.json
@@ -19,6 +19,12 @@
       "matches": ["topics"]
     }
   ],
+  "userstyles": [
+    {
+      "url": "style.css",
+      "matches": ["https://scratch.mit.edu/discuss/*/"]
+    }
+  ],
   "dynamicEnable": true,
   "dynamicDisable": true
 }

--- a/addons/live-read-topics/style.css
+++ b/addons/live-read-topics/style.css
@@ -1,4 +1,4 @@
-.tcl:not(highlighted-necropost) .sa-live-read-topics-new-posts {
+.tcl:not(.highlighted-necropost) .sa-live-read-topics-new-posts {
   display: none;
 }
 

--- a/addons/live-read-topics/style.css
+++ b/addons/live-read-topics/style.css
@@ -1,0 +1,11 @@
+.tcl:not(highlighted-necropost) .sa-live-read-topics-new-posts {
+  display: none;
+}
+
+/** necropost-highlight compatibility */
+.highlighted-necropost .sa-live-read-topics-new-posts {
+  color: currentcolor !important;
+  font-weight: normal !important;
+  cursor: text;
+  text-decoration: none !important;
+}

--- a/addons/live-read-topics/subforums.js
+++ b/addons/live-read-topics/subforums.js
@@ -1,0 +1,11 @@
+export default async function ({ addon, msg, console }) {
+  new BroadcastChannel("sa-live-read-topics").addEventListener("message", (e) => {
+    const el = document.querySelector(`.tclcon a[href='/discuss/topic/${e.data}/']`);
+    if (!el) return;
+    el.parentElement.classList.add("topic_isread");
+    const icon = el.parentElement.parentElement.parentElement.querySelector(".inew");
+    if (!icon) return;
+    icon.classList.remove("inew");
+    icon.classList.add("forumicon");
+  });
+}

--- a/addons/live-read-topics/subforums.js
+++ b/addons/live-read-topics/subforums.js
@@ -3,7 +3,7 @@ export default async function ({ addon, msg, console }) {
     const el = document.querySelector(`.tclcon a[href='/discuss/topic/${e.data}/']`);
     if (!el) return;
     el.parentElement.classList.add("topic_isread");
-    const icon = el.parentElement.parentElement.parentElement.querySelector(".inew");
+    const icon = el.closest(".tcl").querySelector(".inew");
     if (!icon) return;
     icon.classList.remove("inew");
     icon.classList.add("forumicon");

--- a/addons/live-read-topics/subforums.js
+++ b/addons/live-read-topics/subforums.js
@@ -3,9 +3,14 @@ export default async function ({ addon, msg, console }) {
     const el = document.querySelector(`.tclcon a[href='/discuss/topic/${e.data}/']`);
     if (!el) return;
     el.parentElement.classList.add("topic_isread");
-    const icon = el.closest(".tcl").querySelector(".inew");
-    if (!icon) return;
-    icon.classList.remove("inew");
-    icon.classList.add("forumicon");
+    const tcl = el.closest(".tcl");
+    const icon = tcl.querySelector(".inew, .iclosed");
+    if (icon) {
+      icon.classList.remove("inew", "iclosed");
+      icon.classList.add("forumicon");
+    }
+    const newPostsLink = tcl.querySelector(".tclcon > a");
+    newPostsLink.classList.add("sa-live-read-topics-new-posts");
+    newPostsLink.removeAttribute("href");
   });
 }

--- a/addons/live-read-topics/topics.js
+++ b/addons/live-read-topics/topics.js
@@ -1,5 +1,4 @@
 export default async function ({ addon, msg, console }) {
-  if (addon.self.disabled) return;
   const topic = location.pathname.split("/")[3];
   new BroadcastChannel("sa-live-read-topics").postMessage(topic);
 }

--- a/addons/live-read-topics/topics.js
+++ b/addons/live-read-topics/topics.js
@@ -1,0 +1,5 @@
+export default async function ({ addon, msg, console }) {
+  if (addon.self.disabled) return;
+  const topic = location.pathname.split("/")[3];
+  new BroadcastChannel("sa-live-read-topics").postMessage(topic);
+}


### PR DESCRIPTION
Resolves #8127

### Changes

Adds a new addon that automatically marks topics as read on forum category pages.

### Reason for changes

When going through topics like questions on QaS, I want to go through all the questions I haven't opened yet. I'll sometimes lose track about which topics I've opened and which I haven't. This would solve that.

### Tests

Tested on Firefox
