### PR TITLE
New addon: Put sprite duplicates next to original sprite

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -160,6 +160,7 @@
   "no-sprite-confirm",
   "costume-editor-shortcuts",
   "live-read-topics",
+  "duplicate-after-sprite",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/duplicate-after-sprite/addon.json
+++ b/addons/duplicate-after-sprite/addon.json
@@ -1,0 +1,20 @@
+{
+  "name": "Put sprite duplicates next to original sprite",
+  "description": "When duplicating a sprite, puts the duplicates next to the original one in the sprite menu.",
+  "versionAdded": "1.43.0",
+  "tags": ["editor"],
+  "userscripts": [
+    {
+      "matches": ["projects"],
+      "url": "userscript.js"
+    }
+  ],
+  "credits": [
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/duplicate-after-sprite/userscript.js
+++ b/addons/duplicate-after-sprite/userscript.js
@@ -1,0 +1,26 @@
+export default async function ({ addon, console }) {
+  await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState === "SHOWING_WITH_ID");
+
+  const SA_DUPLICATE_OF = Symbol("SA_DUPLICATE_OF");
+
+  const duplicate = addon.tab.traps.vm.runtime.targets[0].sprite.constructor.prototype.duplicate;
+  addon.tab.traps.vm.runtime.targets[0].sprite.constructor.prototype.duplicate = function () {
+    return duplicate.call(this).then((sprite) => {
+      sprite[SA_DUPLICATE_OF] = this;
+      return sprite;
+    });
+  };
+
+  const addTarget = addon.tab.traps.vm.runtime.addTarget;
+  addon.tab.traps.vm.runtime.addTarget = function (target) {
+    addTarget.call(this, target);
+    if (!addon.self.disabled && SA_DUPLICATE_OF in target.sprite) {
+      addon.tab.traps.vm.reorderTarget(
+        addon.tab.traps.vm.runtime.targets.length - 1,
+        addon.tab.traps.vm.runtime.targets.findIndex(
+          (candidate) => candidate.sprite === target.sprite[SA_DUPLICATE_OF]
+        ) + 1
+      );
+    }
+  };
+}


### PR DESCRIPTION
Resolves #8272

### Changes

Adds a new addon that ensures that sprite duplicates are always positioned next to the original sprite

### Reason for changes

Convenience

### Tests

Tested in MS Edge