### PR TITLE
mediarecorder: update description

### DIFF
--- a/addons/mediarecorder/addon.json
+++ b/addons/mediarecorder/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Project video recorder",
-  "description": "Adds a \"start recording\" button to the editor menu bar that allows you to record the project's stage.",
+  "description": "Adds a \"record\" button to the editor menu bar that allows you to record the project's stage.",
   "tags": ["editor", "editorMenuBar", "recommended"],
   "userscripts": [
     {


### PR DESCRIPTION
The description of the Project video recorder addon wasn't updated when the button's label was changed from "Start Recording" to "Record".