### PR TITLE
Don't allow pausing online multiplayer games

### DIFF
--- a/addons-l10n/en/pause.json
+++ b/addons-l10n/en/pause.json
@@ -1,4 +1,5 @@
 {
   "pause/pause": "Pause",
-  "pause/play": "Resume"
+  "pause/play": "Resume",
+  "pause/cannot-pause": "This project cannot be paused"
 }

--- a/addons/pause/check-online.js
+++ b/addons/pause/check-online.js
@@ -1,0 +1,95 @@
+let hasOnlineFeatures;
+
+/** Guesses whether the project has cloud variable features */
+const scanForOnlineFeatures = (vm, console, msg) => {
+  // Well, only if it actually has cloud variables :P
+  if (!vm.runtime.hasCloudData()) {
+    hasOnlineFeatures = false;
+    return;
+  }
+
+  const allBlocks = vm.runtime.targets.flatMap((target) => Object.values(target.blocks._blocks));
+  // Map the names and values of cloud variables to an object
+  const cloudVariables = {};
+  const globalVariables = vm.runtime.getTargetForStage().variables;
+  for (let id of Object.keys(globalVariables)) {
+    if (globalVariables[id].isCloud) {
+      cloudVariables[globalVariables[id].name] = globalVariables[id].value;
+    }
+  }
+
+  const keys = Object.keys(cloudVariables);
+  const values = Object.values(cloudVariables);
+
+  const varsHaveInvalidNumbers = values.some((i) => String(Number(i)) !== i);
+  const areVarNamesSequential = keys.some((i) => i.endsWith("2")) && keys.some((i) => i.endsWith("3"));
+  const usesUsernameBlock = allBlocks.some((block) => block.opcode === "sensing_username");
+
+  if (varsHaveInvalidNumbers && areVarNamesSequential && usesUsernameBlock) {
+    // It's definitely online
+    onlineFeaturesDetected();
+    document.querySelector(".pause-btn").title = msg("cannot-pause");
+    console.log("Online features detected - pause disabled.");
+  } else if (varsHaveInvalidNumbers || areVarNamesSequential || usesUsernameBlock) {
+    // It might be online, we'll analyze during runtime
+    threshold = 5;
+    console.log("This Cloud project has the following characteristics:", {
+      varsHaveInvalidNumbers,
+      areVarNamesSequential,
+      usesUsernameBlock,
+    });
+  }
+};
+
+let interactions = 0;
+let threshold = 10;
+let timeout;
+/** Tracks incoming and outgoing data for cloud variables */
+const onDataTransferred = (value) => {
+  const hasInvalidNumbers = String(Number(value)) !== value;
+  if (hasInvalidNumbers) interactions++;
+  clearTimeout(timeout);
+  if (interactions < threshold) {
+    // Reset counter after 1.2s
+    timeout = setTimeout(() => (interactions = 0), 1200);
+  } else {
+    onlineFeaturesDetected();
+  }
+};
+
+function onlineFeaturesDetected() {
+  hasOnlineFeatures = true;
+  document.querySelector(".pause-btn").classList.add("disabled");
+}
+
+export const getHasOnlineFeatures = () => hasOnlineFeatures;
+export const checkForOnlineFeatures = async (addon, console, msg) => {
+  await addon.tab.redux.waitForState((state) => state.scratchGui.projectState.loadingState.startsWith("SHOWING"));
+  scanForOnlineFeatures(addon.tab.traps.vm, console, msg);
+  if (hasOnlineFeatures === undefined) {
+    const originalSend = addon.tab.traps.vm.runtime.ioDevices.cloud.provider.connection.send;
+    addon.tab.traps.vm.runtime.ioDevices.cloud.provider.connection.send = function (data) {
+      originalSend.call(this, data);
+      const json = JSON.parse(data);
+      if (!hasOnlineFeatures && json.name) {
+        onDataTransferred(json.value);
+        if (hasOnlineFeatures) {
+          document.querySelector(".pause-btn").title = msg("cannot-pause");
+          console.log("Online features detected - pause disabled.");
+        }
+      }
+    };
+    const originalOnMessage = addon.tab.traps.vm.runtime.ioDevices.cloud.provider.connection.onmessage;
+    addon.tab.traps.vm.runtime.ioDevices.cloud.provider.connection.onmessage = function (message) {
+      originalOnMessage.call(this, message);
+      const json = JSON.parse(message.data);
+      if (!hasOnlineFeatures && json.name) {
+        onDataTransferred(json.value);
+        if (hasOnlineFeatures) {
+          document.querySelector(".pause-btn").title = msg("cannot-pause");
+          console.log("Online features detected - pause disabled.");
+        }
+      }
+    };
+  }
+};

--- a/addons/pause/style.css
+++ b/addons/pause/style.css
@@ -11,3 +11,7 @@
 .pause-btn:hover {
   background-color: hsla(260, 60%, 60%, 0.15);
 }
+
+.pause-btn.disabled {
+  opacity: 0.5;
+}

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -1,7 +1,14 @@
 import { isPaused, setPaused, onPauseChanged, setup } from "../debugger/module.js";
+import { checkForOnlineFeatures, getHasOnlineFeatures } from "./check-online.js";
 
 export default async function ({ addon, console, msg }) {
   setup(addon);
+  checkForOnlineFeatures(addon, console, msg);
+
+  function togglePause() {
+    if (getHasOnlineFeatures() && !isPaused()) return;
+    setPaused(!isPaused());
+  }
 
   const img = document.createElement("img");
   img.className = "pause-btn";
@@ -12,7 +19,7 @@ export default async function ({ addon, console, msg }) {
     img.src = addon.self.dir + (isPaused() ? "/play.svg" : "/pause.svg");
     img.title = isPaused() ? msg("play") : msg("pause");
   };
-  img.addEventListener("click", () => setPaused(!isPaused()));
+  img.addEventListener("click", togglePause);
   addon.tab.displayNoneWhileDisabled(img);
   addon.self.addEventListener("disabled", () => setPaused(false));
   setSrc();
@@ -28,7 +35,7 @@ export default async function ({ addon, console, msg }) {
       if (e.altKey && (e.key.toLowerCase() === "x" || e.keyCode === 88) && !addon.self.disabled) {
         e.preventDefault();
         e.stopImmediatePropagation();
-        setPaused(!isPaused());
+        togglePause();
       }
     },
     { capture: true }


### PR DESCRIPTION
### Addresses:

- https://github.com/ScratchAddons/ScratchAddons/pull/5838#pullrequestreview-2910954458

- > @DNin01 your review adds a new perspective I didn't think about. Maybe we should add an option to prevent pause for projects with cloud variables, maybe even mitigations for the addon itself (not just this option)?
  >
  > _Originally posted by @iqnite in [#5838 (comment)](https://github.com/ScratchAddons/ScratchAddons/issues/5838#issuecomment-2956646246)_

### Changes

Added an algorithm that is used to determine whether a project is okay to pause, based on metadata and runtime activity analysis. Basically, **if it thinks the project is a multiplayer game, the pause function will be disabled**.

Characteristics and patterns that are considered:
- Whether the project has sequentially named Cloud variables (e.g., player1, player2, player3...)
- If the project uses the "username" block
- How often data is read, sent, and received
- Whether sent data has valid or invalid numbers

### Reason for changes

Pausing a game that connects with other players can cause issues and mess up their sessions unless the project was designed to explicitly handle players momentarily disconnecting. That is unfair, so this change solves this part of the problem.

### Tests

Tested all logic on several different projects.

### Status

**This addition hasn't been extensively discussed or had an issue open; the problems were only briefly mentioned on a pull request with related changes, so this implementation may not be final. Do not merge the pull request until a conclusion has been reached.**

If this pull request doesn't make it, I'll consider integrating it with an auto-pause feature like #5838, since _us_ pausing an online game would be our fault, not the user's fault.
