### PR TITLE
Allow running on scratchfoundation/scratch-editor

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -3,7 +3,7 @@ const PERMISSIONS_IGNORED_IN_FIREFOX = [];
 // These host permissions below should be removed during production manifest gen.
 const PERMISSIONS_ALWAYS_IGNORED = [
   "scripting",
-  "https://scratchfoundation.github.io/scratch-gui/*",
+  "https://scratchfoundation.github.io/scratch-editor/*",
   "https://scratchfoundation.github.io/*",
   "http://localhost:8333/*",
   "http://localhost:8601/*",

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
     {
       "matches": [
         "https://scratch.mit.edu/*",
-        "https://scratchfoundation.github.io/scratch-gui/*",
+        "https://scratchfoundation.github.io/scratch-editor/*",
         "http://localhost:8333/*",
         "http://localhost:8601/*",
         "http://localhost:8602/*"
@@ -32,7 +32,7 @@
     {
       "matches": [
         "https://scratch.mit.edu/*",
-        "https://scratchfoundation.github.io/scratch-gui/*",
+        "https://scratchfoundation.github.io/scratch-editor/*",
         "http://localhost:8333/*",
         "http://localhost:8601/*",
         "http://localhost:8602/*"
@@ -52,7 +52,7 @@
     "https://scratch.mit.edu/*",
     "https://api.scratch.mit.edu/*",
     "https://clouddata.scratch.mit.edu/*",
-    "https://scratchfoundation.github.io/scratch-gui/*",
+    "https://scratchfoundation.github.io/scratch-editor/*",
     "http://localhost/*"
   ],
   "permissions": [


### PR DESCRIPTION
### Changes

Changes `scratch-gui` to `scratch-editor` when running the extension on `scratchfoundation.github.io`.

### Reason for changes

Scratch is migrating to `scratch-editor` and has added a warning to the top of `scratch-gui`'s README stating it will be archived, so I don't think compatibility needs to be kept for it.

### Tests

Tested on Firefox, running on a subpath doesn't seem to matter.
