### PR TITLE
Fix `search-sprites` after update

### DIFF
--- a/addons/search-sprites/userscript.js
+++ b/addons/search-sprites/userscript.js
@@ -27,8 +27,8 @@ export default async function ({ addon, console, msg }) {
       const visible =
         !query ||
         containsQuery(sprite.children[0].children[1].innerText) ||
-        (containsQuery(sprite.children[0].children[2].children[0].innerText) &&
-          sprite.children[0].classList.contains("sa-folders-folder"));
+        (sprite.children[0].classList.contains("sa-folders-folder") &&
+          containsQuery(sprite.children[0].children[2].children[0].innerText));
       sprite.style.display = visible ? "" : "none";
     }
   };


### PR DESCRIPTION
Resolves #8640

### Explanation

Previously, the `sprite-search` addon expected to find a folder name within the third child element of a sprite pane item. Before the React 18 update, this ended up being part of a context menu, which luckily prevented an error from occurring when the candidate was a sprite, not a folder. However, after the React 18 update, this menu element was moved outside of the sprite, causing the selected element to be `undefined` and leading to an error.

### Changes

I have changed this addon so that it first checks that the sprite pane item is a folder before trying to search for the folder name element. Before, these conditions were swapped.

### Tests

`sprite-search` and `folders` tested.
