### PR TITLE
Display easter eggs cetegory name when open

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -125,6 +125,9 @@
   "popupFeatures": {
     "message": "Extension Popup Features"
   },
+  "easterEggs": {
+    "message": "Easter Eggs"
+  },
   "theme": {
     "message": "Theme:"
   },

--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -5,6 +5,7 @@
         sel: category.id === selectedCategory && !this.$root.relatedAddonsOpen,
         hasParent: category.parent,
       }"
+    v-if="!category.hidden"
     v-show="shouldShow"
     transition="expand"
     :style="{ marginBottom: category.marginBottom ? '12px' : 0 }"

--- a/webpages/settings/data/categories.js
+++ b/webpages/settings/data/categories.js
@@ -90,4 +90,9 @@ export default [
     name: chrome.i18n.getMessage("popupFeatures"),
     marginBottom: true,
   },
+  {
+    id: "easterEgg",
+    name: chrome.i18n.getMessage("easterEggs"),
+    hidden: true,
+  },
 ];


### PR DESCRIPTION
When displaying easter egss the settings page now shows the category name in the header and when no search results are found.

### Tests

Tested on Chromium
