### PR TITLE
ctrl-click-run-scripts: new Blockly

### DIFF
--- a/addons/ctrl-click-run-scripts/userscript.js
+++ b/addons/ctrl-click-run-scripts/userscript.js
@@ -7,19 +7,20 @@ export default async function ({ addon, console }) {
   const originalBlocklyListen = vm.editingTarget.blocks.constructor.prototype.blocklyListen;
 
   let ctrlKeyPressed = false;
-  document.addEventListener(
-    "mousedown",
-    function (e) {
-      ctrlKeyPressed = e.ctrlKey || e.metaKey;
-    },
-    {
-      capture: true,
-    }
-  );
+  const onMouseDown = function (e) {
+    ctrlKeyPressed = e.ctrlKey || e.metaKey;
+  };
+  document.addEventListener("mousedown", onMouseDown, { capture: true }); // for old Blockly
+  document.addEventListener("pointerdown", onMouseDown, { capture: true }); // for new Blockly
 
   // Limits all script running to CTRL + click
   const newBlocklyListen = function (e) {
-    if (!addon.self.disabled && e.element === "stackclick" && !ctrlKeyPressed) {
+    if (
+      !addon.self.disabled &&
+      // new Blockly || old Blockly
+      ((e.type === "click" && e.targetType === "block") || e.element === "stackclick") &&
+      !ctrlKeyPressed
+    ) {
       return;
     } else {
       originalBlocklyListen.call(this, e);


### PR DESCRIPTION
### Changes

Updates "Ctrl+Click to run scripts" to work with modern Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox.