### PR TITLE
`mediarecorder`: Add recording format selector

### DIFF
--- a/addons/mediarecorder/style.css
+++ b/addons/mediarecorder/style.css
@@ -29,7 +29,7 @@
   margin: 0.5rem auto;
 }
 
-.mediaRecorderPopup p :not(:first-child) {
+.mediaRecorderPopup p:not(.recordOptionDescription) :not(:first-child) {
   margin-left: 1rem;
 }
 


### PR DESCRIPTION
Resolves #8074
Resolves #8087

### Changes

Adds a selector to the `mediarecorder` video recording options dialog that allows you to choose between recording as mp4 and webm, if available.

### Reason for changes

To allow users to choose the recording format that works best for them.

### Tests

Tested on Edge.
