### PR TITLE
`auto-follow-topics`: use internal DjangoBB feature

### DIFF
--- a/addons/auto-follow-topics/userscript.js
+++ b/addons/auto-follow-topics/userscript.js
@@ -1,22 +1,6 @@
 export default async function ({ addon, console, msg }) {
-  const getTopics = () => JSON.parse(sessionStorage.getItem("auto-follow-topics") || "[]");
-  const setTopics = (topics) => sessionStorage.setItem("auto-follow-topics", JSON.stringify(topics));
-  const postError = () => Boolean(document.querySelector(".errorlist"));
-  const topicID = location.href.split("/")[5];
-
-  document.querySelector("[name=AddPostForm]")?.addEventListener("click", (event) => {
-    const ids = getTopics();
-    ids.push(topicID);
-    setTopics(ids);
-  });
-
-  const topics = getTopics();
-  if (topics.includes(topicID) && !postError()) {
-    // Check if the user ran into the 60 second rule as well
-    const followBtn = document.querySelectorAll(".follow-button")[1];
-    followBtn.focus();
-    followBtn.click();
-    // Remove the topic we've followed now
-    setTopics(topics.filter((topic) => topic !== topicID));
+  const subscribeCheckbox = document.querySelector("#id_subscribe");
+  if (subscribeCheckbox && !subscribeCheckbox.checked) {
+    subscribeCheckbox.checked = true;
   }
 }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #8135

### Changes

Uses the internal follow discussion checkbox instead

### Reason for changes

This makes following faster and fixes a few issues with our current implementation of the addon

### Tests

Tested using firefox 134.0.2. No known issues.