### PR TITLE
Do not reload when changing forceEnglish

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -316,8 +316,7 @@ let fuse;
         inputElem.click();
       },
       applyLanguageSettings() {
-        alert(chrome.i18n.getMessage("importSuccess"));
-        chrome.runtime.reload();
+        chrome.runtime.sendMessage("reloadAddonManifests", () => location.reload());
       },
       openFullSettings() {
         window.open(


### PR DESCRIPTION
### Changes

Changing the "Show addon names and descriptions in English" setting now only requires a settings page reload instead of a full extension reload.

https://github.com/user-attachments/assets/c9988f92-3741-4134-beb1-cff5b504b632

### Reason for changes

It's better to reload only the resources that are necessary.

### Tests

Tested in Edge 141. Addons still work after toggling setting.

Help me find edge cases?