### PR TITLE
Fix ESLint action

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -30,4 +30,4 @@ jobs:
         run: |
           npm i globals @eslint/js @eslint/eslintrc
           npx eslint . --config eslint.config.mjs
-        continue-on-error: true
+


### PR DESCRIPTION
Removes `continue-on-error: true` from the ESLint action. Does anyone know why that was there since it's the last step?

### Tests

I'll see when I click create