### PR TITLE
Remove support for port 8602

### DIFF
--- a/.github/gen-manifest.mjs
+++ b/.github/gen-manifest.mjs
@@ -7,7 +7,6 @@ const PERMISSIONS_ALWAYS_IGNORED = [
   "https://scratchfoundation.github.io/*",
   "http://localhost:8333/*",
   "http://localhost:8601/*",
-  "http://localhost:8602/*",
   "http://localhost/*",
 ];
 

--- a/addon-api/content-script/Tab.js
+++ b/addon-api/content-script/Tab.js
@@ -8,8 +8,7 @@ import * as modal from "./modal.js";
 
 const DATA_PNG = "data:image/png;base64,";
 
-const isScratchGui =
-  location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
+const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
 
 const contextMenuCallbacks = [];
 const CONTEXT_MENU_ORDER = ["editor-devtools", "block-switching", "blocks2image", "swap-local-global"];

--- a/background/firefox-localhost-support.js
+++ b/background/firefox-localhost-support.js
@@ -1,7 +1,7 @@
 if (typeof browser === "object" && chrome.scripting) {
   const manifest = chrome.runtime.getManifest();
   const manifestScripts = manifest.content_scripts.filter((script) =>
-    script.matches.includes("http://localhost:8602/*")
+    script.matches.includes("http://localhost:8601/*")
   );
   const scripts = manifestScripts.map((scriptObj, i) => ({
     id: `ff_${i}`,

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -413,7 +413,7 @@ function userscriptMatches(data, scriptOrStyle, addonId) {
 
   let _url = data.url;
   let _parsedURL = new URL(_url);
-  if (_parsedURL.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(_parsedURL.port)) {
+  if (_parsedURL.origin === "https://scratchfoundation.github.io" || _parsedURL.port === "8601") {
     // Run addons on scratch-gui
     _url = "https://scratch.mit.edu/projects/editor/";
     _parsedURL = new URL(_url);

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -12,7 +12,7 @@ if (window.frameElement && window.frameElement.getAttribute("src") === null)
   throw "Scratch Addons: iframe without src attribute ignored";
 if (document.documentElement instanceof SVGElement) throw "Scratch Addons: SVG document ignored";
 if (new URL(location.href).hostname === "localhost") {
-  if (!["8333", "8601", "8602"].includes(new URL(location.href).port)) {
+  if (!["8333", "8601"].includes(new URL(location.href).port)) {
     throw "Scratch Addons: this localhost port is not supported";
   }
 }

--- a/content-scripts/inject/module.js
+++ b/content-scripts/inject/module.js
@@ -37,8 +37,7 @@ const comlinkIframe3 = document.getElementById("scratchaddons-iframe-3");
 const comlinkIframe4 = document.getElementById("scratchaddons-iframe-4");
 const _cs_ = Comlink.wrap(Comlink.windowEndpoint(comlinkIframe2.contentWindow, comlinkIframe1.contentWindow));
 
-const isScratchGui =
-  location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
+const isScratchGui = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
 
 const page = {
   _globalState: null,

--- a/content-scripts/prototype-handler.js
+++ b/content-scripts/prototype-handler.js
@@ -11,7 +11,7 @@ function immediatelyRunFunctionInMainWorld(fn) {
   div.remove();
 }
 
-const isLocal = location.origin === "https://scratchfoundation.github.io" || ["8601", "8602"].includes(location.port);
+const isLocal = location.origin === "https://scratchfoundation.github.io" || location.port === "8601";
 if ((!(document.documentElement instanceof SVGElement) && location.pathname.split("/")[1] === "projects") || isLocal) {
   immediatelyRunFunctionInMainWorld(() => {
     const oldBind = Function.prototype.bind;

--- a/manifest.json
+++ b/manifest.json
@@ -22,8 +22,7 @@
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-editor/*",
         "http://localhost:8333/*",
-        "http://localhost:8601/*",
-        "http://localhost:8602/*"
+        "http://localhost:8601/*"
       ],
       "run_at": "document_start",
       "js": ["libraries/thirdparty/cs/comlink.js", "libraries/common/cs/text-color.js", "content-scripts/cs.js"],
@@ -34,8 +33,7 @@
         "https://scratch.mit.edu/*",
         "https://scratchfoundation.github.io/scratch-editor/*",
         "http://localhost:8333/*",
-        "http://localhost:8601/*",
-        "http://localhost:8602/*"
+        "http://localhost:8601/*"
       ],
       "run_at": "document_start",
       "js": ["content-scripts/prototype-handler.js", "content-scripts/load-redux.js", "content-scripts/fix-console.js"],


### PR DESCRIPTION
### Changes

Removes references to port number 8602 from the code.

### Reason for changes

Because of https://github.com/scratchfoundation/scratch-gui/pull/9648, there isn't a reason for SA to run on that port anymore.

### Tests

Verified that port 8601 still works in both browsers.