### PR TITLE
Add sticky footer class to forum userscript

### DIFF
--- a/addons/infinite-scroll/forumScroll.js
+++ b/addons/infinite-scroll/forumScroll.js
@@ -1,4 +1,6 @@
 export default async function ({ addon, console, msg }) {
+  document.body.classList.add("sa-collapse-footer");
+
   // Present on forum pages with tbody. Used as a switch to
   // query for table and posts, and determine append/insert location.
   let vf = document.getElementById("vf");


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/pull/6633#issuecomment-2725901668

### Changes

Adds the sticky footer body class when the infinite scrolling forum userscript is run.

### Reason for changes

So the sticky footer's "Only on infinite scrolling pages" setting works as expected on the forums.

### Tests

Tested on Chromium.