### PR TITLE
Fix huge lag spike when opening insert blocks by name menu in TurboWarp with some extensions

### DIFF
--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -762,7 +762,7 @@ class TokenTypeBlock extends TokenType {
 
   /**
    * @param {QueryInfo} query
-   * @param {number} idxi
+   * @param {number} idx
    * @param {number} depth
    * @returns
    */

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -753,7 +753,7 @@ class TokenTypeBlock extends TokenType {
     enumerateStringForms();
 
     if (this.stringForms.length >= WorkspaceQuerier.MAX_STRING_FORMS) {
-      console.log(
+      console.warn(
         "Warning: Block '" + this.block.id + "' has too many string forms. Search results may not be very good."
       );
       this.stringForms.length = 0;
@@ -1222,12 +1222,12 @@ export default class WorkspaceQuerier {
       }
       ++query.resultCount;
       if (!limited && query.resultCount >= WorkspaceQuerier.MAX_RESULTS) {
-        console.log("Warning: Workspace query exceeded maximum result count.");
+        console.warn("Warning: Workspace query exceeded maximum result count.");
         limited = true;
       }
 
       if (!query.canCreateMoreTokens()) {
-        console.log("Warning: Workspace query exceeded maximum token count.");
+        console.warn("Warning: Workspace query exceeded maximum token count.");
         limited = true;
         break;
       }

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -733,9 +733,7 @@ class TokenTypeBlock extends TokenType {
           strings.push(...blockPart.toLowerCase().split(" "));
         } else if (blockPart.type === BlockInputType.ENUM) {
           for (const enumValue of blockPart.values) {
-
-            if (this.stringForms.length >= WorkspaceQuerier.MAX_RESULTS)
-                return;
+            if (this.stringForms.length >= WorkspaceQuerier.MAX_RESULTS) return;
 
             enumerateStringForms(
               partIdx + 1,
@@ -755,8 +753,10 @@ class TokenTypeBlock extends TokenType {
     enumerateStringForms();
 
     if (this.stringForms.length >= WorkspaceQuerier.MAX_STRING_FORMS) {
-        console.log("Warning: Block '" + this.block.id + "' has too many string forms. Search results may not be very good.");
-        this.stringForms.length = 0;
+      console.log(
+        "Warning: Block '" + this.block.id + "' has too many string forms. Search results may not be very good."
+      );
+      this.stringForms.length = 0;
     }
   }
 
@@ -1175,9 +1175,9 @@ export default class WorkspaceQuerier {
    */
   static MAX_TOKENS = 100000;
 
-   /**
-    * The maximum number of string forms a block can have before we give up.
-    */
+  /**
+   * The maximum number of string forms a block can have before we give up.
+   */
   static MAX_STRING_FORMS = 500;
 
   /**

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -733,6 +733,10 @@ class TokenTypeBlock extends TokenType {
           strings.push(...blockPart.toLowerCase().split(" "));
         } else if (blockPart.type === BlockInputType.ENUM) {
           for (const enumValue of blockPart.values) {
+
+            if (this.stringForms.length >= WorkspaceQuerier.MAX_RESULTS)
+                return;
+
             enumerateStringForms(
               partIdx + 1,
               [...strings, ...enumValue.string.toLowerCase().split(" ")],
@@ -749,11 +753,16 @@ class TokenTypeBlock extends TokenType {
     };
 
     enumerateStringForms();
+
+    if (this.stringForms.length >= WorkspaceQuerier.MAX_STRING_FORMS) {
+        console.log("Warning: Block '" + this.block.id + "' has too many string forms. Search results may not be very good.");
+        this.stringForms.length = 0;
+    }
   }
 
   /**
    * @param {QueryInfo} query
-   * @param {number} idx
+   * @param {number} idxi
    * @param {number} depth
    * @returns
    */
@@ -1159,12 +1168,17 @@ export default class WorkspaceQuerier {
   /**
    * The maximum number of results to find before we give up searching sub-blocks.
    */
-  static MAX_RESULTS = 1000;
+  static MAX_RESULTS = 2000;
 
   /**
    * The maximum number of tokens to find before giving up.
    */
-  static MAX_TOKENS = 10000;
+  static MAX_TOKENS = 100000;
+
+   /**
+    * The maximum number of string forms a block can have before we give up.
+    */
+  static MAX_STRING_FORMS = 500;
 
   /**
    * Indexes a workspace in preparation for querying it.


### PR DESCRIPTION
This fixed an issue where with certain TurboWarp extensions installed, opening the middle click popup menu would cause a huge lag spike, up to 20-30 seconds. I forgot to put a limit on one of the loops, nothing in normal Scratch should be effected as the limit can't be hit by the vanilla blocks.