### PR TITLE
blocks2image: new Blockly

### DIFF
--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -328,6 +328,12 @@ export default async function ({ addon, console, msg }) {
 
     svgchild = svgchild.cloneNode(true);
     svgchild.setAttribute("transform", `translate(${-Math.min(...xArr) + scale},${translateY}) scale(${scale})`);
+
+    // Include comment text in the exported SVG
+    for (const textarea of svgchild.querySelectorAll(".blocklyTextarea")) {
+      textarea.innerText = textarea.value;
+    }
+
     setCSSVars(svg);
     svg.append(makeStyle());
     svg.append(svgchild);

--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -259,12 +259,13 @@ export default async function ({ addon, console, msg }) {
       }, {});
     };
 
+    const getHref = (item) => item.getAttribute("xlink:href") || item.getAttribute("href");
     const externalImages = /*Object.*/ groupBy(
       Array.from(svg.querySelectorAll("image")).filter((item) => {
-        const iconUrl = item.getAttribute("xlink:href");
+        const iconUrl = getHref(item);
         return iconUrl && !iconUrl.startsWith("data:");
       }),
-      (item) => item.getAttribute("xlink:href")
+      (item) => getHref(item)
     );
 
     // replace external images with data URIs
@@ -276,7 +277,10 @@ export default async function ({ addon, console, msg }) {
           reader.addEventListener("load", () => resolve(reader.result));
           reader.readAsDataURL(blob);
         });
-        externalImages[iconUrl].forEach((item) => item.setAttribute("xlink:href", dataUri));
+        externalImages[iconUrl].forEach((item) => {
+          item.removeAttribute("href");
+          item.setAttribute("xlink:href", dataUri);
+        });
       })
     );
     if (isExportPNG) {

--- a/addons/blocks2image/userscript.js
+++ b/addons/blocks2image/userscript.js
@@ -5,7 +5,9 @@ export default async function ({ addon, console, msg }) {
 
   function makeStyle() {
     let style = document.createElement("style");
-    style.textContent = Blockly.registry ? "" : `
+    style.textContent = Blockly.registry
+      ? ""
+      : `
     .blocklyText {
         fill: ${Blockly.Colours.text};
         font-family: "Helvetica Neue", Helvetica, sans-serif;


### PR DESCRIPTION
### Changes

Makes the Save blocks as image addon compatible with modern Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox. When "Save All as Image" is used on new Blockly, comments are included in the image, which I think makes sense.