### PR TITLE
scratch3to2: fix cat ears

### DIFF
--- a/addons/scratch3to2/comments.css
+++ b/addons/scratch3to2/comments.css
@@ -23,10 +23,13 @@
 .comments-root-reply:empty {
   padding: 0;
 }
-.comment .avatar {
+.comment .avatar-wrapper,
+.preview .comment .avatar-wrapper {
   margin-right: 10px;
-  width: 45px;
-  height: 45px;
+  --avatar-size: 45px;
+}
+.comment .avatar,
+.preview .comment img.avatar {
   border-radius: 0;
   box-shadow: none;
 }

--- a/addons/scratch3to2/explore_and_search.css
+++ b/addons/scratch3to2/explore_and_search.css
@@ -199,8 +199,7 @@
   border-radius: 0;
 }
 .grid .thumbnail .thumbnail-info .creator-image img {
-  margin-left: -1px;
-  margin-right: 7px;
+  box-sizing: border-box;
   border: 1px solid var(--darkWww-border-15, #ddd);
   border-radius: 0;
 }

--- a/addons/scratch3to2/main.css
+++ b/addons/scratch3to2/main.css
@@ -321,6 +321,7 @@ a:hover {
   background-size: auto;
 }
 .account-nav .user-info {
+  display: inline-block;
   height: 35px;
   padding: 0 10px;
   background-clip: padding-box;
@@ -328,9 +329,14 @@ a:hover {
   border-right: 1px solid transparent;
   line-height: 35px;
 }
-.account-nav .user-info .avatar {
+.account-nav .user-info .avatar-wrapper {
+  vertical-align: middle;
   margin-top: -3px;
   margin-right: 5px;
+  --avatar-size: 26px;
+}
+.account-nav .user-info .avatar {
+  box-sizing: border-box;
   border: 1px solid #ccc;
   border-radius: 1px;
 }

--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -48,8 +48,9 @@
 
 /* Title */
 .preview > .inner > .preview-row:first-child {
-  min-height: 45px;
-  padding: 7px 20px 2px;
+  min-height: 47px;
+  padding: 2px 20px;
+  align-items: center;
   background-color: var(--darkWww-gray-scratchr2, #f7f7f7);
   border-top: 1px solid var(--darkWww-gray-boxHighlight, white);
   border-bottom: 1px solid var(--darkWww-box-scratchr2Border, #e0e0e0);
@@ -57,10 +58,12 @@
   color: var(--darkWww-gray-scratchr2Text, #322f31);
   text-shadow: var(--darkWww-gray-scratchr2TextShadow, 0 1px white);
 }
-.preview .project-header img.avatar {
+.preview .project-header .avatar-wrapper {
   vertical-align: middle;
-  width: 40px;
-  height: 40px;
+  --avatar-size: 42px;
+}
+.preview .project-header img.avatar {
+  box-sizing: border-box;
   border: 1px solid var(--darkWww-border-15, #ccc);
   border-radius: 0;
 }
@@ -70,11 +73,13 @@
   line-height: 20px;
 }
 .preview .project-title {
-  margin-bottom: -3px;
   color: var(--darkWww-gray-scratchr2HeaderText, #554747);
   font-size: 22px;
   font-weight: bold;
   line-height: 26px;
+}
+.preview .project-title.no-edit {
+  margin-bottom: -3px;
 }
 .preview .project-header .inplace-input {
   height: 38px;
@@ -110,7 +115,6 @@
 
 /* Remix, See inside, turbowarp-player */
 .preview .project-buttons {
-  margin-top: 2px;
   margin-right: -2px;
 }
 .preview .remix-button,
@@ -396,10 +400,12 @@
   border-radius: 0;
   border-bottom: 1px solid var(--darkWww-border, #ddd);
 }
-.preview img.avatar.remix {
+.preview .remix-credit .avatar-wrapper {
   margin-right: 5px;
-  width: 30px;
-  height: 30px;
+  --avatar-size: 32px;
+}
+.preview img.avatar.remix {
+  box-sizing: border-box;
   border: 1px solid var(--darkWww-border-15, #ccc);
   border-radius: 0;
 }
@@ -788,11 +794,6 @@
 }
 .preview .comments-container .comments-allowed-input {
   margin-right: 0;
-}
-.preview .comment img.avatar {
-  width: 45px;
-  height: 45px;
-  border-radius: 0;
 }
 .compose-comment .compose-bottom-row .compose-limit {
   color: var(--darkWww-box-scratchr2ButtonText, #666);

--- a/addons/scratch3to2/studio.css
+++ b/addons/scratch3to2/studio.css
@@ -289,6 +289,7 @@
   line-height: 0;
 }
 .studio-project-tile .studio-project-avatar {
+  box-sizing: border-box;
   border: 1px solid var(--darkWww-border-15, #ddd);
   border-radius: 0;
 }
@@ -335,6 +336,7 @@
   line-height: 0;
 }
 .studio-member-tile .studio-member-image {
+  box-sizing: border-box;
   border: 1px solid var(--darkWww-border-20, #ccc);
   border-radius: 0;
 }


### PR DESCRIPTION
Resolves #8731

### Changes

Fixes the styling of profile pictures, specifically those with cat ears (membership badge).

<img width="606" height="93" alt="image" src="https://github.com/user-attachments/assets/c58d49e5-bb39-4b1d-9f62-33db085c27fc" />

<img width="258" height="100" alt="image" src="https://github.com/user-attachments/assets/ec34dc36-ad91-4fe9-aefc-a9b481ced7fe" />

### Tests

Tested on Edge and Firefox. I used the following code to add ears to every profile picture on the page:
```js
for (const wrapper of document.querySelectorAll(".avatar-wrapper")) {
    wrapper.classList.add("avatar-badge-wrapper");
    wrapper.querySelector(".avatar").classList.add("avatar-badge");
}
```