### PR TITLE
no-sprite-confirm: React 18 support

### DIFF
--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,5 +1,5 @@
 export default async ({ addon, console }) => {
-  document.body.addEventListener("click", () => {
+  document.body.addEventListener("pointerup", () => {
     setTimeout(() => {
       const confirmButton = document.querySelector("[class^='delete-confirmation-prompt_ok-button_']");
       if (!addon.self.disabled && confirmButton) confirmButton.click();


### PR DESCRIPTION
### Changes

Makes no-sprite-confirm work on React 18. There's apparently some code somewhere that calls `stopPropagation()` on the click event, so the addon now listens for pointerup instead.

### Tests

Tested on Edge (current Scratch version and React 18 branch).