### PR TITLE
dark-www & scratch3to2: style new "Set Thumbnail" button & modal

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -169,6 +169,7 @@ body:not(.sa-body-editor) input.formik-radio-input,
 .wedo .project-card,
 .transfer-host-modal .cancel-button,
 .transfer-host-modal .transfer-password-input,
+.update-thumbnail-info-modal .update-thumbnail-info-modal-inner,
 .comments-container .sa-emoji-picker,
 .studio-compose-container .sa-emoji-picker {
   background-color: var(--darkWww-box);
@@ -198,6 +199,7 @@ body:not(.sa-body-editor) .button.white,
   border-color: transparent !important;
   color: var(--darkWww-box-text);
 }
+body:not(.sa-body-editor) [class*="stage-header_rightSection_"],
 .expect .keynote .card {
   background-color: transparent;
 }

--- a/addons/scratch3to2/main.css
+++ b/addons/scratch3to2/main.css
@@ -559,6 +559,7 @@ body:not(.sa-body-editor) .select select > option {
 }
 .modal-header,
 .report-modal-header,
+.update-thumbnail-info-modal .update-thumbnail-info-modal-title,
 .youtube-video-modal-container .cards-modal-header.mint-green,
 .cards-modal-container .cards-modal-header,
 .mod-feedback .feedback-header {
@@ -572,6 +573,7 @@ body:not(.sa-body-editor) .select select > option {
 }
 .modal-title,
 .report-content-label,
+.update-thumbnail-info-modal .update-thumbnail-info-modal-title,
 .cards-modal-container .cards-modal-header .cards-title {
   color: var(--darkWww-box-scratchr2HeaderText, #554747);
   text-align: left;

--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -267,6 +267,27 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button_"]:not(.sa-gamepad-
 body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"]:not(.sa-gamepad-container *) {
   display: none;
 }
+[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"] {
+  height: 26px;
+  padding: 0 10px;
+  background-image: linear-gradient(
+    var(--darkWww-box-scratchr2ButtonGradientTop, white),
+    var(--darkWww-box-scratchr2ButtonGradientBottom, #ccc)
+  );
+  border: 1px solid var(--darkWww-box-scratchr2ButtonBorder, #999);
+  color: var(--darkWww-box-scratchr2ButtonText, #666);
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 24px;
+  text-shadow: 0 1px var(--darkWww-box, white);
+}
+[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"]:hover {
+  background-color: var(--darkWww-box-scratchr2ButtonHover, #e6e6e6);
+  background-image: none;
+}
+[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"]:active {
+  filter: none;
+}
 [class*="stage-header_embed-scratch-logo_"] img {
   padding: 0.8rem 2.4rem; /* hide original image */
   background-repeat: no-repeat;
@@ -310,6 +331,11 @@ body:not(.sa-body-editor) [class*="stage_green-flag-overlay_"] {
 }
 body:not(.sa-body-editor) [class*="stage_green-flag-overlay_"] > img {
   display: none;
+}
+
+/* Scratch's Set Thumbnail modal */
+.update-thumbnail-info-modal .update-thumbnail-info-modal-title {
+  height: auto;
 }
 
 /* Description */
@@ -606,7 +632,7 @@ body:not(.sa-body-editor) [class*="stage_green-flag-overlay_"] > img {
   height: 46px; /* two lines */
 }
 
-/* Set Thumbnail modal */
+/* animated-thumb modal */
 .sa-animated-thumb-popup-content {
   padding: 0;
 }


### PR DESCRIPTION
### Changes

<img width="374" height="159" alt="image" src="https://github.com/user-attachments/assets/57cd7125-3ef8-4ca9-b9e1-1372045e77d4" /><br />
<img width="571" height="369" alt="image" src="https://github.com/user-attachments/assets/edc42d8c-bc57-4651-b76e-1d7a7e85e6ac" /><br />
<img width="231" height="72" alt="image" src="https://github.com/user-attachments/assets/bfdefcb8-30f4-4de9-b1fb-e67e058e5f42" />

### Reason for changes

Scratch will add a "Set Thumbnail" button on the project page.

### Tests

Tested locally on Edge.

The modal normally only opens when the button is clicked for the first time. To open it again, delete the `isFirstManualThumbnailUpdate` key in localStorage and reload the page.