### PR TITLE
Fix welcome page & remove some dead code

### DIFF
--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -557,16 +557,6 @@ export default async function ({ addon, msg, console }) {
         let blocks = this.getCallsToProcedureById(item.data.labelID);
         this.carousel.build(item, blocks, instanceBlock);
       } else if (cls === "receive") {
-        /*
-          let blocks = [this.workspace.getBlockById(li.data.labelID)];
-          if (li.data.clones) {
-              for (const cloneID of li.data.clones) {
-                  blocks.push(this.workspace.getBlockById(cloneID))
-              }
-          }
-          blocks = blocks.concat(getCallsToEventsByName(li.data.eventName));
-        */
-        // Now, fetch the events from the scratch runtime instead of blockly
         let blocks = this.getCallsToEventsByName(item.data.eventName);
         if (!instanceBlock) {
           // Can we start by selecting the first block on 'this' sprite

--- a/background/transition.js
+++ b/background/transition.js
@@ -6,13 +6,10 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   const developerMode = (await chrome.management.getSelf()).installType;
   const currentVersion = chrome.runtime.getManifest().version;
   const [major, minor, _] = currentVersion.split(".");
-  if (details.previousVersion && details.previousVersion.startsWith("0")) {
-    chrome.tabs.create({ url: `https://scratchaddons.com/${localeSlash}scratch-messaging-transition/?${utm}` });
-  } else if (details.reason === "install" && !developerMode) {
-    chrome.tabs.create({ url: `https://scratchaddons.com/${localeSlash}welcome/?${utm}` });
-  }
-
   if (details.reason === "install") {
+    if (!developerMode) {
+      chrome.tabs.create({ url: `https://scratchaddons.com/${localeSlash}welcome/?${utm}` });
+    }
     chrome.storage.local.set({
       bannerSettings: { lastShown: `${major}.${minor}` },
     });

--- a/background/transition.js
+++ b/background/transition.js
@@ -3,7 +3,7 @@ const utm = `utm_source=extension&utm_medium=tabscreate&utm_campaign=v${chrome.r
 const uiLanguage = (chrome.i18n.getUILanguage && chrome.i18n.getUILanguage()) || navigator.language;
 const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
 chrome.runtime.onInstalled.addListener(async (details) => {
-  const developerMode = (await chrome.management.getSelf()).installType === "development"
+  const developerMode = (await chrome.management.getSelf()).installType === "development";
   const currentVersion = chrome.runtime.getManifest().version;
   const [major, minor, _] = currentVersion.split(".");
   if (details.reason === "install") {

--- a/background/transition.js
+++ b/background/transition.js
@@ -3,7 +3,7 @@ const utm = `utm_source=extension&utm_medium=tabscreate&utm_campaign=v${chrome.r
 const uiLanguage = (chrome.i18n.getUILanguage && chrome.i18n.getUILanguage()) || navigator.language;
 const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
 chrome.runtime.onInstalled.addListener(async (details) => {
-  const developerMode = (await chrome.management.getSelf()).installType;
+  const developerMode = (await chrome.management.getSelf()).installType === "development"
   const currentVersion = chrome.runtime.getManifest().version;
   const [major, minor, _] = currentVersion.split(".");
   if (details.reason === "install") {

--- a/background/transition.js
+++ b/background/transition.js
@@ -14,9 +14,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
       bannerSettings: { lastShown: `${major}.${minor}` },
     });
   }
-});
-chrome.management.getSelf((result) => {
-  if (result.installType !== "development") {
+  if (!developerMode) {
     chrome.runtime.setUninstallURL(`https://scratchaddons.com/${localeSlash}farewell?${utm}`);
   }
 });

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -112,19 +112,6 @@
           :required="!!setting.min"
         />
       </template>
-      <template v-if="setting.type === 'key'"
-        ><input
-          type="text"
-          class="setting-input"
-          v-model="addonSettings[setting.id]"
-          @input="updateSettings"
-          @keydown="keySettingKeyDown"
-          @keyup="keySettingKeyUp"
-          :disabled="!addon._enabled"
-          :placeholder="setting.default"
-          maxlength="100"
-          spellcheck="false"
-      /></template>
       <template v-if="setting.type === 'color'">
         <picker
           :value="addonSettings[setting.id] || setting.default"

--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -90,26 +90,6 @@ export default async function ({ template }) {
         let input = this.$event.target;
         if (!input.validity.valid) this.addonSettings[this.setting.id] = this.setting.default;
       },
-      keySettingKeyDown(e) {
-        e.preventDefault();
-        e.target.value = e.ctrlKey
-          ? "Ctrl" +
-            (e.shiftKey ? " + Shift" : "") +
-            (e.key === "Control" || e.key === "Shift"
-              ? ""
-              : (e.ctrlKey ? " + " : "") +
-                (e.key.toUpperCase() === e.key
-                  ? e.code.includes("Digit")
-                    ? e.code.substring(5, e.code.length)
-                    : e.key
-                  : e.key.toUpperCase()))
-          : "";
-      },
-      keySettingKeyUp(e) {
-        // Ctrl by itself isn't a hotkey
-        if (e.target.value === "Ctrl") e.target.value = "";
-        this.updateOption(e.target.value);
-      },
       getTableSetting(id) {
         return this.setting.row.find((setting) => setting.id === id);
       },


### PR DESCRIPTION
Specifically some commented out `find-bar` code, the `key` setting type that was never added to the schema and the code that opened the Scratch messaging extension transion page.

Also fixes a bug that caused the welcome page to never open on install.