### PR TITLE
gamepad: move button after Set Thumbnail

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -416,13 +416,18 @@ export default class Tab extends Listenable {
     const sharedSpaces = {
       stageHeader: {
         // Non-fullscreen stage header only
-        element: () => q("[class^='stage-header_stage-size-row']"),
+        element: () =>
+          q("[class*='stage-header_setThumbnailButton_']")
+            ? q("[class*='stage-header_rightSection_']")
+            : q("[class*='stage-header_stage-size-row_']"),
         from: () => [],
         until: () => [
           // Small/big stage buttons (for editor mode)
-          q("[class^='stage-header_stage-size-toggle-group']"),
+          q("[class*='stage-header_stage-size-toggle-group_']"),
           // Full screen icon (for player mode)
-          q("[class^='stage-header_stage-size-row']").lastChild,
+          q("[class*='stage-header_setThumbnailButton_']")
+            ? q("[class*='stage-header_rightSection_']").lastChild
+            : q("[class*='stage-header_stage-size-row_']").lastChild,
         ],
       },
       fullscreenStageHeader: {

--- a/addons/gamepad/style.css
+++ b/addons/gamepad/style.css
@@ -4,6 +4,9 @@
 [dir="rtl"] .sa-gamepad-container {
   margin-left: 0.2rem;
 }
+[class*="stage-header_rightSection_"] > .sa-gamepad-container {
+  margin: 0;
+}
 
 .sa-gamepad-popup-outer {
   /* above fullscreen */


### PR DESCRIPTION
### Changes

Before:
<img width="274" height="67" alt="image" src="https://github.com/user-attachments/assets/295754f7-2b06-4d52-8f2d-c51568d4bacb" />

After:
<img width="251" height="66" alt="image" src="https://github.com/user-attachments/assets/8cefb165-8cac-4935-a110-19da612f2261" />

Nothing is changed in the editor or on the current Scratch website.

### Tests

Tested locally on Edge.