### PR TITLE
editor-preview-comments: New Blockly support and move dark mode styling

### DIFF
--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -81,7 +81,8 @@ export default async function ({ addon, console }) {
       return;
     }
 
-    const el = e.target.closest(".blocklyBubbleCanvas > g, .blocklyBlockCanvas .blocklyDraggable[data-id]");
+    // Note: .blocklyBubbleCanvas > g can be a flyout checkobox on modern Blockly
+    const el = e.target.closest(".blocklyComment.blocklyCollapsed, .blocklyBubbleCanvas > g, .blocklyBlockCanvas .blocklyDraggable[data-id]:not(.blocklyShadow)");
     if (el === hoveredElement) {
       // Nothing to do.
       return;
@@ -94,16 +95,16 @@ export default async function ({ addon, console }) {
     let text = null;
     if (
       addon.settings.get("hover-view") &&
-      e.target.closest(".blocklyBubbleCanvas > g") &&
+      e.target.closest(".blocklyComment.blocklyCollapsed, .blocklyBubbleCanvas > g") &&
       // Hovering over the thin line that connects comments to blocks should never show a preview
       !e.target.closest("line")
     ) {
-      const collapsedText = el.querySelector("text.scratchCommentText");
-      if (collapsedText.getAttribute("display") !== "none") {
+      const collapsedText = el.querySelector("text.blocklyCommentPreview, text.scratchCommentText");
+      if (collapsedText && collapsedText.getAttribute("display") !== "none") {
         const textarea = el.querySelector("textarea");
         text = textarea.value;
       }
-    } else if (e.target.closest(".blocklyBlockCanvas .blocklyDraggable[data-id]")) {
+    } else if (e.target.closest(".blocklyBlockCanvas .blocklyDraggable[data-id]:not(.blocklyShadow)")) {
       const id = el.dataset.id;
       const block = getBlock(id);
       const comment = getComment(block);

--- a/addons/editor-comment-previews/userscript.js
+++ b/addons/editor-comment-previews/userscript.js
@@ -82,7 +82,9 @@ export default async function ({ addon, console }) {
     }
 
     // Note: .blocklyBubbleCanvas > g can be a flyout checkobox on modern Blockly
-    const el = e.target.closest(".blocklyComment.blocklyCollapsed, .blocklyBubbleCanvas > g, .blocklyBlockCanvas .blocklyDraggable[data-id]:not(.blocklyShadow)");
+    const el = e.target.closest(
+      ".blocklyComment.blocklyCollapsed, .blocklyBubbleCanvas > g, .blocklyBlockCanvas .blocklyDraggable[data-id]:not(.blocklyShadow)"
+    );
     if (el === hoveredElement) {
       // Nothing to do.
       return;

--- a/addons/editor-comment-previews/userstyle.css
+++ b/addons/editor-comment-previews/userstyle.css
@@ -17,7 +17,7 @@
   pointer-events: none;
 
   color: var(--editorDarkMode-input-text, #575e75);
-  background-color: var(--editorDarkMode-input-transparent90, rgba(255, 255, 255, 0.9));
+  background-color: var(--editorDarkMode-input-transparent90, rgb(255 255 255 / 90%));
   border-style: none;
   border-radius: 8px;
   filter: drop-shadow(0px 5px 5px rgb(0 0 0 / 10%));
@@ -27,7 +27,7 @@
 
 @supports (backdrop-filter: blur(16px)) {
   .sa-comment-preview-inner {
-    background-color: var(--editorDarkMode-input-transparent75, rgba(255, 255, 255, 0.75));
+    background-color: var(--editorDarkMode-input-transparent75, rgb(255 255 255 / 75%));
     backdrop-filter: blur(16px);
   }
 }

--- a/addons/editor-comment-previews/userstyle.css
+++ b/addons/editor-comment-previews/userstyle.css
@@ -16,8 +16,8 @@
   white-space: pre-wrap;
   pointer-events: none;
 
-  color: rgb(87, 94, 117);
-  background-color: rgb(255 255 255 / 90%);
+  color: var(--editorDarkMode-input-text, #575e75);
+  background-color: var(--editorDarkMode-input-transparent90, rgba(255, 255, 255, 0.9));
   border-style: none;
   border-radius: 8px;
   filter: drop-shadow(0px 5px 5px rgb(0 0 0 / 10%));
@@ -27,7 +27,7 @@
 
 @supports (backdrop-filter: blur(16px)) {
   .sa-comment-preview-inner {
-    background-color: rgb(255 255 255 / 75%);
+    background-color: var(--editorDarkMode-input-transparent75, rgba(255, 255, 255, 0.75));
     backdrop-filter: blur(16px);
   }
 }
@@ -46,6 +46,6 @@
 }
 
 .sa-comment-preview-reduce-transparency {
-  background-color: rgb(255 255 255);
+  background-color: var(--editorDarkMode-input, white);
   backdrop-filter: none;
 }

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -737,17 +737,3 @@ div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="de
   /* The <object> gets a white background if color-scheme is dark. */
   color-scheme: light;
 }
-/* For `editor-comment-previews` */
-.sa-comment-preview-inner {
-  color: var(--editorDarkMode-input-text);
-  background-color: var(--editorDarkMode-input-transparent90);
-}
-@supports (backdrop-filter: blur(16px)) {
-  .sa-comment-preview-inner {
-    background-color: var(--editorDarkMode-input-transparent75);
-    backdrop-filter: blur(16px);
-  }
-}
-.sa-comment-preview-reduce-transparency {
-  background-color: var(--editorDarkMode-input);
-}


### PR DESCRIPTION
### Changes

Adds modern Blockly support `editor-preview-comments`. It was already mostly working but hovering over collapsed comments and the middle section of custom block definitions are now fixed.

Also moves the dark mode support out of `editor-dark-mode` and into the addon.

### Tests

Tested on both editors on Chromium.