### PR TITLE
Fix debugger blocks not being coloured sometimes on project load

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -186,6 +186,13 @@ const injectWorkspace = (ScratchBlocks) => {
     };
   }
 
+  // recolour existing procedure blocks incase this injection is called after the blocks have already been created
+  for (const block of ScratchBlocks.mainWorkspace.getAllBlocks(false)) {
+    if (block.type === "procedures_call" || block.parentBlock_?.type === "procedures_call"){
+      block.applyColour?.() || block.updateColour?.();
+    }
+  }
+
   // We use Scratch's extension category mechanism to create a new category.
   // https://github.com/scratchfoundation/scratch-gui/blob/ddd2fa06f2afa140a46ec03be91796ded861e65c/src/containers/blocks.jsx#L344
   // https://github.com/scratchfoundation/scratch-vm/blob/a0c11d6d8664a4f2d55632e70630d09ec6e9ae28/src/engine/runtime.js#L1381

--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -188,7 +188,7 @@ const injectWorkspace = (ScratchBlocks) => {
 
   // recolour existing procedure blocks incase this injection is called after the blocks have already been created
   for (const block of ScratchBlocks.mainWorkspace.getAllBlocks(false)) {
-    if (block.type === "procedures_call" || block.parentBlock_?.type === "procedures_call"){
+    if (block.type === "procedures_call" || block.parentBlock_?.type === "procedures_call") {
       block.applyColour?.() || block.updateColour?.();
     }
   }


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #8585

### Changes

Adds a recolouring step after initial injection to resolve the case in which the injection happens after blocks already created.

### Reason for changes

See issue.

### Tests

https://github.com/user-attachments/assets/e11f57e8-c741-47bf-8fdc-850ac5fa5987

