### PR TITLE
fix #8288

### DIFF
--- a/addons/asset-conflict-dialog/userscript.js
+++ b/addons/asset-conflict-dialog/userscript.js
@@ -94,7 +94,7 @@ export default async function ({ addon, console, msg }) {
       // abuses the fact that new costumes don't have an asset property and new sounds have a format property set to ""
       const isNewAsset =
         (type === "costume" && !assetObj.asset && assetObj?.skinId === null) ||
-        (type === "sound" && assetObj.format === "" && !assetObj.asset.clean);
+        (type === "sound" && assetObj.format === "" && !assetObj.asset?.clean);
       if (isNewAsset) return originalFn.call(this, ...args);
 
       // folders addon compatibility


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #8288

### Changes

Allows unset asset prop when checking clean on asset prop.

### Reason for changes

See issue. Randomness was likely due to race conditions.

### Tests

Added 25 surprise assets without error.
