### PR TITLE
New addon: Compact Profile

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -161,6 +161,7 @@
   "costume-editor-shortcuts",
   "live-read-topics",
   "recolor-custom-blocks",
+  "compact-profile",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,0 +1,30 @@
+{
+  "name": "Compact Profile Sliders",
+  "description": "Groups Scratch profile sliders side by side, making profiles more compact and easier to browse.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "This addon arranges profile sliders in pairs and enables horizontal scrolling for better visibility.",
+      "id": "profileCompactNotice"
+    }
+  ],
+  "credits": [
+    {
+      "name": "VIGARPAST_777",
+      "link": "https://scratch.mit.edu/users/VIGARPAST_777/"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["users"]
+    }
+  ],
+  "settings": [],
+  "tags": ["profile", "layout", "ui"],
+  "versionAdded": "1.0.0",
+  "enabledByDefault": true,
+  "libraries": []
+}

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,0 +1,43 @@
+export default async function({ addon }) {
+    await addon.tab.waitForElement('.box.slider-carousel-container', { markAsSeen: true });
+
+    const arrangeSliders = () => {
+        const sliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+
+        for (let i = 0; i < sliders.length - 1; i += 2) {
+            const left = sliders[i];
+            const right = sliders[i + 1];
+
+            const wrapper = document.createElement('div');
+            wrapper.style.display = 'flex';
+            wrapper.style.justifyContent = 'space-between';
+            wrapper.style.marginBottom = '20px';
+
+            left.style.width = '48%';
+            right.style.width = '48%';
+            left.style.display = 'block';
+            right.style.display = 'block';
+
+            const container = left.parentNode;
+            container.insertBefore(wrapper, left);
+            wrapper.appendChild(left);
+            wrapper.appendChild(right);
+
+            [left, right].forEach(box => {
+                const carousel = box.querySelector('.slider-carousel, .sliderCarousel');
+                if (carousel) {
+                    carousel.style.overflowX = 'auto';
+                    carousel.style.scrollBehavior = 'smooth';
+                }
+            });
+        }
+    };
+
+    arrangeSliders();
+
+    const observer = new MutationObserver(() => {
+        arrangeSliders();
+    });
+
+    observer.observe(document.querySelector('#profile') || document.body, { childList: true, subtree: true });
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #

### Changes

- Added a Scratch Addons userscript that compacts profile sliders on user pages.
- Groups all `.box.slider-carousel-container` elements in pairs, placing one on the left and one on the right.
- Sets uniform width for paired sliders and enables smooth horizontal scrolling.
- Works for any language, independent of `<h4>` text or element IDs.
- Supports sliders for Projects, Favorites, Following, Followers, Studios, and Curated Studios.
- Uses a `MutationObserver` to dynamically regroup sliders if new content loads.

**Screenshots / Video:**  
_(Optional: Include images or a short screen capture showing grouped sliders)_

### Reason for changes

- Profiles can be very long for active users; grouping sliders reduces vertical space and improves readability.
- Makes it easier to navigate projects, favorites, followers, and studios without excessive scrolling.
- Fully compatible with Scratch Addons and future-proof for language changes.

### Tests

- Verified on **Chrome** and **Firefox**.  
- Confirmed sliders group correctly for profiles in different languages.  
- Horizontal scrolling works for all slider types.  
- No console errors or layout issues observed.
