### PR TITLE
scratch3to2: stage button fixes

### DIFF
--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -264,6 +264,12 @@ body:not(.sa-body-editor) [class*="stage-header_stage-button_"]:not(.sa-gamepad-
   background-repeat: no-repeat;
   background-position: center center;
 }
+body:not(.sa-body-editor) [class*="stage-header_stage-button_"]:active {
+  background-color: transparent;
+}
+body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"] {
+  filter: none;
+}
 body:not(.sa-body-editor) [class*="stage-header_stage-button-icon_"]:not(.sa-gamepad-container *) {
   display: none;
 }


### PR DESCRIPTION
### Changes

Fixes the following bugs that would happen if scratch3to2 and website dark mode were both enabled:
* The gamepad icon was white on a light background
* The full screen and gamepad buttons had a purple background when pressed

### Tests

Tested on Edge and Firefox.