### PR TITLE
`player-thumb`: Never disable controls in editor

### DIFF
--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -37,7 +37,6 @@ export default async function ({ addon, console }) {
       alerts.style.display = "flex";
     }
     if (e.detail.action.type === "scratch-gui/vm-status/SET_STARTED_STATE") {
-      controls.classList.remove("sa-controls-disabled");
       thumb.remove();
       addon.tab.redux.removeEventListener("statechanged", handleStateChange);
     }

--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -37,6 +37,7 @@ export default async function ({ addon, console }) {
       alerts.style.display = "flex";
     }
     if (e.detail.action.type === "scratch-gui/vm-status/SET_STARTED_STATE") {
+      controls.classList.remove("sa-controls-disabled");
       thumb.remove();
       addon.tab.redux.removeEventListener("statechanged", handleStateChange);
     }

--- a/addons/player-thumb/userstyle.css
+++ b/addons/player-thumb/userstyle.css
@@ -10,7 +10,7 @@
   z-index: 4999;
 }
 
-.sa-controls-disabled > img {
+body:not(.sa-body-editor) .sa-controls-disabled > img {
   pointer-events: none;
   opacity: 0.5;
 }


### PR DESCRIPTION
Resolves #7928

### Changes

Adds `body:not(.sa-body-editor)` to the selector for disabling the project controls so it never happens in the editor.

### Reason for changes

I haven't seen any reports about disabled controls on the project page and if it does ever happen at least the user is able to open the editor as a workaround without reloading the page.

### Tests

I can't reproduce the issue but the addon still works as before on Chromium.
