### PR TITLE
"Set thumbnail" → "upload thumbnail"

### DIFF
--- a/addons-l10n/en/animated-thumb.json
+++ b/addons-l10n/en/animated-thumb.json
@@ -1,5 +1,5 @@
 {
-  "animated-thumb/set-thumbnail": "Set Thumbnail",
+  "animated-thumb/set-thumbnail": "Upload Thumbnail",
   "animated-thumb/added-by": "Button added by Scratch Addons browser extension",
   "animated-thumb/description": "Upload a thumbnail from a file, or click \"Use Stage\" to use the current stage as the thumbnail.",
   "animated-thumb/keep-thumb": "Stop thumbnail auto-saving (Recommended)",

--- a/addons/animated-thumb/addon.json
+++ b/addons/animated-thumb/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Thumbnail setter",
+  "name": "Thumbnail uploader",
   "description": "Adds a button to the bottom-right of the project page to set the thumbnail of your project to any image (including gifs).",
   "userscripts": [
     {


### PR DESCRIPTION
<div align=center><table><td>

**Update:** Superseded by #8456. </td></table></div>

~~Tracked by #8454~~

### Changes

Renames the `animated-thumb` button and addon.

### Reason for changes

Scratch is adding its own "Set Thumbnail" button, so renaming our addon will make it more distinct.

This change may be temporary; #8456 will add a combobutton that will combine these two features in the future.