### PR TITLE
dark-www: style membership features

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -526,7 +526,7 @@ p.callout,
 .banner-outer:not(.banner-danger) .banner-button /* Share */ {
   background-color: #ffab1a;
 }
-.membership-label-text  {
+.membership-label-text {
   color: var(--darkWww-button-text);
 }
 .row .col-sm-9 input[type="radio"]:checked::after {


### PR DESCRIPTION
### Changes

Adds styles for new Scratch Membership features on the website:
* A "Member" label. This will be shown next to members' usernames in places where there's no profile picture. Elsewhere, the profile picture will have cat ears.
  <img width="206" height="207" alt="image" src="https://github.com/user-attachments/assets/d653d82f-7915-4954-873e-88d44b992f25" />
* A new FAQ section on the Membership page.

### Tests

Tested locally on Edge.