### PR TITLE
Fix `paint-by-default`

### DIFF
--- a/addons/paint-by-default/userscript.js
+++ b/addons/paint-by-default/userscript.js
@@ -111,7 +111,6 @@ export default async function ({ addon, console }) {
       elementToClick.click();
     },
     {
-      bubble: true,
       capture: true,
     }
   );


### PR DESCRIPTION
Resolves #8615

### Changes

~~Moves `paint-by-default`'s event listeners from the body to the individual buttons.~~

### Reason for changes

After the React 18 update using `stopPropagation()` in the click listener on the body isn't enough to prevent the asset library from opening. ~~I have done the same to `mousemove` for consistency.~~

### Tests

Tested on Chromium