### PR TITLE
`recolor-custom-blocks`: Check for correct workspace

### DIFF
--- a/addons/recolor-custom-blocks/userscript.js
+++ b/addons/recolor-custom-blocks/userscript.js
@@ -464,7 +464,7 @@ export default async function ({ addon, console }) {
   const oldBlockInitSvg = Blockly.BlockSvg.prototype.initSvg;
   Blockly.BlockSvg.prototype.initSvg = function (...args) {
     const initSvgResult = oldBlockInitSvg.call(this, ...args);
-    if (this.type === "procedures_declaration" && !this.recolorCustomBlockInjected) {
+    if (this.type === "procedures_declaration" && !this.recolorCustomBlockInjected && !this.workspace.toolbox_) {
       addColorMenu(this);
       shimOnChangeFn(this);
       updateBlockColors(this);


### PR DESCRIPTION
Resolves #8635 
### Tests

Tested on Chromium on both versions of Blockly.