### PR TITLE
Fix Permissions page being opened twice

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -713,5 +713,7 @@ let fuse;
     }
   });
 
-  chrome.runtime.sendMessage("checkPermissions");
+  if (!isIframe) {
+    chrome.runtime.sendMessage("checkPermissions");
+  }
 })();


### PR DESCRIPTION
Resolves #7433

Fixes a bug causing two copies of the Permissions page being opened when clicking the extension icon on Firefox. One was opened by the popup and another by the settings page iframe inside the popup.