### PR TITLE
debugger: add default label to timer blocks

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -46,7 +46,7 @@ export const getCustomBlock = (proccode) => {
 const getArgumentId = (index) => `arg${index}`;
 
 const getNamesIdsDefaults = (blockData) => [
-  blockData.args,
+  blockData.args.map((arg) => arg.name),
   blockData.args.map((_, i) => getArgumentId(i)),
   blockData.args.map(() => ""),
 ];
@@ -103,7 +103,8 @@ export const addBlock = (proccode, { args, callback, hidden, displayName }) => {
 
   const blockData = {
     id: proccode,
-    args,
+    // Arguments can be specified as strings or objects.
+    args: args.map((arg) => (typeof arg === "string" ? { name: arg } : arg)),
     handler: callback,
     hide: !!hidden,
     displayName,
@@ -255,18 +256,35 @@ const injectWorkspace = (ScratchBlocks) => {
     };
   }
 
+  // Replace proc code with display name when initializing the block.
   const newCreateAllInputs = (originalCreateAllInputs) =>
     function (...args) {
       const blockData = getCustomBlock(this.procCode_);
       if (blockData) {
         const originalProcCode = this.procCode_;
         this.procCode_ = blockData.displayName;
+        this.saArgs = blockData.args;
         const ret = originalCreateAllInputs.call(this, ...args);
         this.procCode_ = originalProcCode;
         return ret;
       }
       return originalCreateAllInputs.call(this, ...args);
     };
+
+  // Apply default argument values.
+  const newPopulateArgument = (originalPopulateArgument) =>
+    function (type, index, ...args) {
+      const procedure = this;
+      const originalSetFieldValue = ScratchBlocks.Block.prototype.setFieldValue;
+      ScratchBlocks.Block.prototype.setFieldValue = function (value, ...args) {
+        const defaultValue = procedure.saArgs ? procedure.saArgs[index].default : undefined;
+        if (defaultValue !== undefined) value = defaultValue;
+        originalSetFieldValue.call(this, value, ...args);
+      };
+      originalPopulateArgument.call(this, type, index, ...args);
+      ScratchBlocks.Block.prototype.setFieldValue = originalSetFieldValue;
+    };
+
   if (ScratchBlocks.registry) {
     // new Blockly
     const originalBlockDoInit = ScratchBlocks.Block.prototype.doInit_;
@@ -275,12 +293,16 @@ const injectWorkspace = (ScratchBlocks) => {
       if (this.type === "procedures_call") {
         const originalCreateAllInputs = this.createAllInputs_;
         this.createAllInputs_ = newCreateAllInputs(originalCreateAllInputs);
+        const originalPopulateArgument = this.populateArgument_;
+        this.populateArgument_ = newPopulateArgument(originalPopulateArgument);
         return result;
       }
     };
   } else {
     const originalCreateAllInputs = ScratchBlocks.Blocks["procedures_call"].createAllInputs_;
     ScratchBlocks.Blocks["procedures_call"].createAllInputs_ = newCreateAllInputs(originalCreateAllInputs);
+    const originalPopulateArgument = ScratchBlocks.Blocks["procedures_call"].populateArgument_;
+    ScratchBlocks.Blocks["procedures_call"].populateArgument_ = newPopulateArgument(originalPopulateArgument);
   }
 
   // Toolbox update may be required to make category appear in flyout

--- a/addons-l10n/en/debugger.json
+++ b/addons-l10n/en/debugger.json
@@ -2,7 +2,6 @@
   "debugger/console": "Logs",
   "debugger/debug": "Debug",
   "debugger/export": "Export",
-  "debugger/tools": "Tools",
   "debugger/clear": "Clear",
   "debugger/close": "Close",
   "debugger/step": "Step",

--- a/addons-l10n/en/debugger.json
+++ b/addons-l10n/en/debugger.json
@@ -20,6 +20,7 @@
   "debugger/block-error": "error %s",
   "debugger/block-start-timer": "start timer %s",
   "debugger/block-stop-timer": "stop timer %s",
+  "debugger/default-timer-label": "timer1",
   "debugger/cannot-pause-player": "Breakpoint block can only be used while on the editor.",
   "debugger/step-desc": "Executes one block.",
   "debugger/tab-logs": "Logs",

--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -126,6 +126,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  box-sizing: content-box;
   padding: 0.3rem 0.6rem;
   color: white;
   cursor: pointer;

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -71,17 +71,17 @@ export default async function ({ addon, console, msg }) {
     },
   });
   addon.tab.addBlock("\u200B\u200Bstart timer\u200B\u200B %s", {
-    args: ["content"],
+    args: [{ name: "label", default: msg("default-timer-label") }],
     displayName: msg("block-start-timer"),
-    callback: ({ content }, thread) => {
-      if (timingTab) timingTab.startTimer(content, thread.target.id, thread.peekStack());
+    callback: ({ label }, thread) => {
+      if (timingTab) timingTab.startTimer(label, thread.target.id, thread.peekStack());
     },
   });
   addon.tab.addBlock("\u200B\u200Bstop timer\u200B\u200B %s", {
-    args: ["content"],
+    args: [{ name: "label", default: msg("default-timer-label") }],
     displayName: msg("block-stop-timer"),
-    callback: ({ content }) => {
-      if (timingTab) timingTab.stopTimer(content);
+    callback: ({ label }) => {
+      if (timingTab) timingTab.stopTimer(label);
     },
   });
 


### PR DESCRIPTION
### Changes

<img width="159" height="180" alt="image" src="https://github.com/user-attachments/assets/a478a031-2a82-4e4b-a87f-5f7293a3b4b6" />

### Reason for changes

To make the input's purpose more obvious.

### Tests

Tested on Edge with old & new Blockly.