### PR TITLE
Don't check `typeof browser` to detect Firefox

### DIFF
--- a/addon-api/common/Self.js
+++ b/addon-api/common/Self.js
@@ -1,4 +1,5 @@
 import Listenable from "./Listenable.js";
+import { isFirefox } from "../../libraries/common/cs/detect-browser.js";
 
 /**
  * Represents information about the addon.
@@ -13,8 +14,7 @@ export default class Self extends Listenable {
     this._addonId = info.id; // In order to receive fireEvent messages from background
     this.id = info.id;
     this._addonObj = addonObj;
-    // catches both Chrome and Chromium
-    this.browser = /Chrom/.test(navigator.userAgent) ? "chrome" : "firefox";
+    this.browser = isFirefox() ? "firefox" : "chrome";
     this.disabled = false;
     this.addEventListener("disabled", () => (this.disabled = true));
     this.addEventListener("reenabled", () => (this.disabled = false));

--- a/addons/gamepad/gamepadlib.js
+++ b/addons/gamepad/gamepadlib.js
@@ -1,3 +1,5 @@
+import { isFirefox } from "../../libraries/common/cs/detect-browser.js";
+
 let console = window.console;
 
 /*
@@ -652,7 +654,7 @@ GamepadLib.browserHasBrokenGamepadAPI = () => {
   // Firefox on Linux before version 123 has a broken gamepad API that results in strange and unusable mappings
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1680982
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1643835
-  if (navigator.userAgent.includes("Firefox") && navigator.userAgent.includes("Linux")) {
+  if (isFirefox() && navigator.userAgent.includes("Linux")) {
     const agentMatch = navigator.userAgent.match(/Firefox\/(\d+)/);
     // If we couldn't find the version number, we'll assume that this is some distant future version of
     // Firefox that we just can't comprehend with the technology of today. Surely gamepad will work well
@@ -662,7 +664,7 @@ GamepadLib.browserHasBrokenGamepadAPI = () => {
   }
   // Firefox on macOS has other bugs that result in strange and unusable mappings
   // eg. https://bugzilla.mozilla.org/show_bug.cgi?id=1434408
-  if (navigator.userAgent.includes("Firefox") && navigator.userAgent.includes("Mac OS")) {
+  if (isFirefox() && navigator.userAgent.includes("Mac OS")) {
     return true;
   }
   return false;

--- a/background/firefox-localhost-support.js
+++ b/background/firefox-localhost-support.js
@@ -1,4 +1,4 @@
-import { isFirefox } from "../libraries/common/detect-browser.js";
+import { isFirefox } from "../libraries/common/cs/detect-browser.js";
 
 if (isFirefox() && chrome.scripting) {
   const manifest = chrome.runtime.getManifest();

--- a/background/handle-auth.js
+++ b/background/handle-auth.js
@@ -1,7 +1,7 @@
 import { startCache } from "./message-cache.js";
 import { openMessageCache } from "../libraries/common/message-cache.js";
 import { purgeDatabase } from "../addons/scratch-notifier/notifier.js";
-import { isFirefox } from "../libraries/common/detect-browser.js";
+import { isFirefox } from "../libraries/common/cs/detect-browser.js";
 
 async function getDefaultStoreId() {
   const CHROME_DEFAULT = "0";

--- a/background/handle-clipboard.js
+++ b/background/handle-clipboard.js
@@ -1,4 +1,4 @@
-import { isFirefox } from "../libraries/common/detect-browser.js";
+import { isFirefox } from "../libraries/common/cs/detect-browser.js";
 
 const dataURLToArrayBuffer = function (dataURL) {
   const byteString = atob(dataURL.split(",")[1]);

--- a/background/imports/util.js
+++ b/background/imports/util.js
@@ -1,4 +1,4 @@
-import { isFirefox } from "../../libraries/common/detect-browser.js";
+import { isFirefox } from "../../libraries/common/cs/detect-browser.js";
 
 // REMINDER: update similar code at /webpages/settings/index.js
 const browserLevelPermissions = ["notifications"];

--- a/libraries/common/cs/detect-browser.js
+++ b/libraries/common/cs/detect-browser.js
@@ -1,0 +1,3 @@
+export function isFirefox() {
+  return typeof new Error().fileName !== "undefined";
+}

--- a/libraries/common/detect-browser.js
+++ b/libraries/common/detect-browser.js
@@ -1,3 +1,0 @@
-export function isFirefox() {
-  return typeof browser?.runtime.getBrowserInfo === "function";
-}

--- a/libraries/common/notification-util.js
+++ b/libraries/common/notification-util.js
@@ -1,3 +1,5 @@
+import { isFirefox } from "./cs/detect-browser.js";
+
 let id = 0;
 
 export default function create(opts) {
@@ -7,7 +9,7 @@ export default function create(opts) {
   if (scratchAddons.muted) return Promise.resolve(null);
   const notifId = `${opts.base}__${Date.now()}_${id++}`;
   let newOpts;
-  if (!/Chrom/.test(navigator.userAgent)) {
+  if (isFirefox()) {
     newOpts = JSON.parse(JSON.stringify(opts));
     // On Firefox, remove notification properties that throw.
     delete newOpts.buttons;

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -9,7 +9,7 @@ import exampleManifest from "./data/example-manifest.js";
 import fuseOptions from "./data/fuse-options.js";
 import globalTheme from "../../libraries/common/global-theme.js";
 import { deserializeSettings, serializeSettings } from "./settings-utils.js";
-import { isFirefox } from "../../libraries/common/detect-browser.js";
+import { isFirefox } from "../../libraries/common/cs/detect-browser.js";
 
 let isIframe = false;
 if (window.parent !== window) {


### PR DESCRIPTION
Resolves #8682

### Changes

Changes the way background and settings page code detects that it's running on Firefox: instead of checking if `window.browser` exists, it now checks if a Firefox-specific API is available. I've made a shared module to detect the browser so that it's easy to update in the future if needed.

### Reason for changes

The `window.browser` namespace will soon exist in both Chromium and Firefox.

### Tests

Tested on Edge v144 (dev channel) and Firefox.