### PR TITLE
middle-click-popup: new Blockly fix

### DIFF
--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -374,7 +374,7 @@ export class BlockTypeInfo {
    * @returns {BlockTypeInfo[]}
    */
   static getBlocks(Blockly, vm, workspace, locale) {
-    const flyoutWorkspace = workspace.getToolbox()?.flyout_.getWorkspace();
+    const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
     if (!flyoutWorkspace) return [];
 
     const blocks = [];


### PR DESCRIPTION
### Changes

Blockly has renamed the `flyout_` attribute of the toolbox to `flyout` without an underscore, which broke the middle click popup addon. This PR updates it.

### Tests

Tested on Edge.