### PR TITLE
zebra-striping: new Blockly

### DIFF
--- a/addons/zebra-striping/userstyle.css
+++ b/addons/zebra-striping/userstyle.css
@@ -7,11 +7,15 @@
   --zebraStriping-replacementGlow: url(#blocklyReplacementGlowFilter);
 }
 
-.sa-zebra-stripe {
+.sa-zebra-stripe,
+.scratch-renderer.default-theme .blocklySelected > .blocklyPathSelected.sa-zebra-stripe,
+.scratch-renderer.high-contrast-theme .blocklySelected > .blocklyPathSelected.sa-zebra-stripe {
   filter: var(--zebraStriping-filter);
 }
 
-.sa-zebra-stripe[filter*="#blocklyReplacementGlowFilter"] {
+.sa-zebra-stripe[filter*="#blocklyReplacementGlowFilter"],
+.scratch-renderer.default-theme .blocklyReplaceable > .blocklyPath.sa-zebra-stripe,
+.scratch-renderer.high-contrast-theme .blocklyReplaceable > .blocklyPath.sa-zebra-stripe {
   filter: var(--zebraStriping-filter) var(--zebraStriping-replacementGlow);
 }
 


### PR DESCRIPTION
### Changes

Updates zebra striping to work with modern Blockly.

### Tests

Tested both Scratch versions on Edge and Firefox.