### PR TITLE
Fix select settings inside table items

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -84,6 +84,7 @@
           :class="{'setting-highlighted': highlightedSettingId === setting.id}"
           :addon="addon"
           :setting="setting"
+          :setting-path="[setting.id]"
           :addon-settings="addonSettings"
           @mouseenter="hoveredSettingId = setting.id"
           @mouseleave="hoveredSettingId = null"

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -36,8 +36,8 @@
               <addon-setting
                 v-for="(id, val) of row"
                 :addon="addon"
-                :table-child="true"
                 :setting="getTableSetting(id)"
+                :setting-path="settingPath.concat([i, id])"
                 :addon-settings="row"
               ></addon-setting>
             </div>
@@ -76,14 +76,14 @@
         <div v-for="option of setting.potentialValues">
           <input
             type="radio"
-            :name="addon._addonId+'-'+setting.id"
-            :id="addon._addonId+'-'+setting.id+'-'+option.id"
+            :name="selectName"
+            :id="selectOptionId(option)"
             :value="option.id"
             :disabled="!addon._enabled"
             v-model="addonSettings[setting.id]"
             @change="updateSettings()"
           />
-          <label class="filter-option" :for="addon._addonId+'-'+setting.id+'-'+option.id">{{ option.name }}</label>
+          <label class="filter-option" :for="selectOptionId(option)">{{ option.name }}</label>
         </div>
       </div>
     </template>

--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -1,10 +1,12 @@
 export default async function ({ template }) {
   const AddonSetting = Vue.extend({
-    props: ["addon", "tableChild", "setting", "addon-settings"],
+    props: ["addon", "setting", "settingPath", "addon-settings"],
     template,
     data() {
       return {
         noResetDropdown: ["table", "boolean", "select"].includes(this.setting.type),
+        tableChild: this.settingPath.length > 1,
+        selectName: `${this.addon._addonId}-${this.settingPath.join("-")}`,
       };
     },
     computed: {
@@ -76,6 +78,9 @@ export default async function ({ template }) {
             }" draggable="false"/>`;
           }
         });
+      },
+      selectOptionId(option) {
+        return `${this.selectName}-${option.id}`;
       },
       checkValidity() {
         // Needed to get just changed input to enforce it's min, max, and integer rule if the user "manually" sets the input to a value.


### PR DESCRIPTION
Moved from #8676. Makes select settings work correctly when they're inside a table row by giving them unique names and IDs.