### PR TITLE
transparent-orphans: new Blockly

### DIFF
--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -40,6 +40,12 @@
       "default": 25
     }
   ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
   "userstyles": [
     {
       "url": "userstyle.css",

--- a/addons/transparent-orphans/userscript.js
+++ b/addons/transparent-orphans/userscript.js
@@ -1,0 +1,20 @@
+export default async function ({ addon, console }) {
+  // Add data-shapes attribute on new Blockly
+  const Blockly = await addon.tab.traps.getBlockly();
+  if (!Blockly.registry) return;
+
+  const addShapeAttribute = (block) => {
+    if (!block.outputConnection && !block.previousConnection) {
+      block.svgGroup.setAttribute("data-shapes", "hat");
+    }
+  };
+  for (const block of addon.tab.traps.getWorkspace().getAllBlocks()) {
+    addShapeAttribute(block);
+  }
+
+  const oldBlockInitSvg = Blockly.BlockSvg.prototype.initSvg;
+  Blockly.BlockSvg.prototype.initSvg = function (...args) {
+    addShapeAttribute(this);
+    return oldBlockInitSvg.call(this, ...args);
+  };
+}


### PR DESCRIPTION
### Changes

Updates "block transparency" to work with modern Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox.