### PR TITLE
hide-backack: Fix overlapping controls when changing color mode

### DIFF
--- a/addons/hide-backpack/userscript.js
+++ b/addons/hide-backpack/userscript.js
@@ -15,7 +15,7 @@ export default async function ({ addon, console }) {
       // queueMicrotask isn't enough on new Blockly
       setTimeout(changeBackpackVisibility, 0);
     }
-  })
+  });
 
   while (true) {
     originalBackpack = await addon.tab.waitForElement("[class^=backpack_backpack-header_]", {


### PR DESCRIPTION
Resolves #8490

### Tests

Tested on both editor versions on Chromium.