### PR TITLE
Fix cat blocks regressions

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -407,11 +407,14 @@ export default async function ({ addon, console }) {
   const vm = addon.tab.traps.vm;
   const getBlockById = (id) => {
     const workspace = addon.tab.traps.getWorkspace();
+    if (!workspace) return null;
     const flyoutWorkspace = workspace.getFlyout().getWorkspace();
     return workspace.getBlockById(id) || flyoutWorkspace.getBlockById(id);
   };
   vm.on("SCRIPT_GLOW_ON", ({ id }) => {
+    if (addon.tab.editorMode !== "editor") return;
     const block = getBlockById(id);
+    if (!block) return;
     // For performance, don't follow the mouse when the stack is glowing
     detachMouseMoveListener(block);
     resetFacePosition(block);
@@ -425,7 +428,10 @@ export default async function ({ addon, console }) {
     }
   });
   vm.on("SCRIPT_GLOW_OFF", ({ id }) => {
-    attachMouseMoveListener(getBlockById(id));
+    if (addon.tab.editorMode !== "editor") return;
+    const block = getBlockById(id);
+    if (!block) return;
+    attachMouseMoveListener(block);
   });
 
   const update = () => {

--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -223,13 +223,13 @@ export default async function ({ addon, console }) {
         block.svgFace_.style.transform = "translate(" + dx + "px, " + dy + "px)";
       }
     };
-    if (addon.settings.get("watch") === true) {
-      attachMouseMoveListener(block);
-    }
+    attachMouseMoveListener(block);
   };
 
   const attachMouseMoveListener = (block) => {
-    document.addEventListener("mousemove", block.windowListener);
+    if (addon.settings.get("watch") === true) {
+      document.addEventListener("mousemove", block.windowListener);
+    }
   };
 
   const detachMouseMoveListener = (block) => {


### PR DESCRIPTION
Resolves #8530

### Changes

Fixes the bugs caused by recent changes to cat-blocks.

### Tests

Tested on Edge. I've verified that:
* When the watch mouse setting is off, cats don't start watching the mouse after running and then stopping the script (first part of the linked issue).
* Running the project after switching from the editor to the project page works normally. (second part of the issue).