### PR TITLE
Add keyboard controls to table row handles

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -203,6 +203,12 @@
   "deleteRow": {
     "message": "Delete row"
   },
+  "moveRow": {
+    "message": "Move row"
+  },
+  "dragRow": {
+    "message": "Drag or use the arrow keys to move"
+  },
   "scratchAddonsTheme": {
     "message": "Scratch Addons theme"
   },

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -28,7 +28,18 @@
               >
                 <img class="icon-type" src="../../images/icons/close.svg" />
               </button>
-              <button :disabled="!addon._enabled" class="addon-buttons handle">
+              <button
+                v-if="addonSettings[setting.id].length > 1"
+                :disabled="!addon._enabled"
+                role="spinbutton"
+                class="addon-buttons handle"
+                :title="msg('dragRow')"
+                :aria-label="msg('moveRow')"
+                :aria-valuenow="i + 1"
+                aria-valuemin="1"
+                :aria-valuemax="addonSettings[setting.id].length"
+                @keydown="shiftTableRow($event, i)"
+              >
                 <img class="icon-type" src="../../images/icons/drag.svg" />
               </button>
             </div>

--- a/webpages/settings/components/addon-setting.js
+++ b/webpages/settings/components/addon-setting.js
@@ -102,6 +102,20 @@ export default async function ({ template }) {
         this.updateSettings();
         if (this.rowDropdownOpen) this.toggleRowDropdown();
       },
+      shiftTableRow(event, oldPosition) {
+        const shift = (event.key === "ArrowDown") - (event.key === "ArrowUp");
+        if (event.ctrlKey || event.metaKey || event.altKey || shift === 0) return;
+        event.preventDefault();
+        const items = this.addonSettings[this.setting.id];
+        const newPosition = Math.max(0, Math.min(oldPosition + shift, items.length - 1));
+        items.splice(newPosition, 0, items.splice(oldPosition, 1)[0]);
+        this.updateSettings();
+
+        // Refocus the handle in its new position
+        setTimeout(() => {
+          this.$el.querySelector(`.setting-table-row:nth-child(${newPosition + 1}) .handle`).focus();
+        }, 0);
+      },
       msg(...params) {
         return this.$root.msg(...params);
       },
@@ -125,8 +139,8 @@ export default async function ({ template }) {
           handle: ".handle",
           animation: 300,
           onUpdate: (event) => {
-            let list = this.vm.addonSettings[this.vm.setting.id];
-            list.splice(event.newIndex, 0, list.splice(event.oldIndex, 1)[0]);
+            const items = this.vm.addonSettings[this.vm.setting.id];
+            items.splice(event.newIndex, 0, items.splice(event.oldIndex, 1)[0]);
             this.vm.updateSettings();
           },
           disabled: !this.vm.addon._enabled,


### PR DESCRIPTION
Resolves (from #8577):
> ` ` Re-order table rows with the keyboard?

### Changes

Before, the handles used to reorder table rows in addon settings only responded to mouse input. Now, you can focus the handle and press the up and down arrow keys to move the table row. When using a screen reader, the handle is supposed to work like a [spin button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/spinbutton_role), which also allows items to be moved incrementally.

### Reason for changes

For better accessibility.

I don't know if this is usually how moving items works, but it'll do.

### Tests

Changes tested using Windows Narrator and Edge.