### PR TITLE
Webpages: Add icon descriptions

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -128,6 +128,24 @@
   "easterEggs": {
     "message": "Easter Eggs"
   },
+  "editorFeature": {
+    "message": "Editor feature"
+  },
+  "playerFeature": {
+    "message": "Project player feature"
+  },
+  "websiteFeature": {
+    "message": "Website feature"
+  },
+  "themeAddon": {
+    "message": "Theme"
+  },
+  "popupFeature": {
+    "message": "Extension popup feature"
+  },
+  "easterEgg": {
+    "message": "Easter egg"
+  },
   "theme": {
     "message": "Theme:"
   },
@@ -170,8 +188,20 @@
   "viewLicenses": {
     "message": "View library licenses"
   },
+  "infoMessage": {
+    "message": "Information"
+  },
+  "noticeMessage": {
+    "message": "Notice"
+  },
+  "warningMessage": {
+    "message": "Warning"
+  },
   "back": {
     "message": "Go back"
+  },
+  "clear": {
+    "message": "Clear"
   },
   "collapse": {
     "message": "Collapse"

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -5,7 +5,7 @@
         <button class="arrow-button" :title="msg(expanded ? 'collapse' : 'expand')">
           <img src="../../images/icons/expand.svg" :class="{'reverted': expanded}" draggable="false" />
         </button>
-        <img :src="addonIconSrc" class="icon-type addon-icon" draggable="false" />
+        <img :src="addonIconSrc" :title="addonIconAlt" class="icon-type addon-icon" draggable="false" />
         <!-- prettier-ignore -->
         <div class="addon-name-and-tags">
           <div class="addon-name tooltip">
@@ -46,6 +46,11 @@
               'notice': 'notice.svg',
               'info': 'help.svg',
             }[info.type || 'info']"
+            :alt="msg({
+              'warning': 'warningMessage',
+              'notice': 'noticeMessage',
+              'info': 'infoMessage',
+            }[info.type || 'info'])"
             draggable="false"
           />{{ info.text }}
         </div>

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -29,6 +29,17 @@ export default async function ({ template }) {
         };
         return `../../images/icons/${map[this.addon._icon]}.svg`;
       },
+      addonIconAlt() {
+        const map = {
+          editor: "editorFeature",
+          player: "playerFeature",
+          community: "websiteFeature",
+          theme: "themeAddon",
+          easterEgg: "easterEgg",
+          popup: "popupFeature",
+        };
+        return chrome.i18n.getMessage(map[this.addon._icon]);
+      },
       addonSettings() {
         return this.$root.addonSettings[this.addon._addonId];
       },

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -267,7 +267,7 @@
             <button disabled v-show="searchInput === ''">
               <img src="../../images/icons/search.svg" class="search-icon" />
             </button>
-            <button v-else @click="clearAndFocusSearch()">
+            <button v-else :title="msg('clear')" @click="clearAndFocusSearch()">
               <img src="../../images/icons/x.svg" class="search-icon" />
             </button>
           </div>
@@ -321,7 +321,7 @@
       <div class="addon-block settings-block">
         <div class="addon-body">
           <div class="addon-topbar">
-            <img src="../../images/icons/theme.svg" class="icon-type addon-icon" draggable="false" />
+            <img src="../../images/icons/theme.svg" aria-hidden="true" class="icon-type addon-icon" draggable="false" />
             <span class="addon-name-and-tags">{{ msg("scratchAddonsTheme") }}</span>
           </div>
           <div class="addon-settings">
@@ -359,6 +359,7 @@
           <div class="addon-topbar">
             <img
               src="../../images/icons/import-export.svg"
+              aria-hidden="true"
               class="icon-type addon-icon"
               :class="{'dark': theme === false}"
               draggable="false"
@@ -382,7 +383,12 @@
         </div>
         <div class="addon-body">
           <div class="addon-topbar">
-            <img src="../../images/icons/translate.svg" class="icon-type addon-icon" draggable="false" />
+            <img
+              src="../../images/icons/translate.svg"
+              aria-hidden="true"
+              class="icon-type addon-icon"
+              draggable="false"
+            />
             <span class="addon-name-and-tags">{{ msg("language") }}</span>
           </div>
           <div class="addon-settings">


### PR DESCRIPTION
Moved from #8663

### Changes

Adds either alt text or tooltips to icons in the settings page which didn't have them before that convey extra information not otherwise available to screen reader users. These icons include:
- Addon type icons
- The `x` button on the search bar
- The icons next to addon information blocks

It's also just nice to have a label on some icons.

Also, the icons in the More Settings menu now have `aria-hidden="true"` because they don't convey any useful information for screen reader users.

### Tests

Tested with:
- Edge 143
- Windows Narrator