### PR TITLE
Add a couple setting descriptions to editor-theme3

### DIFF
--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -359,7 +359,7 @@
     },
     {
       "name": "Comments",
-      "description": "When using colored text on a black/white background this setting effects the borders of standalone comments.",
+      "description": "When using colored text on a black/white background this setting affects the borders of standalone comments.",
       "id": "comment-color",
       "type": "color",
       "default": "#FEF49C"

--- a/addons/editor-theme3/addon.json
+++ b/addons/editor-theme3/addon.json
@@ -30,11 +30,6 @@
       "id": "aboutHighContrast",
       "type": "info",
       "text": "The new High Contrast block colors are available as a preset below."
-    },
-    {
-      "id": "whatsInsertionMarker",
-      "type": "info",
-      "text": "When dragging a block, an \"insertion marker\" is the shadow that appears when moved near to other blocks."
     }
   ],
   "relatedAddons": ["zebra-striping", "custom-block-text", "custom-block-shape"],
@@ -364,6 +359,7 @@
     },
     {
       "name": "Comments",
+      "description": "When using colored text on a black/white background this setting effects the borders of standalone comments.",
       "id": "comment-color",
       "type": "color",
       "default": "#FEF49C"
@@ -406,6 +402,7 @@
     },
     {
       "name": "Insertion marker style",
+      "description": "When dragging a block, an \"insertion marker\" is the shadow that appears when moved near to other blocks.",
       "id": "fillStyle",
       "type": "select",
       "default": "gray",

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -282,6 +282,9 @@ body.iframe .setting-label {
   width: auto;
   margin-bottom: 5px;
 }
+body.iframe .setting-help-icon {
+  margin-bottom: 5px;
+}
 body.iframe .setting-input {
   flex-shrink: 0;
 }

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -280,9 +280,8 @@ body.iframe .settings-column > .addon-setting {
 }
 body.iframe .setting-label {
   width: auto;
-  margin-bottom: 5px;
 }
-body.iframe .setting-help-icon {
+body.iframe .setting-label-container {
   margin-bottom: 5px;
 }
 body.iframe .setting-input {


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/issues/8353#issuecomment-2904449426

### Changes

Moves the insertion marker notice into a setting description and adds one about comments in the colored text mode. Also fixes the help icon alignment in the popup.

### Reason for changes

Although the notice was always visible it was far from the settings that effected it. Since there are multiple though this might not be any better.

### Tests

Tested on Brave.
