### PR TITLE
`<is in editor?>` block for debugger

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -63,6 +63,18 @@ export default class Tab extends Listenable {
     return blocks.addBlock(proccode, opts);
   }
   /**
+   * Adds a custom reporter block definition. Internally this is a special-cased argument reporter block.
+   * @param {string} proccode the procedure definition code
+   * @param {boolean} isBoolean - whether the block is hexagonal.
+   * @param {object} opts - options.
+   * @param {Tab~blockCallback} opts.callback - the callback, the returned value is the output of the block.
+   * @param {boolean=} opts.hidden - whether the block is hidden from the palette.
+   */
+  addReporterBlock(proccode, isBoolean, opts) {
+    blocks.init(this);
+    return blocks.addReporterBlock(proccode, isBoolean, opts);
+  }
+  /**
    * Removes a stack block definition. Should not be called in most cases.
    * @param {string} proccode the procedure definition code of the block
    */

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -67,7 +67,7 @@ export default class Tab extends Listenable {
    * @param {string} proccode the procedure definition code
    * @param {boolean} isBoolean - whether the block is hexagonal.
    * @param {object} opts - options.
-   * @param {Tab~blockCallback} opts.callback - the callback, the returned value is the output of the block.
+   * @param {function} opts.callback - the callback, the returned value is the output of the block.
    * @param {boolean=} opts.hidden - whether the block is hidden from the palette.
    */
   addReporterBlock(proccode, isBoolean, opts) {

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -1,6 +1,13 @@
 {
   "name": "Debugger",
-  "description": "Adds a new \"debugger\" window to the editor. Allows for logging into the \"Logs\" tab of the debugger window using the \"log\", \"warn\" and \"error\" blocks. The \"breakpoint\" block will pause the project when executed. All running stacks of blocks can be viewed in the \"Threads\" tab of the debugger window, and when paused the \"Step\" button can be used to execute the next block. A graph of frames per second and number of clones can be viewed in the \"Performance\" tab.",
+  "description": "Adds a new \"debugger\" window to the editor. Allows for logging into the \"Logs\" tab of the debugger window using the \"log\", \"warn\" and \"error\" blocks. The \"breakpoint\" block will pause the project when executed. All running stacks of blocks can be viewed in the \"Threads\" tab of the debugger window, and when paused the \"Step\" button can be used to execute the next block. A graph of frames per second and number of clones can be viewed in the \"Performance\" tab. The \"is it in editor?\" block allows to check if the project is running in the editor.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "Debug blocks only work for Scratch Addons users with this enabled. The \"is in editor?\" block cannot therefore it cannot be used as an anti-cheat method.",
+      "id": "debuggerBlocks"
+    }
+  ],
   "credits": [
     {
       "name": "Tacodiva",
@@ -17,6 +24,10 @@
     },
     {
       "name": "retronbv"
+    },
+    {
+      "name": "Valmontechno",
+      "link": "https://github.com/Valmontechno"
     }
   ],
   "userscripts": [
@@ -84,9 +95,9 @@
   "tags": ["editor", "codeEditor", "featured"],
   "versionAdded": "1.16.0",
   "latestUpdate": {
-    "version": "1.33.0",
-    "temporaryNotice": "Graph animation is now disabled by default to increase performance. You can re-enable it if you want.",
-    "newSettings": ["fancy_graphs"]
+    "version": "1.43.0",
+    "temporaryNotice": "New available block: \"is in editor?\"",
+    "isMajor": true
   },
   "libraries": ["chartjs", "scratch-gui", "scratch-vm"]
 }

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -68,6 +68,11 @@ export default async function ({ addon, console, msg }) {
       logMessage(content, thread, "error");
     },
   });
+  addon.tab.addReporterBlock("\u200B\u200Bis in editor?\u200B\u200B", true, {
+    callback: () => {
+      return document.body.classList.contains("sa-body-editor") ? true : 0;
+    }
+  });
 
   const vm = addon.tab.traps.vm;
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
Resolves #8362

### Changes

Add the `addReporterBlock()` function to the `addon.Tab` API. It adds a block that can return a value to the toolbox. Internally this is a special-cased argument reporter block like the "is compiled?" block of TurboWarp.

This allows to add the <img src="https://github.com/user-attachments/assets/4aa6b052-cbb6-41a4-847a-b46fc0cdc2b1" height="30"> block to the Debugger category.
You can test this block on this project https://scratch.mit.edu/projects/1182533047

### Reason for changes

View #8362

### Notice

The [`blocks.js`](https://github.com/Valmontechno/ScratchAddons/blob/a742be44d812bbb3075b2bdc5ce200f23bea0790/addon-api/content-script/blocks.js#L117C14-L117C31) module that allow to add blocks use the the `proccode` to identify the blocks, however the argument reporter blocks haven't `proccode` propriety and use instead the field value. I still use the "proccode" name because it used by all functions in the module. This should probably be changed.