### PR TITLE
Make addonPreview a boolean option

### DIFF
--- a/addons/compact-messages/addon.json
+++ b/addons/compact-messages/addon.json
@@ -41,9 +41,7 @@
       "max": 16
     }
   ],
-  "addonPreview": {
-    "type": "compact-messages"
-  },
+  "addonPreview": true,
   "userstyles": [
     {
       "url": "styles.css",

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2733,9 +2733,7 @@
       }
     }
   ],
-  "addonPreview": {
-    "type": "dark-www"
-  },
+  "addonPreview": true,
   "presetPreview": {
     "type": "palette",
     "colors": ["button", "navbar", "page", "box", "gray", "blue"]

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1537,9 +1537,7 @@
       }
     }
   ],
-  "addonPreview": {
-    "type": "editor-dark-mode"
-  },
+  "addonPreview": true,
   "presetPreview": {
     "type": "palette",
     "colors": ["primary", "menuBar", "page", "accent", "workspace", "selector"]

--- a/addons/stage-monitor/addon.json
+++ b/addons/stage-monitor/addon.json
@@ -138,9 +138,7 @@
       }
     }
   ],
-  "addonPreview": {
-    "type": "stage-monitor"
-  },
+  "addonPreview": true,
   "presetPreview": {
     "type": "stage-monitor-preset"
   },

--- a/addons/workspace-dots/addon.json
+++ b/addons/workspace-dots/addon.json
@@ -29,9 +29,7 @@
       "if": { "settings": { "theme": ["dots", "crosshairs", "lines", "vertical", "horizontal"] } }
     }
   ],
-  "addonPreview": {
-    "type": "workspace-dots"
-  },
+  "addonPreview": true,
   "dynamicEnable": true,
   "dynamicDisable": true,
   "credits": [{ "name": "Jazza", "link": "https://scratch.mit.edu/users/greeny--231" }]

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -66,8 +66,7 @@
       >
         <div class="setting-label">{{ msg("preview") }}</div>
         <component
-          :is="'preview-' + addon.addonPreview.type"
-          :options="addon.addonPreview"
+          :is="'preview-' + addon._addonId"
           :settings="addonSettings"
           :hovered-setting-id="hoveredSettingId"
           @areahover="highlightSetting"

--- a/webpages/settings/components/previews/compact-messages.js
+++ b/webpages/settings/components/previews/compact-messages.js
@@ -2,7 +2,7 @@ import cssVariables from "../../../../libraries/common/vue-css-variables.js";
 
 export default async function ({ template }) {
   const CompactMessagesPreview = Vue.extend({
-    props: ["options", "settings", "hoveredSettingId"],
+    props: ["settings", "hoveredSettingId"],
     template,
     methods: {
       cssVariables,

--- a/webpages/settings/components/previews/dark-www.js
+++ b/webpages/settings/components/previews/dark-www.js
@@ -3,7 +3,7 @@ import { textColor } from "../../../../libraries/common/cs/text-color.esm.js";
 
 export default async function ({ template }) {
   const WebsiteDarkModePreview = Vue.extend({
-    props: ["options", "settings", "hoveredSettingId"],
+    props: ["settings", "hoveredSettingId"],
     template,
     data() {
       return {

--- a/webpages/settings/components/previews/editor-dark-mode.js
+++ b/webpages/settings/components/previews/editor-dark-mode.js
@@ -3,7 +3,7 @@ import { textColor, multiply, alphaBlend, makeHsv } from "../../../../libraries/
 
 export default async function ({ template }) {
   const EditorDarkModePreview = Vue.extend({
-    props: ["options", "settings", "hoveredSettingId"],
+    props: ["settings", "hoveredSettingId"],
     template,
     data() {
       return {

--- a/webpages/settings/components/previews/stage-monitor.js
+++ b/webpages/settings/components/previews/stage-monitor.js
@@ -3,7 +3,7 @@ import { textColor } from "../../../../libraries/common/cs/text-color.esm.js";
 
 export default async function ({ template }) {
   const StageMonitorPreview = Vue.extend({
-    props: ["options", "settings", "hoveredSettingId"],
+    props: ["settings", "hoveredSettingId"],
     template,
     computed: {
       colors() {

--- a/webpages/settings/components/previews/workspace-dots.js
+++ b/webpages/settings/components/previews/workspace-dots.js
@@ -1,6 +1,6 @@
 export default async function ({ template }) {
   const WorkspaceDotsPreview = Vue.extend({
-    props: ["options", "settings", "hoveredSettingId"],
+    props: ["settings", "hoveredSettingId"],
     template,
     computed: {
       spacing() {


### PR DESCRIPTION
Resolves #8292

### Changes

Turns `addonPreview` into a boolean option.

### Reason for changes

To save a few keystrokes and to simplify the schema a little but honestly this is kind of an unnecessary change.

### Tests

Tested on Chromium.