### PR TITLE
discuss-button: remove About link for existing users

### DIFF
--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -749,6 +749,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
         if (addonId === "discuss-button" && (settings._version || 0) < 1) {
           // Transition v1.44.2 to v1.44.3
           if (settings.items) settings.items = settings.items.filter((i) => i.url !== "/about");
+          settings._version = 1;
           madeAnyChanges = madeChangesToAddon = true;
         }
       }


### PR DESCRIPTION
### Changes

Fixes the migration code for `discuss-button`.

### Tests

Tested on Firefox.