### PR TITLE
Add addon: Compact Scratch Profile Sliders

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -161,6 +161,7 @@
   "costume-editor-shortcuts",
   "live-read-topics",
   "recolor-custom-blocks",
+  "compact-profile",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Compact profile sliders",
-  "description": "Rearranges Scratch profile sections into a two-column layout by pairing sliders side by side.",
+  "name": "Compact Scratch Profile Sliders",
+  "description": "Rearranges the profile sections into a cleaner two-column layout by pairing sliders side by side, making profiles more compact and readable.",
   "credits": [
     {
       "name": "VIGARPAST_777",
@@ -10,16 +10,16 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["users"]
+      "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyles.css",
-      "matches": ["users"]
+      "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
-  "tags": ["community", "profiles"],
-  "versionAdded": "1.38.0",
-  "enabledByDefault": false
+  "settings": [],
+  "versionAdded": "1.44.0",
+  "tags": ["profiles", "ui", "featured"]
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Compact Scratch Profile Sliders",
-  "description": "Rearranges the profile sections into a cleaner two-column layout by pairing sliders side by side, making profiles more compact and readable.",
+  "description": "Reorganizes profile sections into a cleaner two-column layout by pairing sliders side by side.",
   "credits": [
     {
       "name": "VIGARPAST_777",
@@ -10,18 +10,15 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/users/*/"]
+      "matches": ["users"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyles.css",
-      "matches": ["https://scratch.mit.edu/users/*/"]
+      "matches": ["users"]
     }
   ],
-  "settings": [],
-  "dynamicEnable": true,
-  "dynamicDisable": true,
-  "tags": ["profiles", "ui", "featured"],
-  "versionAdded": "1.44.0"
+  "versionAdded": "1.44.0",
+  "tags": ["community", "profiles"]
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Compact Scratch Profile Sliders",
-  "description": "Groups all sliders on Scratch profiles in pairs for shared projects, favorited projects, followed studios, curated studios, following, and followers.",
+  "name": "Compact profile sliders",
+  "description": "Rearranges Scratch profile sections into a cleaner two-column layout by pairing sliders side by side.",
   "credits": [
     {
       "name": "VIGARPAST_777",
@@ -19,7 +19,7 @@
       "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
-  "settings": [],
+  "tags": ["community", "profiles", "layout"],
   "versionAdded": "1.0.0",
-  "tags": ["profiles", "community", "sliders"]
+  "enabledByDefault": false
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,0 +1,30 @@
+{
+  "name": "Compact Profile Sliders",
+  "description": "Groups Scratch profile sliders side by side, making profiles more compact and easier to browse.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "This addon arranges profile sliders in pairs and enables horizontal scrolling for better visibility.",
+      "id": "profileCompactNotice"
+    }
+  ],
+  "credits": [
+    {
+      "name": "VIGARPAST_777",
+      "link": "https://scratch.mit.edu/users/VIGARPAST_777/"
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["users"]
+    }
+  ],
+  "settings": [],
+  "tags": ["profile", "layout", "ui"],
+  "versionAdded": "1.0.0",
+  "enabledByDefault": true,
+  "libraries": []
+}

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,18 +1,25 @@
 {
   "name": "Compact Scratch Profile Sliders",
-  "description": "Groups Scratch profile sliders in pairs for a more compact layout, fully language-independent.",
+  "description": "Rearranges the profile sections into a cleaner two-column layout by pairing sliders side by side, making profiles more compact and readable.",
+  "credits": [
+    {
+      "name": "VIGARPAST_777",
+      "link": "https://scratch.mit.edu/users/VIGARPAST_777/"
+    }
+  ],
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["users"]
+      "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyles.css",
-      "matches": ["users"]
+      "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
+  "settings": [],
   "versionAdded": "1.44.0",
-  "tags": ["community", "profiles"]
+  "tags": ["profiles", "ui", "featured"]
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -20,6 +20,8 @@
     }
   ],
   "settings": [],
-  "versionAdded": "1.44.0",
-  "tags": ["profiles", "ui", "featured"]
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "tags": ["profiles", "ui", "featured"],
+  "versionAdded": "1.44.0"
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,12 +1,6 @@
 {
   "name": "Compact Scratch Profile Sliders",
-  "description": "Reorganizes profile sections into a cleaner two-column layout by pairing sliders side by side.",
-  "credits": [
-    {
-      "name": "VIGARPAST_777",
-      "link": "https://scratch.mit.edu/users/VIGARPAST_777/"
-    }
-  ],
+  "description": "Groups Scratch profile sliders in pairs for a more compact layout, fully language-independent.",
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Compact Scratch Profiles",
-  "description": "Groups profile sliders into pairs in the order: Shared, Favorites, Studios I follow, Studios I curate, Following, Followers.",
+  "name": "Compact Scratch Profile Sliders",
+  "description": "Groups all sliders on Scratch profiles in pairs for shared projects, favorited projects, followed studios, curated studios, following, and followers.",
   "credits": [
     {
       "name": "VIGARPAST_777",
@@ -15,10 +15,11 @@
   ],
   "userstyles": [
     {
-      "url": "userstyle.css",
+      "url": "userstyles.css",
       "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
-  "tags": ["profiles", "community", "featured"],
-  "versionAdded": "1.0.0"
+  "settings": [],
+  "versionAdded": "1.0.0",
+  "tags": ["profiles", "community", "sliders"]
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,30 +1,25 @@
 {
-  "name": "Compact Profile Sliders",
-  "description": "Groups Scratch profile sliders side by side, making profiles more compact and easier to browse.",
-  "info": [
-    {
-      "type": "notice",
-      "text": "This addon arranges profile sliders in pairs and enables horizontal scrolling for better visibility.",
-      "id": "profileCompactNotice"
-    }
-  ],
+  "name": "Compact profile sliders",
+  "description": "Displays profile sliders (projects, favorites, followers, etc.) side by side instead of stacked vertically.",
   "credits": [
     {
       "name": "VIGARPAST_777",
       "link": "https://scratch.mit.edu/users/VIGARPAST_777/"
     }
   ],
-  "dynamicEnable": true,
-  "dynamicDisable": true,
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["users"]
+      "matches": ["https://scratch.mit.edu/users/*/"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "userstyles.css",
+      "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
   "settings": [],
-  "tags": ["profile", "layout", "ui"],
   "versionAdded": "1.0.0",
-  "enabledByDefault": true,
-  "libraries": []
+  "tags": ["community", "profiles", "ui", "layout"]
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Compact profile sliders",
-  "description": "Rearranges Scratch profile sections into a cleaner two-column layout by pairing sliders side by side.",
+  "description": "Rearranges Scratch profile sections into a two-column layout by pairing sliders side by side.",
   "credits": [
     {
       "name": "VIGARPAST_777",
@@ -10,16 +10,16 @@
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/users/*/"]
+      "matches": ["users"]
     }
   ],
   "userstyles": [
     {
       "url": "userstyles.css",
-      "matches": ["https://scratch.mit.edu/users/*/"]
+      "matches": ["users"]
     }
   ],
-  "tags": ["community", "profiles", "layout"],
-  "versionAdded": "1.0.0",
+  "tags": ["community", "profiles"],
+  "versionAdded": "1.38.0",
   "enabledByDefault": false
 }

--- a/addons/compact-profile/addon.json
+++ b/addons/compact-profile/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Compact profile sliders",
-  "description": "Displays profile sliders (projects, favorites, followers, etc.) side by side instead of stacked vertically.",
+  "name": "Compact Scratch Profiles",
+  "description": "Groups profile sliders into pairs in the order: Shared, Favorites, Studios I follow, Studios I curate, Following, Followers.",
   "credits": [
     {
       "name": "VIGARPAST_777",
@@ -15,11 +15,10 @@
   ],
   "userstyles": [
     {
-      "url": "userstyles.css",
+      "url": "userstyle.css",
       "matches": ["https://scratch.mit.edu/users/*/"]
     }
   ],
-  "settings": [],
-  "versionAdded": "1.0.0",
-  "tags": ["community", "profiles", "ui", "layout"]
+  "tags": ["profiles", "community", "featured"],
+  "versionAdded": "1.0.0"
 }

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,45 +1,32 @@
 export default async function ({ addon }) {
-    const groupSliders = () => {
-        const allSliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
-        const parentContainer = allSliders[0]?.parentNode;
-        if (!allSliders.length || !parentContainer) return;
+  function groupSliders() {
+    const boxes = Array.from(document.querySelectorAll(".box.slider-carousel-container"));
 
-        const order = [];
-        allSliders.forEach(slider => {
-            const carousel = slider.querySelector('.slider-carousel');
-            if (!carousel) return;
-            const items = carousel.querySelectorAll('li');
-            if (!items.length) return;
+    const order = [
+      "shared",
+      "favorites",
+      "studios-following",
+      "studios-curating",
+      "following",
+      "followers"
+    ];
 
-            if (carousel.querySelector('.gallery')) order.push(slider);
-            else order.push(slider);
-        });
+    const orderedBoxes = [];
+    order.forEach(id => {
+      const box = boxes.find(el => el.querySelector(`#${id}`));
+      if (box) orderedBoxes.push(box);
+    });
 
-        for (let i = 0; i < order.length - 1; i += 2) {
-            const left = order[i];
-            const right = order[i + 1];
+    for (let i = 0; i < orderedBoxes.length - 1; i += 2) {
+      const left = orderedBoxes[i];
+      const right = orderedBoxes[i + 1];
+      const parent = document.createElement("div");
+      parent.className = "sa-compact-row";
+      left.parentNode.insertBefore(parent, left);
+      parent.appendChild(left);
+      parent.appendChild(right);
+    }
+  }
 
-            const flexWrapper = document.createElement('div');
-            flexWrapper.className = 'sa-slider-flex-wrapper';
-            left.style.width = '48%';
-            right.style.width = '48%';
-            left.style.display = 'block';
-            right.style.display = 'block';
-
-            parentContainer.insertBefore(flexWrapper, left);
-            flexWrapper.appendChild(left);
-            flexWrapper.appendChild(right);
-
-            [left, right].forEach(box => {
-                const carousel = box.querySelector('.slider-carousel');
-                if (carousel) {
-                    carousel.style.overflowX = 'auto';
-                    carousel.style.scrollBehavior = 'smooth';
-                }
-            });
-        }
-    };
-
-    window.addEventListener('load', groupSliders);
-    addon.self.addEventListener('enabled', groupSliders);
-};
+  groupSliders();
+}

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,32 +1,45 @@
 export default async function ({ addon }) {
-  function groupSliders() {
-    const boxes = Array.from(document.querySelectorAll(".box.slider-carousel-container"));
+    function groupSliders() {
+        const allSliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+        const parentContainer = allSliders[0]?.parentNode;
+        if (!allSliders.length || !parentContainer) return;
 
-    const order = [
-      "shared",
-      "favorites",
-      "studios-following",
-      "studios-curating",
-      "following",
-      "followers"
-    ];
+        const order = [];
+        allSliders.forEach(slider => {
+            const carousel = slider.querySelector('.slider-carousel');
+            if (!carousel) return;
+            const items = carousel.querySelectorAll('li');
+            if (!items.length) return;
+            order.push(slider);
+        });
 
-    const orderedBoxes = [];
-    order.forEach(id => {
-      const box = boxes.find(el => el.querySelector(`#${id}`));
-      if (box) orderedBoxes.push(box);
-    });
+        for (let i = 0; i < order.length - 1; i += 2) {
+            const left = order[i];
+            const right = order[i + 1];
 
-    for (let i = 0; i < orderedBoxes.length - 1; i += 2) {
-      const left = orderedBoxes[i];
-      const right = orderedBoxes[i + 1];
-      const parent = document.createElement("div");
-      parent.className = "sa-compact-row";
-      left.parentNode.insertBefore(parent, left);
-      parent.appendChild(left);
-      parent.appendChild(right);
+            const flexWrapper = document.createElement('div');
+            flexWrapper.style.display = 'flex';
+            flexWrapper.style.justifyContent = 'space-between';
+            flexWrapper.style.marginBottom = '20px';
+
+            left.style.width = '48%';
+            right.style.width = '48%';
+            left.style.display = 'block';
+            right.style.display = 'block';
+
+            parentContainer.insertBefore(flexWrapper, left);
+            flexWrapper.appendChild(left);
+            flexWrapper.appendChild(right);
+
+            [left, right].forEach(box => {
+                const carousel = box.querySelector('.slider-carousel');
+                if (carousel) {
+                    carousel.style.overflowX = 'auto';
+                    carousel.style.scrollBehavior = 'smooth';
+                }
+            });
+        }
     }
-  }
 
-  groupSliders();
+    groupSliders();
 }

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,21 +1,39 @@
 export default async function ({ addon }) {
-  function groupSliders() {
-    const boxes = Array.from(document.querySelectorAll(".box.slider-carousel-container"));
-    const order = ["shared", "favorites", "studios-following", "studios-curating", "following", "followers"];
-    const orderedBoxes = [];
-    order.forEach(id => {
-      const box = boxes.find(el => el.querySelector(`#${id}`));
-      if (box) orderedBoxes.push(box);
+  const allSliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+  const parentContainer = allSliders[0]?.parentNode;
+  if (!allSliders.length || !parentContainer) return;
+
+  const ordered = [];
+  allSliders.forEach(slider => {
+    const carousel = slider.querySelector('.slider-carousel');
+    if (!carousel) return;
+    ordered.push(slider);
+  });
+
+  for (let i = 0; i < ordered.length - 1; i += 2) {
+    const left = ordered[i];
+    const right = ordered[i + 1];
+
+    const wrapper = document.createElement('div');
+    wrapper.style.display = 'flex';
+    wrapper.style.justifyContent = 'space-between';
+    wrapper.style.marginBottom = '20px';
+
+    left.style.width = '48%';
+    right.style.width = '48%';
+    left.style.display = 'block';
+    right.style.display = 'block';
+
+    parentContainer.insertBefore(wrapper, left);
+    wrapper.appendChild(left);
+    wrapper.appendChild(right);
+
+    [left, right].forEach(box => {
+      const carousel = box.querySelector('.slider-carousel');
+      if (carousel) {
+        carousel.style.overflowX = 'auto';
+        carousel.style.scrollBehavior = 'smooth';
+      }
     });
-    for (let i = 0; i < orderedBoxes.length - 1; i += 2) {
-      const left = orderedBoxes[i];
-      const right = orderedBoxes[i + 1];
-      const parent = document.createElement("div");
-      parent.className = "sa-slider-flex-wrapper";
-      left.parentNode.insertBefore(parent, left);
-      parent.appendChild(left);
-      parent.appendChild(right);
-    }
   }
-  groupSliders();
-}
+};

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,0 +1,43 @@
+export default async function({ addon }) {
+    await addon.tab.waitForElement('.box.slider-carousel-container', { markAsSeen: true });
+
+    const arrangeSliders = () => {
+        const sliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+
+        for (let i = 0; i < sliders.length - 1; i += 2) {
+            const left = sliders[i];
+            const right = sliders[i + 1];
+
+            const wrapper = document.createElement('div');
+            wrapper.style.display = 'flex';
+            wrapper.style.justifyContent = 'space-between';
+            wrapper.style.marginBottom = '20px';
+
+            left.style.width = '48%';
+            right.style.width = '48%';
+            left.style.display = 'block';
+            right.style.display = 'block';
+
+            const container = left.parentNode;
+            container.insertBefore(wrapper, left);
+            wrapper.appendChild(left);
+            wrapper.appendChild(right);
+
+            [left, right].forEach(box => {
+                const carousel = box.querySelector('.slider-carousel, .sliderCarousel');
+                if (carousel) {
+                    carousel.style.overflowX = 'auto';
+                    carousel.style.scrollBehavior = 'smooth';
+                }
+            });
+        }
+    };
+
+    arrangeSliders();
+
+    const observer = new MutationObserver(() => {
+        arrangeSliders();
+    });
+
+    observer.observe(document.querySelector('#profile') || document.body, { childList: true, subtree: true });
+}

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,30 +1,45 @@
-export default async function({ addon }) {
-    const sliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+export default async function ({ addon }) {
+    const groupSliders = () => {
+        const allSliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+        const parentContainer = allSliders[0]?.parentNode;
+        if (!allSliders.length || !parentContainer) return;
 
-    function findSlider(keywords) {
-        return sliders.find(box => {
-            const title = box.querySelector('.box-head h4')?.textContent.toLowerCase() || '';
-            return keywords.some(k => title.includes(k));
-        }) || null;
-    }
+        const order = [];
+        allSliders.forEach(slider => {
+            const carousel = slider.querySelector('.slider-carousel');
+            if (!carousel) return;
+            const items = carousel.querySelectorAll('li');
+            if (!items.length) return;
 
-    const shared    = findSlider(["compartid", "shared", "partagé", "geteilt", "公開"]);
-    const favorites = findSlider(["favorit", "favorites", "favoris", "favoriten", "收藏"]);
-    const studiosFollowing = findSlider(["siguiendo estudios", "studios i follow", "studios que sigo", "suivis", "gefolgte studios", "追蹤工作室"]);
-    const studiosCurated   = findSlider(["estudios que curo", "curated studios", "ateliers gérés", "verwaltete studios", "管理的工作室"]);
-    const following = findSlider(["siguiendo", "following", "abonnements", "folgt", "關注"]);
-    const followers = findSlider(["seguidores", "followers", "abonnés", "folger", "粉絲"]);
+            if (carousel.querySelector('.gallery')) order.push(slider);
+            else order.push(slider);
+        });
 
-    function makeRow(left, right) {
-        if (!left) return;
-        const row = document.createElement('div');
-        row.className = 'tm-compact-row';
-        left.parentNode.insertBefore(row, left);
-        row.appendChild(left);
-        if (right) row.appendChild(right);
-    }
+        for (let i = 0; i < order.length - 1; i += 2) {
+            const left = order[i];
+            const right = order[i + 1];
 
-    makeRow(shared, favorites);
-    makeRow(studiosFollowing, studiosCurated);
-    makeRow(following, followers);
-}
+            const flexWrapper = document.createElement('div');
+            flexWrapper.className = 'sa-slider-flex-wrapper';
+            left.style.width = '48%';
+            right.style.width = '48%';
+            left.style.display = 'block';
+            right.style.display = 'block';
+
+            parentContainer.insertBefore(flexWrapper, left);
+            flexWrapper.appendChild(left);
+            flexWrapper.appendChild(right);
+
+            [left, right].forEach(box => {
+                const carousel = box.querySelector('.slider-carousel');
+                if (carousel) {
+                    carousel.style.overflowX = 'auto';
+                    carousel.style.scrollBehavior = 'smooth';
+                }
+            });
+        }
+    };
+
+    window.addEventListener('load', groupSliders);
+    addon.self.addEventListener('enabled', groupSliders);
+};

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,43 +1,26 @@
-export default async function({ addon }) {
-    await addon.tab.waitForElement('.box.slider-carousel-container', { markAsSeen: true });
+export default async function ({ addon, console }) {
+  const sliders = Array.from(document.querySelectorAll(".box.slider-carousel-container"))
+    .filter(el => !el.dataset.compacted);
 
-    const arrangeSliders = () => {
-        const sliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
+  for (let i = 0; i < sliders.length; i += 2) {
+    const left = sliders[i];
+    const right = sliders[i + 1];
+    if (!left) break;
 
-        for (let i = 0; i < sliders.length - 1; i += 2) {
-            const left = sliders[i];
-            const right = sliders[i + 1];
+    const wrapper = document.createElement("div");
+    wrapper.className = "sa-compact-wrapper";
 
-            const wrapper = document.createElement('div');
-            wrapper.style.display = 'flex';
-            wrapper.style.justifyContent = 'space-between';
-            wrapper.style.marginBottom = '20px';
+    left.dataset.compacted = "true";
+    wrapper.appendChild(left);
 
-            left.style.width = '48%';
-            right.style.width = '48%';
-            left.style.display = 'block';
-            right.style.display = 'block';
+    if (right) {
+      right.dataset.compacted = "true";
+      wrapper.appendChild(right);
+    }
 
-            const container = left.parentNode;
-            container.insertBefore(wrapper, left);
-            wrapper.appendChild(left);
-            wrapper.appendChild(right);
-
-            [left, right].forEach(box => {
-                const carousel = box.querySelector('.slider-carousel, .sliderCarousel');
-                if (carousel) {
-                    carousel.style.overflowX = 'auto';
-                    carousel.style.scrollBehavior = 'smooth';
-                }
-            });
-        }
-    };
-
-    arrangeSliders();
-
-    const observer = new MutationObserver(() => {
-        arrangeSliders();
-    });
-
-    observer.observe(document.querySelector('#profile') || document.body, { childList: true, subtree: true });
+    const parent = left.parentNode;
+    if (parent) {
+      parent.insertBefore(wrapper, right ? right.nextSibling : left.nextSibling);
+    }
+  }
 }

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,33 +1,21 @@
 export default async function ({ addon }) {
   function groupSliders() {
     const boxes = Array.from(document.querySelectorAll(".box.slider-carousel-container"));
-
-    const order = [
-      "shared",
-      "favorites",
-      "studios-following",
-      "studios-curating",
-      "following",
-      "followers"
-    ];
-
+    const order = ["shared", "favorites", "studios-following", "studios-curating", "following", "followers"];
     const orderedBoxes = [];
     order.forEach(id => {
       const box = boxes.find(el => el.querySelector(`#${id}`));
       if (box) orderedBoxes.push(box);
     });
-
     for (let i = 0; i < orderedBoxes.length - 1; i += 2) {
       const left = orderedBoxes[i];
       const right = orderedBoxes[i + 1];
       const parent = document.createElement("div");
-      parent.className = "sa-compact-row";
+      parent.className = "sa-slider-flex-wrapper";
       left.parentNode.insertBefore(parent, left);
       parent.appendChild(left);
       parent.appendChild(right);
     }
   }
-
   groupSliders();
 }
-

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,39 +1,32 @@
 export default async function ({ addon }) {
-  const allSliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
-  const parentContainer = allSliders[0]?.parentNode;
-  if (!allSliders.length || !parentContainer) return;
+  function groupSliders() {
+    const boxes = Array.from(document.querySelectorAll(".box.slider-carousel-container"));
 
-  const ordered = [];
-  allSliders.forEach(slider => {
-    const carousel = slider.querySelector('.slider-carousel');
-    if (!carousel) return;
-    ordered.push(slider);
-  });
+    const order = [
+      "shared",
+      "favorites",
+      "studios-following",
+      "studios-curating",
+      "following",
+      "followers"
+    ];
 
-  for (let i = 0; i < ordered.length - 1; i += 2) {
-    const left = ordered[i];
-    const right = ordered[i + 1];
-
-    const wrapper = document.createElement('div');
-    wrapper.style.display = 'flex';
-    wrapper.style.justifyContent = 'space-between';
-    wrapper.style.marginBottom = '20px';
-
-    left.style.width = '48%';
-    right.style.width = '48%';
-    left.style.display = 'block';
-    right.style.display = 'block';
-
-    parentContainer.insertBefore(wrapper, left);
-    wrapper.appendChild(left);
-    wrapper.appendChild(right);
-
-    [left, right].forEach(box => {
-      const carousel = box.querySelector('.slider-carousel');
-      if (carousel) {
-        carousel.style.overflowX = 'auto';
-        carousel.style.scrollBehavior = 'smooth';
-      }
+    const orderedBoxes = [];
+    order.forEach(id => {
+      const box = boxes.find(el => el.querySelector(`#${id}`));
+      if (box) orderedBoxes.push(box);
     });
+
+    for (let i = 0; i < orderedBoxes.length - 1; i += 2) {
+      const left = orderedBoxes[i];
+      const right = orderedBoxes[i + 1];
+      const parent = document.createElement("div");
+      parent.className = "sa-compact-row";
+      left.parentNode.insertBefore(parent, left);
+      parent.appendChild(left);
+      parent.appendChild(right);
+    }
   }
-};
+
+  groupSliders();
+}

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -1,26 +1,30 @@
-export default async function ({ addon, console }) {
-  const sliders = Array.from(document.querySelectorAll(".box.slider-carousel-container"))
-    .filter(el => !el.dataset.compacted);
+export default async function({ addon }) {
+    const sliders = Array.from(document.querySelectorAll('.box.slider-carousel-container'));
 
-  for (let i = 0; i < sliders.length; i += 2) {
-    const left = sliders[i];
-    const right = sliders[i + 1];
-    if (!left) break;
-
-    const wrapper = document.createElement("div");
-    wrapper.className = "sa-compact-wrapper";
-
-    left.dataset.compacted = "true";
-    wrapper.appendChild(left);
-
-    if (right) {
-      right.dataset.compacted = "true";
-      wrapper.appendChild(right);
+    function findSlider(keywords) {
+        return sliders.find(box => {
+            const title = box.querySelector('.box-head h4')?.textContent.toLowerCase() || '';
+            return keywords.some(k => title.includes(k));
+        }) || null;
     }
 
-    const parent = left.parentNode;
-    if (parent) {
-      parent.insertBefore(wrapper, right ? right.nextSibling : left.nextSibling);
+    const shared    = findSlider(["compartid", "shared", "partagé", "geteilt", "公開"]);
+    const favorites = findSlider(["favorit", "favorites", "favoris", "favoriten", "收藏"]);
+    const studiosFollowing = findSlider(["siguiendo estudios", "studios i follow", "studios que sigo", "suivis", "gefolgte studios", "追蹤工作室"]);
+    const studiosCurated   = findSlider(["estudios que curo", "curated studios", "ateliers gérés", "verwaltete studios", "管理的工作室"]);
+    const following = findSlider(["siguiendo", "following", "abonnements", "folgt", "關注"]);
+    const followers = findSlider(["seguidores", "followers", "abonnés", "folger", "粉絲"]);
+
+    function makeRow(left, right) {
+        if (!left) return;
+        const row = document.createElement('div');
+        row.className = 'tm-compact-row';
+        left.parentNode.insertBefore(row, left);
+        row.appendChild(left);
+        if (right) row.appendChild(right);
     }
-  }
+
+    makeRow(shared, favorites);
+    makeRow(studiosFollowing, studiosCurated);
+    makeRow(following, followers);
 }

--- a/addons/compact-profile/userscript.js
+++ b/addons/compact-profile/userscript.js
@@ -30,3 +30,4 @@ export default async function ({ addon }) {
 
   groupSliders();
 }
+

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -1,10 +1,11 @@
-.sa-slider-flex-wrapper {
+
+.sa-compact-row {
   display: flex;
   justify-content: space-between;
   margin-bottom: 20px;
 }
 
-.sa-slider-flex-wrapper .slider-carousel {
+.sa-compact-row .slider-carousel {
   overflow-x: auto;
   scroll-behavior: smooth;
 }

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -1,14 +1,10 @@
-.tm-compact-row {
+.sa-slider-flex-wrapper {
     display: flex;
     justify-content: space-between;
-    gap: 16px;
     margin-bottom: 20px;
 }
-.tm-compact-row .box.slider-carousel-container {
-    flex: 1;
-    max-width: 48%;
-}
-.tm-compact-row .slider-carousel {
+
+.sa-slider-flex-wrapper .slider-carousel {
     overflow-x: auto;
     scroll-behavior: smooth;
 }

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -1,11 +1,16 @@
-
 .sa-compact-row {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 20px;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 20px;
+    gap: 2%;
 }
 
-.sa-compact-row .slider-carousel {
-  overflow-x: auto;
-  scroll-behavior: smooth;
+.sa-compact-row .box.slider-carousel-container {
+    width: 48%;
+    display: block;
+}
+
+.sa-compact-row .box.slider-carousel-container .slider-carousel {
+    overflow-x: auto;
+    scroll-behavior: smooth;
 }

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -1,11 +1,14 @@
-.sa-compact-wrapper {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 16px;
+.tm-compact-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
 }
-
-.sa-compact-wrapper .box.slider-carousel-container {
-  flex: 1;
-  max-width: 48%;
+.tm-compact-row .box.slider-carousel-container {
+    flex: 1;
+    max-width: 48%;
+}
+.tm-compact-row .slider-carousel {
+    overflow-x: auto;
+    scroll-behavior: smooth;
 }

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -1,11 +1,10 @@
 .sa-slider-flex-wrapper {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
 }
 
 .sa-slider-flex-wrapper .slider-carousel {
-    overflow-x: auto;
-    scroll-behavior: smooth;
+  overflow-x: auto;
+  scroll-behavior: smooth;
 }
-

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -8,3 +8,4 @@
     overflow-x: auto;
     scroll-behavior: smooth;
 }
+

--- a/addons/compact-profile/userstyles.css
+++ b/addons/compact-profile/userstyles.css
@@ -1,0 +1,11 @@
+.sa-compact-wrapper {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.sa-compact-wrapper .box.slider-carousel-container {
+  flex: 1;
+  max-width: 48%;
+}


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->
Resolves #8548

### Changes
This pull request adds a new addon: **Compact Scratch Profile Sliders**.  
It rearranges the profile sections into a cleaner two-column layout by pairing sliders side by side.  

The order is preserved as:
1. Shared Projects  
2. Favorited Projects  
3. Followed Studios  
4. Curated Studios  
5. Following  
6. Followers  

Additional improvements:
- Smooth horizontal scrolling for all carousels  
- Responsive layout with equal widths for paired sliders  

### Reason for changes
Scratch profile pages can feel cluttered and require a lot of vertical scrolling.  
This addon makes profiles look more compact and organized, while still keeping all sections accessible.  

It improves readability and helps users quickly access the content they care about, especially on larger monitors.  

### Screenshots / Videos
I forgot to make an screenshot.

### Tests
- Tested on Chrome and Firefox  
- Works with profiles in different languages (no hardcoded keywords)  
- Verified with accounts that have all sections: shared projects, favorites, followed studios, curated studios, following, and followers  

### Credits
Addon created by [VIGARPAST_777](https://scratch.mit.edu/users/VIGARPAST_777/).
