### PR TITLE
Fix code for updating flyout on new Blockly

### DIFF
--- a/libraries/common/cs/update-all-blocks.js
+++ b/libraries/common/cs/update-all-blocks.js
@@ -21,9 +21,13 @@ export async function updateAllBlocks(
       if (updateFlyout) {
         if (blockly.registry) {
           // new Blockly: can't use clearWorkspaceAndLoadFromXml() here because it breaks the flyout
+          // Events have to be reenabled here because flyout.show() creates new blocks with new IDs
+          // and the VM needs to be notified about that.
+          blockly.Events.enable();
           flyout.setRecyclingEnabled(false);
           flyout.show(toolbox.getInitialFlyoutContents());
           flyout.setRecyclingEnabled(true);
+          blockly.Events.disable();
         } else {
           const flyoutWorkspace = flyout.getWorkspace();
           blockly.Xml.clearWorkspaceAndLoadFromXml(blockly.Xml.workspaceToDom(flyoutWorkspace), flyoutWorkspace);


### PR DESCRIPTION
### Changes

Fixes a bug introduced in one of my recent PRs: clicking on blocks in the flyout to run them didn't work in the new Blockly editor if custom-block-text or editor-square-inputs was enabled.

### Tests

Tested on Edge and Firefox.