### PR TITLE
`disable-auto-save`: Allow leaving editor without saving

### DIFF
--- a/addons-l10n/en/disable-auto-save.json
+++ b/addons-l10n/en/disable-auto-save.json
@@ -1,3 +1,7 @@
 {
-  "disable-auto-save/save-and-leave": "Message by \"disable auto-save\" addon from Scratch Addons: going to the project page will save your changes. Do you want to save the project and leave the editor?"
+  "disable-auto-save/alert-title": "Disable autosave addon",
+  "disable-auto-save/unsaved-changes": "Do you want to save your changes before leaving the editor?",
+  "disable-auto-save/save": "Save",
+  "disable-auto-save/discard": "Don't save",
+  "disable-auto-save/cancel": "Back"
 }

--- a/addons-l10n/en/disable-auto-save.json
+++ b/addons-l10n/en/disable-auto-save.json
@@ -1,5 +1,6 @@
 {
-  "disable-auto-save/alert-title": "\"Disable auto-save\" addon",
+  "disable-auto-save/alert-title": "Exit to Project Page",
+  "disable-auto-save/alert-subtitle": "Message from \"Disable auto-save\" addon",
   "disable-auto-save/unsaved-changes": "Do you want to save your changes before leaving the editor?",
   "disable-auto-save/save": "Save",
   "disable-auto-save/discard": "Don't save",

--- a/addons-l10n/en/disable-auto-save.json
+++ b/addons-l10n/en/disable-auto-save.json
@@ -1,5 +1,5 @@
 {
-  "disable-auto-save/alert-title": "Disable autosave addon",
+  "disable-auto-save/alert-title": "\"Disable auto-save\" addon",
   "disable-auto-save/unsaved-changes": "Do you want to save your changes before leaving the editor?",
   "disable-auto-save/save": "Save",
   "disable-auto-save/discard": "Don't save",

--- a/addons/disable-auto-save/addon.json
+++ b/addons/disable-auto-save/addon.json
@@ -11,10 +11,24 @@
   "credits": [
     {
       "name": "RustingRobot"
+    },
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
+    },
+    {
+      "name": "Chrome_Cat",
+      "link": "https://scratch.mit.edu/users/Chrome_Cat/"
     }
   ],
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "userstyles": [
+    {
+      "url": "modal.css",
+      "matches": ["projects"]
+    }
+  ],
   "userscripts": [
     {
       "url": "userscript.js",

--- a/addons/disable-auto-save/modal.css
+++ b/addons/disable-auto-save/modal.css
@@ -1,0 +1,24 @@
+.unsavedChangesDialog {
+  box-sizing: border-box;
+  width: 400px;
+  max-height: 80vh;
+  max-width: 85%;
+  margin-top: 12vh;
+  margin-left: auto;
+  margin-right: auto;
+  overflow-y: auto;
+}
+
+.unsavedChangesDialog .sa-editor-modal-content {
+  padding: 1.5rem 2.25rem;
+}
+
+.unsavedChangesDialog .sa-editor-modal-content > p {
+  margin-top: 0;
+}
+
+.unsavedChangesDialog-actions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}

--- a/addons/disable-auto-save/modal.css
+++ b/addons/disable-auto-save/modal.css
@@ -1,20 +1,14 @@
 .unsavedChangesDialog {
   box-sizing: border-box;
   width: 400px;
-  max-height: 80vh;
+  max-height: 76vh;
   max-width: 85%;
-  margin-top: 12vh;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 12vh auto;
   overflow-y: auto;
 }
 
 .unsavedChangesDialog .sa-editor-modal-content {
   padding: 1.5rem 2.25rem;
-}
-
-.unsavedChangesDialog .sa-editor-modal-content > p {
-  margin-top: 0;
 }
 
 .unsavedChangesDialog-actions {

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -27,6 +27,7 @@ export default async ({ addon, console, msg }) => {
     });
     modal.container.classList.add("unsavedChangesDialog");
 
+    appendChildWithAttributes(modal.content, "b", { textContent: msg("alert-subtitle") });
     appendChildWithAttributes(modal.content, "p", { textContent: msg("unsaved-changes") });
     const buttonRow = appendChildWithAttributes(modal.content, "div", {
       className: addon.tab.scratchClass("prompt_button-row", { others: "unsavedChangesDialog-actions" }),
@@ -39,6 +40,7 @@ export default async ({ addon, console, msg }) => {
       });
     }
     buttons.save.classList.add(addon.tab.scratchClass("prompt_ok-button"));
+    buttons.save.focus();
 
     // On any button click:
     buttonRow.addEventListener(
@@ -64,6 +66,10 @@ export default async ({ addon, console, msg }) => {
     );
 
     modal.closeButton.addEventListener("click", modal.remove);
+    modal.container.parentElement.addEventListener("click", modal.remove);
+    modal.container.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") modal.remove();
+    });
   }
 
   while (true) {

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -48,7 +48,7 @@ export default async ({ addon, console, msg }) => {
       // All buttons close the modal
       modal.remove();
 
-      if (selection === "discard") {
+      if (e.target.value === "discard") {
         // Mark changes as saved to avoid a save-on-navigation
         setProjectChanged(false);
         // Wait for the state change to register

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -1,4 +1,12 @@
 export default async ({ addon, console, msg }) => {
+  function appendChildWithAttributes(parent, type, attrs = {}) {
+    const element = document.createElement(type);
+    Object.assign(element, attrs);
+    parent.appendChild(element);
+    return element;
+  }
+  const PROJECT_PAGE_BUTTON = "[class*='community-button_community-button_']";
+
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", ({ detail }) => {
     if (addon.self.disabled || detail.action.type !== "timeout/SET_AUTOSAVE_TIMEOUT_ID") return;
@@ -6,8 +14,54 @@ export default async ({ addon, console, msg }) => {
     console.log("Pending autosave prevented.");
   });
 
+  function showSaveAlert() {
+    const modal = addon.tab.createModal(msg("alert-title"), {
+      isOpen: true,
+      useEditorClasses: true,
+    });
+    modal.container.classList.add("unsavedChangesDialog");
+
+    appendChildWithAttributes(modal.content, "p", { textContent: msg("unsaved-changes") });
+    const buttonRow = appendChildWithAttributes(modal.content, "div", {
+      className: addon.tab.scratchClass("prompt_button-row", { others: "unsavedChangesDialog-actions" }),
+    });
+    const buttons = {};
+    for (const option of ["cancel", "discard", "save"]) {
+      buttons[option] = appendChildWithAttributes(buttonRow, "button", {
+        value: option,
+        textContent: msg(option),
+      });
+    }
+    buttons.save.classList.add(addon.tab.scratchClass("prompt_ok-button"));
+
+    // On any button click:
+    buttonRow.addEventListener(
+      "click",
+      async (e) => {
+        if (!e.target.matches("button")) return;
+        // All buttons close the modal
+        modal.remove();
+
+        if (e.target.value === "discard") {
+          // Mark changes as saved to avoid a save-on-navigation
+          addon.tab.redux.dispatch({
+            type: "scratch-gui/project-changed/SET_PROJECT_CHANGED",
+            changed: false,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        if (e.target.value === "discard" || e.target.value === "save") {
+          document.querySelector(PROJECT_PAGE_BUTTON).click();
+        }
+      },
+      { bubble: true }
+    );
+
+    modal.closeButton.addEventListener("click", modal.remove);
+  }
+
   while (true) {
-    const btn = await addon.tab.waitForElement('[class*="community-button_community-button_"]', {
+    const btn = await addon.tab.waitForElement(PROJECT_PAGE_BUTTON, {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
@@ -22,13 +76,14 @@ export default async ({ addon, console, msg }) => {
         // Don't show if it's on someone else's project page,
         // or if there are no changes.
         if (
+          e.isTrusted &&
           !addon.self.disabled &&
           addon.tab.redux.state.scratchGui.projectChanged &&
-          document.querySelector('[class*="project-title-input_title-field_"]') &&
-          !confirm(msg("save-and-leave"))
+          document.querySelector("[class*='project-title-input_title-field_']")
         ) {
           e.preventDefault();
           e.stopPropagation();
+          showSaveAlert();
         }
       },
       { capture: true }

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -5,7 +5,13 @@ export default async ({ addon, console, msg }) => {
     parent.appendChild(element);
     return element;
   }
-  const PROJECT_PAGE_BUTTON = "[class*='community-button_community-button_']";
+  function setProjectChanged(changed) {
+    addon.tab.redux.dispatch({
+      type: "scratch-gui/project-changed/SET_PROJECT_CHANGED",
+      changed,
+    });
+  }
+  const PAGE_BUTTON_SELECTOR = "[class*='community-button_community-button_']";
 
   addon.tab.redux.initialize();
   addon.tab.redux.addEventListener("statechanged", ({ detail }) => {
@@ -44,14 +50,14 @@ export default async ({ addon, console, msg }) => {
 
         if (e.target.value === "discard") {
           // Mark changes as saved to avoid a save-on-navigation
-          addon.tab.redux.dispatch({
-            type: "scratch-gui/project-changed/SET_PROJECT_CHANGED",
-            changed: false,
-          });
+          setProjectChanged(false);
           await new Promise((resolve) => setTimeout(resolve, 0));
+          document.querySelector(PAGE_BUTTON_SELECTOR).click();
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          setProjectChanged(true);
         }
-        if (e.target.value === "discard" || e.target.value === "save") {
-          document.querySelector(PROJECT_PAGE_BUTTON).click();
+        if (e.target.value === "save") {
+          document.querySelector(PAGE_BUTTON_SELECTOR).click();
         }
       },
       { bubble: true }
@@ -61,7 +67,7 @@ export default async ({ addon, console, msg }) => {
   }
 
   while (true) {
-    const btn = await addon.tab.waitForElement(PROJECT_PAGE_BUTTON, {
+    const btn = await addon.tab.waitForElement(PAGE_BUTTON_SELECTOR, {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
       reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -48,12 +48,13 @@ export default async ({ addon, console, msg }) => {
       // All buttons close the modal
       modal.remove();
 
-      if (e.target.value === "discard") {
+      if (selection === "discard") {
         // Mark changes as saved to avoid a save-on-navigation
         setProjectChanged(false);
-        await new Promise((resolve) => setTimeout(resolve, 0)); // wait
+        // Wait for the state change to register
+        await addon.tab.redux.waitForState((state) => state !== "scratch-gui/project-changed/SET_PROJECT_CHANGED");
         document.querySelector(PAGE_BUTTON_SELECTOR).click();
-        await new Promise((resolve) => setTimeout(resolve, 0)); // wait
+        // Then we can mark it as changed again
         setProjectChanged(true);
       }
       if (e.target.value === "save") {

--- a/addons/disable-auto-save/userscript.js
+++ b/addons/disable-auto-save/userscript.js
@@ -43,27 +43,23 @@ export default async ({ addon, console, msg }) => {
     buttons.save.focus();
 
     // On any button click:
-    buttonRow.addEventListener(
-      "click",
-      async (e) => {
-        if (!e.target.matches("button")) return;
-        // All buttons close the modal
-        modal.remove();
+    buttonRow.addEventListener("click", async (e) => {
+      if (!e.target.matches("button")) return;
+      // All buttons close the modal
+      modal.remove();
 
-        if (e.target.value === "discard") {
-          // Mark changes as saved to avoid a save-on-navigation
-          setProjectChanged(false);
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          document.querySelector(PAGE_BUTTON_SELECTOR).click();
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          setProjectChanged(true);
-        }
-        if (e.target.value === "save") {
-          document.querySelector(PAGE_BUTTON_SELECTOR).click();
-        }
-      },
-      { bubble: true }
-    );
+      if (e.target.value === "discard") {
+        // Mark changes as saved to avoid a save-on-navigation
+        setProjectChanged(false);
+        await new Promise((resolve) => setTimeout(resolve, 0)); // wait
+        document.querySelector(PAGE_BUTTON_SELECTOR).click();
+        await new Promise((resolve) => setTimeout(resolve, 0)); // wait
+        setProjectChanged(true);
+      }
+      if (e.target.value === "save") {
+        document.querySelector(PAGE_BUTTON_SELECTOR).click();
+      }
+    });
 
     modal.closeButton.addEventListener("click", modal.remove);
     modal.container.parentElement.addEventListener("click", modal.remove);


### PR DESCRIPTION
Previously, when you clicked "See Project Page" with `disable-auto-save` enabled, you would receive a confirmation asking you if you want to return to the project page _and_ save your changes.

This PR adds a custom alert to this addon. It introduces a third option, "Don't save", which returns you to the project page _without_ saving any changes.

<img width="419" height="232" alt="Disable autosave addon prompt" src="https://github.com/user-attachments/assets/52821e05-9ea1-423d-aceb-4063e6caa20f" />

### Tests

All cases tested.

### Thanks to…

- @Joeclinton1 for the modal code