### PR TITLE
place-backpack-code-at-cursor: new Blockly

### DIFF
--- a/addons/place-backpack-code-at-cursor/userscript.js
+++ b/addons/place-backpack-code-at-cursor/userscript.js
@@ -22,8 +22,11 @@ export default async function ({ addon, console }) {
     const BLOCKS_DEFAULT_SCALE = 0.675; // would be better if we could get this from lib/layout-constants.js
     const { targets } = redux.state.scratchGui.workspaceMetrics;
     const { isRtl } = redux.state.locales;
-    const { left, right } = workspace.scrollbar.hScroll.outerSvg_.getBoundingClientRect();
-    const { top } = workspace.scrollbar.vScroll.outerSvg_.getBoundingClientRect();
+    const { hScroll, vScroll } = workspace.scrollbar;
+    const hScrollSvg = hScroll.outerSvg || hScroll.outerSvg_; // new Blockly || old Blockly
+    const vScrollSvg = vScroll.outerSvg || vScroll.outerSvg_;
+    const { left, right } = hScrollSvg.getBoundingClientRect();
+    const { top } = vScrollSvg.getBoundingClientRect();
 
     const insideWorkspace = isRtl ? mouseX > left : mouseX < right;
     const topBlock = blocks.find((block) => block.topLevel);


### PR DESCRIPTION
### Changes

Makes "place backpack code at mouse" compatible with modern Blockly.

### Tests

Tested on Edge and Firefox. Dropping code from the backpack is quite broken on new Blockly, even with SA disabled (for example: dropping a script twice causes all other scripts to disappear), but it does get placed at the mouse position when the addon is enabled.

To test this, you can:
1. Clone scratch-www and change the version of `@scratch/scratch-gui` in package.json to `^11.1.0-spork.15`
2. Download and run cors-anywhere
3. In the scratch-www directory: `API_HOST=http://localhost:8080/https://api.scratch.mit.edu BACKPACK_HOST=http://localhost:8080/https://backpack.scratch.mit.edu npm start`
4. Use [Redirector](https://github.com/einaregilsson/Redirector) to make `/session` work