### PR TITLE
Disable some addons for April Fools - 2025

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -4,8 +4,11 @@
  */
 
 import { updateAllBlocks } from "../../libraries/common/cs/update-all-blocks.js";
+import { isScratchAprilFools25 } from "../hide-flyout/april-fools.js";
 
 export default async function ({ addon, console }) {
+  if (await isScratchAprilFools25(addon.tab.redux)) return;
+
   const Blockly = await addon.tab.traps.getBlockly();
 
   const shouldWatchMouseCursor = addon.settings.get("watch");

--- a/addons/columns/userscript.js
+++ b/addons/columns/userscript.js
@@ -1,4 +1,15 @@
+import { isScratchAprilFools25 } from "../hide-flyout/april-fools.js";
+
 export default async function ({ addon, msg, console }) {
+  if (await isScratchAprilFools25(addon.tab.redux)) {
+    const removeStyles = () => {
+      document.querySelector("link[rel=stylesheet][data-addon-id=columns]").remove();
+    };
+    removeStyles();
+    addon.self.addEventListener("reenabled", () => setTimeout(removeStyles, 500));
+    return;
+  }
+
   const Blockly = await addon.tab.traps.getBlockly();
 
   // https://github.com/scratchfoundation/scratch-blocks/blob/893c7e7ad5bfb416eaed75d9a1c93bdce84e36ab/core/toolbox.js#L235

--- a/addons/data-category-tweaks-v2/userscript.js
+++ b/addons/data-category-tweaks-v2/userscript.js
@@ -1,6 +1,9 @@
 import updateToolboxXML from "../../libraries/common/cs/update-toolbox-xml.js";
+import { isScratchAprilFools25 } from "../hide-flyout/april-fools.js";
 
 export default async function ({ addon, console, msg, safeMsg }) {
+  if (await isScratchAprilFools25(addon.tab.redux)) return;
+
   const ScratchBlocks = await addon.tab.traps.getBlockly();
 
   const SMALL_GAP = 8;

--- a/addons/hide-flyout/april-fools.js
+++ b/addons/hide-flyout/april-fools.js
@@ -1,0 +1,22 @@
+const MARCH_31TH = 1743379200; // GMT March 31, 2025 12:00:00 AM
+const APRIL_3RD = 1743638400; // GMT April 3, 2025 12:00:00 AM
+
+export const isScratchAprilFools25 = async (redux) => {
+  const now = Date.now() / 1000;
+  if (now > APRIL_3RD) return false;
+
+  if (document.readyState !== "complete") {
+    // data-category-tweaks-v2
+    await new Promise((resolve) => window.addEventListener("load", () => resolve(), { once: true }));
+  }
+
+  let isAprilFools = false;
+  if (!redux.state && now < APRIL_3RD && now > MARCH_31TH) isAprilFools = true;
+  else {
+    await redux.waitForState((state) => state.session?.session?.flags);
+    isAprilFools = Object.entries(redux.state.session.session.flags).some(
+      ([k, v]) => k.includes("normal") && v === true
+    );
+  }
+  return isAprilFools;
+};

--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -1,4 +1,8 @@
+import { isScratchAprilFools25 } from "./april-fools.js";
+
 export default async function ({ addon, console, msg }) {
+  if (await isScratchAprilFools25(addon.tab.redux)) return;
+
   let placeHolderDiv = null;
   let lockObject = null;
   let lockButton = null;


### PR DESCRIPTION
Clone of #7308

Lessons learnt from last year:
- It's definitely not April Fools after April 3rd 2025 (if there's any problem with the detection code, we don't need to ship an update to fix it)
- Switch all addons that have this check to runAtComplete:true by waiting until page load, this ensures Redux works properly

For testing: use the Overrides feature of Chrome Devtools to set the everything_is_totally_normal flag to true on GET /session

TODOs

- [ ] Check if any additional addons have been added this year that would also need disabling
- [ ] Ensure those addons with userstyles that affect the page do get their styles removed (in special, the columns addon)