### PR TITLE
Fix debugger header buttons

### DIFF
--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -107,7 +107,7 @@
   height: 20px;
 }
 
-.sa-debugger-unpause {
+.sa-debugger-unpause:not(:hover) {
   animation: saDebuggerUnpause 2s infinite alternate;
 }
 

--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -40,6 +40,7 @@
 .sa-debugger-interface [class*="card_header-buttons_"] {
   background-color: #29beb8;
   border-color: #3aa8a4;
+  text-wrap-mode: nowrap;
 }
 
 .sa-debugger-interface h1 {
@@ -87,6 +88,18 @@
 }
 .sa-debugger-tabs li.sa-debugger-tab-selected img {
   filter: none;
+}
+
+.sa-debugger-header-buttons {
+  width: 100%;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: repeat(4, 1fr);
+  direction: rtl;
+}
+
+.sa-debugger-header-buttons > div {
+  min-width: 0;
 }
 
 .sa-debugger-header-buttons img {

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -514,11 +514,11 @@ export default async function ({ addon, console, msg }) {
     tabContentContainer.appendChild(tab.content);
 
     removeAllChildren(buttonContainerElement);
-    buttonContainerElement.appendChild(unpauseButton.element);
+    buttonContainerElement.prepend(unpauseButton.element);
     for (const button of tab.buttons) {
-      buttonContainerElement.appendChild(button.element);
+      buttonContainerElement.prepend(button.element);
     }
-    buttonContainerElement.appendChild(closeButton.element);
+    buttonContainerElement.prepend(closeButton.element);
 
     if (isInterfaceVisible) {
       activeTab.show();


### PR DESCRIPTION
Resolves #8216

### Changes

Fixes the bug where not all buttons in the debugger header were displayed in full.
Now, all the buttons are displayed correctly no matter the language.
The right buttons can be reduced if there is no enough space and they all will be the same dimension. In addition the buttons occupy alway the same size in all tabs.
<p>
<img height="280" alt="image" src="https://github.com/user-attachments/assets/b31ce8ac-1810-4ea1-8ef8-d47bd728bd2f" />
<img height="280" alt="image" src="https://github.com/user-attachments/assets/000956de-d069-46b5-b1ff-e2754a3c203c" />
</p>

Also, fixes a minor bug that made that the resume button isn't always highlighted on hover.

### Tests

Google Chrome: 139.0.7258.66
Microsoft Edge: 139.0.3405.86
OS: Windows 10

Tested languages: English, French, Spanish, Portuguese, Japanese, Korean