### PR TITLE
Add latestUpdate to forum-post-countdown

### DIFF
--- a/addons/forum-post-countdown/addon.json
+++ b/addons/forum-post-countdown/addon.json
@@ -5,6 +5,7 @@
   "versionAdded": "1.34.0",
   "latestUpdate": {
     "version": "1.43.0",
+    "temporaryNotice": "The countdown is now more accurate.",
     "newSettings": ["retry"]
   },
   "userscripts": [

--- a/addons/forum-post-countdown/addon.json
+++ b/addons/forum-post-countdown/addon.json
@@ -3,6 +3,10 @@
   "description": "After submitting a forum post, displays a countdown on the submit button showing how long you have to wait before posting again.",
   "tags": ["community", "forums"],
   "versionAdded": "1.34.0",
+  "latestUpdate": {
+    "version": "1.43.0",
+    "newSettings": ["retry"]
+  },
   "userscripts": [
     {
       "url": "userscript.js",


### PR DESCRIPTION
### Changes

Marks `forum-post-countdown`'s retry setting as new on the settings page. I can also add a mention about the improved accuracy but didn't for now.

### Tests

Tested on Chromium.