### PR TITLE
Responsive update notification

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -604,24 +604,6 @@ const showBanner = () => {
   const notifOuterBody = document.createElement("div");
   const notifInnerBody = Object.assign(document.createElement("div"), {
     id: "sa-notification",
-    style: `
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    width: 700px;
-    max-height: 270px;
-    display: flex;
-    align-items: center;
-    padding: 10px;
-    border-radius: 10px;
-    background-color: #222;
-    color: white;
-    z-index: 99999;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    text-shadow: none;
-    box-shadow: 0 0 20px 0px #0000009e;
-    font-size: 14px;
-    line-height: normal;`,
   });
   /*
   const notifImageLink = Object.assign(document.createElement("a"), {
@@ -633,31 +615,24 @@ const showBanner = () => {
   // Thumbnails were 100px height
   */
   const notifImage = Object.assign(document.createElement("img"), {
+    className: "sa-notification-image",
     // alt: chrome.i18n.getMessage("hexColorPickerAlt"),
     src: chrome.runtime.getURL("/images/cs/icon.png"),
-    style: "height: 150px; border-radius: 5px; padding: 20px",
   });
   const notifText = Object.assign(document.createElement("div"), {
     id: "sa-notification-text",
-    style: "margin: 12px;",
   });
   const notifTitle = Object.assign(document.createElement("span"), {
-    style: "font-size: 18px; line-height: normal; display: inline-block; margin-bottom: 12px;",
+    className: "sa-notification-title",
     textContent: chrome.i18n.getMessage("extensionUpdate"),
   });
   const notifClose = Object.assign(document.createElement("img"), {
-    style: `
-    float: right;
-    cursor: pointer;
-    width: 24px;`,
+    className: "sa-notification-close",
     title: chrome.i18n.getMessage("close"),
     src: chrome.runtime.getURL("../images/cs/close.svg"),
     draggable: false,
   });
   notifClose.addEventListener("click", () => notifInnerBody.remove(), { once: true });
-
-  const NOTIF_TEXT_STYLE = "display: block; color: white !important;";
-  const NOTIF_LINK_STYLE = "color: #1aa0d8; font-weight: normal; text-decoration: underline;";
 
   //
   const _uiLanguage = chrome.i18n.getUILanguage();
@@ -665,13 +640,12 @@ const showBanner = () => {
   //
 
   const notifInnerText0 = Object.assign(document.createElement("span"), {
-    style: NOTIF_TEXT_STYLE + "font-weight: bold;",
+    className: "sa-notification-subtitle",
     textContent: chrome.i18n
       .getMessage("extensionHasUpdated", DOLLARS)
       .replace(/\$(\d+)/g, (_, i) => [chrome.runtime.getManifest().version][Number(i) - 1]),
   });
   const notifInnerText1 = Object.assign(document.createElement("span"), {
-    style: NOTIF_TEXT_STYLE,
     innerHTML: escapeHTML(chrome.i18n.getMessage("extensionUpdateInfo1_v1_42", DOLLARS)).replace(
       /\$(\d+)/g,
       (_, i) =>
@@ -684,19 +658,15 @@ const showBanner = () => {
           Object.assign(document.createElement("a"), {
             href: "https://scratch.mit.edu/scratch-addons-extension/settings?source=updatenotif",
             target: "_blank",
-            style: NOTIF_LINK_STYLE,
             textContent: chrome.i18n.getMessage("scratchAddonsSettings"),
           }).outerHTML,
         ][Number(i) - 1]
     ),
   });
   const notifInnerText2 = Object.assign(document.createElement("span"), {
-    style: NOTIF_TEXT_STYLE,
     textContent: chrome.i18n.getMessage("extensionUpdateInfo2_v1_42"),
   });
-  const notifFooter = Object.assign(document.createElement("span"), {
-    style: NOTIF_TEXT_STYLE,
-  });
+  const notifFooter = document.createElement("span");
   const uiLanguage = chrome.i18n.getUILanguage();
   const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
   const utm = `utm_source=extension&utm_medium=updatenotification&utm_campaign=v${
@@ -705,7 +675,6 @@ const showBanner = () => {
   const notifFooterChangelog = Object.assign(document.createElement("a"), {
     href: `https://scratchaddons.com/${localeSlash}changelog?${utm}`,
     target: "_blank",
-    style: NOTIF_LINK_STYLE,
     textContent: chrome.i18n.getMessage("notifChangelog"),
   });
   const notifFooterFeedback = Object.assign(document.createElement("a"), {
@@ -713,17 +682,15 @@ const showBanner = () => {
       chrome.runtime.getManifest().version
     }&${utm}`,
     target: "_blank",
-    style: NOTIF_LINK_STYLE,
     textContent: chrome.i18n.getMessage("feedback"),
   });
   const notifFooterTranslate = Object.assign(document.createElement("a"), {
     href: "https://scratchaddons.com/translate",
     target: "_blank",
-    style: NOTIF_LINK_STYLE,
     textContent: chrome.i18n.getMessage("translate"),
   });
   const notifFooterLegal = Object.assign(document.createElement("span"), {
-    style: NOTIF_TEXT_STYLE + "font-size: 12px;",
+    className: "sa-notification-legal",
     textContent: chrome.i18n.getMessage("notAffiliated"),
   });
   notifFooter.appendChild(notifFooterChangelog);
@@ -734,8 +701,8 @@ const showBanner = () => {
   notifFooter.appendChild(makeBr());
   notifFooter.appendChild(notifFooterLegal);
 
-  notifText.appendChild(notifTitle);
   notifText.appendChild(notifClose);
+  notifText.appendChild(notifTitle);
   notifText.appendChild(makeBr());
   notifText.appendChild(notifInnerText0);
   notifText.appendChild(makeBr());
@@ -753,6 +720,87 @@ const showBanner = () => {
   notifOuterBody.appendChild(notifInnerBody);
 
   document.body.appendChild(notifOuterBody);
+
+  document.body.appendChild(
+    Object.assign(document.createElement("style"), {
+      textContent: `
+        #sa-notification {
+          position: fixed;
+          bottom: 20px;
+          right: 20px;
+          width: 700px;
+          max-width: calc(100% - 60px);
+          max-height: calc(100vh - 60px);
+          max-height: calc(100svh - 60px);
+          overflow-y: auto;
+          display: flex;
+          align-items: center;
+          padding: 10px;
+          border-radius: 10px;
+          background-color: #222;
+          color: white;
+          z-index: 99999;
+          font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+          text-shadow: none;
+          box-shadow: 0 0 20px 0px #0000009e;
+          font-size: 14px;
+          line-height: normal;
+        }
+
+        .sa-notification-image {
+          height: 150px;
+          border-radius: 5px;
+          padding: 20px;
+        }
+
+        #sa-notification-text {
+          margin: 12px;
+        }
+
+        #sa-notification-text > span {
+          display: block;
+          color: white !important;
+        }
+
+        .sa-notification-title {
+          font-size: 18px;
+          line-height: normal;
+        }
+
+        .sa-notification-close {
+          float: right;
+          cursor: pointer;
+          margin-left: 12px;
+          margin-bottom: 12px;
+          width: 24px;
+        }
+
+        .sa-notification-subtitle {
+          font-weight: bold;
+        }
+
+        #sa-notification-text a {
+          color: #1aa0d8;
+          font-weight: normal;
+          text-decoration: underline;
+        }
+
+        .sa-notification-legal {
+          font-size: 12px;
+        }
+
+        @media (max-width: 600px) {
+          #sa-notification {
+            flex-direction: column;
+          }
+
+          .sa-notification-image {
+            display: none;
+          }
+        }
+      `,
+    })
+  );
 };
 
 const handleBanner = async () => {


### PR DESCRIPTION
### Changes

Updates the CSS for the update notification to support narrow screens.

I decided to hide the SA logo because it takes up a lot of space without adding any information. If we ever start adding [screenshots](https://github.com/ScratchAddons/ScratchAddons/pull/1016) to update notifications again (I think we should), this will need to be changed.

### Tests

Tested on Firefox for Android.

<img width="360" height="490" alt="mobile_update_notif" src="https://github.com/user-attachments/assets/0c45b0fd-c2cb-4ddc-99b6-deb0171da797" />