### PR TITLE
Allow dragging debugger on touchscreen

### DIFF
--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -163,7 +163,7 @@ export default async function ({ addon, console, msg }) {
     moveInterface(lastX, lastY);
   });
   interfaceHeader.addEventListener("pointerdown", handleStartDrag);
-  interfaceHeader.addEventListener("touchstart", (e) => e.preventDefault());
+  interfaceHeader.addEventListener("touchmove", (e) => e.preventDefault());
 
   interfaceHeader.append(tabListElement, buttonContainerElement);
   interfaceFooter.appendChild(footerButtonContainer);

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -138,12 +138,12 @@ export default async function ({ addon, console, msg }) {
     mouseOffsetY = e.clientY - interfaceContainer.offsetTop;
     lastX = e.clientX;
     lastY = e.clientY;
-    document.addEventListener("mouseup", handleStopDrag);
-    document.addEventListener("mousemove", handleDragInterface);
+    document.addEventListener("pointerup", handleStopDrag);
+    document.addEventListener("pointermove", handleDragInterface);
   };
   const handleStopDrag = () => {
-    document.removeEventListener("mouseup", handleStopDrag);
-    document.removeEventListener("mousemove", handleDragInterface);
+    document.removeEventListener("pointerup", handleStopDrag);
+    document.removeEventListener("pointermove", handleDragInterface);
   };
   const moveInterface = (x, y) => {
     lastX = x;
@@ -162,7 +162,8 @@ export default async function ({ addon, console, msg }) {
   window.addEventListener("resize", () => {
     moveInterface(lastX, lastY);
   });
-  interfaceHeader.addEventListener("mousedown", handleStartDrag);
+  interfaceHeader.addEventListener("pointerdown", handleStartDrag);
+  interfaceHeader.addEventListener("touchstart", (e) => e.preventDefault());
 
   interfaceHeader.append(tabListElement, buttonContainerElement);
   interfaceFooter.appendChild(footerButtonContainer);


### PR DESCRIPTION
Resolves #5727

- **Before changes:** The Debugger window could not be dragged on a touch screen, and doing so would scroll the page instead.
- **After changes:** The Debugger window can now be properly dragged by its title bar with both mouse and touch input.

### Tests

Tested with Edge DevTools Device Emulation.
