### PR TITLE
scratchr2: fix empty navbar items

### DIFF
--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -311,6 +311,7 @@ select:focus {
   background-color: var(--darkWww-navbar-border, rgba(0, 0, 0, 0.1));
 }
 #topnav ul.site-nav li a {
+  vertical-align: middle;
   height: 33px;
   padding: 13px 15px 4px 15px;
   color: var(--darkWww-navbar-text, white);


### PR DESCRIPTION
Resolves #8576

### Changes

Makes empty navbar items added using the Customizable navigation bar addon display correctly when Scratch 2.0 → 3.0 is enabled.

### Tests

Tested on Edge.