### PR TITLE
dark-www: fix profile comment report background

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -690,3 +690,8 @@ input.link.black {
   border-color: var(--darkWww-page-forumErrorColor);
   color: var(--darkWww-page-forumErrorColor);
 }
+
+/* Reported profile comments */
+#comments .comment.just_removed {
+  background-color: #f003;
+}


### PR DESCRIPTION
Sets the reported profile comment background to be mostly transparent for dark mode support.

![2025-06-26_16-06-25](https://github.com/user-attachments/assets/4ff0ced4-86ce-46e4-9af0-457c73a68623)
![2025-06-26_16-06-49](https://github.com/user-attachments/assets/fb3c1f2c-c061-44ac-bfd6-f26e6149ed83)


### Tests

Tested with inspect element in Firefox and then by adding the `just_removed` class to a comment.

With the "Scratch's default colors" preset it is the same as with the addon is disabled except when using `scratchr2`, but I can add a new CSS variable if needed.