### PR TITLE
Fix editor message count padding with custom-menu-bar

### DIFF
--- a/addons/custom-menu-bar/menu-labels.css
+++ b/addons/custom-menu-bar/menu-labels.css
@@ -6,7 +6,8 @@
   justify-content: center;
 }
 
-[class*="menu-bar_hoverable"] > span:not(.sa-editormessages-count) {
+[class*="settings-menu_dropdown-label_"],
+[class*="menu-bar_collapsible-label_"] {
   margin: 0;
   padding: 0;
 }

--- a/addons/custom-menu-bar/menu-labels.css
+++ b/addons/custom-menu-bar/menu-labels.css
@@ -6,7 +6,7 @@
   justify-content: center;
 }
 
-[class*="menu-bar_hoverable"] > span {
+[class*="menu-bar_hoverable"] > span:not(.sa-editormessages-count) {
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
### Changes

Fixes this with editor messages enabled and custom-menu-bar set to labels only:
![image](https://github.com/user-attachments/assets/61f239ba-bc17-489c-ba27-e986ad65132f)

### Tests

Tested on Brave