### PR TITLE
Style share modal & other fixes

### DIFF
--- a/addons/animated-thumb/userscript.js
+++ b/addons/animated-thumb/userscript.js
@@ -295,8 +295,10 @@ export default async function ({ addon, console, msg }) {
         })
         .then(() => {
           // Remove the tooltip
-          tooltip.remove();
-          localStorage.setItem("saAnimatedThumbHideDropdownTooltip", "1");
+          if (tooltip) {
+            tooltip.remove();
+            localStorage.setItem("saAnimatedThumbHideDropdownTooltip", "1");
+          }
 
           // Add message to the Set Thumbnail modal when it's opened instead
           addon.tab

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -169,6 +169,7 @@ body:not(.sa-body-editor) input.formik-radio-input,
 .wedo .project-card,
 .transfer-host-modal .cancel-button,
 .transfer-host-modal .transfer-password-input,
+.share-modal .share-modal-inner,
 .update-thumbnail-info-modal .update-thumbnail-info-modal-inner,
 .comments-container .sa-emoji-picker,
 .studio-compose-container .sa-emoji-picker {
@@ -190,7 +191,8 @@ body:not(.sa-body-editor) .button.white,
 .index .title-banner p a button,
 .financials-section .financials-button,
 .donate-section .donate-button,
-.initiatives-section .initiatives-subsection-content .bubble.inverted {
+.initiatives-section .initiatives-subsection-content .bubble.inverted,
+.share-modal .change-thumbnail-button {
   background-color: var(--darkWww-box);
 }
 .ReactModal__Content[style*="background: rgb(255, 255, 255)"] {
@@ -235,7 +237,8 @@ a.social-messages-profile-link:link,
 .studio-project-tile .studio-project-username,
 .studio-member-tile .studio-member-role,
 body:not(.sa-body-editor) .join-flow-title,
-.registration-step .bold-link {
+.registration-step .bold-link,
+.checkbox-container {
   color: var(--darkWww-box-text);
 }
 .activity-li .social-message-date,
@@ -707,7 +710,8 @@ body:not(.sa-body-editor) .select select,
 p.callout,
 .input,
 .row .col-sm-9 input[type="radio"]:not(:checked),
-.extension-landing .tip-box {
+.extension-landing .tip-box,
+.checkbox-container input[type=checkbox]:not(:checked) {
   border-color: var(--darkWww-border);
 }
 .grid .thumbnail,

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -711,7 +711,7 @@ p.callout,
 .input,
 .row .col-sm-9 input[type="radio"]:not(:checked),
 .extension-landing .tip-box,
-.checkbox-container input[type=checkbox]:not(:checked) {
+.checkbox-container input[type="checkbox"]:not(:checked) {
   border-color: var(--darkWww-border);
 }
 .grid .thumbnail,

--- a/addons/scratch3to2/explore_and_search.css
+++ b/addons/scratch3to2/explore_and_search.css
@@ -170,7 +170,7 @@ body:not(.sa-body-editor) .outer .sort-mode .select select {
   right: 11px;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-top: 4px solid var(--darkWww-box-scratchr2Caret, black);
+  border-top: 4px solid var(--darkWww-box-scratchr2BlackText, black);
   opacity: 0.5;
   pointer-events: none;
 }

--- a/addons/scratch3to2/main.css
+++ b/addons/scratch3to2/main.css
@@ -559,6 +559,7 @@ body:not(.sa-body-editor) .select select > option {
 }
 .modal-header,
 .report-modal-header,
+.share-modal .title,
 .update-thumbnail-info-modal .update-thumbnail-info-modal-title,
 .youtube-video-modal-container .cards-modal-header.mint-green,
 .cards-modal-container .cards-modal-header,
@@ -573,6 +574,7 @@ body:not(.sa-body-editor) .select select > option {
 }
 .modal-title,
 .report-content-label,
+.share-modal .title,
 .update-thumbnail-info-modal .update-thumbnail-info-modal-title,
 .cards-modal-container .cards-modal-header .cards-title {
   color: var(--darkWww-box-scratchr2HeaderText, #554747);

--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -267,7 +267,8 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button_"]:not(.sa-gamepad-
 body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"]:not(.sa-gamepad-container *) {
   display: none;
 }
-[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"] {
+[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"],
+.sa-set-thumbnail-dropdown-button {
   height: 26px;
   padding: 0 10px;
   background-image: linear-gradient(
@@ -281,12 +282,31 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"]:not(.sa-gam
   line-height: 24px;
   text-shadow: 0 1px var(--darkWww-box, white);
 }
-[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"]:hover {
+[dir="ltr"] .sa-set-thumbnail-dropdown-button {
+  border-left: none;
+}
+[dir="rtl"] .sa-set-thumbnail-dropdown-button {
+  border-right: none;
+}
+[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"]:hover,
+.sa-set-thumbnail-dropdown-button:hover {
   background-color: var(--darkWww-box-scratchr2ButtonHover, #e6e6e6);
   background-image: none;
 }
-[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"]:active {
+[class*="stage-header_rightSection_"] [class*="stage-header_setThumbnailButton_"]:active,
+.sa-set-thumbnail-dropdown-button:active {
   filter: none;
+}
+.sa-set-thumbnail-dropdown-button img {
+  display: none;
+}
+.sa-set-thumbnail-dropdown-button::before {
+  content: "";
+  display: block;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid var(--darkWww-box-scratchr2BlackText, black);
+  opacity: 0.5;
 }
 [class*="stage-header_embed-scratch-logo_"] img {
   padding: 0.8rem 2.4rem; /* hide original image */


### PR DESCRIPTION
### Changes

* Adds styles for the new share confirmation modal
* Makes the dropdown button added by animated-thumb 2.0-styled when scratch3to2 is enabled
* Fixes bugs in animated-thumb and scratch3to2

Screenshots:

<p><img width="829" height="842" alt="image" src="https://github.com/user-attachments/assets/9a8ee882-1ac8-4b7f-95c1-f64d3e05cfdc" /></p>
<p><img width="274" height="73" alt="image" src="https://github.com/user-attachments/assets/7f9e2a63-c81a-480f-9830-8128bf159486" /></p>

### Tests

Tested on Edge.