### PR TITLE
Webpages: Improve screen reader navigation experience

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -128,6 +128,24 @@
   "easterEggs": {
     "message": "Easter Eggs"
   },
+  "editorFeature": {
+    "message": "Editor feature"
+  },
+  "websiteFeature": {
+    "message": "Website feature"
+  },
+  "playerFeature": {
+    "message": "Project player feature"
+  },
+  "themeAddon": {
+    "message": "Theme"
+  },
+  "popupFeature": {
+    "message": "Extension popup feature"
+  },
+  "easterEgg": {
+    "message": "Easter egg"
+  },
   "theme": {
     "message": "Theme:"
   },
@@ -169,6 +187,15 @@
   },
   "viewLicenses": {
     "message": "View library licenses"
+  },
+  "infoMessage": {
+    "message": "Information"
+  },
+  "noticeMessage": {
+    "message": "Notice"
+  },
+  "warningMessage": {
+    "message": "Warning"
   },
   "back": {
     "message": "Go back"
@@ -259,6 +286,9 @@
   },
   "search": {
     "message": "Search"
+  },
+  "clearSearch": {
+    "message": "Clear search query"
   },
   "permissionsTitle": {
     "message": "Permissions - Scratch Addons"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -296,8 +296,13 @@
   "search": {
     "message": "Search"
   },
+  "searchAddons": {
+    "message": "Search add-ons",
+    "description": "A label used by screen readers."
+  },
   "clearSearch": {
-    "message": "Clear search query"
+    "message": "Clear search query",
+    "description": "A label used by screen readers."
   },
   "expandedAddonGroup": {
     "message": "$1 section, expanded",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -188,6 +188,15 @@
   "viewLicenses": {
     "message": "View library licenses"
   },
+  "infoBox": {
+    "message": "Information message"
+  },
+  "noticeBox": {
+    "message": "Notice message"
+  },
+  "warningBox": {
+    "message": "Warning message"
+  },
   "infoMessage": {
     "message": "Information"
   },
@@ -289,6 +298,22 @@
   },
   "clearSearch": {
     "message": "Clear search query"
+  },
+  "expandedAddonGroup": {
+    "message": "$1 section, expanded",
+    "description": "A label used by screen readers."
+  },
+  "collapsedAddonGroup": {
+    "message": "$1 section, collapsed",
+    "description": "A label used by screen readers."
+  },
+  "enabledAddon": {
+    "message": "$1, add-on, on",
+    "description": "A label used by screen readers."
+  },
+  "disabledAddon": {
+    "message": "$1, add-on, off",
+    "description": "A label used by screen readers."
   },
   "permissionsTitle": {
     "message": "Permissions - Scratch Addons"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -312,20 +312,16 @@
     "message": "$1 section, collapsed",
     "description": "A label used by screen readers."
   },
-  "enabledAddon": {
+  "enabledAddonBlock": {
     "message": "$1, add-on, on",
     "description": "A label used by screen readers."
   },
-  "disabledAddon": {
+  "disabledAddonBlock": {
     "message": "$1, add-on, off",
     "description": "A label used by screen readers."
   },
-  "nameAddon": {
-    "message": "$1 add-on",
-    "description": "A label used by screen readers."
-  },
-  "nameSetting": {
-    "message": "$1 setting",
+  "addonSettingsBlock": {
+    "message": "Add-on settings",
     "description": "A label used by screen readers."
   },
   "permissionsTitle": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -315,6 +315,14 @@
     "message": "$1, add-on, off",
     "description": "A label used by screen readers."
   },
+  "nameAddon": {
+    "message": "$1 add-on",
+    "description": "A label used by screen readers."
+  },
+  "nameSetting": {
+    "message": "$1 setting",
+    "description": "A label used by screen readers."
+  },
   "permissionsTitle": {
     "message": "Permissions - Scratch Addons"
   },

--- a/webpages/popup/index.html
+++ b/webpages/popup/index.html
@@ -18,7 +18,7 @@
     <link rel="preload" href="../styles/colors-light.css" as="style" />
   </head>
   <body class="loading">
-    <div id="header">
+    <div id="header" role="banner">
       <div id="title">
         <img src="../../images/icon-transparent.svg" id="logo" alt="Logo" draggable="false" />
         <span id="title-text" v-cloak>
@@ -31,17 +31,20 @@
       </a>
     </div>
     <div id="popups">
-      <div id="popup-bar" v-cloak>
-        <div id="popup-chooser">
+      <nav id="popup-bar" v-cloak>
+        <div id="popup-chooser" role="tablist">
           <button
             v-for="popup of popups"
+            role="tab"
             class="popup-name"
             :class="{ sel: currentPopup === popup }"
-            :aria-labelledby="'popup-' + popups.indexOf(popup)"
+            :aria-controls="'tab-' + popups.indexOf(popup)"
+            :aria-selected="currentPopup === popup ? 'true' : 'false'"
+            :aria-labelledby="'popup-anchor-' + popups.indexOf(popup)"
             @click="setPopup(popup)"
           >
-            <img v-if="popup.icon" aria-hidden="true" :src="popup.icon" class="popup-icon" draggable="false" />
-            <a :id="'popup-' + popups.indexOf(popup)" class="popup-title">{{ popup.name }}</a>
+            <img v-if="popup.icon" :src="popup.icon" class="popup-icon" draggable="false" />
+            <a :id="'popup-anchor-' + popups.indexOf(popup)" class="popup-title">{{ popup.name }}</a>
             <span v-if="popup.fullscreen" class="popout" @click="openInNewTab(popup)">
               <img
                 src="../../images/icons/popout.svg"
@@ -52,8 +55,11 @@
             </span>
           </button>
         </div>
-      </div>
+      </nav>
       <iframe
+        role="tabpanel"
+        :id="'tab-' + popups.indexOf(popup)"
+        :aria-label="popup.name"
         v-cloak
         v-for="popup in popupsWithIframes"
         v-show="currentPopup === popup"

--- a/webpages/popup/index.html
+++ b/webpages/popup/index.html
@@ -37,10 +37,11 @@
             v-for="popup of popups"
             class="popup-name"
             :class="{ sel: currentPopup === popup }"
+            :aria-labelledby="'popup-' + popups.indexOf(popup)"
             @click="setPopup(popup)"
           >
-            <img v-if="popup.icon" :src="popup.icon" class="popup-icon" draggable="false" />
-            <a class="popup-title">{{ popup.name }}</a>
+            <img v-if="popup.icon" aria-hidden="true" :src="popup.icon" class="popup-icon" draggable="false" />
+            <a :id="'popup-' + popups.indexOf(popup)" class="popup-title">{{ popup.name }}</a>
             <span v-if="popup.fullscreen" class="popout" @click="openInNewTab(popup)">
               <img
                 src="../../images/icons/popout.svg"

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -42,12 +42,12 @@
           v-model="addon._enabled"
           :aria-label="msg('nameAddon', [addon.name])"
           @click="toggleAddonRequest"
-          :aria-describedby="(addon._enabled ? 'addon-description-full-' : 'addon-description-') + addon._addonId"
+          :aria-describedby="'addon-description-' + addon._addonId"
         />
       </div>
     </div>
     <div class="addon-settings" v-if="everExpanded" v-show="expanded">
-      <div class="addon-description-full" :id="'addon-description-full-' + addon._addonId">{{ addon.description }}</div>
+      <div class="addon-description-full">{{ addon.description }}</div>
       <div class="addon-message addon-update" v-if="showUpdateNotice" :aria-label="msg('updateBox')">
         <addon-tag tag="new"></addon-tag>
         {{ addon.latestUpdate.temporaryNotice }}

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -3,7 +3,7 @@
     class="addon-body"
     v-show="shouldShow"
     :id="'addon-' + addon._addonId"
-    :aria-label="msg(addon._enabled ? 'enabledAddon' : 'disabledAddon', [addon.name])"
+    :aria-label="msg(addon._enabled ? 'enabledAddonBlock' : 'disabledAddonBlock', [addon.name])"
   >
     <div class="addon-topbar">
       <div class="clickable-area" @click="expanded = !expanded">
@@ -14,7 +14,7 @@
         <!-- prettier-ignore -->
         <div class="addon-name-and-tags">
           <div class="addon-name tooltip">
-            <span role="heading" aria-level="3">{{ addon.name }}</span>
+            <span role="heading" aria-level="3" :id="'addon-name-' + addon._addonId">{{ addon.name }}</span>
             <span v-if="devMode" class="tooltiptext tooltiptexttop">{{ addon._addonId }}</span>
           </div><!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
         </div>
@@ -40,8 +40,8 @@
           type="checkbox"
           class="switch"
           v-model="addon._enabled"
-          :aria-label="msg('nameAddon', [addon.name])"
           @click="toggleAddonRequest"
+          :aria-labelledby="'addon-name-' + addon._addonId"
           :aria-describedby="'addon-description-' + addon._addonId"
         />
       </div>

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -1,5 +1,10 @@
 <template>
-  <div class="addon-body" v-show="shouldShow" :id="'addon-' + addon._addonId">
+  <div
+    class="addon-body"
+    v-show="shouldShow"
+    :id="'addon-' + addon._addonId"
+    :aria-label="msg(addon._enabled ? 'enabledAddon' : 'disabledAddon', [addon.name])"
+  >
     <div class="addon-topbar">
       <div class="clickable-area" @click="expanded = !expanded">
         <button class="arrow-button" :title="msg(expanded ? 'collapse' : 'expand')">
@@ -39,7 +44,14 @@
         {{ addon.latestUpdate.temporaryNotice }}
       </div>
       <div id="info" v-for="info of addon.info">
-        <div :class="['addon-message', 'addon-' + (info.type || 'info')]">
+        <div
+          :class="['addon-message', 'addon-' + (info.type || 'info')]"
+          :aria-label="msg({
+            'warning': 'warningBox',
+            'notice': 'noticeBox',
+            'info': 'infoBox',
+          }[info.type || 'info'])"
+        >
           <img
             :src="'../../images/icons/' + {
               'warning': 'warning.svg',

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -14,7 +14,7 @@
         <!-- prettier-ignore -->
         <div class="addon-name-and-tags">
           <div class="addon-name tooltip">
-            <span>{{ addon.name }}</span>
+            <span role="heading" aria-level="3">{{ addon.name }}</span>
             <span v-if="devMode" class="tooltiptext tooltiptexttop">{{ addon._addonId }}</span>
           </div><!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
         </div>

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -104,7 +104,11 @@
           @areahover="highlightSetting"
         />
       </div>
-      <div class="settings-column" v-bind:class="[!addon._enabled ? 'disabled' : '']">
+      <div
+        class="settings-column"
+        v-bind:class="[!addon._enabled ? 'disabled' : '']"
+        :aria-label="msg('addonSettingsBlock')"
+      >
         <addon-setting
           v-for="setting of addon.settings"
           :class="{'setting-highlighted': highlightedSettingId === setting.id}"

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -5,7 +5,7 @@
         <button class="arrow-button" :title="msg(expanded ? 'collapse' : 'expand')">
           <img src="../../images/icons/expand.svg" :class="{'reverted': expanded}" draggable="false" />
         </button>
-        <img :src="addonIconSrc" class="icon-type addon-icon" draggable="false" />
+        <img :src="addonIconSrc" :title="addonIconAlt" class="icon-type addon-icon" draggable="false" />
         <!-- prettier-ignore -->
         <div class="addon-name-and-tags">
           <div class="addon-name tooltip">
@@ -46,6 +46,11 @@
               'notice': 'notice.svg',
               'info': 'help.svg',
             }[info.type || 'info']"
+            :alt="msg({
+              'warning': 'warningMessage',
+              'notice': 'noticeMessage',
+              'info': 'infoMessage',
+            }[info.type || 'info'])"
             draggable="false"
           />{{ info.text }}
         </div>

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -19,7 +19,9 @@
           </div><!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
         </div>
       </div>
-      <div class="addon-description" v-show="!expanded" dir="auto">{{ addon.description }}</div>
+      <div class="addon-description" :id="'addon-description-' + addon._addonId" v-show="!expanded" dir="auto">
+        {{ addon.description }}
+      </div>
       <div class="addon-check">
         <div v-show="expanded && addon._enabled" v-if="addon.settings" class="addon-split-button dropdown-parent">
           <button
@@ -34,12 +36,19 @@
             <li role="menuitem" tabindex="0" @click="importPreset">{{ msg('import') }}</li>
           </dropdown>
         </div>
-        <input type="checkbox" class="switch" v-model="addon._enabled" @click="toggleAddonRequest" />
+        <input
+          type="checkbox"
+          class="switch"
+          v-model="addon._enabled"
+          :aria-label="msg('nameAddon', [addon.name])"
+          @click="toggleAddonRequest"
+          :aria-describedby="(addon._enabled ? 'addon-description-full-' : 'addon-description-') + addon._addonId"
+        />
       </div>
     </div>
     <div class="addon-settings" v-if="everExpanded" v-show="expanded">
-      <div class="addon-description-full">{{ addon.description }}</div>
-      <div class="addon-message addon-update" v-if="showUpdateNotice">
+      <div class="addon-description-full" :id="'addon-description-full-' + addon._addonId">{{ addon.description }}</div>
+      <div class="addon-message addon-update" v-if="showUpdateNotice" :aria-label="msg('updateBox')">
         <addon-tag tag="new"></addon-tag>
         {{ addon.latestUpdate.temporaryNotice }}
       </div>

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -29,6 +29,17 @@ export default async function ({ template }) {
         };
         return `../../images/icons/${map[this.addon._icon]}.svg`;
       },
+      addonIconAlt() {
+        const map = {
+          editor: "editorFeature",
+          player: "playerFeature",
+          community: "websiteFeature",
+          theme: "themeAddon",
+          easterEgg: "easterEgg",
+          popup: "popupFeature",
+        };
+        return chrome.i18n.getMessage(map[this.addon._icon]);
+      },
       addonSettings() {
         return this.$root.addonSettings[this.addon._addonId];
       },

--- a/webpages/settings/components/addon-group-header.html
+++ b/webpages/settings/components/addon-group-header.html
@@ -9,7 +9,7 @@
     <button class="arrow-button" :title="msg(group.expanded ? 'collapse' : 'expand')">
       <img src="../../images/icons/expand.svg" :class="{ 'reverted': group.expanded }" draggable="false" />
     </button>
-    {{ group.name }} ({{ shownCount }})
+    <span role="heading" aria-level="2">{{ group.name }} ({{ shownCount }})</span>
   </div>
 </template>
 

--- a/webpages/settings/components/addon-group-header.html
+++ b/webpages/settings/components/addon-group-header.html
@@ -1,5 +1,11 @@
 <template>
-  <div class="addon-group" v-show="shouldShow" @click="toggle" :class="{  'margin-above': marginAbove }">
+  <div
+    class="addon-group"
+    v-show="shouldShow"
+    @click="toggle"
+    :class="{ 'margin-above': marginAbove }"
+    :aria-label="msg(group.expanded ? 'expandedAddonGroup' : 'collapsedAddonGroup', [group.name])"
+  >
     <button class="arrow-button" :title="msg(group.expanded ? 'collapse' : 'expand')">
       <img src="../../images/icons/expand.svg" :class="{ 'reverted': group.expanded }" draggable="false" />
     </button>

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -10,8 +10,15 @@
     <div class="setting-label-container">
       <div class="setting-label" v-html="settingsName(addon)"></div>
       <div v-if="setting.description" :class="{tooltip: addon._enabled}" :tabindex="addon._enabled ? '0' : '-1' ">
-        <img src="../../images/icons/help.svg" class="icon-type setting-help-icon" />
-        <span class="tooltiptext tooltiptexttop">{{setting.description}}</span>
+        <img
+          src="../../images/icons/help.svg"
+          class="icon-type setting-help-icon"
+          tabindex="-1"
+          :aria-labelledby="'setting-description-' + setting.id"
+        />
+        <span aria-hidden="true" :id="'setting-description-' + setting.id" class="tooltiptext tooltiptexttop"
+          >{{setting.description}}</span
+        >
       </div>
       <addon-tag v-if="isNewOption" tag="new"></addon-tag>
     </div>
@@ -69,10 +76,18 @@
         type="checkbox"
         class="switch blue"
         v-model="addonSettings[setting.id]"
+        :aria-label="msg('nameSetting', [setting.name])"
+        :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
         @change="updateSettings()"
         :disabled="!addon._enabled"
       />
-      <div v-if="setting.type === 'select'" class="filter-options" role="radiogroup">
+      <div
+        v-if="setting.type === 'select'"
+        class="filter-options"
+        role="radiogroup"
+        :aria-label="msg('nameSetting', [setting.name])"
+        :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
+      >
         <div v-for="option of setting.potentialValues">
           <input
             type="radio"
@@ -93,6 +108,8 @@
           type="number"
           class="setting-input number"
           v-model="addonSettings[setting.id]"
+          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           min="0"
@@ -104,6 +121,8 @@
           type="number"
           class="setting-input number"
           v-model="addonSettings[setting.id]"
+          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           :min="setting.min"
@@ -116,6 +135,8 @@
           type="text"
           class="setting-input string"
           v-model="addonSettings[setting.id]"
+          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
           :placeholder="setting.default"
@@ -126,6 +147,8 @@
       </template>
       <template v-if="setting.type === 'color'">
         <picker
+          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           :value="addonSettings[setting.id] || setting.default"
           :setting="setting"
           :addon="addon"

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -3,12 +3,13 @@
     v-show="show"
     class="addon-setting"
     :class="{
-    'boolean-setting': setting.type === 'boolean',
-    'number-setting': setting.type === 'integer' || setting.type === 'positive_integer',
-  }"
+      'boolean-setting': setting.type === 'boolean',
+      'number-setting': setting.type === 'integer' || setting.type === 'positive_integer',
+    }"
+    :aria-label="msg('addonSettingsBlock')"
   >
     <div class="setting-label-container">
-      <div class="setting-label" v-html="settingsName(addon)"></div>
+      <div class="setting-label" :id="'setting-name-' + setting.id" v-html="settingsName(addon)"></div>
       <div v-if="setting.description" :class="{tooltip: addon._enabled}" :tabindex="addon._enabled ? '0' : '-1' ">
         <img
           src="../../images/icons/help.svg"
@@ -16,9 +17,9 @@
           tabindex="-1"
           :aria-labelledby="'setting-description-' + setting.id"
         />
-        <span aria-hidden="true" :id="'setting-description-' + setting.id" class="tooltiptext tooltiptexttop"
-          >{{setting.description}}</span
-        >
+        <span aria-hidden="true" :id="'setting-description-' + setting.id" class="tooltiptext tooltiptexttop">
+          {{ setting.description }}
+        </span>
       </div>
       <addon-tag v-if="isNewOption" tag="new"></addon-tag>
     </div>
@@ -76,7 +77,7 @@
         type="checkbox"
         class="switch blue"
         v-model="addonSettings[setting.id]"
-        :aria-label="msg('nameSetting', [setting.name])"
+        :aria-labelledby="'setting-name-' + setting.id"
         :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
         @change="updateSettings()"
         :disabled="!addon._enabled"
@@ -85,7 +86,7 @@
         v-if="setting.type === 'select'"
         class="filter-options"
         role="radiogroup"
-        :aria-label="msg('nameSetting', [setting.name])"
+        :aria-labelledby="'setting-name-' + setting.id"
         :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
       >
         <div v-for="option of setting.potentialValues">
@@ -108,7 +109,7 @@
           type="number"
           class="setting-input number"
           v-model="addonSettings[setting.id]"
-          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-labelledby="'setting-name-' + setting.id"
           :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
@@ -121,7 +122,7 @@
           type="number"
           class="setting-input number"
           v-model="addonSettings[setting.id]"
-          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-labelledby="'setting-name-' + setting.id"
           :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
@@ -135,7 +136,7 @@
           type="text"
           class="setting-input string"
           v-model="addonSettings[setting.id]"
-          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-labelledby="'setting-name-' + setting.id"
           :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           @change="checkValidity() || updateSettings()"
           :disabled="!addon._enabled"
@@ -147,7 +148,7 @@
       </template>
       <template v-if="setting.type === 'color'">
         <picker
-          :aria-label="msg('nameSetting', [setting.name])"
+          :aria-labelledby="'setting-name-' + setting.id"
           :aria-describedby="setting.description ? 'setting-description-' + setting.id : ''"
           :value="addonSettings[setting.id] || setting.default"
           :setting="setting"

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -6,7 +6,6 @@
       'boolean-setting': setting.type === 'boolean',
       'number-setting': setting.type === 'integer' || setting.type === 'positive_integer',
     }"
-    :aria-label="msg('addonSettingsBlock')"
   >
     <div class="setting-label-container">
       <div class="setting-label" :id="'setting-name-' + setting.id" v-html="settingsName(addon)"></div>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -258,9 +258,9 @@
               <button class="arrow-button" :title="msg('back')" @click="backRelatedAddon()">
                 <img src="../../images/icons/left-arrow.svg" draggable="false" />
               </button>
-              <span>{{ msg("relatedTo", relatedToAddonName) }}</span>
+              <span role="heading" aria-level="1">{{ msg("relatedTo", relatedToAddonName) }}</span>
             </div>
-            <span v-else>{{ selectedCategoryName }}</span>
+            <span role="heading" aria-level="1" v-else>{{ selectedCategoryName }}</span>
           </div>
           <div
             role="search"

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -176,7 +176,7 @@
     <script src="index.js" type="module"></script>
   </head>
   <body v-cloak :class="{light: theme}">
-    <div class="navbar">
+    <div role="banner" class="navbar">
       <button
         id="sidebar-toggle"
         class="header-button"
@@ -199,7 +199,7 @@
       </button>
     </div>
     <div class="main">
-      <div
+      <nav
         class="categories-block"
         v-click-outside="closesidebar"
         v-show="!isIframe"
@@ -236,7 +236,7 @@
           <img src="../../images/icons/wrench.svg" draggable="false" />
           <span>{{ msg("moreSettings") }}</span>
         </button>
-      </div>
+      </nav>
       <button
         v-show="!isIframe && smallMode === false"
         class="categories-shrink"
@@ -251,7 +251,7 @@
       </button>
 
       <!-- This is the main menu, where the searchbar and the addon items are located -->
-      <div class="addons-block">
+      <main class="addons-block">
         <div class="addons-block-header">
           <div v-if="!isIframe" class="category-header-title" v-cloak>
             <div v-if="relatedAddonsOpen" class="related-addons-header">
@@ -262,7 +262,13 @@
             </div>
             <span v-else>{{ selectedCategoryName }}</span>
           </div>
-          <div v-cloak class="search-box" v-if="!relatedAddonsOpen" :class="{smallMode: smallMode === true}">
+          <div
+            role="search"
+            v-cloak
+            class="search-box"
+            v-if="!relatedAddonsOpen"
+            :class="{smallMode: smallMode === true}"
+          >
             <input type="text" id="searchBox" :placeholder="searchMsg" v-model="searchInputReal" autofocus />
             <button disabled aria-hidden="true" v-show="searchInput === ''">
               <img src="../../images/icons/search.svg" class="search-icon" />
@@ -309,7 +315,7 @@
             </div>
           </template>
         </div>
-      </div>
+      </main>
     </div>
     <modal
       class="more-settings"

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -268,8 +268,9 @@
             class="search-box"
             v-if="!relatedAddonsOpen"
             :class="{smallMode: smallMode === true}"
+            :aria-label="msg('searchAddons')"
           >
-            <input type="text" id="searchBox" :placeholder="searchMsg" v-model="searchInputReal" autofocus />
+            <input type="text" id="searchBox" :placeholder="msg('search')" v-model="searchInputReal" autofocus />
             <button disabled aria-hidden="true" v-show="searchInput === ''">
               <img src="../../images/icons/search.svg" class="search-icon" />
             </button>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -264,10 +264,10 @@
           </div>
           <div v-cloak class="search-box" v-if="!relatedAddonsOpen" :class="{smallMode: smallMode === true}">
             <input type="text" id="searchBox" :placeholder="searchMsg" v-model="searchInputReal" autofocus />
-            <button disabled v-show="searchInput === ''">
+            <button disabled aria-hidden="true" v-show="searchInput === ''">
               <img src="../../images/icons/search.svg" class="search-icon" />
             </button>
-            <button v-else @click="clearAndFocusSearch()">
+            <button v-else :aria-label="msg('clearSearch')" @click="clearAndFocusSearch()">
               <img src="../../images/icons/x.svg" class="search-icon" />
             </button>
           </div>
@@ -321,7 +321,7 @@
       <div class="addon-block settings-block">
         <div class="addon-body">
           <div class="addon-topbar">
-            <img src="../../images/icons/theme.svg" class="icon-type addon-icon" draggable="false" />
+            <img src="../../images/icons/theme.svg" aria-hidden="true" class="icon-type addon-icon" draggable="false" />
             <span class="addon-name-and-tags">{{ msg("scratchAddonsTheme") }}</span>
           </div>
           <div class="addon-settings">
@@ -359,6 +359,7 @@
           <div class="addon-topbar">
             <img
               src="../../images/icons/import-export.svg"
+              aria-hidden="true"
               class="icon-type addon-icon"
               :class="{'dark': theme === false}"
               draggable="false"
@@ -382,7 +383,12 @@
         </div>
         <div class="addon-body">
           <div class="addon-topbar">
-            <img src="../../images/icons/translate.svg" class="icon-type addon-icon" draggable="false" />
+            <img
+              src="../../images/icons/translate.svg"
+              aria-hidden="true"
+              class="icon-type addon-icon"
+              draggable="false"
+            />
             <span class="addon-name-and-tags">{{ msg("language") }}</span>
           </div>
           <div class="addon-settings">

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -109,7 +109,6 @@ let fuse;
         isIframe,
         addonGroups: addonGroups.filter((g) => (isIframe ? g.iframeShow : g.fullscreenShow)),
         categories,
-        searchMsg: this.msg("search"),
         browserLevelPermissions,
         grantedOptionalPermissions,
         addonListObjs: [],


### PR DESCRIPTION
### Changes

These changes are the start of improvements to screen reader accessibility.

Screen reader users will notice the following enhancements:
- Landmarks have been added.
- Semantics have been added to the addon list.
- More icons have been assigned labels or alt text.
- Groups of related content and important region markers have been labeled.

Let me know if I missed anything.

### Commit summary

- **Initial changes**
  1. 🏷️ [**Add labels to icons**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/c115e22e02b5195dc67b874732739030edd9238b) — adds either alt text or tooltips to several graphics.
  2. 🏳️ [**Label groups and landmarks**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/35ac77a8454dfdc998a5bf5f85a9e9b300184ad4) — adds landmarks to the banner, navigation, and main content, and adds ARIA attributes to blocks of content like addon bodies, addon group separators, and info boxes.
  3. 🫧 [**Popup updates**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/eb83ba1ada50323ba95aca966593cb0a816533d8) — applies the above changes to the extension's popup.
  4. 🔖 [**Label blocks and inputs**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/09c738b21e93c37328dc525fa4291b4d48bf85b4) — adds ARIA labels to addon checkboxes/inputs, setting description tooltip containers, and "new features" message boxes.
  5. 📂 [**Semantics in addon list**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/dfaca92c8cc63154aa973de001e1ac999c2f7fda) — turns some elements in the addon listing page into headings.
- **Revisions since pull request open**
  1. 🔘 [**Fix addon switch description**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/cb3302dfbf894fd32d726187afceb0abc4c1dafe) — corrects a mistake in a previous change that added descriptions to addon toggle switches.
  2. 📍 [**Change addon name labels to level 3 headings**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/92d783a7954c46ff2be5ed89a4f1476d19000fd9) — changes addon names to headings as well.
  3. 🖊️ [**Label nested search landmark**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/97e30c96e9ccc904b31f2b9857bcf38ce911fee6) — changes the spoken label of the addon search bar landmark for clarification, plus removes `searchMsg`.
  4. 🔗 [**Do not use aria-label on inputs**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/0b0a8467925d35d3d774dc1d11cade62c35c66dd) — adds a label to addon settings groups, links inputs to setting label elements, and renames some strings.
  5. 🎛️ [**Correct location of addon settings group**](https://github.com/ScratchAddons/ScratchAddons/pull/8663/commits/8853dc5cc84087889347eb034daeb1347bc3a7da) — moves the label for addon setting groups to the block that contains all the settings. Previously, it was used on the settings themselves by mistake.

### Tests

Tested with:
- Edge 141
- Windows Narrator
