### PR TITLE
New addon: `flag-menu`

### DIFF
--- a/addons-l10n/en/flag-menu.json
+++ b/addons-l10n/en/flag-menu.json
@@ -1,5 +1,6 @@
 {
-  "flag-menu/toggle-turbo": "toggle turbo mode",
+  "flag-menu/turbo-on": "turn on turbo mode",
+  "flag-menu/turbo-off": "turn off turbo mode",
   "flag-menu/set-fps": "switch to {fps} fps",
   "flag-menu/mute": "mute project",
   "flag-menu/unmute": "unmute project"

--- a/addons-l10n/en/flag-menu.json
+++ b/addons-l10n/en/flag-menu.json
@@ -1,0 +1,5 @@
+{
+  "flag-menu/toggle-turbo": "toggle turbo mode",
+  "flag-menu/set-fps": "switch to {fps} fps",
+  "flag-menu/toggle-mute": "toggle mute"
+}

--- a/addons-l10n/en/flag-menu.json
+++ b/addons-l10n/en/flag-menu.json
@@ -1,5 +1,6 @@
 {
   "flag-menu/toggle-turbo": "toggle turbo mode",
   "flag-menu/set-fps": "switch to {fps} fps",
-  "flag-menu/toggle-mute": "toggle mute"
+  "flag-menu/mute": "mute project",
+  "flag-menu/unmute": "unmute project"
 }

--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -42,6 +42,7 @@
     }
   ],
   "tags": ["player", "featured"],
+  "relatedAddons": ["flag-menu"],
   "versionAdded": "1.1.0",
   "enabledByDefault": false,
   "libraries": ["scratch-gui"]

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, console }) {
+export default async function ({ addon, console, msg }) {
   // TODO: test whether e.altKey is true in chromebooks when alt+clicking.
   // If so, no timeout needed, similar to mute-project addon.
 
@@ -13,8 +13,8 @@ export default async function ({ addon, console }) {
   // flag-menu addon
   function updateToggleFramerateLabel(menuItem) {
     if (!menuItem) return;
-    const number = mode ? 30 : addon.settings.get("framerate");
-    menuItem.textContent = `switch to ${number} fps`;
+    const fps = mode ? 30 : addon.settings.get("framerate");
+    menuItem.textContent = msg("/flag-menu/set-fps", { fps });
   }
   (async () => {
     const menuItem = await addon.tab.waitForElement("#sa-flag-menu-fps", {

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -13,9 +13,7 @@ export default async function ({ addon, console }) {
   // flag-menu addon
   function updateToggleFramerateLabel(menuItem) {
     if (!menuItem) return;
-    const number = mode
-      ? 30
-      : addon.settings.get("framerate");
+    const number = mode ? 30 : addon.settings.get("framerate");
     menuItem.textContent = `switch to ${number} fps`;
   }
   (async () => {

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -20,7 +20,7 @@ export default async function ({ addon, console, msg }) {
     const menuItem = await addon.tab.waitForElement("#sa-flag-menu-fps", {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
-    menuItem.style.display = "block";
+    menuItem.style.display = "flex";
     addon.tab.displayNoneWhileDisabled(menuItem);
     updateToggleFramerateLabel(menuItem);
   })();

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -10,6 +10,23 @@ export default async function ({ addon, console }) {
   const fastFlag = addon.self.dir + "/svg/fast-flag.svg";
   let vanillaFlag = null;
 
+  // flag-menu addon
+  function updateToggleFramerateLabel(menuItem) {
+    if (!menuItem) return;
+    const number = mode
+      ? 30
+      : addon.settings.get("framerate");
+    menuItem.textContent = `switch to ${number} fps`;
+  }
+  (async () => {
+    const menuItem = await addon.tab.waitForElement("#sa-flag-menu-fps", {
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+    });
+    menuItem.style.display = "block";
+    addon.tab.displayNoneWhileDisabled(menuItem);
+    updateToggleFramerateLabel(menuItem);
+  })();
+
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
       markAsSeen: true,
@@ -43,6 +60,7 @@ export default async function ({ addon, console }) {
         }
       } else setFPS(30);
       updateFlag();
+      updateToggleFramerateLabel(document.getElementById("sa-flag-menu-fps"));
     };
     const flagListener = (e) => {
       if (addon.self.disabled) return;
@@ -68,6 +86,7 @@ export default async function ({ addon, console }) {
       if (vm.runtime._steppingInterval) {
         setFPS(addon.settings.get("framerate"));
       }
+      updateToggleFramerateLabel(document.getElementById("sa-flag-menu-fps"));
     });
     addon.self.addEventListener("disabled", () => changeMode(false));
     vm.runtime.start = function () {

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -161,6 +161,7 @@
   "costume-editor-shortcuts",
   "live-read-topics",
   "recolor-custom-blocks",
+  "flag-menu",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -53,8 +53,7 @@
 [class*="menu-bar_menu-bar-menu"] {
   margin-top: 2rem;
 }
-[class*="menu_menu-item"],
-.flag-menu-item {
+[class*="menu_menu-item"] {
   line-height: 1.75rem;
   padding: 0 0.5rem;
 }

--- a/addons/editor-compact/userstyle.css
+++ b/addons/editor-compact/userstyle.css
@@ -53,7 +53,8 @@
 [class*="menu-bar_menu-bar-menu"] {
   margin-top: 2rem;
 }
-[class*="menu_menu-item"] {
+[class*="menu_menu-item"],
+.flag-menu-item {
   line-height: 1.75rem;
   padding: 0 0.5rem;
 }

--- a/addons/flag-menu/addon.json
+++ b/addons/flag-menu/addon.json
@@ -29,5 +29,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.44.0",
   "tags": ["player", "featured"],
+  "enabledByDefault": true,
   "relatedAddons": ["60fps", "mute-project"]
 }

--- a/addons/flag-menu/addon.json
+++ b/addons/flag-menu/addon.json
@@ -1,0 +1,33 @@
+{
+  "name": "Green flag context menu",
+  "description": "Lets you toggle turbo mode and other settings by right clicking the green flag.",
+  "info": [
+    {
+      "id": "longpress",
+      "text": "On a touch screen, you can open the context menu by pressing and holding the green flag."
+    }
+  ],
+  "credits": [
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects", "projectEmbeds"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "context_menu.css",
+      "matches": ["projects", "projectEmbeds"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.44.0",
+  "tags": ["player", "featured"],
+  "relatedAddons": ["60fps", "mute-project"]
+}

--- a/addons/flag-menu/context_menu.css
+++ b/addons/flag-menu/context_menu.css
@@ -4,39 +4,12 @@
   display: none;
 }
 
-/* Styles reused from https://github.com/scratchfoundation/scratch-gui/blob/develop/src/components/context-menu/context-menu.css */
-
-.flag-context-menu {
-  min-width: 130px;
-  padding: 5px 0;
-  margin: 2px 0 0;
-  font-size: 0.85rem;
-  text-align: left;
-  background-color: var(--editorDarkMode-input, white);
-  border: 1px solid var(--editorDarkMode-border, #00000026);
-  border-radius: calc(0.5rem / 2);
-  box-shadow: 0px 0px 5px 1px #00000026;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
-  z-index: 10000;
+.sa-flag-context-menu {
   position: fixed;
   pointer-events: none;
 }
 
-.flag-context-menu.ctx-menu-open {
+.sa-flag-context-menu.sa-flag-menu-open {
   opacity: 1 !important;
   pointer-events: auto;
-}
-
-.flag-menu-item {
-  padding: 8px 12px;
-  color: var(--editorDarkMode-input-text);
-  white-space: nowrap;
-  cursor: pointer;
-  transition: 0.1s ease;
-}
-
-.flag-menu-item:hover {
-  background-color: var(--editorDarkMode-primary, #855cd6);
-  color: var(--editorDarkMode-primary-text, white);
 }

--- a/addons/flag-menu/context_menu.css
+++ b/addons/flag-menu/context_menu.css
@@ -1,0 +1,40 @@
+/* Hide context menu items related to other addons by default */
+#sa-flag-menu-fps, #sa-flag-menu-mute {
+  display: none;
+}
+
+/* Styles reused from https://github.com/scratchfoundation/scratch-gui/blob/develop/src/components/context-menu/context-menu.css */
+
+.flag-context-menu {
+  min-width: 130px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  font-size: 0.85rem;
+  text-align: left;
+  background-color: white;
+  border: 1px solid #00000026;
+  border-radius: calc(0.5rem / 2);
+  box-shadow: 0px 0px 5px 1px #00000026;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 10000;
+  position: fixed;
+  pointer-events: none;
+}
+
+.flag-context-menu.ctx-menu-open {
+  opacity: 1 !important;
+  pointer-events: auto;
+}
+
+.flag-menu-item {
+  padding: 8px 12px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: 0.1s ease;
+}
+
+.flag-menu-item:hover {
+  background: #855cd6;
+  color: white;
+}

--- a/addons/flag-menu/context_menu.css
+++ b/addons/flag-menu/context_menu.css
@@ -1,5 +1,6 @@
 /* Hide context menu items related to other addons by default */
-#sa-flag-menu-fps, #sa-flag-menu-mute {
+#sa-flag-menu-fps,
+#sa-flag-menu-mute {
   display: none;
 }
 

--- a/addons/flag-menu/context_menu.css
+++ b/addons/flag-menu/context_menu.css
@@ -6,10 +6,8 @@
 
 .sa-flag-context-menu {
   position: fixed;
-  pointer-events: none;
 }
 
 .sa-flag-context-menu.sa-flag-menu-open {
-  opacity: 1 !important;
-  pointer-events: auto;
+  visibility: visible !important;
 }

--- a/addons/flag-menu/context_menu.css
+++ b/addons/flag-menu/context_menu.css
@@ -12,8 +12,8 @@
   margin: 2px 0 0;
   font-size: 0.85rem;
   text-align: left;
-  background-color: white;
-  border: 1px solid #00000026;
+  background-color: var(--editorDarkMode-input, white);
+  border: 1px solid var(--editorDarkMode-border, #00000026);
   border-radius: calc(0.5rem / 2);
   box-shadow: 0px 0px 5px 1px #00000026;
   pointer-events: none;
@@ -30,12 +30,13 @@
 
 .flag-menu-item {
   padding: 8px 12px;
+  color: var(--editorDarkMode-input-text);
   white-space: nowrap;
   cursor: pointer;
   transition: 0.1s ease;
 }
 
 .flag-menu-item:hover {
-  background: #855cd6;
-  color: white;
+  background-color: var(--editorDarkMode-primary, #855cd6);
+  color: var(--editorDarkMode-primary-text, white);
 }

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, console }) {
+export default async function ({ addon, console, msg }) {
   let greenFlag;
 
   const contextMenu = Object.assign(document.createElement("nav"), {
@@ -10,7 +10,7 @@ export default async function ({ addon, console }) {
       role: "menuitem",
       className: "flag-menu-item",
       id: "sa-flag-menu-turbo",
-      textContent: "toggle turbo mode",
+      textContent: msg("toggle-turbo"),
     }),
     Object.assign(document.createElement("div"), {
       role: "menuitem",
@@ -21,7 +21,7 @@ export default async function ({ addon, console }) {
       role: "menuitem",
       className: "flag-menu-item",
       id: "sa-flag-menu-mute",
-      textContent: "toggle mute",
+      textContent: msg("toggle-mute"),
     })
   );
 

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -22,7 +22,7 @@ export default async function ({ addon, console }) {
       className: "flag-menu-item",
       id: "sa-flag-menu-mute",
       textContent: "toggle mute",
-    }),
+    })
   );
 
   function closeContextMenu() {

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -1,0 +1,70 @@
+export default async function ({ addon, console }) {
+  let greenFlag;
+
+  const contextMenu = Object.assign(document.createElement("nav"), {
+    role: "menu",
+    className: "flag-context-menu",
+  });
+  contextMenu.append(
+    Object.assign(document.createElement("div"), {
+      role: "menuitem",
+      className: "flag-menu-item",
+      id: "sa-flag-menu-turbo",
+      textContent: "toggle turbo mode",
+    }),
+    Object.assign(document.createElement("div"), {
+      role: "menuitem",
+      className: "flag-menu-item",
+      id: "sa-flag-menu-fps",
+    }),
+    Object.assign(document.createElement("div"), {
+      role: "menuitem",
+      className: "flag-menu-item",
+      id: "sa-flag-menu-mute",
+      textContent: "toggle mute",
+    }),
+  );
+
+  function closeContextMenu() {
+    contextMenu.classList.remove("ctx-menu-open");
+  }
+  document.addEventListener("mousedown", (e) => {
+    if (!e.target.closest(".flag-context-menu")) closeContextMenu();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeContextMenu();
+  });
+
+  contextMenu.querySelector("#sa-flag-menu-turbo").addEventListener("click", () => {
+    closeContextMenu();
+    greenFlag.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+  });
+  contextMenu.querySelector("#sa-flag-menu-fps").addEventListener("click", () => {
+    closeContextMenu();
+    greenFlag.dispatchEvent(new MouseEvent("click", { bubbles: true, altKey: true }));
+  });
+  contextMenu.querySelector("#sa-flag-menu-mute").addEventListener("click", () => {
+    closeContextMenu();
+    greenFlag.dispatchEvent(new MouseEvent("click", { bubbles: true, ctrlKey: true }));
+  });
+
+  contextMenu.style.opacity = 0; // Setting opacity here fixes a visual glitch on dynamic enable
+  addon.tab.displayNoneWhileDisabled(contextMenu);
+  addon.self.addEventListener("disabled", closeContextMenu);
+
+  while (true) {
+    greenFlag = await addon.tab.waitForElement("[class^='green-flag']", {
+      markAsSeen: true,
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+    });
+
+    greenFlag.parentElement.appendChild(contextMenu);
+    greenFlag.addEventListener("contextmenu", (e) => {
+      if (addon.self.disabled) return;
+      e.preventDefault();
+      contextMenu.classList.add("ctx-menu-open");
+      contextMenu.style.left = e.clientX + "px";
+      contextMenu.style.top = e.clientY + "px";
+    });
+  }
+}

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -3,33 +3,33 @@ export default async function ({ addon, console, msg }) {
 
   const contextMenu = Object.assign(document.createElement("nav"), {
     role: "menu",
-    className: "flag-context-menu",
+    className: addon.tab.scratchClass("context-menu_context-menu", { others: "sa-flag-context-menu" }),
   });
   contextMenu.append(
     Object.assign(document.createElement("div"), {
       role: "menuitem",
-      className: "flag-menu-item",
+      className: addon.tab.scratchClass("context-menu_menu-item"),
       id: "sa-flag-menu-turbo",
       textContent: msg("toggle-turbo"),
     }),
     Object.assign(document.createElement("div"), {
       role: "menuitem",
-      className: "flag-menu-item",
+      className: addon.tab.scratchClass("context-menu_menu-item"),
       id: "sa-flag-menu-fps",
     }),
     Object.assign(document.createElement("div"), {
       role: "menuitem",
-      className: "flag-menu-item",
+      className: addon.tab.scratchClass("context-menu_menu-item"),
       id: "sa-flag-menu-mute",
       textContent: msg("toggle-mute"),
     })
   );
 
   function closeContextMenu() {
-    contextMenu.classList.remove("ctx-menu-open");
+    contextMenu.classList.remove("sa-flag-menu-open");
   }
   document.addEventListener("mousedown", (e) => {
-    if (!e.target.closest(".flag-context-menu")) closeContextMenu();
+    if (!e.target.closest("[role='menu']")) closeContextMenu();
   });
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape") closeContextMenu();
@@ -62,7 +62,7 @@ export default async function ({ addon, console, msg }) {
     greenFlag.addEventListener("contextmenu", (e) => {
       if (addon.self.disabled) return;
       e.preventDefault();
-      contextMenu.classList.add("ctx-menu-open");
+      contextMenu.classList.add("sa-flag-menu-open");
       contextMenu.style.left = e.clientX + "px";
       contextMenu.style.top = e.clientY + "px";
     });

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -21,7 +21,6 @@ export default async function ({ addon, console, msg }) {
       role: "menuitem",
       className: addon.tab.scratchClass("context-menu_menu-item"),
       id: "sa-flag-menu-mute",
-      textContent: msg("mute"),
     })
   );
 

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -1,25 +1,32 @@
 export default async function ({ addon, console, msg }) {
   let greenFlag;
 
+  const contextMenuClass = addon.tab.scratchClass("context-menu_context-menu") ||
+    addon.tab.scratchClass("context-menu_context-menu-content"); // React 16 || React 18
   const contextMenu = Object.assign(document.createElement("nav"), {
     role: "menu",
-    className: addon.tab.scratchClass("context-menu_context-menu", { others: "sa-flag-context-menu" }),
+    className: `${contextMenuClass} sa-flag-context-menu`,
   });
+  const createItem = ({ id, text = "" } = {}) => {
+    const item = Object.assign(document.createElement("div"), {
+      role: "menuitem",
+      className: addon.tab.scratchClass("context-menu_menu-item"),
+      id,
+      textContent: text,
+    });
+    item.addEventListener("mouseenter", () => item.setAttribute("data-highlighted", ""))
+    item.addEventListener("mouseleave", () => item.removeAttribute("data-highlighted"));
+    return item;
+  };
   contextMenu.append(
-    Object.assign(document.createElement("div"), {
-      role: "menuitem",
-      className: addon.tab.scratchClass("context-menu_menu-item"),
+    createItem({
       id: "sa-flag-menu-turbo",
-      textContent: msg("turbo-on"),
+      text: msg("turbo-on"),
     }),
-    Object.assign(document.createElement("div"), {
-      role: "menuitem",
-      className: addon.tab.scratchClass("context-menu_menu-item"),
+    createItem({
       id: "sa-flag-menu-fps",
     }),
-    Object.assign(document.createElement("div"), {
-      role: "menuitem",
-      className: addon.tab.scratchClass("context-menu_menu-item"),
+    createItem({
       id: "sa-flag-menu-mute",
     })
   );

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -5,28 +5,21 @@ export default async function ({ addon, console, msg }) {
     role: "menu",
     className: addon.tab.scratchClass("context-menu_context-menu-content", { others: "sa-flag-context-menu" }),
   });
-  const createItem = ({ id, text = "" } = {}) => {
+  const createItem = (id, textContent = "") => {
     const item = Object.assign(document.createElement("div"), {
       role: "menuitem",
       className: addon.tab.scratchClass("context-menu_menu-item"),
       id,
-      textContent: text,
+      textContent,
     });
     item.addEventListener("mouseenter", () => item.setAttribute("data-highlighted", ""));
     item.addEventListener("mouseleave", () => item.removeAttribute("data-highlighted"));
     return item;
   };
   contextMenu.append(
-    createItem({
-      id: "sa-flag-menu-turbo",
-      text: msg("turbo-on"),
-    }),
-    createItem({
-      id: "sa-flag-menu-fps",
-    }),
-    createItem({
-      id: "sa-flag-menu-mute",
-    })
+    createItem("sa-flag-menu-turbo", msg("turbo-on")),
+    createItem("sa-flag-menu-fps"),
+    createItem("sa-flag-menu-mute")
   );
 
   function closeContextMenu() {

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -1,8 +1,8 @@
 export default async function ({ addon, console, msg }) {
   let greenFlag;
 
-  const contextMenuClass = addon.tab.scratchClass("context-menu_context-menu") ||
-    addon.tab.scratchClass("context-menu_context-menu-content"); // React 16 || React 18
+  const contextMenuClass =
+    addon.tab.scratchClass("context-menu_context-menu") || addon.tab.scratchClass("context-menu_context-menu-content"); // React 16 || React 18
   const contextMenu = Object.assign(document.createElement("nav"), {
     role: "menu",
     className: `${contextMenuClass} sa-flag-context-menu`,
@@ -14,7 +14,7 @@ export default async function ({ addon, console, msg }) {
       id,
       textContent: text,
     });
-    item.addEventListener("mouseenter", () => item.setAttribute("data-highlighted", ""))
+    item.addEventListener("mouseenter", () => item.setAttribute("data-highlighted", ""));
     item.addEventListener("mouseleave", () => item.removeAttribute("data-highlighted"));
     return item;
   };

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -10,7 +10,7 @@ export default async function ({ addon, console, msg }) {
       role: "menuitem",
       className: addon.tab.scratchClass("context-menu_menu-item"),
       id: "sa-flag-menu-turbo",
-      textContent: msg("toggle-turbo"),
+      textContent: msg("turbo-on"),
     }),
     Object.assign(document.createElement("div"), {
       role: "menuitem",
@@ -50,6 +50,13 @@ export default async function ({ addon, console, msg }) {
   contextMenu.style.opacity = 0; // Setting opacity here fixes a visual glitch on dynamic enable
   addon.tab.displayNoneWhileDisabled(contextMenu);
   addon.self.addEventListener("disabled", closeContextMenu);
+
+  addon.tab.traps.vm.on("TURBO_MODE_ON", () => {
+    contextMenu.querySelector("#sa-flag-menu-turbo").textContent = msg("turbo-off");
+  });
+  addon.tab.traps.vm.on("TURBO_MODE_OFF", () => {
+    contextMenu.querySelector("#sa-flag-menu-turbo").textContent = msg("turbo-on");
+  });
 
   while (true) {
     greenFlag = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -1,11 +1,9 @@
 export default async function ({ addon, console, msg }) {
   let greenFlag;
 
-  const contextMenuClass =
-    addon.tab.scratchClass("context-menu_context-menu") || addon.tab.scratchClass("context-menu_context-menu-content"); // React 16 || React 18
   const contextMenu = Object.assign(document.createElement("nav"), {
     role: "menu",
-    className: `${contextMenuClass} sa-flag-context-menu`,
+    className: addon.tab.scratchClass("context-menu_context-menu-content", { others: "sa-flag-context-menu" }),
   });
   const createItem = ({ id, text = "" } = {}) => {
     const item = Object.assign(document.createElement("div"), {
@@ -54,7 +52,7 @@ export default async function ({ addon, console, msg }) {
     greenFlag.dispatchEvent(new MouseEvent("click", { bubbles: true, ctrlKey: true }));
   });
 
-  contextMenu.style.opacity = 0; // Setting opacity here fixes a visual glitch on dynamic enable
+  contextMenu.style.visibility = "hidden"; // Setting visibility here fixes a visual glitch on dynamic enable
   addon.tab.displayNoneWhileDisabled(contextMenu);
   addon.self.addEventListener("disabled", closeContextMenu);
 

--- a/addons/flag-menu/userscript.js
+++ b/addons/flag-menu/userscript.js
@@ -21,7 +21,7 @@ export default async function ({ addon, console, msg }) {
       role: "menuitem",
       className: addon.tab.scratchClass("context-menu_menu-item"),
       id: "sa-flag-menu-mute",
-      textContent: msg("toggle-mute"),
+      textContent: msg("mute"),
     })
   );
 
@@ -53,7 +53,7 @@ export default async function ({ addon, console, msg }) {
   addon.self.addEventListener("disabled", closeContextMenu);
 
   while (true) {
-    greenFlag = await addon.tab.waitForElement("[class^='green-flag']", {
+    greenFlag = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });

--- a/addons/mute-project/addon.json
+++ b/addons/mute-project/addon.json
@@ -32,6 +32,6 @@
   "dynamicDisable": true,
   "versionAdded": "1.7.0",
   "tags": ["player", "recommended"],
-  "relatedAddons": ["vol-slider"],
+  "relatedAddons": ["vol-slider", "flag-menu"],
   "libraries": ["scratch-gui"]
 }

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -43,7 +43,7 @@ export default async function ({ addon, console, msg }) {
     const menuItem = await addon.tab.waitForElement("#sa-flag-menu-mute", {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
-    menuItem.style.display = "block";
+    menuItem.style.display = "flex";
     addon.tab.displayNoneWhileDisabled(menuItem);
     updateMuteUnmuteLabel(menuItem);
   })();

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -1,6 +1,6 @@
 import { setup, isMuted, onVolumeChanged, setMuted } from "../vol-slider/module.js";
 
-export default async function ({ addon, console }) {
+export default async function ({ addon, console, msg }) {
   const vm = addon.tab.traps.vm;
   setup(vm);
 
@@ -14,6 +14,7 @@ export default async function ({ addon, console }) {
 
   const updateIcon = () => {
     icon.style.display = addon.self.disabled || !isMuted() ? "none" : "";
+    updateMuteUnmuteLabel(document.getElementById("sa-flag-menu-mute"));
   };
   onVolumeChanged(updateIcon);
   updateIcon();
@@ -33,12 +34,18 @@ export default async function ({ addon, console }) {
   });
 
   // flag-menu addon
+  function updateMuteUnmuteLabel(menuItem) {
+    if (!menuItem) return;
+    const key = isMuted() ? "unmute" : "mute";
+    menuItem.textContent = msg("/flag-menu/" + key);
+  }
   (async () => {
     const menuItem = await addon.tab.waitForElement("#sa-flag-menu-mute", {
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
     menuItem.style.display = "block";
     addon.tab.displayNoneWhileDisabled(menuItem);
+    updateMuteUnmuteLabel(menuItem);
   })();
 
   while (true) {

--- a/addons/mute-project/userscript.js
+++ b/addons/mute-project/userscript.js
@@ -32,6 +32,15 @@ export default async function ({ addon, console }) {
     }
   });
 
+  // flag-menu addon
+  (async () => {
+    const menuItem = await addon.tab.waitForElement("#sa-flag-menu-mute", {
+      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
+    });
+    menuItem.style.display = "block";
+    addon.tab.displayNoneWhileDisabled(menuItem);
+  })();
+
   while (true) {
     let button = await addon.tab.waitForElement("[class^='green-flag_green-flag']", {
       markAsSeen: true,

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -409,7 +409,7 @@ async function onInfoAvailable({ globalState: globalStateMsg, addonsWithUserscri
         if (everLoadedUserscriptAddons.has(addonId)) {
           if (!dynamicDisable) return;
           // Addon was reenabled
-          document.querySelector(`[data-sa-hide-disabled-style=${addonId}]`).remove();
+          document.querySelector(`[data-sa-hide-disabled-style='${addonId}']`).remove();
           _page_.fireEvent({ name: "reenabled", addonId, target: "self" });
         } else {
           if (!dynamicEnable) return;
@@ -459,7 +459,7 @@ async function onInfoAvailable({ globalState: globalStateMsg, addonsWithUserscri
         disabledDynamicAddons.add(addonId);
         const style = document.createElement("style");
         style.dataset.saHideDisabledStyle = addonId;
-        style.textContent = `[data-sa-hide-disabled=${addonId}] { display: none !important; }`;
+        style.textContent = `[data-sa-hide-disabled='${addonId}'] { display: none !important; }`;
         document.body.appendChild(style);
         _page_.fireEvent({ name: "disabled", addonId, target: "self" });
       } else {


### PR DESCRIPTION
Resolves #7230

### Changes

- Adds a new addon which adds a context menu to the green flag. It lets you toggle turbo mode, higher framerate, and mute. Now mobile users can finally use turbo mode without having to enter the editor!
- Related addons have been updated to utilize their context menu items.
- Also fixed an issue that prevents the displayNoneWhileDisabled API from working on addons beginning with a number.

It looks like this:
![Green flag context menu](https://github.com/user-attachments/assets/f75821ed-3434-4506-81f9-c66b8b027f5d)

*Context menu items (other than toggle turbo mode) only appear if their respective addons are enabled.

### Tests

Tested on Edge 140 with a mouse and with DevTools Device Emulation.

To do:
- [ ] Use `touchstart` instead of `contextmenu`
- [x] Localize
- [x] Dynamic disable, enable, and setting changes work for all updated addons
- [x] `editor-dark-mode` compatibility
- [x] `editor-compact` compatibility