### PR TITLE
Update updateAllBlocks

### DIFF
--- a/libraries/common/cs/update-all-blocks.js
+++ b/libraries/common/cs/update-all-blocks.js
@@ -27,10 +27,7 @@ export async function updateAllBlocks(
         if (blockly.registry) {
           // new Blockly
           toolbox.render(workspace.options.languageTree);
-          toolbox.selectItem_(
-            null,
-            toolbox.contents_.find((item) => item.id_ === selectedItemId)
-          );
+          toolbox.selectItem_(null, toolbox.contents.get(selectedItemId));
         } else {
           toolbox.categoryMenu_.populate(workspace.options.languageTree);
           toolbox.selectCategoryById(selectedItemId, false);


### PR DESCRIPTION
### Changes

Updates the modern Blockly part of the `updateAllBlocks()` implementation.

### Reason for changes

Blockly renamed the toolbox's `contents_` attribute to `contents` and changed it from an array to a map.

![image](https://github.com/user-attachments/assets/e0288820-c966-40e3-80e3-659e4cf5149f)

### Tests

Tested on Edge.