### PR TITLE
`pause`: New options for auto-pause and pause button visibility

### DIFF
--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -1,6 +1,12 @@
 {
   "name": "Pause button",
   "description": "Adds a button to pause the project next to the green flag.",
+  "info": [
+    {
+      "text": "The project can also be paused with Alt+X (Option+X on macOS).",
+      "id": "keybind"
+    }
+  ],
   "credits": [
     {
       "name": "Jeffalo"
@@ -33,7 +39,6 @@
       "type": "boolean",
       "id": "pause-button",
       "name": "Show pause button",
-      "description": "When hidden, you can still pause by pressing Alt+X or Option+X.",
       "default": true
     },
     {

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -40,7 +40,7 @@
       "type": "boolean",
       "id": "auto-pause",
       "name": "Pause automatically",
-      "description": "The project pauses automatically when the window does not have focus. May not work on all projects.",
+      "description": "The project pauses automatically when the window does not have focus. Does not apply to cloud projects.",
       "default": false
     }
   ],

--- a/addons/pause/addon.json
+++ b/addons/pause/addon.json
@@ -1,18 +1,16 @@
 {
   "name": "Pause button",
   "description": "Adds a button to pause the project next to the green flag.",
-  "info": [
-    {
-      "text": "The project can also be paused with Alt+X (Option+X on macOS).",
-      "id": "keybind"
-    }
-  ],
   "credits": [
     {
       "name": "Jeffalo"
     },
     {
       "name": "GarboMuffin"
+    },
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
     }
   ],
   "dynamicEnable": true,
@@ -30,10 +28,27 @@
       "matches": ["projects", "projectEmbeds"]
     }
   ],
+  "settings": [
+    {
+      "type": "boolean",
+      "id": "pause-button",
+      "name": "Show pause button",
+      "description": "When hidden, you can still pause by pressing Alt+X or Option+X.",
+      "default": true
+    },
+    {
+      "type": "boolean",
+      "id": "auto-pause",
+      "name": "Pause automatically",
+      "description": "The project pauses automatically when the window does not have focus. May not work on all projects.",
+      "default": false
+    }
+  ],
   "tags": ["player", "recommended"],
   "latestUpdate": {
-    "version": "1.33.0",
-    "temporaryNotice": "There's now a keybind to pause projects.",
+    "version": "1.44.0",
+    "temporaryNotice": "The pause button can now be hidden, and you can choose to have projects pause automatically in the background.",
+    "newSettings": ["pause-button", "auto-pause"],
     "isMajor": false
   },
   "enabledByDefault": true

--- a/addons/pause/check-online.js
+++ b/addons/pause/check-online.js
@@ -1,0 +1,29 @@
+let lastTransfer = -Infinity;
+
+/** Returns true unless cloud data was transferred in the last 15s */
+export const autoPauseAvailable = () => lastTransfer < performance.now() - 15000;
+
+const onDataTransferred = (message) => {
+  if (!message.name) return; // Ignore handshakes
+  lastTransfer = performance.now();
+};
+
+export async function startCheckingCloudTraffic(api) {
+  await api.redux.waitForState((state) => state.scratchGui.projectState.loadingState.startsWith("SHOWING"));
+  // If the project has cloud variables, monitor traffic so that
+  // we can avoid automatically pausing during communication
+  if (api.traps.vm.runtime.hasCloudData()) {
+    const originalSend = api.traps.vm.runtime.ioDevices.cloud.provider.connection.send;
+    api.traps.vm.runtime.ioDevices.cloud.provider.connection.send = function (data) {
+      originalSend.call(this, data);
+      const json = JSON.parse(data);
+      onDataTransferred(json);
+    };
+    const originalOnMessage = api.traps.vm.runtime.ioDevices.cloud.provider.connection.onmessage;
+    api.traps.vm.runtime.ioDevices.cloud.provider.connection.onmessage = function (message) {
+      originalOnMessage.call(this, message);
+      const json = JSON.parse(message.data);
+      onDataTransferred(json);
+    };
+  }
+}

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -1,8 +1,11 @@
 import { isPaused, setPaused, onPauseChanged, setup } from "../debugger/module.js";
+import { autoPauseAvailable, startCheckingCloudTraffic } from "./check-online.js";
 
 export default async function ({ addon, console, msg }) {
   setup(addon);
+  startCheckingCloudTraffic(addon.tab);
 
+  let autoResume = false;
   const img = document.createElement("img");
   img.className = "pause-btn";
   img.draggable = false;
@@ -13,10 +16,13 @@ export default async function ({ addon, console, msg }) {
     img.title = isPaused() ? msg("play") : msg("pause");
   };
   img.addEventListener("click", () => setPaused(!isPaused()));
-  addon.tab.displayNoneWhileDisabled(img);
   addon.self.addEventListener("disabled", () => setPaused(false));
   setSrc();
   onPauseChanged(setSrc);
+
+  const updateVisibility = () => {
+    img.toggleAttribute("hidden", addon.self.disabled || !addon.settings.get("pause-button"));
+  };
 
   document.addEventListener(
     "keydown",
@@ -34,11 +40,40 @@ export default async function ({ addon, console, msg }) {
     { capture: true }
   );
 
+  const doAutoPause = () => {
+    if (!addon.self.disabled && addon.settings.get("auto-pause") && autoPauseAvailable()) {
+      if (!isPaused()) {
+        autoResume = true;
+        setPaused(true);
+      }
+    } else {
+      console.warn("Auto-pause unavailable");
+    }
+  };
+  const doAutoUnpause = () => {
+    if (autoResume) {
+      setPaused(false);
+      autoResume = false;
+    }
+  };
+
+  window.addEventListener("focus", doAutoUnpause);
+  window.addEventListener("blur", doAutoPause);
+
+  addon.self.addEventListener("disabled", updateVisibility);
+  addon.self.addEventListener("reenabled", updateVisibility);
+  addon.settings.addEventListener("change", updateVisibility);
+
   while (true) {
     await addon.tab.waitForElement("[class^='green-flag']", {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
     addon.tab.appendToSharedSpace({ space: "afterGreenFlag", element: img, order: 0 });
+    const commentTextarea = document.querySelector(".comments-container textarea");
+    if (commentTextarea) {
+      commentTextarea.addEventListener("blur", doAutoUnpause);
+      commentTextarea.addEventListener("focus", doAutoPause);
+    }
   }
 }

--- a/addons/pause/userscript.js
+++ b/addons/pause/userscript.js
@@ -7,22 +7,23 @@ export default async function ({ addon, console, msg }) {
 
   let autoResume = false;
   const img = document.createElement("img");
-  img.className = "pause-btn";
-  img.draggable = false;
-  img.title = msg("pause");
 
   const setSrc = () => {
     img.src = addon.self.dir + (isPaused() ? "/play.svg" : "/pause.svg");
     img.title = isPaused() ? msg("play") : msg("pause");
   };
-  img.addEventListener("click", () => setPaused(!isPaused()));
-  addon.self.addEventListener("disabled", () => setPaused(false));
-  setSrc();
-  onPauseChanged(setSrc);
-
   const updateVisibility = () => {
     img.toggleAttribute("hidden", addon.self.disabled || !addon.settings.get("pause-button"));
   };
+
+  img.className = "pause-btn";
+  img.draggable = false;
+  img.title = msg("pause");
+  img.addEventListener("click", () => setPaused(!isPaused()));
+  addon.self.addEventListener("disabled", () => setPaused(false));
+  updateVisibility();
+  setSrc();
+  onPauseChanged(setSrc);
 
   document.addEventListener(
     "keydown",


### PR DESCRIPTION
Resolves #5836
Same as #5838 by @iqnite but a different implementation, and additional features.

## New features `2`

### Automatic pausing

Adds a new setting that, when enabled, allows the project to pause automatically when one of the following things happens:

- Focus leaves the browser window
- You switch browser tabs
- You start typing a comment

...and automatically resume when focus returns.

However, it will not pause automatically if Cloud variables were updated in the last 15 seconds.

### Show/hide pause button

Another new setting was added, Show pause button, which hides the pause button when turned off. When hidden, pause can still be toggled via keyboard shortcut.

This is useful alongside the auto-pause feature if you for some reason only want the auto-pause feature and don't need a button to manually pause the project.

## Additional context

This feature was based on work that ended up becoming #8478, but here, the online feature detection has been stripped down from a complicated algorithm to a much simpler check for activity in the last 15 seconds, a process that ensures that projects with live user interaction aren't messed up by the auto-pausing.

## Tests

Everything works as expected on both projects with and without Cloud variables.