### PR TITLE
Add types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug.yml
+++ b/.github/ISSUE_TEMPLATE/---bug.yml
@@ -1,5 +1,6 @@
 name: 🐛 Bug
 description: Report a bug.
+type: Bug
 labels: ["status: needs triage", "type: bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/--feature.yml
+++ b/.github/ISSUE_TEMPLATE/--feature.yml
@@ -1,10 +1,11 @@
 name: ✨ Feature
 description: Suggest a feature or improvement!
+type: Enhancement
 labels: ["status: needs triage", "type: enhancement"]
 body:
   - type: markdown
     attributes:
-      value: | 
+      value: |
         ### Read before creating!
 
         - Avoid creating duplicates! Read the FAQ page and search through issues and discussions before creating one.

--- a/.github/ISSUE_TEMPLATE/--new-addon.yml
+++ b/.github/ISSUE_TEMPLATE/--new-addon.yml
@@ -1,10 +1,11 @@
 name: ➕ New addon
 description: Suggest a new addon!
+type: Enhancement
 labels: ["new addon", "scope: addon", "type: enhancement"]
 body:
   - type: markdown
     attributes:
-      value: | 
+      value: |
         ### Read before creating!
 
         - Avoid creating duplicates! Read the FAQ page and search through issues and discussions before creating one.


### PR DESCRIPTION
### Changes

Each issue template now includes a `type` property so newly opened issues are tagged with the appropriate issue type. This utilizes GitHub's new issue types system.

This does not make any changes to labels.
