### PR TITLE
Cleanup blocks improvements

### DIFF
--- a/addons-l10n/en/editor-cleanup-plus.json
+++ b/addons-l10n/en/editor-cleanup-plus.json
@@ -1,6 +1,6 @@
 {
   "editor-cleanup-plus/orphaned": "{count, plural, one {Cleanup Plus: Delete 1 orphaned reporter block?} other {Developer tools: Delete # orphaned reporter blocks?} }",
-  "editor-cleanup-plus/unused-var": "{count, plural, one {Cleanup Plus: Delete 1 unused local variable? Here it is:\n} other {Developer tools: Delete # unused local variables? Here they are:\n} }",
-  "editor-cleanup-plus/unused-list": "{count, plural, one {Cleanup Plus: Delete 1 unused local list? Here it is:\n} other {Developer tools: Delete # unused local lists? Here they are:\n} }",
+  "editor-cleanup-plus/unused-var": "{count, plural, one {Cleanup Plus: Delete 1 unused local variable? Here it is:\n{names}} other {Developer tools: Delete # unused local variables? Here they are:\n{names}} }",
+  "editor-cleanup-plus/unused-list": "{count, plural, one {Cleanup Plus: Delete 1 unused local list? Here it is:\n{names}} other {Developer tools: Delete # unused local lists? Here they are:\n{names}} }",
   "editor-cleanup-plus/clean-plus": "Clean up Blocks +"
 }

--- a/addons-l10n/en/editor-cleanup-plus.json
+++ b/addons-l10n/en/editor-cleanup-plus.json
@@ -1,6 +1,6 @@
 {
   "editor-cleanup-plus/orphaned": "{count, plural, one {Cleanup Plus: Delete 1 orphaned reporter block?} other {Developer tools: Delete # orphaned reporter blocks?} }",
-  "editor-cleanup-plus/unused-var": "{count, plural, one {Cleanup Plus: Delete 1 unused local variable? Here it is:\n{names}} other {Developer tools: Delete # unused local variables? Here they are:\n{names}} }",
-  "editor-cleanup-plus/unused-list": "{count, plural, one {Cleanup Plus: Delete 1 unused local list? Here it is:\n{names}} other {Developer tools: Delete # unused local lists? Here they are:\n{names}} }",
+  "editor-cleanup-plus/unused-var": "{count, plural, one {Cleanup Plus: Delete 1 unused local variable? Here it is:\n{names}} other {Cleanup Plus: Delete # unused local variables? Here they are:\n{names}} }",
+  "editor-cleanup-plus/unused-list": "{count, plural, one {Cleanup Plus: Delete 1 unused local list? Here it is:\n{names}} other {Cleanup Plus: Delete # unused local lists? Here they are:\n{names}} }",
   "editor-cleanup-plus/clean-plus": "Clean up Blocks +"
 }

--- a/addons/editor-cleanup-plus/addon.json
+++ b/addons/editor-cleanup-plus/addon.json
@@ -10,6 +10,14 @@
       "link": "https://scratch.mit.edu/users/Chrome_Cat/"
     }
   ],
+  "settings": [
+    {
+      "name": "Find unused variables",
+      "id": "promptUnused",
+      "type": "boolean",
+      "default": false
+    }
+  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "userscripts": [

--- a/addons/editor-cleanup-plus/addon.json
+++ b/addons/editor-cleanup-plus/addon.json
@@ -13,6 +13,7 @@
   "settings": [
     {
       "name": "Find unused variables",
+      "description": "Find unused reporters, variables and lists for this sprite only and ask to delete them.",
       "id": "promptUnused",
       "type": "boolean",
       "default": false

--- a/addons/editor-cleanup-plus/addon.json
+++ b/addons/editor-cleanup-plus/addon.json
@@ -28,5 +28,5 @@
   ],
   "versionAdded": "1.43.0",
   "tags": ["editor", "codeEditor", "recommended"],
-  "enabledByDefault": false
+  "enabledByDefault": true
 }

--- a/addons/editor-cleanup-plus/userscript.js
+++ b/addons/editor-cleanup-plus/userscript.js
@@ -85,24 +85,24 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
     const workspace = addon.tab.traps.getWorkspace();
     const map = workspace.getVariableMap();
     const vars = map.getVariablesOfType("");
-    const unusedVariables = [];
+    const unusedLocals = [];
 
     for (const row of vars) {
       if (row.isLocal) {
         const usages = getVariableUsesById(row.getId(), workspace);
         if (!usages || usages.length === 0) {
-          unusedVariables.push(row);
+          unusedLocals.push(row);
         }
       }
     }
 
-    if (unusedVariables.length > 0) {
+    if (unusedLocals.length > 0) {
       const message = msg("unused-var", {
-        count: unusedVariables.length,
-        names: unusedVariables.map((x) => x.name).join(", "),
+        count: unusedLocals.length,
+        names: unusedLocals.map((x) => x.name).join(", "),
       });
       if (confirm(message)) {
-        for (const orphan of unusedVariables) {
+        for (const orphan of unusedLocals) {
           workspace.deleteVariableById(orphan.getId());
         }
       }

--- a/addons/editor-cleanup-plus/userscript.js
+++ b/addons/editor-cleanup-plus/userscript.js
@@ -41,28 +41,32 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
       }
     }
 
-    let cursorX = 48;
+    const gridSize = workspace.getGrid().spacing || workspace.getGrid().spacing_; // new blockly || old blockly
+
+    // coordinates start between the workspace dots but script-snap snaps to them
+    let cursorX = gridSize / 2;
 
     let maxWidths = result.maxWidths;
 
     for (const column of columns) {
-      let cursorY = 64;
+      let cursorY = gridSize / 2;
       let maxWidth = 0;
 
       for (const block of column.blocks) {
-        let extraHeight = 72;
         let xy = block.getRelativeToSurfaceXY();
         if (cursorX - xy.x !== 0 || cursorY - xy.y !== 0) {
           block.moveBy(cursorX - xy.x, cursorY - xy.y);
         }
         let heightWidth = block.getHeightWidth();
-        cursorY += heightWidth.height + extraHeight;
+        cursorY += heightWidth.height + gridSize;
+        cursorY += gridSize - ((cursorY + gridSize / 2) % gridSize);
 
         let maxWidthWithComments = maxWidths[block.id] || 0;
         maxWidth = Math.max(maxWidth, Math.max(heightWidth.width, maxWidthWithComments));
       }
 
-      cursorX += maxWidth + 96;
+      cursorX += maxWidth + gridSize;
+      cursorX += gridSize - ((cursorX + gridSize / 2) % gridSize);
     }
 
     let topComments = workspace.getTopComments();

--- a/addons/script-snap/userscript.js
+++ b/addons/script-snap/userscript.js
@@ -24,7 +24,7 @@ export default async function ({ addon, console }) {
       else workspace.grid.spacing = 40;
       workspace.grid.update(workspace.scale);
     } else {
-      console.log(addon.settings.get("grid"))
+      console.log(addon.settings.get("grid"));
       workspace.grid_.snapToGrid_ = enabled;
       if (enabled) workspace.grid_.spacing_ = Number(addon.settings.get("grid"));
       else workspace.grid_.spacing_ = 40;

--- a/addons/script-snap/userscript.js
+++ b/addons/script-snap/userscript.js
@@ -19,12 +19,14 @@ export default async function ({ addon, console }) {
     if (Blockly.registry) {
       // New Blockly
       workspace.grid.snapToGrid = enabled;
-      if (enabled) workspace.grid.spacing = addon.settings.get("grid");
+      // TODO: Fix the root cause of the type bug (#8268)
+      if (enabled) workspace.grid.spacing = Number(addon.settings.get("grid"));
       else workspace.grid.spacing = 40;
       workspace.grid.update(workspace.scale);
     } else {
+      console.log(addon.settings.get("grid"))
       workspace.grid_.snapToGrid_ = enabled;
-      if (enabled) workspace.grid_.spacing_ = addon.settings.get("grid");
+      if (enabled) workspace.grid_.spacing_ = Number(addon.settings.get("grid"));
       else workspace.grid_.spacing_ = 40;
       workspace.grid_.update(workspace.scale);
     }

--- a/addons/script-snap/userscript.js
+++ b/addons/script-snap/userscript.js
@@ -19,14 +19,12 @@ export default async function ({ addon, console }) {
     if (Blockly.registry) {
       // New Blockly
       workspace.grid.snapToGrid = enabled;
-      // TODO: Fix the root cause of the type bug (#8268)
-      if (enabled) workspace.grid.spacing = Number(addon.settings.get("grid"));
+      if (enabled) workspace.grid.spacing = addon.settings.get("grid");
       else workspace.grid.spacing = 40;
       workspace.grid.update(workspace.scale);
     } else {
-      console.log(addon.settings.get("grid"));
       workspace.grid_.snapToGrid_ = enabled;
-      if (enabled) workspace.grid_.spacing_ = Number(addon.settings.get("grid"));
+      if (enabled) workspace.grid_.spacing_ = addon.settings.get("grid");
       else workspace.grid_.spacing_ = 40;
       workspace.grid_.update(workspace.scale);
     }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -733,6 +733,15 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
           delete settings.hoverToolbar;
           madeAnyChanges = madeChangesToAddon = true;
         }
+
+        if (addonId === "editor-devtools" && settings.enableCleanUpPlus === false) {
+          // Transition v1.42 to v1.43
+          // Disable editor-cleanup-plus if turned off in editor-devtools
+          addonsEnabled["editor-cleanup-plus"] = false;
+          delete settings.enableCleanUpPlus;
+          madeChangesToAddon = true;
+          madeAnyChanges = true;
+        }
       }
 
       if (addonsEnabled[addonId] === undefined) addonsEnabled[addonId] = !!manifest.enabledByDefault;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -736,7 +736,8 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
 
         if (addonId === "editor-cleanup-plus" && addonsEnabled[addonId] === undefined) {
           if (addonSettings["editor-devtools"]?.enableCleanUpPlus !== undefined) {
-            const enabledStatus = addonsEnabled["editor-devtools"] && addonSettings["editor-devtools"].enableCleanUpPlus;
+            const enabledStatus =
+              addonsEnabled["editor-devtools"] && addonSettings["editor-devtools"].enableCleanUpPlus;
             addonsEnabled[addonId] = enabledStatus;
             madeAnyChanges = true;
           } else {

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -734,13 +734,14 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
           madeAnyChanges = madeChangesToAddon = true;
         }
 
-        if (addonId === "editor-devtools" && settings.enableCleanUpPlus === false) {
-          // Transition v1.42 to v1.43
-          // Disable editor-cleanup-plus if turned off in editor-devtools
-          addonsEnabled["editor-cleanup-plus"] = false;
-          delete settings.enableCleanUpPlus;
-          madeChangesToAddon = true;
-          madeAnyChanges = true;
+        if (addonId === "editor-cleanup-plus" && addonsEnabled[addonId] === undefined) {
+          if (addonSettings["editor-devtools"]?.enableCleanUpPlus !== undefined) {
+            const enabledStatus = addonsEnabled["editor-devtools"] && addonSettings["editor-devtools"].enableCleanUpPlus;
+            addonsEnabled[addonId] = enabledStatus;
+            madeAnyChanges = true;
+          } else {
+            // Respect the value of enabledByDefault (by doing nothing)
+          }
         }
       }
 


### PR DESCRIPTION
Resolves #4131
Progress on #6671

### Changes

- The unsued variable and related prompts are now optional and disabled by default
- Aligns scripts to the same grid as `script-snap`
- Don't modify the unused block messages directly
- Changes a bunch of `let`s to `const`s
- ~~Renames `unusedLocals` to `unusedVariables`~~
- Gets the workspace more directly
- Enables the addon by default

### Reason for changes

It's annoying getting so many prompts and cleanup not using the same grid.

### Tests

Tested on Chromium.