### PR TITLE
Fix -0 being logged as 0 in debugger

### DIFF
--- a/addons/debugger/logs.js
+++ b/addons/debugger/logs.js
@@ -133,7 +133,7 @@ export default async function createLogsTab({ debug, addon, console, msg }) {
 
   const addLog = (text, thread, type) => {
     const log = {
-      text,
+      text: Object.is(text, -0) ? "-0" : text, // Preserve -0 in stringification
       type,
       count: 1,
       preview: true,


### PR DESCRIPTION
In floating point math, there are two distinct values for 0 and -0. This difference is subtle, but it does make a difference in some obscure cases (eg `1/-0 === -Infinity` instead of `Infinity`). Because `(-0).toString() === "0"` when the debugger tries to log a statement which reports -0, it logs "0". [This can cause some confusion](https://github.com/TurboWarp/scratch-vm/issues/224). Making this debug tool print the value accurately (even when Scratch itself doesn't) makes sense to me.

Before: 
<img width="474" height="242" alt="image" src="https://github.com/user-attachments/assets/3f71ef29-f854-47cc-be42-e4502aefeef0" />

After:
<img width="424" height="273" alt="image" src="https://github.com/user-attachments/assets/5501aa15-161e-4226-bfa5-c27210883d8e" />
