### PR TITLE
scratch-messaging: show number of identical studio activity messages

### DIFF
--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -275,7 +275,10 @@
             >
           </div>
           <div class="message-type-details" v-show="messageTypeExtended.studioActivity">
-            <div class="thread-list" v-for="studio of studioActivity">{{{ studioActivityHTML(studio) }}}</div>
+            <div class="thread-list" v-for="studio of studioActivity">
+              {{{ studioActivityHTML(studio) }}}
+              <span v-if="studio.amount > 1">({{ studio.amount }})</span>
+            </div>
           </div>
         </div>
 

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -641,10 +641,15 @@ export default async ({ addon, msg, safeMsg }) => {
             });
           } else if (message.type === "studioactivity") {
             // We only want one message per studio
-            if (!this.studioActivity.find((obj) => obj.studioId === message.gallery_id)) {
+            // If there are more, the number of messages is shown next to the message
+            const existingMessage = this.studioActivity.find((obj) => obj.studioId === message.gallery_id);
+            if (existingMessage) {
+              existingMessage.amount++;
+            } else {
               this.studioActivity.push({
                 studioId: message.gallery_id,
                 studioTitle: message.title,
+                amount: 1,
               });
             }
             this.studioActivityAmt++;


### PR DESCRIPTION
### Changes

![image](https://github.com/user-attachments/assets/53016448-3414-4750-958a-35abdeb9cb77)

### Reason for changes

https://github.com/ScratchAddons/ScratchAddons/pull/7513#issuecomment-2157889735

### Tests

Tested on Edge and Firefox.