### PR TITLE
Fix number settings

### DIFF
--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -88,7 +88,7 @@ export default async function ({ template }) {
       checkValidity() {
         // Needed to get just changed input to enforce it's min, max, and integer rule if the user "manually" sets the input to a value.
         let input = this.$event.target;
-        this.addonSettings[this.setting.id] = input.validity.valid ? input.value : this.setting.default;
+        if (!input.validity.valid) this.addonSettings[this.setting.id] = this.setting.default;
       },
       keySettingKeyDown(e) {
         e.preventDefault();


### PR DESCRIPTION
Resolves #8268

Tested on Edge and Firefox.

This was actually a bug in the settings page code - it was reading the input's `value` attribute, which is a string.