### PR TITLE
`fix-costume-drag`: Delta time

### DIFF
--- a/addons/fix-costume-drag/userscript.js
+++ b/addons/fix-costume-drag/userscript.js
@@ -133,8 +133,11 @@ export default async function ({ addon, console }) {
 
           // Auto scroll
           const edgeSize = 30; // Distance from the top/bottom to trigger scroll
-          const delta = performance.now() - lastTime; // Calculate delta time
-          const scrollAmount = (scrollSpeed * Math.min(delta, 100)) / 15;
+          const deltaTime = performance.now() - lastTime;
+          // Drag updates happen whenever you move your mouse or the list is scrolled, so if your mouse
+          // approaches the auto-scroll zone very slowly, the rate of drag updates will decrease which
+          // means delta time will be greater. That's why it is capped at 100ms:
+          const scrollAmount = (scrollSpeed / 15) * Math.min(deltaTime, 100);
           if (this.props.dragInfo.currentOffset.y < containerRect.top + edgeSize) {
             scrollContainer.scrollTop -= scrollAmount;
           } else if (this.props.dragInfo.currentOffset.y > containerRect.bottom - edgeSize) {


### PR DESCRIPTION
### Changes

Updates @The2AndOnly's addon (again):
- Added delta timing to ensure the auto scroll speed remains consistent between different refresh rates.
  - Maximum delta is 0.1 (1/10 sec.)
- Also slightly sped up auto scrolling (changed `SPEED_PRESETS`) so you can move costumes faster.

### Videos

| Before | After |
|---|---|
| <video src=https://github.com/user-attachments/assets/c935cc90-5223-48a4-b3a7-17c64a36b89c> | <video src=https://github.com/user-attachments/assets/4218dd2c-8e36-42e6-a4af-ed641b52bf79> |

<sup>Recording 60 FPS and screen refreshing at 120 Hz in both. Note that the `fps` addon is a slightly inaccurate counter.</sup>

### Tests

Tested on Edge 143 using both 60 Hz and 120 Hz settings.

### Known issues

- Scrolling will begin to slow down if the project FPS drops below 10 (you can notice this in the video). This is caused by the delta maximum.
- Measurements only occur every drag update (including from auto scrolling), so if your mouse approaches the edge slowly, delta will have maxed out which causes a jump. However, this isn't a noticeable inconvenience under normal use, especially since delta is limited as mentioned before.