### PR TITLE
dark-www: style membership label on scratchr2 pages

### DIFF
--- a/addons/dark-www/experimental_scratchr2.css
+++ b/addons/dark-www/experimental_scratchr2.css
@@ -397,10 +397,7 @@ button:hover,
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button {
-  background-image: linear-gradient(
-    var(--darkWww-button-scratchr2),
-    var(--darkWww-button-scratchr2)
-  );
+  background-image: linear-gradient(var(--darkWww-button-scratchr2), var(--darkWww-button-scratchr2));
   border-color: var(--darkWww-button-scratchr2);
   color: var(--darkWww-button-scratchr2ButtonText);
 }
@@ -413,10 +410,7 @@ button:hover,
   color: var(--darkWww-button-scratchr2ButtonText);
 }
 .button:hover {
-  background-image: linear-gradient(
-    var(--darkWww-button-scratchr2Hover),
-    var(--darkWww-button-scratchr2Hover)
-  );
+  background-image: linear-gradient(var(--darkWww-button-scratchr2Hover), var(--darkWww-button-scratchr2Hover));
 }
 input:focus,
 textarea:focus,


### PR DESCRIPTION
Resolves #8736

### Changes

* Adds styles for the membership labels on scratchr2 pages. One for scratch-www pages was already added in a previous PR.
* Removes the fix for a Scratch bug that no longer exists.

### Tests

Tested on Edge.