### PR TITLE
fix-editor-comments: new Blockly

### DIFF
--- a/addons/fix-editor-comments/userscript.js
+++ b/addons/fix-editor-comments/userscript.js
@@ -6,54 +6,73 @@ export default async function ({ addon, console }) {
   });
   const Blockly = await addon.tab.traps.getBlockly();
 
-  /*
-   * When a block with a comment attached is dragged, the comment now properly
-   * stores its updated position.
-   * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/scratch_bubble.js#L536
-   */
-  const originalBlockMove = Blockly.ScratchBubble.prototype.setAnchorLocation;
-  Blockly.ScratchBubble.prototype.setAnchorLocation = function (xy) {
-    if (!addon.self.disabled && addon.settings.get("fix-drag")) {
-      var event = new Blockly.Events.CommentMove(this.comment);
-      this.anchorXY_ = xy;
-      if (this.rendered_) {
-        this.positionBubble_();
-      }
-      event.recordNew();
-      Blockly.Events.fire(event);
-    } else {
-      return originalBlockMove.call(this, xy);
-    }
-  };
+  if (!Blockly.registry) {
+    // This code fixes issues that only exist in old Blockly
 
-  /*
-   * Do not use the widest block in the stack to calculate comment location.
-   * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/scratch_block_comment.js#L307
-   */
-  const originalPosition = Blockly.ScratchBlockComment.prototype.autoPosition_;
-  Blockly.ScratchBlockComment.prototype.autoPosition_ = function () {
-    if (!addon.self.disabled && addon.settings.get("leash")) {
-      if (!this.needsAutoPositioning_ || this.isMinimized_) return;
-      let offset = 8 * Blockly.BlockSvg.GRID_UNIT;
-      this.x_ = this.block_.RTL ? this.iconXY_.x - this.width_ - offset : this.iconXY_.x + offset;
-      this.y_ = this.iconXY_.y - Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2;
-    } else return originalPosition.call(this);
-  };
+    /*
+     * When a block with a comment attached is dragged, the comment now properly
+     * stores its updated position.
+     * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/scratch_bubble.js#L536
+     */
+    const originalBlockMove = Blockly.ScratchBubble.prototype.setAnchorLocation;
+    Blockly.ScratchBubble.prototype.setAnchorLocation = function (xy) {
+      if (!addon.self.disabled && addon.settings.get("fix-drag")) {
+        var event = new Blockly.Events.CommentMove(this.comment);
+        this.anchorXY_ = xy;
+        if (this.rendered_) {
+          this.positionBubble_();
+        }
+        event.recordNew();
+        Blockly.Events.fire(event);
+      } else {
+        return originalBlockMove.call(this, xy);
+      }
+    };
+
+    /*
+     * Do not use the widest block in the stack to calculate comment location.
+     * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/scratch_block_comment.js#L307
+     */
+    const originalPosition = Blockly.ScratchBlockComment.prototype.autoPosition_;
+    Blockly.ScratchBlockComment.prototype.autoPosition_ = function () {
+      if (!addon.self.disabled && addon.settings.get("leash")) {
+        if (!this.needsAutoPositioning_ || this.isMinimized_) return;
+        let offset = 8 * Blockly.BlockSvg.GRID_UNIT;
+        this.x_ = this.block_.RTL ? this.iconXY_.x - this.width_ - offset : this.iconXY_.x + offset;
+        this.y_ = this.iconXY_.y - Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2;
+      } else return originalPosition.call(this);
+    };
+  }
 
   /*
    * When setting a comment's location, keep the Y position level with the block.
-   * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/bubble_dragger.js#L139
-   * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/bubble_dragger.js#L202
    */
-
-  const originalCommentEndDrag = Blockly.BubbleDragger.prototype.endBubbleDrag;
-  Blockly.BubbleDragger.prototype.endBubbleDrag = function (e, currentDragDeltaXY) {
-    if (!addon.self.disabled && addon.settings.get("straighten") && this.draggingBubble_.comment) {
-      const y = this.draggingBubble_.comment.iconXY_.y - Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2;
-      currentDragDeltaXY.y = y - this.startXY_.y;
-    }
-    return originalCommentEndDrag.call(this, e, currentDragDeltaXY);
-  };
+  if (Blockly.registry) {
+    // new Blockly
+    // https://github.com/google/blockly/blob/e6e57dd/core/dragging/dragger.ts#L99
+    const originalOnDragEnd = Blockly.dragging.Dragger.prototype.onDragEnd;
+    Blockly.dragging.Dragger.prototype.onDragEnd = function (...args) {
+      if (!addon.self.disabled && addon.settings.get("straighten") && this.draggable.dropAnchor) {
+        // Magic number 16 is from here:
+        // https://github.com/scratchfoundation/scratch-blocks/blob/91c8b63/src/scratch_comment_bubble.js#L119
+        this.draggable.moveTo(this.draggable.location.x, this.draggable.anchor.y - 16);
+      }
+      return originalOnDragEnd.call(this, ...args);
+    };
+  } else {
+    /*
+     * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/bubble_dragger.js#L139
+     * https://github.com/scratchfoundation/scratch-blocks/blob/develop/core/bubble_dragger.js#L202
+     */
+    const originalCommentEndDrag = Blockly.BubbleDragger.prototype.endBubbleDrag;
+    Blockly.BubbleDragger.prototype.endBubbleDrag = function (e, currentDragDeltaXY) {
+      if (!addon.self.disabled && addon.settings.get("straighten") && this.draggingBubble_.comment) {
+        const y = this.draggingBubble_.comment.iconXY_.y - Blockly.ScratchBubble.TOP_BAR_HEIGHT / 2;
+        currentDragDeltaXY.y = y - this.startXY_.y;
+      }
+      return originalCommentEndDrag.call(this, e, currentDragDeltaXY);
+    };
+  }
 
   // Enforces the Y position even while dragging (disabled)
   /*const originalCommentDrag = Blockly.BubbleDragger.prototype.dragBubble;


### PR DESCRIPTION
### Changes

Updates the "keep block comment connections straight" setting of "better editor comments" to work with modern Blockly. Other settings fix Scratch issues that are fixed in the new version of scratch-blocks.

### Tests

Tested on Edge and Firefox.