### PR TITLE
Add "related addons" relationships

### DIFF
--- a/addons/better-emojis/addon.json
+++ b/addons/better-emojis/addon.json
@@ -2,6 +2,7 @@
   "name": "Better emojis",
   "description": "Replaces the emojis in comments on the website with improved vector designs.",
   "tags": ["community", "comments"],
+  "relatedAddons": ["emoji-picker"],
   "credits": [
     {
       "name": "getbent",

--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -35,6 +35,7 @@
     }
   ],
   "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["block-duplicate"],
   "dynamicDisable": true,
   "dynamicEnable": true,
   "enabledByDefault": false,

--- a/addons/block-count/addon.json
+++ b/addons/block-count/addon.json
@@ -2,6 +2,7 @@
   "name": "Block count",
   "description": "Shows the total number of blocks in a project in the editor menu bar. Previously part of \"sprite and script count\".",
   "tags": ["editor", "editorMenuBar"],
+  "relatedAddons": ["project-info"],
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/block-duplicate/addon.json
+++ b/addons/block-duplicate/addon.json
@@ -22,5 +22,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.21.0",
   "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["block-cherry-picking"],
   "enabledByDefault": false
 }

--- a/addons/block-switching/addon.json
+++ b/addons/block-switching/addon.json
@@ -20,6 +20,7 @@
     }
   ],
   "tags": ["editor", "codeEditor", "recommended"],
+  "relatedAddons": ["middle-click-popup"],
   "settings": [
     {
       "name": "Motion blocks",

--- a/addons/columns/addon.json
+++ b/addons/columns/addon.json
@@ -8,6 +8,7 @@
     }
   ],
   "tags": ["editor", "codeEditor", "theme", "featured"],
+  "relatedAddons": ["data-category-tweaks-v2"],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "userscripts": [

--- a/addons/confirm-actions/addon.json
+++ b/addons/confirm-actions/addon.json
@@ -66,5 +66,6 @@
     "newSettings": ["removingprojects"]
   },
   "tags": ["community", "recommended"],
+  "relatedAddons": ["no-sprite-confirm"],
   "enabledByDefault": false
 }

--- a/addons/curator-link/addon.json
+++ b/addons/curator-link/addon.json
@@ -34,5 +34,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.4.0",
   "tags": ["community"],
+  "relatedAddons": ["more-links"],
   "enabledByDefault": false
 }

--- a/addons/custom-block-shape/addon.json
+++ b/addons/custom-block-shape/addon.json
@@ -2,6 +2,7 @@
   "name": "Customizable block shape",
   "description": "Adjust the padding, corner radius, and notch height of blocks.",
   "tags": ["editor", "codeEditor", "theme", "featured"],
+  "relatedAddons": ["editor-theme3"],
   "credits": [
     {
       "name": "SheepTester",

--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -2,6 +2,7 @@
   "name": "Customizable code area zoom",
   "description": "Choose custom settings for the minimum, maximum, speed, and start size of the zoom of scripts in the code area, and autohide the controls.",
   "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["items-per-row"],
   "credits": [
     {
       "name": "ErrorGamer2000",

--- a/addons/dark-www/addon.json
+++ b/addons/dark-www/addon.json
@@ -2,6 +2,7 @@
   "name": "Website dark mode and customizable colors",
   "description": "Customize colors used by the Scratch website. Multiple dark themes by different authors available. If you don't need dark mode but want to change the default colors you can select the \"Scratch's default colors\" preset and tweak it.",
   "tags": ["community", "theme", "featured"],
+  "relatedAddons": ["editor-dark-mode"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/data-category-tweaks-v2/addon.json
+++ b/addons/data-category-tweaks-v2/addon.json
@@ -37,5 +37,6 @@
     }
   ],
   "tags": ["editor", "codeEditor", "recommended"],
+  "relatedAddons": ["columns"],
   "enabledByDefault": false
 }

--- a/addons/discuss-button/addon.json
+++ b/addons/discuss-button/addon.json
@@ -122,6 +122,7 @@
     "isMajor": false
   },
   "tags": ["community", "featured"],
+  "relatedAddons": ["expanding-search-bar"],
   "enabledByDefault": false,
   "updateUserstylesOnSettingsChange": true
 }

--- a/addons/editor-buttons-reverse-order/addon.json
+++ b/addons/editor-buttons-reverse-order/addon.json
@@ -2,6 +2,7 @@
   "name": "Reverse order of project controls",
   "description": "Moves the green flag and stop buttons to the right and the full screen button to the left, like in Scratch 2.0.",
   "tags": ["player", "theme", "featured"],
+  "relatedAddons": ["editor-stage-left", "scartch3to2"],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "userstyles": [

--- a/addons/editor-comment-previews/addon.json
+++ b/addons/editor-comment-previews/addon.json
@@ -2,6 +2,7 @@
   "name": "Editor comment previews",
   "description": "Allows you to preview the contents of comments by hovering over collapsed comments and blocks. You can use this to view comments that are off-screen, identify a loop block from the bottom by its preview, fit many long comments in a small space, and more.",
   "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["fix-editor-comments"],
   "credits": [
     {
       "name": "lisa_wolfgang",

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1550,5 +1550,6 @@
     "isMajor": true
   },
   "tags": ["editor", "theme", "featured"],
+  "relatedAddons": ["dark-www", "theme3"],
   "enabledByDefault": false
 }

--- a/addons/editor-stage-left/addon.json
+++ b/addons/editor-stage-left/addon.json
@@ -28,6 +28,7 @@
     }
   ],
   "tags": ["editor", "theme", "featured"],
+  "relatedAddons": ["scratch3to2", "editor-buttons-reverse-order"],
   "versionAdded": "1.1.0",
   "enabledByDefault": false
 }

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -437,6 +437,7 @@
     }
   ],
   "tags": ["editor", "theme", "codeEditor", "featured"],
+  "relatedAddons": ["editor-dark-mode", "custom-block-shape", "transparent-orphans", "zebra-striping"],
   "enabledByDefault": false,
   "presets": [
     {

--- a/addons/editor-unshare-button/addon.json
+++ b/addons/editor-unshare-button/addon.json
@@ -20,5 +20,6 @@
     }
   ],
   "tags": ["editor", "editorMenuBar"],
+  "relatedAddons": ["share-through-mystuff"],
   "versionAdded": "1.20.0"
 }

--- a/addons/emoji-picker/addon.json
+++ b/addons/emoji-picker/addon.json
@@ -24,5 +24,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.21.0",
   "tags": ["community", "comments", "featured"],
+  "relatedAddons": ["better-emojis"],
   "enabledByDefault": false
 }

--- a/addons/expanding-search-bar/addon.json
+++ b/addons/expanding-search-bar/addon.json
@@ -19,5 +19,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.16.0",
   "tags": ["community", "featured"],
+  "relatedAddons": ["discuss-button"],
   "enabledByDefault": false
 }

--- a/addons/fix-editor-comments/addon.json
+++ b/addons/fix-editor-comments/addon.json
@@ -2,6 +2,7 @@
   "name": "Better editor comments",
   "description": "Makes numerous changes to comments in the Scratch editor: fixes a bug where comments attached to blocks don't save their positions correctly after dragging, prevents block comments from spawning off-screen in large scripts, keeps block comment connections straight, and more.",
   "tags": ["editor", "codeEditor", "recommended"],
+  "relatedAddons": ["editor-comment-previews"],
   "credits": [
     {
       "name": "GarboMuffin",

--- a/addons/hide-delete-button/addon.json
+++ b/addons/hide-delete-button/addon.json
@@ -2,6 +2,7 @@
   "name": "Hide delete button",
   "description": "Hides delete button (trash can icon) from sprites, costumes and sounds. They can still be deleted using the right click context menu.",
   "tags": ["editor", "featured"],
+  "relatedAddons": ["no-sprite-confirm"],
   "info": [
     {
       "text": "Tip: If you accidentally delete a sprite, costume, or sound, you can undo the deletion by clicking Edit in the menu bar then Restore.",

--- a/addons/horizontal-mystuff-tabs/addon.json
+++ b/addons/horizontal-mystuff-tabs/addon.json
@@ -2,6 +2,7 @@
   "name": "Horizontal My Stuff tabs",
   "description": "Moves the My Stuff navigation buttons (\"All Projects\", \"My Studios\", \"Trash\") to the top of the page, instead of keeping them on the left.",
   "tags": ["community", "theme"],
+  "relatedAddons": ["scratchr2"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/items-per-row/addon.json
+++ b/addons/items-per-row/addon.json
@@ -2,6 +2,7 @@
   "name": "More items per row",
   "description": "Lets you change the number of items displayed in a single row in a grid of projects, studios, or users.",
   "tags": ["community", "featured"],
+  "relatedAddons": ["custom-zoom"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/middle-click-popup/addon.json
+++ b/addons/middle-click-popup/addon.json
@@ -19,6 +19,7 @@
     }
   ],
   "tags": ["editor", "codeEditor", "recommended"],
+  "relatedAddons": ["block-switching"],
   "enabledByDefault": true,
   "userscripts": [
     {

--- a/addons/more-links/addon.json
+++ b/addons/more-links/addon.json
@@ -14,6 +14,7 @@
   ],
   "versionAdded": "1.0.0",
   "tags": ["community", "featured"],
+  "relatedAddons": ["curator-link"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -31,5 +31,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.7.0",
-  "tags": ["player", "recommended"]
+  "tags": ["player", "recommended"],
+  "relatedAddons": ["vol-slider"]
 }

--- a/addons/no-sprite-confirm/addon.json
+++ b/addons/no-sprite-confirm/addon.json
@@ -22,5 +22,6 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.40.0",
-  "tags": ["editor", "danger", "featured"]
+  "tags": ["editor", "danger", "featured"],
+  "relatedAddons": ["hide-delete-button", "confirmations"]
 }

--- a/addons/old-studio-layout/addon.json
+++ b/addons/old-studio-layout/addon.json
@@ -17,6 +17,7 @@
     }
   ],
   "tags": ["community", "theme", "studios", "featured"],
+  "relatedAddons": ["scratchr2", "items-per-row", "studio-followers"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/project-info/addon.json
+++ b/addons/project-info/addon.json
@@ -2,6 +2,7 @@
   "name": "Sprite and script count",
   "description": "Shows the number of sprites and scripts a project has next to the Remix button.",
   "tags": ["community", "projectPage", "featured"],
+  "relatedAddons": ["block-count"],
   "credits": [
     {
       "name": "TheColaber",

--- a/addons/scratch3to2/addon.json
+++ b/addons/scratch3to2/addon.json
@@ -2,6 +2,7 @@
   "name": "Scratch 3.0 \u2192 2.0",
   "description": "Makes Scratch 3.0-styled pages look like Scratch 2.0.",
   "tags": ["community", "theme", "featured"],
+  "relatedAddons": ["scratchr2", "editor-stage-left", "editor-buttons-reverse-order"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/scratchr2/addon.json
+++ b/addons/scratchr2/addon.json
@@ -2,6 +2,7 @@
   "name": "Scratch 2.0 \u2192 3.0",
   "description": "Makes Scratch 2.0-styled pages look like Scratch 3.0.",
   "tags": ["community", "theme", "recommended"],
+  "relatedAddons": ["scratch3to2", "old-studio-layout", "horizontal-mystuff-tabs"],
   "credits": [
     {
       "name": "Maximouse",

--- a/addons/share-through-mystuff/addon.json
+++ b/addons/share-through-mystuff/addon.json
@@ -23,6 +23,7 @@
   "dynamicDisable": true,
   "dynamicEnable": true,
   "tags": ["community"],
+  "relatedAddons": ["editor-unshare-button"],
   "versionAdded": "1.31.0",
   "enabledByDefault": false
 }

--- a/addons/studio-followers/addon.json
+++ b/addons/studio-followers/addon.json
@@ -26,5 +26,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.17.0",
   "tags": ["community", "studios", "featured"],
+  "relatedAddons": ["old-studio-layout"],
   "enabledByDefault": false
 }

--- a/addons/transparent-orphans/addon.json
+++ b/addons/transparent-orphans/addon.json
@@ -2,6 +2,7 @@
   "name": "Block transparency",
   "description": "Adjust the transparency for blocks in the editor, with separate options for orphaned blocks (those without a hat block at the top) and blocks that are being dragged.",
   "tags": ["editor", "codeEditor"],
+  "relatedAddons": ["editor-theme3"],
   "versionAdded": "1.15.0",
   "dynamicDisable": true,
   "dynamicEnable": true,

--- a/addons/true-youtube-links/addon.json
+++ b/addons/true-youtube-links/addon.json
@@ -17,5 +17,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.0.0",
   "tags": ["community", "forums"],
+  "relatedAddons": ["youtube-fullscreen"],
   "enabledByDefault": false
 }

--- a/addons/vol-slider/addon.json
+++ b/addons/vol-slider/addon.json
@@ -58,5 +58,6 @@
     "newSettings": ["always"],
     "isMajor": true
   },
-  "tags": ["player", "recommended"]
+  "tags": ["player", "recommended"],
+  "relatedAddons": ["mute-project"]
 }

--- a/addons/youtube-fullscreen/addon.json
+++ b/addons/youtube-fullscreen/addon.json
@@ -18,5 +18,6 @@
   "dynamicDisable": false,
   "dynamicEnable": false,
   "tags": ["community", "forums"],
+  "relatedAddons": ["true-youtube-links"],
   "enabledByDefault": false
 }

--- a/addons/zebra-striping/addon.json
+++ b/addons/zebra-striping/addon.json
@@ -15,6 +15,7 @@
     }
   ],
   "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["editor-theme3"],
   "userscripts": [
     {
       "url": "userscript.js",


### PR DESCRIPTION
Continues #6104

Some notes:
1. Relationships are not bidrectional by design, but most times they will probably be
2. This is a work in progress based on [this table](https://github.com/ScratchAddons/ScratchAddons/pull/6104#issuecomment-1563406851)
3. `We should ensure a majority of the related-addon relationships we add aren't just subcategories. For example, I'm not sure if color picker addons should be related to each other. They aren't directly related - they simply affect the same area of the editor.` [source](https://github.com/ScratchAddons/ScratchAddons/pull/6104#issuecomment-1563429915)
4. Feedback is welcome, but let's try not to discuss excessively over links