### PR TITLE
horizontal-mystuff-tabs: change alignment

### DIFF
--- a/addons/horizontal-mystuff-tabs/style.css
+++ b/addons/horizontal-mystuff-tabs/style.css
@@ -18,7 +18,7 @@
   position: absolute;
   z-index: 1;
   top: 47px;
-  left: 32px;
+  left: 19px;
   margin: 0;
   background-color: transparent;
   border: none;
@@ -43,8 +43,8 @@
 .v-tabs li a {
   padding-top: 2px;
   padding-bottom: 4px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 12px;
+  padding-right: 12px;
   border: 1px solid transparent;
   border-radius: 4px 4px 0 0;
   color: var(--darkWww-gray-scratchr2ButtonText, #666);


### PR DESCRIPTION
### Changes

Aligns the text of the first tab with the My Stuff header and the sort dropdown.

![image](https://github.com/user-attachments/assets/08b67498-557f-4cc0-8866-2b163e92a6b9)
![image](https://github.com/user-attachments/assets/e881a55a-3503-40ab-9661-70e008b6b209)

### Reason for changes

Previously, the border of the first tab was aligned with the header, which looked weird when the first tab wasn't selected:
![image](https://github.com/user-attachments/assets/94cfb9ca-e45a-4fe4-bbfd-bd8c0e8fbe2d)

### Tests

Tested on Edge.