### PR TITLE
Add Material icons to addon credits

### DIFF
--- a/addons/material-forum-editor-buttons/addon.json
+++ b/addons/material-forum-editor-buttons/addon.json
@@ -19,6 +19,12 @@
       "note": "addon version",
       "id": "addonVersion",
       "link": "https://github.com/Secret-chest"
+    },
+    {
+      "name": "Google",
+      "note": "icons",
+      "id": "icons",
+      "link": "https://fonts.google.com/icons?icon.set=Material+Icons"
     }
   ],
   "enabledByDefault": false,

--- a/addons/variable-manager/addon.json
+++ b/addons/variable-manager/addon.json
@@ -7,6 +7,12 @@
     },
     {
       "name": "GarboMuffin"
+    },
+    {
+      "name": "Google",
+      "note": "search icon",
+      "id": "searchIcon",
+      "link": "https://fonts.google.com/icons?icon.set=Material+Icons"
     }
   ],
   "userscripts": [


### PR DESCRIPTION
Adds Material icons to the credits of material-forum-editor-buttons and variable-manager.