### PR TITLE
editor-searchable-dropdowns: new Blockly

### DIFF
--- a/addons-l10n/en/editor-searchable-dropdowns.json
+++ b/addons-l10n/en/editor-searchable-dropdowns.json
@@ -3,5 +3,6 @@
   "editor-searchable-dropdowns/createLocalVariable": "Create variable \"{name}\" for this sprite only",
   "editor-searchable-dropdowns/createGlobalList": "Create list \"{name}\" for all sprites",
   "editor-searchable-dropdowns/createLocalList": "Create list \"{name}\" for this sprite only",
-  "editor-searchable-dropdowns/createBroadcast": "Create message \"{name}\""
+  "editor-searchable-dropdowns/createBroadcast": "Create message \"{name}\"",
+  "editor-searchable-dropdowns/noResults": "No results"
 }

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -78,7 +78,7 @@ export default async function ({ addon }) {
     else if (el.matches(".mediaRecorderPopupContent input[type=number]")) {
       // Number inputs in `mediarecorder` addon modal
       return true;
-    } else if (el.className.includes("input_input-form_")) {
+    } else if (el.matches("[class*=input_input-form_]")) {
       if (el.matches("[class*=sprite-info_sprite-info_] [class*=input_input-small_]")) {
         // Sprite X/Y coordinates, size and direction (excludes sprite name)
         return true;

--- a/addons/editor-searchable-dropdowns/addon.json
+++ b/addons/editor-searchable-dropdowns/addon.json
@@ -22,5 +22,6 @@
   ],
   "versionAdded": "1.0.0",
   "tags": ["editor", "codeEditor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": false,
+  "libraries": ["scratch-blocks"]
 }

--- a/addons/editor-searchable-dropdowns/userscript.css
+++ b/addons/editor-searchable-dropdowns/userscript.css
@@ -24,6 +24,14 @@
   overflow-x: hidden;
 }
 
+.u-dropdown-no-results {
+  opacity: 0.5;
+  cursor: default;
+}
+.blocklyDropDownDiv .blocklyMenu .blocklyMenuItem.u-dropdown-no-results:hover {
+  background-color: transparent;
+}
+
 .u-dropdown-selected-item {
   background-color: var(--colour-menuHover);
 }

--- a/addons/editor-searchable-dropdowns/userscript.css
+++ b/addons/editor-searchable-dropdowns/userscript.css
@@ -23,3 +23,7 @@
 .blocklyDropDownDiv .goog-menu {
   overflow-x: hidden;
 }
+
+.u-dropdown-selected-item {
+  background-color: var(--colour-menuHover);
+}

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -21,7 +21,7 @@ export default async function ({ addon, console, msg }) {
   const newVariable = (workspace, ...args) => {
     if (Blockly.registry) {
       // new Blockly
-      // TODO: LINK
+      // https://github.com/scratchfoundation/scratch-blocks/blob/91c8b63/src/variables.ts#L126-L137
       const VariableModel = Blockly.registry.getClass(Blockly.registry.Type.VARIABLE_MODEL, Blockly.registry.DEFAULT);
       const variable = new VariableModel(workspace, ...args);
       workspace.getVariableMap().addVariable(variable);

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -22,10 +22,7 @@ export default async function ({ addon, console, msg }) {
     if (Blockly.registry) {
       // new Blockly
       // TODO: LINK
-      const VariableModel = Blockly.registry.getClass(
-        Blockly.registry.Type.VARIABLE_MODEL,
-        Blockly.registry.DEFAULT
-      );
+      const VariableModel = Blockly.registry.getClass(Blockly.registry.Type.VARIABLE_MODEL, Blockly.registry.DEFAULT);
       const variable = new VariableModel(workspace, ...args);
       workspace.getVariableMap().addVariable(variable);
       Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(variable));
@@ -33,7 +30,7 @@ export default async function ({ addon, console, msg }) {
     } else {
       return workspace.createVariable(...args);
     }
-  }
+  };
 
   const ADDON_ITEMS = {
     createGlobalVariable: {
@@ -85,7 +82,7 @@ export default async function ({ addon, console, msg }) {
       }));
     currentDropdownOptions = resultOfLastGetOptions;
     updateSearch();
-  }
+  };
 
   if (Blockly.registry) {
     // new Blockly
@@ -103,7 +100,7 @@ export default async function ({ addon, console, msg }) {
           setTimeout(() => searchBar.scrollIntoView(), 0);
         }
       };
-    }
+    };
 
     // FieldDropdown.showEditor_() calls Menu.render(), then DropDownDiv.showPositionedByField().
     // We override Menu.render() so that when showPositionedByField() is called, the search bar is
@@ -117,7 +114,7 @@ export default async function ({ addon, console, msg }) {
         initSearchBar();
       }
       return menu;
-    }
+    };
   } else {
     const oldDropDownDivShow = Blockly.DropDownDiv.show;
     Blockly.DropDownDiv.show = function (...args) {

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -18,26 +18,43 @@ export default async function ({ addon, console, msg }) {
     return !vm.editingTarget.lookupVariableByNameAndType(name, type);
   };
 
+  const newVariable = (workspace, ...args) => {
+    if (Blockly.registry) {
+      // new Blockly
+      // TODO: LINK
+      const VariableModel = Blockly.registry.getClass(
+        Blockly.registry.Type.VARIABLE_MODEL,
+        Blockly.registry.DEFAULT
+      );
+      const variable = new VariableModel(workspace, ...args);
+      workspace.getVariableMap().addVariable(variable);
+      Blockly.Events.fire(new (Blockly.Events.get(Blockly.Events.VAR_CREATE))(variable));
+      return variable;
+    } else {
+      return workspace.createVariable(...args);
+    }
+  }
+
   const ADDON_ITEMS = {
     createGlobalVariable: {
       enabled: (name) => canUseAsGlobalVariableName(name, ""),
-      createVariable: (workspace, name) => workspace.createVariable(name),
+      createVariable: (workspace, name) => newVariable(workspace, name),
     },
     createLocalVariable: {
       enabled: (name) => canUseAsLocalVariableName(name, ""),
-      createVariable: (workspace, name) => workspace.createVariable(name, "", null, true),
+      createVariable: (workspace, name) => newVariable(workspace, name, "", null, true),
     },
     createGlobalList: {
       enabled: (name) => canUseAsGlobalVariableName(name, "list"),
-      createVariable: (workspace, name) => workspace.createVariable(name, "list"),
+      createVariable: (workspace, name) => newVariable(workspace, name, "list"),
     },
     createLocalList: {
       enabled: (name) => canUseAsLocalVariableName(name, "list"),
-      createVariable: (workspace, name) => workspace.createVariable(name, "list", null, true),
+      createVariable: (workspace, name) => newVariable(workspace, name, "list", null, true),
     },
     createBroadcast: {
       enabled: (name) => canUseAsGlobalVariableName(name, "broadcast_msg"),
-      createVariable: (workspace, name) => workspace.createVariable(name, "broadcast_msg"),
+      createVariable: (workspace, name) => newVariable(workspace, name, "broadcast_msg"),
     },
   };
 
@@ -51,15 +68,7 @@ export default async function ({ addon, console, msg }) {
   let currentDropdownOptions = [];
   let resultOfLastGetOptions = [];
 
-  const oldDropDownDivShow = Blockly.DropDownDiv.show;
-  Blockly.DropDownDiv.show = function (...args) {
-    blocklyDropdownMenu = document.querySelector(".blocklyDropdownMenu");
-    if (!blocklyDropdownMenu) {
-      return oldDropDownDivShow.call(this, ...args);
-    }
-
-    blocklyDropdownMenu.focus = () => {}; // no-op focus() so it can't steal it from the search bar
-
+  const initSearchBar = () => {
     searchBar = document.createElement("input");
     addon.tab.displayNoneWhileDisabled(searchBar);
     searchBar.type = "text";
@@ -76,29 +85,73 @@ export default async function ({ addon, console, msg }) {
       }));
     currentDropdownOptions = resultOfLastGetOptions;
     updateSearch();
+  }
 
-    // Call the original show method after adding everything so that it can perform the correct size calculations
-    const ret = oldDropDownDivShow.call(this, ...args);
+  if (Blockly.registry) {
+    // new Blockly
+    const oldFieldDropdownCreate = Blockly.FieldDropdown.prototype.dropdownCreate;
+    Blockly.FieldDropdown.prototype.dropdownCreate = function () {
+      oldFieldDropdownCreate.call(this);
+      this.menu_.saSearchable = true;
+      this.menu_.focus = () => {
+        // Only focus once - by default, Blockly focuses the menu every time it's hovered
+        this.menu_.focus = () => {};
+        if (searchBar) {
+          // This is really strange, but if you don't reinsert the search bar into the DOM then focus() doesn't work
+          blocklyDropdownMenu.insertBefore(searchBar, blocklyDropdownMenu.firstChild);
+          searchBar.focus();
+        }
+      };
+    }
 
-    // Lock the size of the dropdown
-    blocklyDropDownContent = Blockly.DropDownDiv.getContentDiv();
-    blocklyDropDownContent.style.width = getComputedStyle(blocklyDropDownContent).width;
-    blocklyDropDownContent.style.height = getComputedStyle(blocklyDropDownContent).height;
+    // FieldDropdown.showEditor_() calls Menu.render(), then DropDownDiv.showPositionedByField().
+    // We override Menu.render() so that when showPositionedByField() is called, the search bar is
+    // already there and the correct size of the menu can be calculated.
+    const oldMenuRender = Blockly.Menu.prototype.render;
+    Blockly.Menu.prototype.render = function (...args) {
+      const menu = oldMenuRender.call(this, ...args);
+      if (this.saSearchable) {
+        blocklyDropDownContent = Blockly.DropDownDiv.getContentDiv();
+        blocklyDropdownMenu = menu;
+        initSearchBar();
+      }
+      return menu;
+    }
+  } else {
+    const oldDropDownDivShow = Blockly.DropDownDiv.show;
+    Blockly.DropDownDiv.show = function (...args) {
+      blocklyDropdownMenu = document.querySelector(".blocklyDropdownMenu");
+      if (!blocklyDropdownMenu) {
+        return oldDropDownDivShow.call(this, ...args);
+      }
 
-    // This is really strange, but if you don't reinsert the search bar into the DOM then focus() doesn't work
-    blocklyDropdownMenu.insertBefore(searchBar, blocklyDropdownMenu.firstChild);
-    searchBar.focus();
+      blocklyDropdownMenu.focus = () => {}; // no-op focus() so it can't steal it from the search bar
 
-    return ret;
-  };
+      initSearchBar();
 
-  const oldDropDownDivClearContent = Blockly.DropDownDiv.clearContent;
-  Blockly.DropDownDiv.clearContent = function () {
-    oldDropDownDivClearContent.call(this);
-    items = [];
-    searchedItems = [];
-    Blockly.DropDownDiv.content_.style.height = "";
-  };
+      // Call the original show method after adding everything so that it can perform the correct size calculations
+      const ret = oldDropDownDivShow.call(this, ...args);
+
+      // Lock the size of the dropdown
+      blocklyDropDownContent = Blockly.DropDownDiv.getContentDiv();
+      blocklyDropDownContent.style.width = getComputedStyle(blocklyDropDownContent).width;
+      blocklyDropDownContent.style.height = getComputedStyle(blocklyDropDownContent).height;
+
+      // This is really strange, but if you don't reinsert the search bar into the DOM then focus() doesn't work
+      blocklyDropdownMenu.insertBefore(searchBar, blocklyDropdownMenu.firstChild);
+      searchBar.focus();
+
+      return ret;
+    };
+
+    const oldDropDownDivClearContent = Blockly.DropDownDiv.clearContent;
+    Blockly.DropDownDiv.clearContent = function () {
+      oldDropDownDivClearContent.call(this);
+      items = [];
+      searchedItems = [];
+      Blockly.DropDownDiv.content_.style.height = "";
+    };
+  }
 
   const oldFieldDropdownGetOptions = Blockly.FieldDropdown.prototype.getOptions;
   Blockly.FieldDropdown.prototype.getOptions = function () {
@@ -106,15 +159,11 @@ export default async function ({ addon, console, msg }) {
     const block = this.sourceBlock_;
     const isStage = vm.editingTarget && vm.editingTarget.isStage;
     if (block) {
-      if (block.category_ === "data") {
-        options.push(getMenuItemMessage("createGlobalVariable"));
+      if (block.type.startsWith("data_")) {
+        const isListBlock = block.type.includes("list");
+        options.push(getMenuItemMessage(isListBlock ? "createGlobalList" : "createGlobalVariable"));
         if (!isStage) {
-          options.push(getMenuItemMessage("createLocalVariable"));
-        }
-      } else if (block.category_ === "data-lists") {
-        options.push(getMenuItemMessage("createGlobalList"));
-        if (!isStage) {
-          options.push(getMenuItemMessage("createLocalList"));
+          options.push(getMenuItemMessage(isListBlock ? "createLocalList" : "createLocalVariable"));
         }
       } else if (block.type === "event_broadcast_menu" || block.type === "event_whenbroadcastreceived") {
         options.push(getMenuItemMessage("createBroadcast"));
@@ -125,8 +174,9 @@ export default async function ({ addon, console, msg }) {
     return options;
   };
 
-  const oldFieldVariableOnItemSelected = Blockly.FieldVariable.prototype.onItemSelected;
-  Blockly.FieldVariable.prototype.onItemSelected = function (menu, menuItem) {
+  const onItemSelectedMethodName = Blockly.registry ? "onItemSelected_" : "onItemSelected";
+  const oldFieldVariableOnItemSelected = Blockly.FieldVariable.prototype[onItemSelectedMethodName];
+  Blockly.FieldVariable.prototype[onItemSelectedMethodName] = function (menu, menuItem) {
     const sourceBlock = this.sourceBlock_;
     if (sourceBlock && sourceBlock.workspace && searchBar.value.length !== 0) {
       const workspace = sourceBlock.workspace;
@@ -146,8 +196,16 @@ export default async function ({ addon, console, msg }) {
 
   function selectItem(item, click) {
     // You can't just use click() or focus() because Blockly uses mousedown and mouseup handlers, not click handlers.
-    item.dispatchEvent(new MouseEvent("mousedown", { relatedTarget: item, bubbles: true }));
-    if (click) item.dispatchEvent(new MouseEvent("mouseup", { relatedTarget: item, bubbles: true }));
+    if (Blockly.registry) {
+      // new Blockly
+      const previousSelection = item.parentElement.querySelector(".u-dropdown-selected-item");
+      if (previousSelection) previousSelection.classList.remove("u-dropdown-selected-item");
+      item.classList.add("u-dropdown-selected-item");
+      if (click) item.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    } else {
+      item.dispatchEvent(new MouseEvent("mousedown", { relatedTarget: item, bubbles: true }));
+      if (click) item.dispatchEvent(new MouseEvent("mouseup", { relatedTarget: item, bubbles: true }));
+    }
 
     // Scroll the item into view if it is offscreen.
     const itemTop = item.offsetTop;
@@ -237,7 +295,7 @@ export default async function ({ addon, console, msg }) {
       event.stopPropagation();
       event.preventDefault();
 
-      const selectedItem = document.querySelector(".goog-menuitem-highlight");
+      const selectedItem = document.querySelector(".goog-menuitem-highlight, .u-dropdown-selected-item");
       if (selectedItem && !selectedItem.hidden) {
         selectItem(selectedItem, true);
         return;
@@ -277,7 +335,7 @@ export default async function ({ addon, console, msg }) {
 
       let selectedIndex = -1;
       for (let i = 0; i < items.length; i++) {
-        if (items[i].element.classList.contains("goog-menuitem-highlight")) {
+        if (items[i].element.matches(".goog-menuitem-highlight, .u-dropdown-selected-item")) {
           selectedIndex = i;
           break;
         }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -100,6 +100,7 @@ export default async function ({ addon, console, msg }) {
           // This is really strange, but if you don't reinsert the search bar into the DOM then focus() doesn't work
           blocklyDropdownMenu.insertBefore(searchBar, blocklyDropdownMenu.firstChild);
           searchBar.focus();
+          setTimeout(() => searchBar.scrollIntoView(), 0);
         }
       };
     }

--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -58,6 +58,7 @@ export default async function ({ addon, console, msg }) {
   let blocklyDropDownContent = null;
   let blocklyDropdownMenu = null;
   let searchBar = null;
+  let noResultsMessage = null;
   // Contains DOM and addon state
   let items = [];
   let searchedItems = [];
@@ -72,10 +73,17 @@ export default async function ({ addon, console, msg }) {
     searchBar.addEventListener("input", updateSearch);
     searchBar.addEventListener("keydown", handleKeyDownEvent);
     searchBar.classList.add("u-dropdown-searchbar");
-    blocklyDropdownMenu.insertBefore(searchBar, blocklyDropdownMenu.firstChild);
+
+    noResultsMessage = document.createElement("div");
+    noResultsMessage.textContent = msg("noResults");
+    noResultsMessage.hidden = true;
+    noResultsMessage.classList.add("u-dropdown-no-results", "blocklyMenuItem", "goog-menuitem");
+
+    blocklyDropdownMenu.insertBefore(noResultsMessage, blocklyDropdownMenu.firstChild);
+    blocklyDropdownMenu.insertBefore(searchBar, noResultsMessage);
 
     items = Array.from(blocklyDropdownMenu.children)
-      .filter((child) => child.tagName !== "INPUT")
+      .filter((child) => !child.matches(".u-dropdown-searchbar, .u-dropdown-no-results"))
       .map((element) => ({
         element,
         text: element.textContent,
@@ -282,9 +290,12 @@ export default async function ({ addon, console, msg }) {
         blocklyDropdownMenu.appendChild(item.element);
       }
     }
+    let visibleItems = 0;
     for (const { item, score } of searchedItems) {
       item.element.hidden = score < 0;
+      if (score >= 0) ++visibleItems;
     }
+    noResultsMessage.hidden = visibleItems > 0;
   }
 
   function handleKeyDownEvent(event) {

--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -26,7 +26,9 @@
 .blocklyDropDownDiv .goog-menuitem-highlight,
 .blocklyDropDownDiv .goog-menuitem-hover,
 .blocklyDropDownDiv .blocklyMenu .blocklyMenuItem:hover,
-.sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight {
+.blocklyDropDownDiv .blocklyMenu .u-dropdown-selected-item,
+.sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight,
+.sa-contextmenu-colored .blocklyContextMenu .blocklyMenuItem:hover {
   background-color: var(--editorTheme3-hoveredItem, rgba(255, 255, 255, 0.3));
 }
 

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -35,6 +35,7 @@
 .blocklyDropDownDiv .goog-menuitem-highlight,
 .blocklyDropDownDiv .goog-menuitem-hover,
 .blocklyDropDownDiv .blocklyMenu .blocklyMenuItem:hover,
+.blocklyDropDownDiv .blocklyMenu .u-dropdown-selected-item,
 .sa-contextmenu-colored .blocklyContextMenu .goog-menuitem-highlight,
 .sa-contextmenu-colored .blocklyContextMenu .blocklyMenuItem:hover {
   background-color: var(--editorTheme3-hoveredItem, rgba(0, 0, 0, 0.2));

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -140,7 +140,7 @@ export default async function ({ addon, msg, console }) {
 
       let ctrlKey = e.ctrlKey || e.metaKey;
 
-      if (e.key.toLowerCase() === "f" && ctrlKey && !e.shiftKey && !document.activeElement.closest(".sa-find-bar")) {
+      if (e.key?.toLowerCase() === "f" && ctrlKey && !e.shiftKey && !document.activeElement.closest(".sa-find-bar")) {
         // Ctrl + F (Override default Ctrl+F find)
         this.findInput.focus();
         this.findInput.select();


### PR DESCRIPTION
### Changes

Updates "block dropdown search" to be compatible with new Blockly. Also fixes two minor bugs in other addons so that the full-screen error popup doesn't appear in development versions of Scratch.

### Tests

Tested both Scratch versions on Edge and Firefox. Scrolling in long dropdowns is slightly broken on new Blockly, but this isn't caused by the addon.