### PR TITLE
`player-thumb`: Double check we're not in editor

### DIFF
--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -12,6 +12,8 @@ export default async function ({ addon, console }) {
 
   // It's possible this runs after the project loads even without dynamic enable
   if (addon.tab.redux.state?.scratchGui?.projectState?.loadingState === "SHOWING_WITH_ID") return;
+  // Second check in case of a URL change
+  if (addon.tab.editorMode === "editor") return;
 
   const alerts = document.querySelector(".project-info-alerts");
   const controls = stageWrapper.querySelector('div[class^="controls_controls-container_"]');


### PR DESCRIPTION
Resolves #8631

### Changes

Adds a second check to ensure that the `player-thumb` addon does not run in the editor, which could previously happen when visiting a `projects/ID/#editor` URL.

Without this, unintended behavior could happen. This patch should fix the issue or at least make it rarer, and although it's a bit rudimentary, it probably wouldn't hurt to have this quick patch until we implement a more proper solution.

### Tests

Tested in Edge 141.