### PR TITLE
editor-dark-mode: style face sensing tooltips

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -484,8 +484,11 @@ img[class*="tool-select-base_tool-select-icon_"],
 .driver-popover[class*="tooltip-face-sensing"] {
   border-color: var(--editorDarkMode-primary);
 }
-.driver-popover[class*="tooltip-face-sensing"] .driver-popover-arrow-side-right {
+.driver-popover-arrow.driver-popover-arrow-side-right[class*="driver-popover-arrow-align-"] {
   border-right-color: var(--editorDarkMode-primary);
+}
+.driver-popover-arrow.driver-popover-arrow-side-left.driver-popover-arrow-align-start {
+  border-left-color: var(--editorDarkMode-primary);
 }
 .sa-body-editor input {
   outline-color: var(--editorDarkMode-primary);


### PR DESCRIPTION
### Changes

Applies `editor-dark-mode`'s colours to the face sensing tooltips.

### Reason for changes

Might as well sense someone sent feedback about it and we'll need to publish a patch release anyway.

### Tests

Tested on Chromium. The weird selectors are because the the tooltip in the library has a `-modal` prefix while the other one doesn't