### PR TITLE
Fix project actions overflow

### DIFF
--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -15,6 +15,22 @@ const contextMenuCallbacks = [];
 const CONTEXT_MENU_ORDER = ["editor-devtools", "block-switching", "blocks2image", "swap-local-global"];
 let createdAnyBlockContextMenus = false;
 
+const PROJECT_ACTIONS_CSS = `
+  @media (min-width: 768px) {
+    .preview > .inner > .preview-row:nth-child(3) {
+      justify-content: flex-end;
+      flex-wrap: wrap;
+    }
+
+    .stats {
+      margin-right: auto;
+    }
+
+    .subactions {
+      display: contents;
+    }
+  }`;
+
 /**
  * APIs specific to userscripts.
  * @extends Listenable
@@ -456,12 +472,32 @@ export default class Tab extends Listenable {
         until: () => [],
       },
       beforeProjectActionButtons: {
-        element: () => q(".flex-row.subactions > .flex-row.action-buttons"),
+        element: () => {
+          if (!q("#sa-project-actions-css")) {
+            document.head.appendChild(
+              Object.assign(document.createElement("style"), {
+                id: "sa-project-actions-css",
+                textContent: PROJECT_ACTIONS_CSS,
+              })
+            );
+          }
+          return q(".flex-row.subactions > .flex-row.action-buttons");
+        },
         from: () => [],
         until: () => [q(".report-button"), q(".action-buttons > div")],
       },
       afterCopyLinkButton: {
-        element: () => q(".flex-row.subactions > .flex-row.action-buttons"),
+        element: () => {
+          if (!q("#sa-project-actions-css")) {
+            document.head.appendChild(
+              Object.assign(document.createElement("style"), {
+                id: "sa-project-actions-css",
+                textContent: PROJECT_ACTIONS_CSS,
+              })
+            );
+          }
+          return q(".flex-row.subactions > .flex-row.action-buttons");
+        },
         from: () => [q(".copy-link-button")],
         until: () => [],
       },

--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -531,7 +531,6 @@ body:not(.sa-body-editor) [class*="stage_green-flag-overlay_"] > img {
 .subactions .share-date {
   margin: 0;
   padding: 5px 15px;
-  border-right: 1px solid var(--darkWww-border-15, #bbb);
   color: var(--darkWww-gray-scratchr2BlackText, black);
   font-size: 13px;
   line-height: 30px;
@@ -554,8 +553,12 @@ body:not(.sa-body-editor) [class*="stage_green-flag-overlay_"] > img {
   font-size: 13px;
   font-weight: normal;
 }
+.subactions .action-buttons > .action-button:first-child,
+.subactions .action-buttons > :first-child > .action-button {
+  border-left: 1px solid var(--darkWww-border-15, #bbb);
+}
 .subactions .action-buttons > .action-button:last-child {
-  border: none;
+  border-right: none;
 }
 .subactions .action-buttons .action-button.studio-button::before,
 .subactions .action-buttons .action-button.copy-link-button::before,


### PR DESCRIPTION
Resolves #6954

### Changes

Before:
<img width="1190" height="64" alt="image" src="https://github.com/user-attachments/assets/f037ca2d-aff7-4602-9a5f-c216122ce307" />
<img width="1193" height="102" alt="image" src="https://github.com/user-attachments/assets/4c6c17c2-be4a-40f3-8733-3e63470bcc33" />
<img width="1189" height="140" alt="image" src="https://github.com/user-attachments/assets/1c42a5d9-2eaf-492b-86ae-f139e31dedaf" />

After:
<img width="1190" height="64" alt="image" src="https://github.com/user-attachments/assets/f037ca2d-aff7-4602-9a5f-c216122ce307" />
<img width="1193" height="102" alt="image" src="https://github.com/user-attachments/assets/4c6c17c2-be4a-40f3-8733-3e63470bcc33" />
<img width="1190" height="104" alt="image" src="https://github.com/user-attachments/assets/99292c8a-e202-4894-8dc2-980acdde841e" />

### Reason for changes

This makes the layout more consistent - the only element that isn't always in the same place is the share date.

### Tests

Tested on Edge and Firefox.