### PR TITLE
Run Transifex action weekly instead of daily

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -2,7 +2,7 @@ name: Sync strings with Transifex
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * Sun"
 jobs:
   transifex:
     name: Transifex


### PR DESCRIPTION
https://github.com/ScratchAddons/ScratchAddons/issues/8382#issuecomment-3014104730

Since development is slowing down this change makes sense regardless.

It would sense to split the push and pull actions in the future so translators can receive new strings without us needing to pull the translated ones.

### Tests

Untested