### PR TITLE
"Costume numbers in block dropdowns" addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -163,6 +163,7 @@
   "fix-costume-drag",
   "recolor-custom-blocks",
   "totally-normal-modes",
+  "dropdown-numbers",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/dropdown-numbers/addon.json
+++ b/addons/dropdown-numbers/addon.json
@@ -1,0 +1,30 @@
+{
+  "name": "Costume numbers in block dropdowns",
+  "description": "Shows the numbers of costumes in block dropdowns.",
+  "credits": [
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
+    },
+    {
+      "name": "mybearworld",
+      "link": "https://scratch.mit.edu/users/mybearworld"
+    }
+  ],
+  "userstyles": [
+    {
+      "matches": ["projects"],
+      "url": "style.css"
+    }
+  ],
+  "userscripts": [
+    {
+      "matches": ["projects"],
+      "url": "userscript.js"
+    }
+  ],
+  "tags": ["editor", "codeEditor", "featured"],
+  "versionAdded": "1.45.0",
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/dropdown-numbers/style.css
+++ b/addons/dropdown-numbers/style.css
@@ -1,0 +1,5 @@
+.sa-dropdown-costume-numbers:not(.sa-dropdown-costume-numbers-cut-three) .goog-menuitem-content[data-index]::before {
+  content: attr(data-index) ". ";
+  opacity: 0.85;
+  font-weight: 400;
+}

--- a/addons/dropdown-numbers/userscript.js
+++ b/addons/dropdown-numbers/userscript.js
@@ -1,0 +1,35 @@
+export default async function ({ addon, console }) {
+  const COSTUME_BLOCKS = {
+    looks_switchcostumeto: {},
+    looks_switchbackdropto: { cutThree: true },
+    looks_switchbackdroptoandwait: { cutThree: true },
+    event_whenbackdropswitchesto: {},
+  };
+
+  const Blockly = await addon.tab.traps.getBlockly();
+
+  async function showCostumeNumbers() {
+    const workspace = await addon.tab.traps.getWorkspace();
+    const block = workspace.getBlockById(document.querySelector(".blocklySelected").dataset.id);
+    if (block.type in COSTUME_BLOCKS) {
+      const dropDownContent = Blockly.DropDownDiv.getContentDiv();
+      dropDownContent.classList.add("sa-dropdown-costume-numbers");
+      const allItems = dropDownContent.querySelectorAll("[role='menuitemcheckbox']");
+      // Exclude previous/next/random backdrop
+      const { cutThree } = COSTUME_BLOCKS[block.type];
+      const limit = allItems.length - !!cutThree * 3;
+      for (let i = 0; i < limit; i++) {
+        allItems[i].lastChild.dataset.index = i + 1;
+      }
+    }
+  }
+  const oldDropDownDivShow = Blockly.DropDownDiv.show;
+  Blockly.DropDownDiv.show = function (...args) {
+    oldDropDownDivShow.call(this, ...args);
+    showCostumeNumbers();
+  };
+  const oldDropDownDivClearContent = Blockly.DropDownDiv.clearContent;
+  Blockly.DropDownDiv.clearContent = function () {
+    oldDropDownDivClearContent.call(this);
+  };
+}


### PR DESCRIPTION
Resolves #4992

<img width="324" height="271" alt="Numbered costume dropdown" src="https://github.com/user-attachments/assets/beb3add8-cd3a-4fc4-83b3-426fbb817312" />

### Changes

This new addon shows numbers next to costume block menu items, showing each costume's place in the list.

### Reason for changes

It allows you to identify costumes by number.

### Notes

Changes tested in Edge 142. Tested together with `editor-searchable-dropdowns`, as shown in the screenshot.

Thanks to @mybearworld for laying this addon's groundwork with #6719, which I adapted to make it.