### PR TITLE
fix: prevent error when adding label to empty custom block (#8396)

### DIFF
--- a/addons/reorder-custom-inputs/userscript.js
+++ b/addons/reorder-custom-inputs/userscript.js
@@ -70,7 +70,7 @@ export default async function ({ addon, console }) {
       // We account for this with a hacky method of adding the delimiter at the end of the last label input
       if (fnName === "addLabelExternal") {
         const lastInput = proc.inputList[proc.inputList.length - 1];
-        if (lastInput.type === INPUT_DUMMY) {
+        if (lastInput?.type === INPUT_DUMMY) {
           lastInput.fieldRow[0].setValue(lastInput.fieldRow[0].getValue() + " %l");
         }
       }


### PR DESCRIPTION
Resolves #8396

### Changes

* Added optional chaining to safely access `lastInput.type` in `addLabelExternal`

### Reason for changes

* Fixes crash when adding a label to an empty custom block

### Tests

* Manually tested in **Chrome**

  * Verified label can be added to empty block without errors
  * Confirmed other custom block editing features still work as expected