### PR TITLE
color-picker: fix bugs and simplify code

### DIFF
--- a/addons/color-picker/code-editor.js
+++ b/addons/color-picker/code-editor.js
@@ -59,21 +59,17 @@ export default async ({ addon, console, msg }) => {
     ScratchBlocks.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
     return r;
   };
-  const originalCallbackFactory = ScratchBlocks.FieldColourSlider.prototype.sliderCallbackFactory_;
-  ScratchBlocks.FieldColourSlider.prototype.sliderCallbackFactory_ = function (...args) {
-    const f = originalCallbackFactory.call(this, ...args);
-    return (event) => {
-      const r = f(event);
-      const div = ScratchBlocks.DropDownDiv.getContentDiv();
-      if (div) {
-        const saColorPickerColor = div.querySelector(".sa-color-picker-color.sa-color-picker-code-color");
-        const saColorPickerText = div.querySelector(".sa-color-picker-text.sa-color-picker-code-text");
-        if (!saColorPickerColor || !saColorPickerText) return r;
-        const color = this.getValue();
-        saColorPickerColor.value = color || "#000000";
-        saColorPickerText.value = color || "";
-      }
-      return r;
-    };
+  const originalUpdateDom = ScratchBlocks.FieldColourSlider.prototype.updateDom_;
+  ScratchBlocks.FieldColourSlider.prototype.updateDom_ = function (...args) {
+    originalUpdateDom.call(this, ...args);
+    const div = ScratchBlocks.DropDownDiv.getContentDiv();
+    if (div) {
+      const saColorPickerColor = div.querySelector(".sa-color-picker-color.sa-color-picker-code-color");
+      const saColorPickerText = div.querySelector(".sa-color-picker-text.sa-color-picker-code-text");
+      if (!saColorPickerColor || !saColorPickerText) return;
+      const color = this.getValue();
+      saColorPickerColor.value = color || "#000000";
+      saColorPickerText.value = color || "";
+    }
   };
 };

--- a/addons/color-picker/code-editor.js
+++ b/addons/color-picker/code-editor.js
@@ -69,8 +69,13 @@ export default async ({ addon, console, msg }) => {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
   const originalShowEditor = ScratchBlocks.FieldColourSlider.prototype.showEditor_;
   ScratchBlocks.FieldColourSlider.prototype.showEditor_ = function (...args) {
+    // Don't show the dropdown until the color picker has been added
+    const oldShowPositionedByBlock = ScratchBlocks.DropDownDiv.showPositionedByBlock;
+    ScratchBlocks.DropDownDiv.showPositionedByBlock = () => {};
     const r = originalShowEditor.call(this, ...args);
     addColorPicker(this);
+    ScratchBlocks.DropDownDiv.showPositionedByBlock = oldShowPositionedByBlock;
+    ScratchBlocks.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
     return r;
   };
   const originalCallbackFactory = ScratchBlocks.FieldColourSlider.prototype.sliderCallbackFactory_;

--- a/addons/color-picker/style.css
+++ b/addons/color-picker/style.css
@@ -47,8 +47,3 @@
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
-
-body.sa-hide-eye-dropper-background div[class*="stage_color-picker-background"] {
-  /* Do not show eye dropper background if the color picker is "fake" */
-  display: none;
-}


### PR DESCRIPTION
Resolves #8537

### Changes

* The hex color picker now sets colors by calling scratch-blocks methods directly instead of using Redux.
* Fixes the color picker dropdown being positioned incorrectly when opening upwards. The arrow position can still be slightly wrong when it's opened for the first time, but that also happens without the addon.
* Selecting a color using the eyedropper now updates the hex color picker input on new Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox.