### PR TITLE
Fix setting layout in popup

### DIFF
--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -177,7 +177,6 @@
     height: 32px;
     box-sizing: border-box;
     padding: 0 12px;
-    margin-left: auto;
     border-radius: 4px 0 0 4px;
     font-family: inherit;
     font-size: 14px;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -278,11 +278,13 @@ body.iframe .settings-column > .addon-setting {
   flex-direction: column;
   align-items: flex-start;
 }
-body.iframe .setting-label {
-  width: auto;
-}
 body.iframe .setting-label-container {
   margin-bottom: 5px;
+  width: auto;
+  max-width: calc(100% - 66px); /* prevent setting description tooltip from overflowing */
+}
+body.iframe .setting-label-container:not(:has(.tooltip)) {
+  max-width: none;
 }
 body.iframe .setting-input {
   flex-shrink: 0;
@@ -292,7 +294,7 @@ body.iframe .addon-setting.boolean-setting {
   flex-direction: row;
   align-items: center;
 }
-body.iframe .addon-setting.boolean-setting .setting-label {
+body.iframe .addon-setting.boolean-setting .setting-label-container {
   margin-bottom: 0;
 }
 body.iframe .presets-column > .setting-label {


### PR DESCRIPTION
Resolves #8399

### Changes

![image](https://github.com/user-attachments/assets/86fff6b9-e35e-49d5-becd-1a2c4a50eb29)

### Reason for changes

* Putting settings closer to their labels makes it easier to see which setting is which.
* Labels that wrap unnecessarily use a lot of extra space.

### Tests

Tested on Edge and Firefox.