### PR TITLE
reorder-custom-inputs: don't unpollute Scratch functions

### DIFF
--- a/addons/reorder-custom-inputs/userscript.js
+++ b/addons/reorder-custom-inputs/userscript.js
@@ -144,11 +144,11 @@ export default async function ({ addon, console }) {
     procedureDeclaration.onChangeFn = function (...args) {
       if (addon.self.disabled) return originalUpdateDeclarationProcCode.call(this, ...args);
       return modifiedUpdateDeclarationProcCode.call(this, ...args);
-    }
+    };
     procedureDeclaration.removeFieldCallback = function (...args) {
       if (addon.self.disabled) return originalRemoveFieldCallback.call(this, ...args);
       return modifiedRemoveFieldCallback.call(this, ...args);
-    }
+    };
 
     for (const inputFn of ["addLabelExternal", "addBooleanExternal", "addStringNumberExternal"]) {
       const originalFn = procedureDeclaration[inputFn];
@@ -158,7 +158,7 @@ export default async function ({ addon, console }) {
       procedureDeclaration[inputFn] = function (...args) {
         if (addon.self.disabled) return originalAddFns[inputFn].call(this, ...args);
         return addInputAfter(originalFn, inputFn).call(this, ...args);
-      }
+      };
     }
   }
 


### PR DESCRIPTION
### Changes

* Adds `addon.self.disabled` checks instead of unpolluting functions when the addon is disabled.
* Removes the additional `getBlockly()` call added by #7892 - there was already one near the end of the userscript. I moved it to the top to make it clearer that `Blockly` refers to the `getBlockly()` result, not `window.Blockly`.

### Reason for changes

https://scratchaddons.com/docs/develop/userscripts/best-practices/#do-not-unpollute-functions

### Tests

Tested on Edge and Firefox.