### PR TITLE
Fix highlighter errors outside editor

### DIFF
--- a/addons/editor-stepping/highlighter.js
+++ b/addons/editor-stepping/highlighter.js
@@ -104,6 +104,7 @@ class Highlighter {
   }
 
   setGlowingThreads(threads) {
+    if (this.addon.tab.editorMode !== "editor") return;
     const elementsToHighlight = new Set();
     const workspace = this.addon.tab.traps.getWorkspace();
 


### PR DESCRIPTION
Adds an editor check to `setGlowingThreads()` since `addon.tab.traps.getWorkspace()` throws an error outside the editor which wasn't the case with `Blockly.getMainWorkspace()`.

I haven't checked if this effects other addons.

Tested on Chromium.