### PR TITLE
Remove uses of deprecated Blockly functions

### DIFF
--- a/addons/data-category-tweaks-v2/userscript.js
+++ b/addons/data-category-tweaks-v2/userscript.js
@@ -49,7 +49,7 @@ export default async function ({ addon, console, msg, safeMsg }) {
       for (const blockXML of xml) {
         if (blockXML.hasAttribute("id")) {
           const id = blockXML.getAttribute("id");
-          const variable = workspace.getVariableById(id);
+          const variable = workspace.getVariableMap().getVariableById(id);
           if (!variable || !variable.isLocal) {
             global.push(blockXML);
           } else {

--- a/addons/rename-broadcasts/userscript.js
+++ b/addons/rename-broadcasts/userscript.js
@@ -102,11 +102,12 @@ export default async function ({ addon, msg, console }) {
     Blockly.Events.setGroup(true);
 
     // Rename in editor. Undo/redo will work automatically.
-    // Old Blockly's renameVariableById() creates a new group, so we need
+    // Old Blockly's renameVariable() creates a new group, so we need
     // to replace setGroup() with a no-op to prevent that.
     const _setGroup = Blockly.Events.setGroup;
     if (!Blockly.registry) Blockly.Events.setGroup = () => {};
-    workspace.getVariableMap().renameVariableById(id, newName);
+    const blocklyVariable = workspace.getVariableMap().getVariableById(id);
+    workspace.getVariableMap().renameVariable(blocklyVariable, newName);
     if (!Blockly.registry) Blockly.Events.setGroup = _setGroup;
 
     // Rename in VM. Need to manually implement undo/redo.
@@ -141,7 +142,8 @@ export default async function ({ addon, msg, console }) {
     }
     // Remove the broadcast from the editor so it doesn't appear in dropdowns.
     // Undo/redo will work automatically for this.
-    workspace.getVariableMap().deleteVariableById(oldId);
+    const oldBlocklyVariable = workspace.getVariableMap().getVariableById(oldId);
+    workspace.getVariableMap().deleteVariable(oldBlocklyVariable);
 
     // Merge in VM to update sprites that aren't open. Need to manually implement undo/redo.
     // To figure out how to undo this operation, we first figure out which blocks we're
@@ -198,7 +200,7 @@ export default async function ({ addon, msg, console }) {
           return;
         }
 
-        const variableAlreadyExists = !!workspace.getVariable(newName, BROADCAST_MESSAGE_TYPE);
+        const variableAlreadyExists = !!workspace.getVariableMap().getVariable(newName, BROADCAST_MESSAGE_TYPE);
         if (variableAlreadyExists) {
           mergeBroadcast(workspace, id, oldName, newName);
         } else {

--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -430,7 +430,7 @@ export default async function ({ addon, msg, console }) {
   addon.tab.createBlockContextMenu(
     (items, block) => {
       if (!addon.self.disabled && block.type.startsWith("data_")) {
-        const variable = block.workspace.getVariableById(block.getVars()[0]);
+        const variable = block.workspace.getVariableMap().getVariableById(block.getVars()[0]);
         if (variable) {
           if (items.length > 0) {
             if (items[0].text === ScratchBlocks.ScratchMsgs.translate("RENAME_VARIABLE")) {

--- a/addons/variable-manager/userscript.js
+++ b/addons/variable-manager/userscript.js
@@ -185,14 +185,15 @@ export default async function ({ addon, console, msg }) {
           nameAlreadyUsed = existingNames.includes(newName);
         } else {
           // Local variables must not conflict with any global variables or local variables in this sprite.
-          nameAlreadyUsed = !!workspace.getVariable(newName, this.scratchVariable.type);
+          nameAlreadyUsed = !!workspace.getVariableMap().getVariable(newName, this.scratchVariable.type);
         }
 
         const isEmpty = !newName.trim();
         if (isEmpty || nameAlreadyUsed) {
           label.value = this.scratchVariable.name;
         } else {
-          workspace.renameVariableById(this.scratchVariable.id, newName);
+          const blocklyVariable = workspace.getVariableMap().getVariableById(this.scratchVariable.id);
+          workspace.getVariableMap().renameVariable(blocklyVariable, newName);
           // Only update the input's value when we need to to avoid resetting undo history.
           if (label.value !== newName) {
             label.value = newName;


### PR DESCRIPTION
### Changes

Changes some addons so that they don't use functions that will be removed in future versions of Blockly.

### Tests

Tested both Scratch versions on Edge.