### PR TITLE
editor-theme3: Add comment icon filter

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -177,6 +177,18 @@
         "g": 0.9,
         "b": 0.9
       }
+    },
+    {
+      "name": "commentFilter",
+      "value": {
+        "type": "textColor",
+        "black": "none",
+        "white": "brightness(0) invert(1)",
+        "source": {
+          "type": "settingValue",
+          "settingId": "comment-color"
+        }
+      }
     }
   ],
   "dynamicEnable": true,

--- a/addons/editor-theme3/color_on_black.css
+++ b/addons/editor-theme3/color_on_black.css
@@ -35,6 +35,11 @@
   color: #ffffff;
 }
 
+.blocklyCommentTopbar > image,
+.scratchCommentTopBar ~ image {
+  filter: brightness(0) invert(1);
+}
+
 /* Compatibility */
 
 .sa-block-color {

--- a/addons/editor-theme3/color_on_white.css
+++ b/addons/editor-theme3/color_on_white.css
@@ -66,6 +66,11 @@
   color: #575e75;
 }
 
+.blocklyCommentTopbar > image,
+.scratchCommentTopBar ~ image {
+  filter: brightness(0);
+}
+
 /* Compatibility */
 
 .sa-block-color {

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -110,6 +110,7 @@
   transform: rotate(-90deg);
 }
 
+.blocklyCommentTopbar > image,
 .scratchCommentTopBar ~ image {
   filter: var(--editorTheme3-commentFilter);
 }

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -109,3 +109,7 @@
   margin-right: auto;
   transform: rotate(-90deg);
 }
+
+.scratchCommentTopBar ~ image {
+  filter: var(--editorTheme3-commentFilter);
+}


### PR DESCRIPTION
Resolves #7944

### Changes

Adds a white filter to the editor comment icons when on a dark background.

### Tests

Tested on Brave