### PR TITLE
editor-theme3: fix broken define hat on new Blockly

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -481,6 +481,14 @@ export default async function ({ addon, console, msg }) {
         this.getOutlinePath(name).setAttribute("fill", this.style.colourSecondary);
       }
     };
+
+    const oldBlockSetStyle = Blockly.BlockSvg.prototype.setStyle;
+    Blockly.BlockSvg.prototype.setStyle = function (...args) {
+      // Prevent hat from being overridden when theme changes
+      const hat = this.hat;
+      oldBlockSetStyle.call(this, ...args);
+      this.hat = hat;
+    };
   } else {
     const oldBlockSetColour = Blockly.Block.prototype.setColour;
     Blockly.Block.prototype.setColour = function (colour, colourSecondary, colourTertiary) {
@@ -880,7 +888,6 @@ export default async function ({ addon, console, msg }) {
                 },
               ])
             ),
-            startHats: true,
           }
         )
       );


### PR DESCRIPTION
### Changes

Fixes theme3 causing define blocks to be rendered wrong - see video in https://github.com/ScratchAddons/ScratchAddons/issues/7768#issuecomment-3146905008.

### Tests

Tested on Edge and Firefox.