### PR TITLE
discuss-button: Add extension settings preset

### DIFF
--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -87,6 +87,10 @@
         {
           "name": "Wiki",
           "values": { "name": "Wiki", "url": "https://scratch-wiki.info/" }
+        },
+        {
+          "name": "Scratch Addons settings",
+          "values": { "name": "Addons", "url": "/scratch-addons-extension/settings/" }
         }
       ]
     },


### PR DESCRIPTION
### Changes

Adds a Scratch Addons settings preset to the customizable navigation bar.

### Reason for changes

It's not obvious it's possible and it could be useful for those who don't pin the extension. I used the Scratch URL instead of the scratchaddons.com one to avoid the redirect message.

### Tests

Tested on Chromium.
