### PR TITLE
Change mention of community Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: 📝 Send feedback
     url: https://scratchaddons.com/feedback
     about: Send a general feedback on our website
-  - name: 🏠 Community Discord
+  - name: 🧑‍💻 Support Discord
     url: https://discord.gg/R5NBqwMjNc
-    about: Discuss about Scratch Addons on our community Discord server (recommended)
+    about: Open a support ticket on Discord
   - name: 🔧 Development Discord
     url: https://discord.gg/Ak8sCDQ
     about: Discuss about Scratch Addons on our development Discord server

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![](https://img.shields.io/github/v/release/ScratchAddons/ScratchAddons?style=flat-square&logo=github&logoColor=white&label=GitHub&color=181717)](https://github.com/ScratchAddons/ScratchAddons/releases)
 
 [![](https://img.shields.io/github/license/ScratchAddons/ScratchAddons?style=flat-square)](https://github.com/ScratchAddons/ScratchAddons/blob/master/LICENSE)
-[![](https://img.shields.io/discord/806602307750985799?style=flat-square&logo=discord&logoColor=white&color=7289da)](https://discord.gg/R5NBqwMjNc)
 [![](https://img.shields.io/badge/website-scratchaddons.com-ff7b26.svg?style=flat-square)](https://scratchaddons.com)
 [![](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fscratchaddons.com%2Fusercount.json&query=countAsString&style=flat-square&label=users&color=%23FF7B27)](https://scratchaddons.com/usercount.json)
 


### PR DESCRIPTION
Updates the issue template config to mention that the Discord server is only for support and removes the badge from the README.