### PR TITLE
Rename "full screen settings" to "settings page"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Be sure to follow our [code of conduct](https://github.com/ScratchAddons/Scratch
 
 Found a bug? Have an idea? You can [open an issue](https://github.com/ScratchAddons/ScratchAddons/issues/new/choose) to report bugs and send feedback! But first, be sure to [search for existing issues](https://github.com/ScratchAddons/ScratchAddons/issues). If there are no similar issues, you can create a new one. You can also open a [discussion](https://github.com/ScratchAddons/ScratchAddons/discussions) to suggest ideas or ask questions. We will take a look at it.
 
-We also have a [feedback form](https://scratchaddons.com/feedback) on our website, which you can access by clicking "Send Feedback" in Scratch Addons' full screen settings page.
+We also have a [feedback form](https://scratchaddons.com/feedback) on our website, which you can access by clicking "Send Feedback" in Scratch Addons' settings page.
 
 ## Contributing code
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -354,10 +354,10 @@
     "description": "Used as a category name for recently used addons"
   },
   "settingsPagePermission": {
-    "message": "To enable the \"$1\" addon, go to the full screen settings page."
+    "message": "To enable the \"$1\" addon, go to the settings page."
   },
   "openFullSettings": {
-    "message": "Open full screen settings"
+    "message": "Open settings page"
   },
   "skipOpenFullSettings": {
     "message": "Cancel"


### PR DESCRIPTION
### Changes

Changes all references to "full screen settings" to say "settings page" instead.

### Reason for changes

The name "full screen settings" doesn't make sense on mobile devices because the popup is also full-screen.

### Tests

Tested on Edge.