### PR TITLE
`editor-dark-mode`: Add Scratch Lab theme (electric boogaloo)

### DIFF
--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -1519,7 +1519,7 @@
         "page": "#e5f0ff",
         "primary": "#4d97ff",
         "highlightText": "#4d97ff",
-        "menuBar": "#3cb371",
+        "menuBar": "#0fbd8c",
         "popup": "#4d97ffe6",
         "activeTab": "#ffffff",
         "tab": "#d9e3f2",


### PR DESCRIPTION
Hi, I'm Zydrolic again. Awhile back I deleted my github account on a whim, and honestly me coming back is yet another whim lol.
Thought I'd redo this PR except with the colors properly double checked <sub>(The old one used a wrong shade of green, by the way)</sub>.

Resolves #7581

### Changes

Adds the colors from Scratch Lab as a theme.

### Reason for changes

"Some people would want their Scratch experience to look like Scratch Labs'." (#7581), though not certain if that really holds true still?

### Tests

LibreWolf 140.0.4-1 (Firefox fork).
Have not tested on anything Chromium-based yet, but I believe this works fine.