### PR TITLE
Only welcome users on store installs

### DIFF
--- a/background/transition.js
+++ b/background/transition.js
@@ -3,18 +3,18 @@ const utm = `utm_source=extension&utm_medium=tabscreate&utm_campaign=v${chrome.r
 const uiLanguage = (chrome.i18n.getUILanguage && chrome.i18n.getUILanguage()) || navigator.language;
 const localeSlash = uiLanguage.startsWith("en") ? "" : `${uiLanguage.split("-")[0]}/`;
 chrome.runtime.onInstalled.addListener(async (details) => {
-  const developerMode = (await chrome.management.getSelf()).installType === "development";
+  const normalInstall = (await chrome.management.getSelf()).installType === "normal";
   const currentVersion = chrome.runtime.getManifest().version;
   const [major, minor, _] = currentVersion.split(".");
   if (details.reason === "install") {
-    if (!developerMode) {
+    if (normalInstall) {
       chrome.tabs.create({ url: `https://scratchaddons.com/${localeSlash}welcome/?${utm}` });
     }
     chrome.storage.local.set({
       bannerSettings: { lastShown: `${major}.${minor}` },
     });
   }
-  if (!developerMode) {
+  if (normalInstall) {
     chrome.runtime.setUninstallURL(`https://scratchaddons.com/${localeSlash}farewell?${utm}`);
   }
 });


### PR DESCRIPTION
Resolves #8597

### Changes

The welcome page and uninstall URL are now only used on [normal installs](https://developer.chrome.com/docs/extensions/reference/api/management#type-ExtensionInstallType:~:text=normal%3A%20The%20extension%20was%20installed%20normally%20via%20a%20.crx%20file) (directly from an extension store), so users won't see these pop up if Scratch Addons was installed through developer mode, an enterprise policy, or some other means.