### PR TITLE
Include settings and presets in search

### DIFF
--- a/webpages/settings/data/fuse-options.js
+++ b/webpages/settings/data/fuse-options.js
@@ -29,10 +29,6 @@ export default {
       weight: 0.4,
     },
     {
-      name: "_english.settings.name",
-      weight: 0.2,
-    },
-    {
       name: "credits.name",
       weight: 0.2,
     },

--- a/webpages/settings/data/fuse-options.js
+++ b/webpages/settings/data/fuse-options.js
@@ -47,6 +47,6 @@ export default {
     {
       name: "presets.name",
       weight: 0.1,
-    }
+    },
   ],
 };

--- a/webpages/settings/data/fuse-options.js
+++ b/webpages/settings/data/fuse-options.js
@@ -25,6 +25,14 @@ export default {
       weight: 0.3,
     },
     {
+      name: "settings.name",
+      weight: 0.4,
+    },
+    {
+      name: "_english.settings.name",
+      weight: 0.2,
+    },
+    {
       name: "credits.name",
       weight: 0.2,
     },
@@ -32,5 +40,13 @@ export default {
       name: "info.text",
       weight: 0.1,
     },
+    {
+      name: "settings.potentialValues.name",
+      weight: 0.1,
+    },
+    {
+      name: "presets.name",
+      weight: 0.1,
+    }
   ],
 };


### PR DESCRIPTION
> I wanted to find "separate lists and variables" to turn it off, though showing "Separate" didn't work.

Adds setting names, `select` setting values and preset names to the settings page search results.

Tested on Chromium in English only.