### PR TITLE
Fix help icon alignment in popup

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -492,7 +492,7 @@
       flex-direction: row;
       align-items: center;
     }
-    .settings-column > .addon-setting.boolean-setting .setting-label {
+    .settings-column > .addon-setting.boolean-setting .setting-label-container {
       margin-bottom: 0;
     }
     .presets-column > .setting-label {

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -415,13 +415,11 @@
   @media (max-width: 700px) {
     .setting-label-container {
       width: auto;
+      margin-bottom: 5px;
       max-width: calc(100% - 66px); /* prevent setting description tooltip from overflowing */
     }
     .setting-label-container:not(:has(.tooltip)) {
       max-width: none;
-    }
-    .setting-label {
-      margin-bottom: 5px;
     }
     .setting-input {
       flex-shrink: 0;


### PR DESCRIPTION
### Changes

Moves the setting label margin back onto the parent when in narrow mode.