### PR TITLE
reorder-custom-inputs: new Blockly

### DIFF
--- a/addons/reorder-custom-inputs/modified-funcs.js
+++ b/addons/reorder-custom-inputs/modified-funcs.js
@@ -1,27 +1,43 @@
+const inputTypes = {
+  DUMMY: 5,
+  VALUE: 1,
+};
+
+const ArgumentType = {
+  STRING: "s",
+  NUMBER: "n",
+  BOOLEAN: "b",
+};
+
 // https://github.com/scratchfoundation/scratch-blocks/blob/f210e042988b91bcdc2abeca7a2d85e178edadb2/blocks_vertical/procedures.js#L205
+// https://github.com/scratchfoundation/scratch-blocks/blob/0f6a3f3/src/blocks/procedures.ts#L257
 export function modifiedCreateAllInputs(connectionMap) {
   // Split the proc into components, by %n, %b, %s and %l (ignoring escaped).
-  var procComponents = this.procCode_.split(/(?=[^\\]%[nbsl])/);
-  procComponents = procComponents.map(function (c) {
+  const procComponents = this.procCode_.split(/(?=[^\\]%[nbsl])/).map(function (c) {
     return c.trim(); // Strip whitespace.
   });
-
   // Create arguments and labels as appropriate.
-  var argumentCount = 0;
-  for (var i = 0, component; (component = procComponents[i]); i++) {
-    var labelText;
+  let argumentCount = 0;
+  for (const component of procComponents) {
+    let labelText;
     // Don't treat %l as an argument
     if (component.substring(0, 1) === "%" && component.substring(1, 2) !== "l") {
-      var argumentType = component.substring(1, 2);
-      if (!(argumentType === "n" || argumentType === "b" || argumentType === "s")) {
+      const argumentType = component.substring(1, 2);
+      if (
+        !(
+          argumentType === ArgumentType.NUMBER ||
+          argumentType === ArgumentType.BOOLEAN ||
+          argumentType === ArgumentType.STRING
+        )
+      ) {
         throw new Error("Found an custom procedure with an invalid type: " + argumentType);
       }
       labelText = component.substring(2).trim();
 
-      var id = this.argumentIds_[argumentCount];
+      const id = this.argumentIds_[argumentCount];
 
-      var input = this.appendValueInput(id);
-      if (argumentType === "b") {
+      const input = this.appendValueInput(id);
+      if (argumentType === ArgumentType.BOOLEAN) {
         input.setCheck("Boolean");
       }
       this.populateArgument_(argumentType, argumentCount, connectionMap, id, input);
@@ -37,22 +53,23 @@ export function modifiedCreateAllInputs(connectionMap) {
 }
 
 //https://github.com/scratchfoundation/scratch-blocks/blob/f210e042988b91bcdc2abeca7a2d85e178edadb2/blocks_vertical/procedures.js#L565
+//https://github.com/scratchfoundation/scratch-blocks/blob/0f6a3f3/src/blocks/procedures.ts#L676
 export function modifiedUpdateDeclarationProcCode(prefixLabels = false) {
   this.procCode_ = "";
   this.displayNames_ = [];
   this.argumentIds_ = [];
-  for (var i = 0; i < this.inputList.length; i++) {
+  for (let i = 0; i < this.inputList.length; i++) {
     if (i !== 0) {
       this.procCode_ += " ";
     }
-    var input = this.inputList[i];
-    if (input.type === 5) {
-      // replaced Blocky.DUMMY_VALUE with 5
+    const input = this.inputList[i];
+    if (input.type === inputTypes.DUMMY) {
+      // replaced Blocky.inputs.inputTypes with inputTypes
       this.procCode_ += (prefixLabels ? "%l " : "") + input.fieldRow[0].getValue(); // modified to prepend %l delimiter, which prevents label merging
-    } else if (input.type === 1) {
-      // replaced Blocky.INPUT_VALUE with 1
+    } else if (input.type === inputTypes.VALUE) {
+      // replaced Blocky.inputs.inputTypes with inputTypes
       // Inspect the argument editor.
-      var target = input.connection.targetBlock();
+      const target = input.connection.targetBlock();
       this.displayNames_.push(target.getFieldValue("TEXT"));
       this.argumentIds_.push(input.name);
       if (target.type === "argument_editor_boolean") {

--- a/addons/reorder-custom-inputs/userscript.js
+++ b/addons/reorder-custom-inputs/userscript.js
@@ -188,6 +188,9 @@ export default async function ({ addon, console }) {
       const originalInit = Blockly.Blocks["procedures_declaration"].init;
       Blockly.Blocks["procedures_declaration"].init = function () {
         originalInit.call(this);
+        originalCreateAllInputs = this.createAllInputs_;
+        originalUpdateDeclarationProcCode = this.onChangeFn;
+        originalRemoveFieldCallback = this.removeFieldCallback;
         polluteProcedureDeclaration(this);
       };
     } else {
@@ -223,20 +226,24 @@ export default async function ({ addon, console }) {
   let INPUT_DUMMY;
   let INPUT_VALUE;
   let FieldTextInputRemovable;
+  let originalCreateAllInputs;
+  let originalUpdateDeclarationProcCode;
+  let originalRemoveFieldCallback;
   if (Blockly.registry) {
     // new Blockly
     INPUT_DUMMY = Blockly.inputs.inputTypes.DUMMY;
     INPUT_VALUE = Blockly.inputs.inputTypes.VALUE;
     FieldTextInputRemovable = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_input_removable");
+    // The other variables are set in enableAddon()
   } else {
     INPUT_DUMMY = Blockly.DUMMY_INPUT;
     INPUT_VALUE = Blockly.INPUT_VALUE;
     FieldTextInputRemovable = Blockly.FieldTextInputRemovable;
+    originalCreateAllInputs = Blockly.Blocks["procedures_declaration"].createAllInputs_;
+    originalUpdateDeclarationProcCode = Blockly.Blocks["procedures_declaration"].onChangeFn;
+    originalRemoveFieldCallback = Blockly.Blocks["procedures_declaration"].removeFieldCallback;
   }
 
-  const originalCreateAllInputs = Blockly.Blocks["procedures_declaration"].createAllInputs_;
-  const originalUpdateDeclarationProcCode = Blockly.Blocks["procedures_declaration"].onChangeFn;
-  const originalRemoveFieldCallback = Blockly.Blocks["procedures_declaration"].removeFieldCallback;
   const originalShowEditor = FieldTextInputRemovable.prototype.showEditor_;
   let originalAddFns = {};
   let selectedField = null;

--- a/addons/reorder-custom-inputs/userscript.js
+++ b/addons/reorder-custom-inputs/userscript.js
@@ -7,7 +7,8 @@ export default async function ({ addon, console }) {
     const path = direction === "left" ? "M 17 13 L 9 21 L 17 30" : "M 9 13 L 17 21 L 9 30";
 
     let widgetDiv;
-    if (Blockly.registry) widgetDiv = Blockly.WidgetDiv.getDiv(); // new Blockly
+    if (Blockly.registry)
+      widgetDiv = Blockly.WidgetDiv.getDiv(); // new Blockly
     else widgetDiv = Blockly.WidgetDiv.DIV;
 
     widgetDiv.insertAdjacentHTML(
@@ -213,7 +214,8 @@ export default async function ({ addon, console }) {
 
   function disableAddon() {
     let widgetDiv;
-    if (Blockly.registry) widgetDiv = Blockly.WidgetDiv.getDiv(); // new Blockly
+    if (Blockly.registry)
+      widgetDiv = Blockly.WidgetDiv.getDiv(); // new Blockly
     else widgetDiv = Blockly.WidgetDiv.DIV;
     widgetDiv.querySelectorAll(".sa-reorder-inputs-arrow").forEach((e) => e.remove());
   }

--- a/addons/reorder-custom-inputs/userscript.js
+++ b/addons/reorder-custom-inputs/userscript.js
@@ -6,7 +6,11 @@ export default async function ({ addon, console }) {
   function createArrow(direction, callback) {
     const path = direction === "left" ? "M 17 13 L 9 21 L 17 30" : "M 9 13 L 17 21 L 9 30";
 
-    Blockly.WidgetDiv.DIV.insertAdjacentHTML(
+    let widgetDiv;
+    if (Blockly.registry) widgetDiv = Blockly.WidgetDiv.getDiv(); // new Blockly
+    else widgetDiv = Blockly.WidgetDiv.DIV;
+
+    widgetDiv.insertAdjacentHTML(
       "beforeend",
       `
             <svg width="20px" height="40px"
@@ -17,10 +21,16 @@ export default async function ({ addon, console }) {
             </svg>`
     );
 
-    Blockly.WidgetDiv.DIV.lastChild.addEventListener("click", callback);
+    widgetDiv.lastChild.addEventListener("click", callback);
+  }
+
+  function createArrows(field) {
+    createArrow("left", () => shiftFieldCallback(field.sourceBlock_, field, "left"));
+    createArrow("right", () => shiftFieldCallback(field.sourceBlock_, field, "right"));
   }
 
   //https://github.com/scratchfoundation/scratch-blocks/blob/f210e042988b91bcdc2abeca7a2d85e178edadb2/blocks_vertical/procedures.js#L674
+  //https://github.com/scratchfoundation/scratch-blocks/blob/0f6a3f3/src/blocks/procedures.ts#L782
   function modifiedRemoveFieldCallback(field) {
     // Do not delete if there is only one input
     if (this.inputList.length === 1) {
@@ -31,7 +41,7 @@ export default async function ({ addon, console }) {
       var input = this.inputList[n];
       if (input.connection) {
         var target = input.connection.targetBlock();
-        if (target.getField(field.name) === field) {
+        if (field.name && target.getField(field.name) === field) {
           inputNameToRemove = input.name;
         }
       } else {
@@ -59,7 +69,7 @@ export default async function ({ addon, console }) {
       // We account for this with a hacky method of adding the delimiter at the end of the last label input
       if (fnName === "addLabelExternal") {
         const lastInput = proc.inputList[proc.inputList.length - 1];
-        if (lastInput.type === Blockly.DUMMY_INPUT) {
+        if (lastInput.type === INPUT_DUMMY) {
           lastInput.fieldRow[0].setValue(lastInput.fieldRow[0].getValue() + " %l");
         }
       }
@@ -79,9 +89,10 @@ export default async function ({ addon, console }) {
 
   function getFieldInputNameAndIndex(field, inputList) {
     for (const [i, input] of inputList.entries()) {
-      const isTargetField = input.connection
-        ? input.connection.targetBlock()?.getField(field.name) === field
-        : input.fieldRow.includes(field);
+      const isTargetField =
+        input.connection && field.name
+          ? input.connection.targetBlock()?.getField(field.name) === field
+          : input.fieldRow.includes(field);
 
       if (isTargetField) {
         return {
@@ -117,9 +128,9 @@ export default async function ({ addon, console }) {
 
   function focusOnInput(input) {
     if (!input) return;
-    if (input.type === Blockly.DUMMY_INPUT) {
+    if (input.type === INPUT_DUMMY) {
       input.fieldRow[0].showEditor_();
-    } else if (input.type === Blockly.INPUT_VALUE) {
+    } else if (input.type === INPUT_VALUE) {
       const target = input.connection.targetBlock();
       target.getField("TEXT").showEditor_();
     }
@@ -171,30 +182,60 @@ export default async function ({ addon, console }) {
 
   function enableAddon() {
     // pollute the procedures_declaration prototype with a modified version that prevents merging, and allows inserting after
-    polluteProcedureDeclaration(Blockly.Blocks["procedures_declaration"]);
+    if (Blockly.registry) {
+      // new Blockly
+      const originalInit = Blockly.Blocks["procedures_declaration"].init;
+      Blockly.Blocks["procedures_declaration"].init = function () {
+        originalInit.call(this);
+        polluteProcedureDeclaration(this);
+      };
+    } else {
+      polluteProcedureDeclaration(Blockly.Blocks["procedures_declaration"]);
+    }
 
     // if custom procedures modal is already open we also directly pollute the existing procedures_declaration block
     if (addon.tab.redux.state.scratchGui.customProcedures.active) {
       polluteProcedureDeclaration(getExistingProceduresDeclarationBlock(), false);
     }
 
-    Blockly.FieldTextInputRemovable.prototype.showEditor_ = function () {
+    FieldTextInputRemovable.prototype.showEditor_ = function () {
       originalShowEditor.call(this);
       if (addon.self.disabled) return;
-      createArrow("left", () => shiftFieldCallback(this.sourceBlock_, this, "left"));
-      createArrow("right", () => shiftFieldCallback(this.sourceBlock_, this, "right"));
+      if (Blockly.registry) {
+        // new Blockly
+        Blockly.renderManagement.finishQueuedRenders().then(() => createArrows(this));
+      } else {
+        createArrows(this);
+      }
       selectedField = this;
     };
   }
 
   function disableAddon() {
-    Blockly.WidgetDiv.DIV.querySelectorAll(".sa-reorder-inputs-arrow").forEach((e) => e.remove());
+    let widgetDiv;
+    if (Blockly.registry) widgetDiv = Blockly.WidgetDiv.getDiv(); // new Blockly
+    else widgetDiv = Blockly.WidgetDiv.DIV;
+    widgetDiv.querySelectorAll(".sa-reorder-inputs-arrow").forEach((e) => e.remove());
+  }
+
+  let INPUT_DUMMY;
+  let INPUT_VALUE;
+  let FieldTextInputRemovable;
+  if (Blockly.registry) {
+    // new Blockly
+    INPUT_DUMMY = Blockly.inputs.inputTypes.DUMMY;
+    INPUT_VALUE = Blockly.inputs.inputTypes.VALUE;
+    FieldTextInputRemovable = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_input_removable");
+  } else {
+    INPUT_DUMMY = Blockly.DUMMY_INPUT;
+    INPUT_VALUE = Blockly.INPUT_VALUE;
+    FieldTextInputRemovable = Blockly.FieldTextInputRemovable;
   }
 
   const originalCreateAllInputs = Blockly.Blocks["procedures_declaration"].createAllInputs_;
   const originalUpdateDeclarationProcCode = Blockly.Blocks["procedures_declaration"].onChangeFn;
   const originalRemoveFieldCallback = Blockly.Blocks["procedures_declaration"].removeFieldCallback;
-  const originalShowEditor = Blockly.FieldTextInputRemovable.prototype.showEditor_;
+  const originalShowEditor = FieldTextInputRemovable.prototype.showEditor_;
   let originalAddFns = {};
   let selectedField = null;
 


### PR DESCRIPTION
### Changes

Updates "rearrangeable custom block inputs" to work with modern Blockly. The important changes are all in `userscript.js`. `modified-funcs.js` only contains style changes to reflect the updated upstream code.

### Tests

Tested both Scratch versions on Edge and Firefox.