### PR TITLE
Make middle click popup results nicer with special characters / number-named variables

### DIFF
--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -461,7 +461,6 @@ class TokenTypeStringEnum extends TokenType {
       const remainingChar = query.length - idx;
       const substr = query.lowercase.substring(idx);
 
-
       if (remainingChar < valueInfo.lower.length) {
         if (valueInfo.lower.startsWith(substr)) {
           // If all we have is a string which could be a number, it doesn't count as a defining feature.
@@ -711,7 +710,6 @@ class TokenTypeBlock extends TokenType {
     this.stringForms = [];
 
     const enumerateStringForms = (partIdx = 0, strings = [], inputs = [], length = 0) => {
-
       /**
        * @param {string} value
        * @returns string[]
@@ -749,7 +747,6 @@ class TokenTypeBlock extends TokenType {
 
           // Split the string up into parts
           strings.push(...splitIntoString(blockPart));
-
         } else if (blockPart.type === BlockInputType.ENUM) {
           for (const enumValue of blockPart.values) {
             if (this.stringForms.length >= WorkspaceQuerier.MAX_RESULTS) return;
@@ -813,8 +810,7 @@ class TokenTypeBlock extends TokenType {
 
         // Special chars get their own string part
         if (QueryInfo.SPECIAL_CHARS.indexOf(query.lowercase[i]) !== -1) {
-          if (i < query.lowercase.length)
-            wordEnd = i + 1;
+          if (i < query.lowercase.length) wordEnd = i + 1;
         } else {
           wordEnd = query.skipUnignorable(i);
         }
@@ -1106,7 +1102,7 @@ class QueryInfo {
   static IGNORABLE_CHARS = [" "];
 
   /** Characters which are treated as dividing string into 'parts' for partial matching */
-  static SPECIAL_CHARS = ["!", "@", "#", "$", "%", "^", "&", "_", "'", "\"", ".", ","];
+  static SPECIAL_CHARS = ["!", "@", "#", "$", "%", "^", "&", "_", "'", '"', ".", ","];
 
   constructor(querier, query, id) {
     /** @type {WorkspaceQuerier} */

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -436,7 +436,6 @@ class TokenTypeStringEnum extends TokenType {
    * @typedef StringEnumValue
    * @property {string} value The string that needs to be in the query
    * @property {string} lower Cached value.toLowerCase()
-   * @property {string[]} parts lower, split up by ignoreable characters.
    */
 
   /**
@@ -450,44 +449,30 @@ class TokenTypeStringEnum extends TokenType {
     this.values = [];
     for (const value of values) {
       let lower = value.string.toLowerCase();
-      const parts = [];
-      {
-        let lastPart = 0;
-        for (let i = 0; i <= lower.length; i++) {
-          const char = lower[i];
-          if (QueryInfo.IGNORABLE_CHARS.indexOf(char) !== -1 || !char) {
-            parts.push(lower.substring(lastPart, i));
-            i = QueryInfo.skipIgnorable(lower, i);
-            lastPart = i;
-          }
-        }
-      }
-      this.values.push({ lower, parts, value });
+
+      this.values.push({ lower, value });
     }
   }
 
   *parseTokens(query, idx, depth) {
     for (let valueIdx = 0; valueIdx < this.values.length; valueIdx++) {
       const valueInfo = this.values[valueIdx];
-      let yieldedToken = false;
 
       const remainingChar = query.length - idx;
       const substr = query.lowercase.substring(idx);
 
-      // If all we have is a string which could be a number, it doesn't count as a defining feature.
-      // This is to get rid of "10" constantly suggesting "10 ^ of ()"
-      let isDefiningFeature = !TokenTypeNumberLiteral.isValidNumber(substr);
 
       if (remainingChar < valueInfo.lower.length) {
         if (valueInfo.lower.startsWith(substr)) {
+          // If all we have is a string which could be a number, it doesn't count as a defining feature.
+          // This is to get rid of "10" constantly suggesting "10 ^ of ()"
+          let isDefiningFeature = !TokenTypeNumberLiteral.isValidNumber(substr);
           const end = remainingChar < 0 ? 0 : query.length;
           yield new Token(idx, end, this, valueInfo, { isTruncated: true, isDefiningFeature });
-          yieldedToken = true;
         }
       } else {
         if (query.lowercase.startsWith(valueInfo.lower, idx)) {
-          yield new Token(idx, idx + valueInfo.lower.length, this, valueInfo, { isDefiningFeature });
-          yieldedToken = true;
+          yield new Token(idx, idx + valueInfo.lower.length, this, valueInfo, { isDefiningFeature: true });
         }
       }
     }
@@ -726,18 +711,52 @@ class TokenTypeBlock extends TokenType {
     this.stringForms = [];
 
     const enumerateStringForms = (partIdx = 0, strings = [], inputs = [], length = 0) => {
+
+      /**
+       * @param {string} value
+       * @returns string[]
+       */
+      function splitIntoString(value) {
+        const strings = [];
+
+        let lastPart = 0;
+        const valueLower = value.toLowerCase();
+        for (let i = 0; i <= valueLower.length; i++) {
+          const char = valueLower[i];
+
+          if (!char) {
+            // End of string
+            strings.push(valueLower.substring(lastPart, i));
+            break;
+          } else if (QueryInfo.IGNORABLE_CHARS.indexOf(char) !== -1) {
+            // Ignorable char
+            strings.push(valueLower.substring(lastPart, i));
+            i = QueryInfo.skipIgnorable(valueLower, i);
+            lastPart = i;
+          } else if (QueryInfo.SPECIAL_CHARS.indexOf(char) !== -1) {
+            // Special char
+            strings.push(valueLower.substring(lastPart, i + 1));
+            lastPart = i + 1;
+          }
+        }
+        return strings;
+      }
+
       for (; partIdx < block.parts.length; partIdx++) {
         let blockPart = block.parts[partIdx];
         if (typeof blockPart === "string") {
           length += blockPart.length;
-          strings.push(...blockPart.toLowerCase().split(" "));
+
+          // Split the string up into parts
+          strings.push(...splitIntoString(blockPart));
+
         } else if (blockPart.type === BlockInputType.ENUM) {
           for (const enumValue of blockPart.values) {
             if (this.stringForms.length >= WorkspaceQuerier.MAX_RESULTS) return;
 
             enumerateStringForms(
               partIdx + 1,
-              [...strings, ...enumValue.string.toLowerCase().split(" ")],
+              [...strings, ...splitIntoString(enumValue.string)],
               [...inputs, enumValue],
               length + enumValue.string.length
             );
@@ -747,6 +766,7 @@ class TokenTypeBlock extends TokenType {
           inputs.push(null);
         }
       }
+
       this.stringForms.push({ strings, inputs, length });
     };
 
@@ -789,7 +809,15 @@ class TokenTypeBlock extends TokenType {
       while (true) {
         i = query.skipIgnorable(i);
 
-        const wordEnd = query.skipUnignorable(i);
+        let wordEnd;
+
+        // Special chars get their own string part
+        if (QueryInfo.SPECIAL_CHARS.indexOf(query.lowercase[i]) !== -1) {
+          if (i < query.lowercase.length)
+            wordEnd = i + 1;
+        } else {
+          wordEnd = query.skipUnignorable(i);
+        }
 
         if (wordEnd === i) {
           if (hasDefiningFeature)
@@ -1076,6 +1104,9 @@ export class QueryResult {
 class QueryInfo {
   /** Characters that can be safely skipped over. */
   static IGNORABLE_CHARS = [" "];
+
+  /** Characters which are treated as dividing string into 'parts' for partial matching */
+  static SPECIAL_CHARS = ["!", "@", "#", "$", "%", "^", "&", "_", "'", "\"", ".", ","];
 
   constructor(querier, query, id) {
     /** @type {WorkspaceQuerier} */


### PR DESCRIPTION

Resolves #8367, sort of resolves #8368

I have made the parser treat some characters as "special" when doing partial matching, so that they don't have to be included in the query. So now with a variable called `_my variable`, just searching for `my variable` will still show results for it. These special characters are in a list which currently contains `!@#$%^&_'".,`. We might need to add more characters to it.

I also made a partial solution for #8368. Making just number inputs count as a match causes problems with `10 ^` showing up everywhere, so I've made a compromise to count it as a match if it matches exactly, so variables called "10" will show up when you search "10". However this doesn't work for partial matching, so if you have a variable called "10 my variable" (as shown in the issue), just typing "10" will not show that as a result. I hope that's an okay compromise.