### PR TITLE
Use new toolbox selector on modern Blockly

### DIFF
--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -305,20 +305,25 @@ input.sa-search-sprites-box {
 }
 
 /* Code tab */
-body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .scratchCategoryMenuItem {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .scratchCategoryMenuItem,
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxCategory {
   padding: 0.25rem 0;
 }
 .scratchCategoryItemBubble,
-.scratchCategoryItemIcon {
+.scratchCategoryItemIcon,
+.categoryBubble,
+.categoryIconBubble {
   width: 1rem;
   height: 1rem;
   background-size: 1rem 1rem;
 }
-body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxDiv {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxDiv,
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolbox {
   height: calc(100% - 2rem) !important;
   scrollbar-width: none;
 }
-body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxDiv::-webkit-scrollbar {
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolboxDiv::-webkit-scrollbar,
+body:not(.sa-columns-enabled) [class*="gui_tab-panel"] .blocklyToolbox::-webkit-scrollbar {
   display: none;
 }
 body:not(.sa-columns-enabled) [class*="gui_tab-panel"] [class*="gui_extension-button-container_"] {

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -388,6 +388,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 
 /* Block category menu background */
 .blocklyToolboxDiv,
+.blocklyToolbox,
 .scratchCategoryMenu {
   background: var(--editorDarkMode-categoryMenu);
   color: var(--editorDarkMode-categoryMenu-text);
@@ -614,6 +615,8 @@ img[src*="c3RvcC1wbGF5YmFjayI+CiAgICAgICAgICAgICAgICAgICAgICAgIDx1c2UgZmlsbD0iYm
 [class*="blocks_blocks_"] .injectionDiv,
 [class*="blocks_blocks_"] .blocklyToolboxDiv,
 [dir="rtl"] [class*="blocks_blocks_"] .blocklyToolboxDiv,
+[class*="blocks_blocks_"] .blocklyToolbox,
+[dir="rtl"] [class*="blocks_blocks_"] .blocklyToolbox,
 [class*="blocks_blocks_"] .blocklyFlyout,
 [dir="rtl"] [class*="blocks_blocks_"] .blocklyFlyout,
 [class*="backpack_backpack-header_"],

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -104,7 +104,7 @@
   /* .blocklyFlyout (z-index: 20) */
   /* .blocklyFlyoutScrollbar (z-index: 30) */
   /* and above these so that dragged sprites aren't obscured: */
-  /* .blocklyToolboxDiv (z-index: 40) */
+  /* .blocklyToolbox (z-index: 40) */
   /* .gui_extension-button-container_b4rCs (z-index: 42) */
   z-index: 43;
   padding-inline: 0.5rem;

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -407,8 +407,8 @@ export default async function ({ addon, console, msg }) {
     toggle = false;
 
     let toolbox;
-    if (Blockly.registry) toolbox = document.querySelector(".blocklyToolbox")
-      else toolbox = document.querySelector(".blocklyToolboxDiv")
+    if (Blockly.registry) toolbox = document.querySelector(".blocklyToolbox");
+    else toolbox = document.querySelector(".blocklyToolboxDiv");
     const addExtensionButton = document.querySelector("[class^=gui_extension-button-container_]");
 
     for (let element of [toolbox, addExtensionButton, flyOut, scrollBar]) {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -409,6 +409,7 @@ export default async function ({ addon, console, msg }) {
     let toolbox;
     if (Blockly.registry) toolbox = document.querySelector(".blocklyToolbox");
     else toolbox = document.querySelector(".blocklyToolboxDiv");
+
     const addExtensionButton = document.querySelector("[class^=gui_extension-button-container_]");
 
     for (let element of [toolbox, addExtensionButton, flyOut, scrollBar]) {

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -406,7 +406,9 @@ export default async function ({ addon, console, msg }) {
     closeFlyout(null, 0);
     toggle = false;
 
-    const toolbox = document.querySelector(".blocklyToolboxDiv");
+    let toolbox;
+    if (Blockly.registry) toolbox = document.querySelector(".blocklyToolbox")
+      else toolbox = document.querySelector(".blocklyToolboxDiv")
     const addExtensionButton = document.querySelector("[class^=gui_extension-button-container_]");
 
     for (let element of [toolbox, addExtensionButton, flyOut, scrollBar]) {


### PR DESCRIPTION
### Changes

Updates `editor-dark-mode` and `hide-flyout` on modern Blockly to use the new toolbox selector. 

Also adds modern Blockly support to `editor-compact`, although there might be some areas I missed.

### Tests

Tested on Chromium on both versions of Scratch.
