### PR TITLE
infinite-scroll: rename "Add to Studio menu" setting to "Browse Projects popup"

### DIFF
--- a/addons/infinite-scroll/addon.json
+++ b/addons/infinite-scroll/addon.json
@@ -11,12 +11,6 @@
   ],
   "settings": [
     {
-      "name": "Forums",
-      "id": "forumScroll",
-      "type": "boolean",
-      "default": true
-    },
-    {
       "name": "Profile Comments",
       "id": "profileCommentScroll",
       "type": "boolean",
@@ -67,6 +61,12 @@
     {
       "name": "Search and Explore",
       "id": "searchExploreScroll",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "Forums",
+      "id": "forumScroll",
       "type": "boolean",
       "default": true
     }


### PR DESCRIPTION
### Changes

Renames Infinite scrolling's `studioBrowseProjectScroll` setting to match the actual name of the feature. Also moves the Forums settings to the bottom because most people don't use the forums.

### Tests

Tested on Firefox.