### PR TITLE
Move cleanup+ split notice to the new addon

### DIFF
--- a/addons/editor-cleanup-plus/addon.json
+++ b/addons/editor-cleanup-plus/addon.json
@@ -10,6 +10,12 @@
       "link": "https://scratch.mit.edu/users/Chrome_Cat/"
     }
   ],
+  "info": [
+    {
+      "text": "This addon was previously part of the \"developer tools\" addon but has moved here.",
+      "id": "developer-tools"
+    }
+  ],
   "settings": [
     {
       "name": "Find unused variables",

--- a/addons/editor-devtools/addon.json
+++ b/addons/editor-devtools/addon.json
@@ -26,10 +26,6 @@
     }
   ],
   "versionAdded": "1.0.0",
-  "latestUpdate": {
-    "version": "1.43.0",
-    "temporaryNotice": "The \"Clean up Blocks +\" option has been moved to a separate addon."
-  },
   "tags": ["editor", "codeEditor", "recommended"],
   "enabledByDefault": true
 }


### PR DESCRIPTION
This is consistent with other addons that have been split off from devtools and removes the misleading new features tag from devtools itself.

Also, should one or two of the other updated addons be promoted to the featured section to even it out?

### Tests

Tested on Brave.