### PR TITLE
Fix forum post coundown triggering on edit

### DIFF
--- a/addons/forum-post-countdown/addon.json
+++ b/addons/forum-post-countdown/addon.json
@@ -11,7 +11,7 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["newPostScreens"]
+      "matches": ["forums"]
     }
   ],
   "userstyles": [

--- a/addons/forum-post-countdown/addon.json
+++ b/addons/forum-post-countdown/addon.json
@@ -11,13 +11,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["topics"]
+      "matches": ["newPostScreens"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["topics"]
+      "matches": ["newPostScreens"]
     }
   ],
   "credits": [

--- a/addons/forum-post-countdown/addon.json
+++ b/addons/forum-post-countdown/addon.json
@@ -11,13 +11,13 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["newPostScreens"]
+      "matches": ["topics"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyle.css",
-      "matches": ["newPostScreens"]
+      "matches": ["topics"]
     }
   ],
   "credits": [

--- a/addons/forum-post-countdown/userscript.js
+++ b/addons/forum-post-countdown/userscript.js
@@ -1,10 +1,10 @@
 export default async function ({ addon, msg }) {
   const submitButton = document.querySelector("#djangobbwrap .form-submit [type=submit]");
 
-  let message = document.querySelector(".success");
+  const message = document.querySelector(".success")?.innerText;
 
-  // This message is not translated by Scratch
-  if (message && message.innerText !== "Post updated.") {
+  // These messages are not translated by Scratch
+  if (message === "Your reply saved." || message === "Topic saved.") {
     localStorage.setItem("sa-forum-post-countdown", Date.now());
   }
 

--- a/addons/forum-post-countdown/userscript.js
+++ b/addons/forum-post-countdown/userscript.js
@@ -3,7 +3,8 @@ export default async function ({ addon, msg }) {
 
   let message = document.querySelector(".success");
 
-  if (message) {
+  // This message is not translated by Scratch
+  if (message && message.innerText !== "Post updated.") {
     localStorage.setItem("sa-forum-post-countdown", Date.now());
   }
 


### PR DESCRIPTION
Resolves #8517

### Changes

Checks the success message to ensure it's not an edit ~~and run on `topics` instead of `newPostScreens` since it doesn't need those pages anymore.~~

### Tests

Tested by editing a post.