### PR TITLE
scratch3to2: remove text shadow from message count on messages page

### DIFF
--- a/addons/scratch3to2/messages.css
+++ b/addons/scratch3to2/messages.css
@@ -36,6 +36,7 @@
 }
 .messages-header-unread {
   padding: 2px 4px;
+  text-shadow: none;
 }
 .messages-admin-list {
   padding: 0 20px;


### PR DESCRIPTION
### Changes

Before:
<img width="156" height="63" alt="image" src="https://github.com/user-attachments/assets/e1e65f4d-cfcb-48ea-98ab-6e50ed88155a" />

After:
<img width="165" height="54" alt="image" src="https://github.com/user-attachments/assets/36be158d-2d0a-42bb-bb5a-43fe30abfdd4" />

### Tests

Tested on Edge and Firefox.