### PR TITLE
Add relationships to 6 addons

### DIFF
--- a/addons/60fps/addon.json
+++ b/addons/60fps/addon.json
@@ -42,6 +42,7 @@
     }
   ],
   "tags": ["player", "featured"],
+  "relatedAddons": ["turbowarp-player"],
   "versionAdded": "1.1.0",
   "enabledByDefault": false,
   "libraries": ["scratch-gui"]

--- a/addons/clones/addon.json
+++ b/addons/clones/addon.json
@@ -48,5 +48,6 @@
     "newSettings": ["projectpage"]
   },
   "tags": ["player", "recommended"],
+  "relatedAddons": ["fps", "debugger"],
   "enabledByDefault": false
 }

--- a/addons/ctrl-click-run-scripts/addon.json
+++ b/addons/ctrl-click-run-scripts/addon.json
@@ -26,6 +26,7 @@
     }
   ],
   "tags": ["editor", "codeEditor"],
+  "relatedAddons": ["fix-pasted-scripts"],
   "versionAdded": "1.15.0",
   "enabledByDefault": false
 }

--- a/addons/debugger/addon.json
+++ b/addons/debugger/addon.json
@@ -100,6 +100,7 @@
     }
   ],
   "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["fps", "clones"],
   "versionAdded": "1.16.0",
   "latestUpdate": {
     "version": "1.44.0",

--- a/addons/fps/addon.json
+++ b/addons/fps/addon.json
@@ -22,5 +22,6 @@
     }
   ],
   "tags": ["editor", "player", "featured"],
+  "relatedAddons": ["clones", "debugger"],
   "versionAdded": "1.42.0"
 }

--- a/addons/turbowarp-player/addon.json
+++ b/addons/turbowarp-player/addon.json
@@ -64,5 +64,6 @@
     }
   ],
   "versionAdded": "1.18.0",
-  "tags": ["community", "projectPage", "featured"]
+  "tags": ["community", "projectPage", "featured"],
+  "relatedAddons": ["60fps"]
 }


### PR DESCRIPTION
### Changes

Adds the following addon relations to help users find what they're looking for:

- #### `ctrl-click-run-scripts` → `fix-pasted-scripts`
  
  In case users find that addon while looking for an addon that prevents scripts from running when duplicated blocks are clicked into place.
  
- #### `turbowarp-button` ↔ `60fps`
  
  Because TurboWarp also has a frame rate control.
  
- #### `debugger` ↔ `fps` ↔ `clones`
  
  Because they all make measurements.