### PR TITLE
`recolor-custom-blocks` & `reorder-custom-inputs`: support `editor-compact`

### DIFF
--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -557,3 +557,7 @@ body:not(.sa-columns-enabled) [class*="gui_tab-panel"] [class*="gui_extension-bu
 [class*="custom-procedures_body"] [role="button"] {
   padding: 0.5rem;
 }
+.sa-rcb-colorButton {
+  height: 1.5rem;
+  padding: 0 !important;
+}

--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -554,6 +554,9 @@ body:not(.sa-columns-enabled) [class*="gui_tab-panel"] [class*="gui_extension-bu
 .blocklyTextRemoveIcon {
   top: -35px;
 }
+.sa-reorder-inputs-arrow {
+  top: -44px;
+}
 [class*="custom-procedures_body"] [role="button"] {
   padding: 0.5rem;
 }

--- a/addons/recolor-custom-blocks/userstyle.css
+++ b/addons/recolor-custom-blocks/userstyle.css
@@ -15,7 +15,7 @@
 }
 .sa-rcb-colorButton {
   aspect-ratio: 1;
-  height: 1.9rem;
+  height: 2rem;
   overflow: hidden;
   border: 2px solid;
   transition: all 0.2s;

--- a/addons/recolor-custom-blocks/userstyle.css
+++ b/addons/recolor-custom-blocks/userstyle.css
@@ -11,19 +11,16 @@
 .sa-rcb-custom-procedures_colors-row {
   display: flex;
   justify-content: space-between;
-  gap: 1.5em;
   margin-top: 1.5em;
 }
 .sa-rcb-colorButton {
-  flex-grow: 1;
   aspect-ratio: 1;
-  width: unset;
-  height: unset;
+  height: 1.9rem;
   overflow: hidden;
   border: 2px solid;
   transition: all 0.2s;
   border-radius: 100%;
-  margin: 0 auto 0.125rem;
+  margin-bottom: 0.125rem;
   padding: 4px;
 }
 .sa-rcb-colorButton:hover {


### PR DESCRIPTION
### Changes

Fixes compatability between recolor custom blocks and compact editor. I set the height to `1.9rem` since it's very close to what it was before. `!important` is used to override `[class*="modal_modal-content"] [class*="box_box"] button` but a higher specificity might be better.

Also fixes the alignment of the icons added by `reorder-custom-inputs` when `editor-compact` is enabled.


### Tests

Tested on Chromium