### PR TITLE
Rename sprite folders to asset folders

### DIFF
--- a/addons/folders/addon.json
+++ b/addons/folders/addon.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sprite folders",
+  "name": "Asset folders",
   "description": "Adds folders to the sprite pane, as well as costume and sound lists. To create a folder, right click any sprite and click \"create folder\". Click a folder to open or close it. Right click a sprite to see what folders you can move it to, or alternatively drag and drop it into an open folder. This feature works by adding \"[folderName]//\" at the beginning of the names for your sprites.",
   "info": [
     {


### PR DESCRIPTION
### Changes

Change sprite folders to asset folders.

### Reason for changes

Sprite folders is a misleading name as it implies that the extension only creates folders for sprites.

### Tests

Will test soon.