### PR TITLE
editor-square-inputs: new Blockly

### DIFF
--- a/addons/editor-square-inputs/userscript.js
+++ b/addons/editor-square-inputs/userscript.js
@@ -15,18 +15,58 @@ export default async function ({ addon }) {
     colour_picker: "color",
   };
 
+  let SQUARE;
+  let CORNER_RADIUS;
+  if (ScratchBlocks.registry) {
+    // new Blockly
+    const constants = new ScratchBlocks.zelos.ConstantProvider();
+    SQUARE = constants.SHAPES.SQUARE;
+    CORNER_RADIUS = constants.CORNER_RADIUS;
+  } else {
+    SQUARE = ScratchBlocks.OUTPUT_SHAPE_SQUARE;
+  }
+
   const originalJsonInit = ScratchBlocks.BlockSvg.prototype.jsonInit;
 
   ScratchBlocks.BlockSvg.prototype.jsonInit = function (json) {
     if (!addon.self.disabled && opcodeToSettings[this.type] && addon.settings.get(opcodeToSettings[this.type])) {
       originalJsonInit.call(this, {
         ...json,
-        outputShape: ScratchBlocks.OUTPUT_SHAPE_SQUARE,
+        outputShape: SQUARE,
       });
     } else {
       originalJsonInit.call(this, json);
     }
   };
+
+  if (ScratchBlocks.registry) {
+    // new Blockly
+
+    const originalFieldTextInputWidgetCreate = ScratchBlocks.FieldTextInput.prototype.widgetCreate_;
+    ScratchBlocks.FieldTextInput.prototype.widgetCreate_ = function () {
+      const htmlInput = originalFieldTextInputWidgetCreate.call(this);
+      if (!addon.self.disabled && this.isFullBlockField() && this.getSourceBlock().getOutputShape() === SQUARE) {
+        // Change border radius of HTML input
+        const div = ScratchBlocks.WidgetDiv.getDiv();
+        const scale = this.workspace_.getAbsoluteScale();
+        const borderRadius = `${CORNER_RADIUS * scale}px`;
+        div.style.borderRadius = borderRadius;
+        htmlInput.style.borderRadius = borderRadius;
+      }
+      return htmlInput;
+    };
+
+    const originalFinalizeHorizontalAlignment = ScratchBlocks.zelos.RenderInfo.prototype.finalizeHorizontalAlignment_;
+    ScratchBlocks.zelos.RenderInfo.prototype.finalizeHorizontalAlignment_ = function () {
+      // Increase minimum width of square inputs
+      const oldMinBlockWidth = this.constants_.MIN_BLOCK_WIDTH;
+      if (!addon.self.disabled && this.block_.getOutputShape() === SQUARE) {
+        this.constants_.MIN_BLOCK_WIDTH = 6 * this.constants_.GRID_UNIT;
+      }
+      originalFinalizeHorizontalAlignment.call(this);
+      this.constants_.MIN_BLOCK_WIDTH = oldMinBlockWidth;
+    };
+  }
 
   function update() {
     updateAllBlocks(addon.tab);

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -618,10 +618,10 @@ export default async function ({ addon, console, msg }) {
 
   if (Blockly.registry) {
     // new Blockly
-    const oldFieldNUmberShowNumPad = FieldNumber.prototype.showNumPad_;
+    const oldFieldNumberShowNumPad = FieldNumber.prototype.showNumPad_;
     FieldNumber.prototype.showNumPad_ = function () {
       // Number pad
-      oldFieldNUmberShowNumPad.call(this);
+      oldFieldNumberShowNumPad.call(this);
       Blockly.DropDownDiv.setColour(
         this.sourceBlock_.getParent().getColour(),
         this.sourceBlock_.getParent().getColourTertiary()


### PR DESCRIPTION
### Changes

Updates "square block inputs" to support modern Blockly. Also fixes an unrelated typo in another addon.

### Tests

Tested both Scratch versions on Edge and Firefox. The square inputs don't look exactly the same in both versions, but I think the new version is better.

Scratch website:
<img width="255" height="113" alt="image" src="https://github.com/user-attachments/assets/fa28892c-92f6-4471-8699-62e02023c0ed" />

New Blockly:
<img width="244" height="113" alt="image" src="https://github.com/user-attachments/assets/8ffcddde-f79f-41a7-a39b-30097bae39b5" />