### PR TITLE
preview-project-description: React 18 support

### DIFF
--- a/addons/preview-project-description/userscript.js
+++ b/addons/preview-project-description/userscript.js
@@ -107,12 +107,14 @@ export default async function ({ addon, console, msg }) {
 
     forceReactRerender();
 
-    if (!document.querySelector(".project-description")) {
-      // Something went wrong for some reason...
-      console.log("Failed to show preview of project notes.");
-      checkboxInput.checked = false;
-      currentlyEnabled = false;
-    }
+    setTimeout(() => {
+      if (!document.querySelector(".project-description")) {
+        // Something went wrong for some reason...
+        console.log("Failed to show preview of project notes.");
+        checkboxInput.checked = false;
+        currentlyEnabled = false;
+      }
+    }, 0);
   }
 
   function forceReactRerender() {


### PR DESCRIPTION
### Changes

Makes the preview-project-description addon work on React 18.

### Tests

Tested [React 18 branch](https://github.com/scratchfoundation/scratch-www/tree/react-18-update) on Edge.