### PR TITLE
Fix not all text being changed to white when timing tools heatmap enabled

### DIFF
--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -113,7 +113,7 @@ class HeatmapManager {
   startRealtimeUpdates(heatmapMax) {
     this.stopRealtimeUpdates(); // Clear any existing interval
     this.realtimeUpdateInterval = setInterval(() => {
-      if (this.config.showHeatmap && this.isProjectRunning() && this.modifiedTimers.size > 0) {
+      if (this.config.showHeatmap && this.modifiedTimers.size > 0) {
         this.updateHeatmapColors(this.currentHeatmapMax, true); // true = only modified timers
       }
     }, 100); // Update every 100ms

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -11,10 +11,10 @@ function recursiveFillBlock(block, fill = null) {
   block.svgPath_.style.fill = fillColor;
 
   // Set text color for blocks with heatmap applied
-  const textElements = Array.from(block.svgGroup_.children)
-    .filter((el) => !el.classList.contains("blocklyDraggable"))
-    .flatMap((el) => Array.from(el.querySelectorAll("text")));
-
+  const textElements = block.svgGroup_.querySelectorAll(
+    ":scope > :not(.blocklyDraggable) text, :scope > text:not(.blocklyDraggable)"
+  );
+  
   if (fill !== null) {
     // Heatmap is being applied - force white text
     textElements.forEach((textEl) => {

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -12,7 +12,7 @@ function recursiveFillBlock(block, fill = null) {
 
   // Set text color for blocks with heatmap applied
   const textElements = block.svgGroup_.querySelectorAll(
-    ":scope > :not(.blocklyDraggable) text, :scope > text:not(.blocklyDraggable)"
+    ":scope > :not(.blocklyDraggable):not([data-shapes='stack']) text, :scope > text"
   );
 
   if (fill !== null) {

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -14,7 +14,7 @@ function recursiveFillBlock(block, fill = null) {
   const textElements = block.svgGroup_.querySelectorAll(
     ":scope > :not(.blocklyDraggable) text, :scope > text:not(.blocklyDraggable)"
   );
-  
+
   if (fill !== null) {
     // Heatmap is being applied - force white text
     textElements.forEach((textEl) => {

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -12,7 +12,7 @@ function recursiveFillBlock(block, fill = null) {
 
   // Set text color for blocks with heatmap applied
   const textElements = block.svgGroup_.querySelectorAll(
-    ":scope > :not(.blocklyDraggable):not([data-shapes='stack']) text, :scope > text"
+    ":scope > :not(.blocklyDraggable):not([data-shapes='stack']) > text, :scope > text"
   );
 
   if (fill !== null) {


### PR DESCRIPTION
 I noticed a bug in my timing tools PR: my css selection for textElements to force to be white (needed for when users have high contrast on, which has black text which doesn't contrast well with heatmap enabled) will exclude certain text elements meaning not all text gets changed to white.

I need to change lines 14-16 of addons\debugger\timing\HeatmapManager.js from 
```js
const textElements = Array.from(block.svgGroup_.children)
    .filter((el) => !el.classList.contains("blocklyDraggable"))
    .flatMap((el) => Array.from(el.querySelectorAll("text")));
```

to

```js
  const textElements = block.svgGroup_.querySelectorAll(
    ":scope > :not(.blocklyDraggable) text, :scope > text:not(.blocklyDraggable)"
  );
```

| Before | After |
|--------|-------|
| <img width="237" height="566" alt="Before" src="https://github.com/user-attachments/assets/a775a1b9-8d75-4aba-b982-f5a6c9d50baa" /> | <img width="226" height="551" alt="image" src="https://github.com/user-attachments/assets/4c0fce1d-a499-430a-bea3-60791c37216b" /> |

---
I additionally have now thrown in a second bug fix, that will make the realtime heatmap updates take effect even if the project runs for less than 100ms.
