### PR TITLE
Move restore messages to `_general.json`

### DIFF
--- a/addons-l10n/en/_general.json
+++ b/addons-l10n/en/_general.json
@@ -5,6 +5,11 @@
   "_general/blocks/green-flag": "flag",
   "_general/blocks/clockwise": "clockwise",
   "_general/blocks/anticlockwise": "anti-clockwise",
+
+  "_general/restore/sprites": "Restore Sprites",
+  "_general/restore/costumes": "Restore Costumes",
+  "_general/restore/sounds": "Restore Sounds",
+
   "_general/meta/managedBySa": "Managed by Scratch Addons",
   "_general/meta/addonSettings": "Addon Settings",
   "_general/meta/message-from-sa": "Message from Scratch Addons"

--- a/addons-l10n/en/delete-others.json
+++ b/addons-l10n/en/delete-others.json
@@ -2,7 +2,5 @@
   "delete-others/deleteOthers": "delete others",
   "delete-others/confirmTitle": "Delete Others",
   "delete-others/infoCostume": "Are you sure you want to delete all other costumes?\nThe deleted costumes can be restored by going to Edit \u2192 Restore Costumes.",
-  "delete-others/infoSound": "Are you sure you want to delete all other sounds?\nThe deleted sounds can be restored by going to Edit \u2192 Restore Sounds.",
-  "delete-others/multiCostumes": "Restore Costumes",
-  "delete-others/multiSounds": "Restore Sounds"
+  "delete-others/infoSound": "Are you sure you want to delete all other sounds?\nThe deleted sounds can be restored by going to Edit \u2192 Restore Sounds."
 }

--- a/addons-l10n/en/folders.json
+++ b/addons-l10n/en/folders.json
@@ -16,8 +16,5 @@
   "folders/delete-folder-contents-prompt-title": "Delete All in Folder",
   "folders/delete-sprites-folder-contents-prompt": "Are you sure you want to delete all sprites in the folder?\n\nThe deleted sprites can be restored by going to Edit \u2192 Restore Sprites.",
   "folders/delete-costumes-folder-contents-prompt": "Are you sure you want to delete all costumes in the folder?\n\nThe deleted costumes can be restored by going to Edit \u2192 Restore Costumes.",
-  "folders/delete-sounds-folder-contents-prompt": "Are you sure you want to delete all sounds in the folder?\n\nThe deleted sounds can be restored by going to Edit \u2192 Restore Sounds.",
-  "folders/restore-sprites": "Restore Sprites",
-  "folders/restore-costumes": "Restore Costumes",
-  "folders/restore-sounds": "Restore Sounds"
+  "folders/delete-sounds-folder-contents-prompt": "Are you sure you want to delete all sounds in the folder?\n\nThe deleted sounds can be restored by going to Edit \u2192 Restore Sounds."
 }

--- a/addons/delete-others/userscript.js
+++ b/addons/delete-others/userscript.js
@@ -28,7 +28,7 @@ export default async function ({ addon, console, msg }) {
           useEditorClasses: true,
         })
       ) {
-        const type = ctx.type === "costume" ? "Costume" : "Sound";
+        const type = ctx.type === "costume" ? "costume" : "sound";
 
         deletedItems = [];
         target = vm.editingTarget;
@@ -94,6 +94,6 @@ export default async function ({ addon, console, msg }) {
 
     // We know that shouldChangeRestoreButtonText = true
     const { deletedItem } = addon.tab.redux.state.scratchGui.restoreDeletion;
-    restoreButton.innerText = msg(`multi${deletedItem}s`);
+    restoreButton.innerText = msg(`/_general/restore/${deletedItem}s`);
   }
 }

--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -899,7 +899,7 @@ export default async function ({ addon, console, msg }) {
             });
             queueMicrotask(() => {
               if (restorationFunctions.length > 1) {
-                restoreButtonMsg = "restore-sprites";
+                restoreButtonMsg = "/_general/restore/sprites";
               }
             });
           } else if (type === "costume" || type === "sound") {
@@ -935,7 +935,7 @@ export default async function ({ addon, console, msg }) {
             });
             queueMicrotask(() => {
               if (restorationFunctions.length + (lastCostumeRemoved !== null) > 1) {
-                restoreButtonMsg = `restore-${type}s`;
+                restoreButtonMsg = `/_general/restore/${type}s`;
               }
             });
           }


### PR DESCRIPTION
### Changes

Moves the strings for restoring multiple items to `_general.json` to avoid duplication and to make sure they're translated identically in both folders and delete-others.

### Tests

Tested on Edge and Firefox.