### PR TITLE
Automate abandoned label

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -33,7 +33,7 @@ jobs:
           stale-pr-message: 'Ping! There has been no activity for 1 year.'
           days-before-stale: -1
           days-before-close: -1
-          days-before-pr-stale: 360
+          days-before-pr-stale: 365
           stale-pr-label: 'status: abandoned'
           operations-per-run: 30
           exempt-all-pr-assignees: true


### PR DESCRIPTION
Resolves #7199

### Changes

Expandes the stale action as @Hans5958 suggested in https://github.com/ScratchAddons/ScratchAddons/issues/7199#issuecomment-1959382281, it labels PRs but doesn't close them.

### Reason for changes

The abandoned label is pretty useless if it has to be applied manually.

### Tests

Untested