### PR TITLE
Move right debugger header buttons to footer

### DIFF
--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -262,3 +262,55 @@
 .sa-debugger-block-preview[data-shape="stacked"] {
   border-radius: 3px;
 }
+
+.sa-debugger-footer {
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
+  display: flex;
+  justify-content: center;
+  padding: 8px 15px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.sa-debugger-footer-buttons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.sa-debugger-footer-buttons > div {
+  background-color: #29beb8;
+  border: 1px solid #3aa8a4;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 4px 8px;
+  color: white;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.sa-debugger-footer-buttons > div:hover {
+  background-color: #3aa8a4;
+}
+
+.sa-debugger-footer-buttons img {
+  width: 16px;
+  height: 16px;
+  filter: brightness(0) invert(1);
+}
+
+.sa-debugger-footer-buttons span {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.sa-debugger-header-buttons > div[title] span {
+  display: none;
+}
+
+.sa-debugger-footer-buttons .sa-debugger-unpause {
+  animation: none !important;
+}

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -110,6 +110,12 @@ export default async function ({ addon, console, msg }) {
   const tabContentContainer = Object.assign(document.createElement("div"), {
     className: "sa-debugger-tab-content",
   });
+  const interfaceFooter = Object.assign(document.createElement("div"), {
+    className: "sa-debugger-footer",
+  });
+  const footerButtonContainer = Object.assign(document.createElement("div"), {
+    className: "sa-debugger-footer-buttons",
+  });
 
   let isInterfaceVisible = false;
   const setInterfaceVisible = (_isVisible) => {
@@ -159,7 +165,8 @@ export default async function ({ addon, console, msg }) {
   interfaceHeader.addEventListener("mousedown", handleStartDrag);
 
   interfaceHeader.append(tabListElement, buttonContainerElement);
-  interfaceContainer.append(interfaceHeader, tabContentContainer);
+  interfaceFooter.appendChild(footerButtonContainer);
+  interfaceContainer.append(interfaceHeader, tabContentContainer, interfaceFooter);
   document.body.append(interfaceContainer);
   moveInterface(0, 0); // necessary to initialize position if running scratch-gui locally
 
@@ -220,6 +227,7 @@ export default async function ({ addon, console, msg }) {
   const closeButton = createHeaderButton({
     text: msg("close"),
     icon: addon.self.dir + "/icons/close.svg",
+    description: msg("close"),
   });
   closeButton.element.addEventListener("click", () => setInterfaceVisible(false));
 
@@ -514,11 +522,13 @@ export default async function ({ addon, console, msg }) {
     tabContentContainer.appendChild(tab.content);
 
     removeAllChildren(buttonContainerElement);
-    buttonContainerElement.appendChild(unpauseButton.element);
-    for (const button of tab.buttons) {
-      buttonContainerElement.appendChild(button.element);
-    }
     buttonContainerElement.appendChild(closeButton.element);
+    
+    removeAllChildren(footerButtonContainer);
+    footerButtonContainer.appendChild(unpauseButton.element);
+    for (const button of tab.buttons) {
+      footerButtonContainer.appendChild(button.element);
+    }
 
     if (isInterfaceVisible) {
       activeTab.show();

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -523,7 +523,7 @@ export default async function ({ addon, console, msg }) {
 
     removeAllChildren(buttonContainerElement);
     buttonContainerElement.appendChild(closeButton.element);
-    
+
     removeAllChildren(footerButtonContainer);
     footerButtonContainer.appendChild(unpauseButton.element);
     for (const button of tab.buttons) {


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #8216

### Changes

Header buttons moved to a new footer, except for close button that remains.
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/2cc6484b-d24d-4edd-b90a-ee0560911961" />

### Reason for changes

Header was crowded. Was preventing us from letting users resize the debugger modal, aswell as causing bugs like #8216 where icons were pushed off when long translations went beyond the fixed width container which was designed for English.

### Tests

It doesn't do anything other than move the buttons, so it's purely an aesthetic change. I checked the buttons still worked and the on hover effects worked.

---

This is one possible design and more design's are discussed in the issue. I just thought the choice was quite clear so I proactively made this PR. It took me less than 10 minutes so if I to redesign it, I don't mind.
