### PR TITLE
search-sprites & editor-stage-left: fix for small stage mode

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -99,3 +99,15 @@
 .sa-stage-hidden [class*="gui_tab-list_"] {
   padding-inline-start: calc(240px + 1.125rem);
 }
+
+/* search-sprites compatibility */
+
+.sa-small-stage [dir="ltr"] .sa-search-sprites-container {
+  right: auto;
+  left: calc(100% - 7.5rem);
+}
+
+.sa-small-stage [dir="rtl"] .sa-search-sprites-container {
+  left: auto;
+  right: calc(100% - 7.5rem);
+}

--- a/addons/search-sprites/search-bar.css
+++ b/addons/search-sprites/search-bar.css
@@ -4,7 +4,7 @@
 
 .sa-search-sprites-container {
   position: absolute;
-  z-index: 21; /* above workspace scrollbar in small stage mode */
+  z-index: 46; /* $z-index-add-button */
   bottom: 0.75rem;
   display: flex;
   width: 2.75rem;

--- a/addons/search-sprites/userscript.js
+++ b/addons/search-sprites/userscript.js
@@ -1,3 +1,5 @@
+import addSmallStageClass from "../../libraries/common/cs/small-stage.js";
+
 export default async function ({ addon, console, msg }) {
   let spritesContainer;
   let spriteSelectorContainer;
@@ -66,6 +68,8 @@ export default async function ({ addon, console, msg }) {
   container.appendChild(searchIcon);
   container.appendChild(resetButton);
 
+  addSmallStageClass();
+
   while (true) {
     await addon.tab.waitForElement("div[class^='sprite-selector_items-wrapper']", {
       markAsSeen: true,
@@ -75,8 +79,7 @@ export default async function ({ addon, console, msg }) {
 
     spritesContainer = document.querySelector('[class^="sprite-selector_items-wrapper"]');
     spriteSelectorContainer = document.querySelector('[class^="sprite-selector_sprite-selector"]');
-    const addButton = document.querySelector('[class*="sprite-selector_add-button"]');
-    spriteSelectorContainer.insertBefore(container, addButton);
+    spriteSelectorContainer.appendChild(container);
     reset(); // Clear search box after going outside then inside
   }
 }


### PR DESCRIPTION
Resolves #8449

### Changes

Makes the sprite search bar expand to the right in small stage mode if editor-stage-left is enabled.

<img width="429" height="570" alt="image" src="https://github.com/user-attachments/assets/68cc076e-98fa-4a33-87d4-13f1e1269b90" />

### Tests

Tested on Edge and Firefox.