### PR TITLE
Fix insert blocks by name not working in sprites with an empty custom block 

### DIFF
--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -868,6 +868,9 @@ class TokenTypeBlock extends TokenType {
    * @yields {Token[]}
    */
   *_parseSubtokens(query, idx, subtokenProviders, depth, tokenProviderIdx = 0, parseNextToken = true) {
+    if (tokenProviderIdx >= subtokenProviders.length)
+      return;
+
     idx = query.skipIgnorable(idx);
     let tokenProvider = subtokenProviders[tokenProviderIdx];
 

--- a/addons/middle-click-popup/WorkspaceQuerier.js
+++ b/addons/middle-click-popup/WorkspaceQuerier.js
@@ -868,8 +868,7 @@ class TokenTypeBlock extends TokenType {
    * @yields {Token[]}
    */
   *_parseSubtokens(query, idx, subtokenProviders, depth, tokenProviderIdx = 0, parseNextToken = true) {
-    if (tokenProviderIdx >= subtokenProviders.length)
-      return;
+    if (tokenProviderIdx >= subtokenProviders.length) return;
 
     idx = query.skipIgnorable(idx);
     let tokenProvider = subtokenProviders[tokenProviderIdx];


### PR DESCRIPTION
Resolves #8397

Added an extra bounds check which should not change anything except resolving the error.