### PR TITLE
Local project share addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -163,6 +163,7 @@
   "fix-costume-drag",
   "recolor-custom-blocks",
   "totally-normal-modes",
+  "local-share",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/local-share/addon.json
+++ b/addons/local-share/addon.json
@@ -1,0 +1,38 @@
+{
+  "name": "Local Project Share",
+  "description": "Send Scratch projects to a local device via HTTP.",
+  "tags": ["editor", "editorMenuBar"],
+  "versionAdded": "1.45.0",
+  "enabledByDefault": false,
+  "settings": [
+    {
+      "name": "Host to send to",
+      "id": "host",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "name": "Port to use",
+      "id": "port",
+      "type": "positive_integer",
+      "default": 3000
+    }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "userstyle.css",
+      "matches": ["projects"]
+    }
+  ],
+  "credits": [
+    {"name": "Br0tcraft"}
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
+}

--- a/addons/local-share/addon.json
+++ b/addons/local-share/addon.json
@@ -16,6 +16,12 @@
       "id": "port",
       "type": "positive_integer",
       "default": 3000
+    },
+    {
+      "name": "Use HTTPS",
+      "id": "useHttps",
+      "type": "boolean",
+      "default": false
     }
   ],
   "userscripts": [

--- a/addons/local-share/addon.json
+++ b/addons/local-share/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Local Project Share",
-  "description": "Send Scratch projects to a local device via HTTP.",
+  "description": "Adds a \"Share locally\" button to the File dropdown menu, allowing you to send the current project to a local device via HTTP.",
   "tags": ["editor", "editorMenuBar"],
   "versionAdded": "1.45.0",
   "enabledByDefault": false,

--- a/addons/local-share/userscript.js
+++ b/addons/local-share/userscript.js
@@ -1,0 +1,257 @@
+//userscript from my Project - Fixed
+export default async function ({ addon, console, msg }) {
+  const vm = addon.tab.traps.vm;
+
+  function formatTime(seconds) {
+    if (!isFinite(seconds) || seconds < 0) return "...";
+    if (seconds < 60) return `${Math.ceil(seconds)}s`;
+    const m = Math.floor(seconds / 60);
+    const s = Math.ceil(seconds % 60);
+    return `${m}m ${s}s`;
+  }
+
+  function getSettings() {
+    return {
+      host: addon.settings.get("host") || "",
+      port: addon.settings.get("port") || 3000,
+    };
+  }
+
+  function getProjectInfo() {
+    let title = "Scratch Project";
+    const titleInput = document.querySelector(".project-title-input");
+    if (titleInput && titleInput.value) {
+      title = titleInput.value;
+    } else {
+      title = document.title.replace(" on Scratch", "");
+    }
+
+    return {
+      title: title,
+      id: location.pathname.split("/")[2] || "local",
+      author: "Me",
+    };
+  }
+
+  async function sendProject(base, onProgress) {
+    /*
+      Should I perform a check here to see if the VM exists?
+      Theoretically, it would be good practice to check if "vm" exists before accessing it.
+      But that's probably unnecessary, right?
+    */
+    if (!vm) throw new Error("Scratch VM not found");
+
+    const blob = await vm.saveProjectSb3();
+    const startTime = Date.now();
+
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      const filename = "project.sb3";
+
+      xhr.open("POST", `${base}/send`);
+      xhr.setRequestHeader("Content-Type", "application/octet-stream");
+      xhr.setRequestHeader("X-File-Name", filename);
+      xhr.setRequestHeader("X-Chunk-Offset", "0");
+
+      if (xhr.upload) {
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) {
+            const percent = (e.loaded / e.total) * 100;
+            const timeElapsed = (Date.now() - startTime) / 1000;
+            const uploadSpeed = e.loaded / timeElapsed;
+            const remainingBytes = e.total - e.loaded;
+            const secondsLeft = remainingBytes / uploadSpeed;
+
+            onProgress(percent, secondsLeft);
+          }
+        };
+      }
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(xhr.response);
+        } else {
+          reject(new Error(`Upload failed: ${xhr.statusText}`));
+        }
+      };
+
+      xhr.onerror = () => reject(new Error("Network error (connection failed)"));
+
+      xhr.send(blob);
+    });
+  }
+
+  async function startTransfer(content, remove) {
+    const hostInput = content.querySelector(".sa-input-host");
+    const portInput = content.querySelector(".sa-input-port");
+
+    const host = hostInput.value.trim();
+    const port = portInput.value.trim();
+
+    if (!host) {
+      hostInput.style.borderColor = "red";
+      return;
+    }
+
+    const btnRow = content.querySelector(".sa-modal-buttons");
+    const progContainer = content.querySelector(".sa-progress-container");
+    const progFill = content.querySelector(".sa-progress-fill");
+    const progText = content.querySelector(".sa-progress-text");
+
+    const base = `http://${host}:${port}`;
+
+    btnRow.style.display = "none";
+    progContainer.style.display = "block";
+    progText.textContent = "Start uploading...";
+    progFill.style.width = "0%";
+    progFill.style.backgroundColor = "#4C97FF";
+
+    try {
+      await sendProject(base, (percent, secondsLeft) => {
+        progFill.style.width = `${percent}%`;
+        if (percent >= 100) {
+          progText.textContent = "Processing...";
+        } else {
+          progText.textContent = `${Math.round(percent)}% / ${formatTime(secondsLeft)}`;
+        }
+      });
+
+      progText.textContent = "Complete!";
+      progFill.style.backgroundColor = "#4CB050";
+
+      setTimeout(() => {
+        remove();
+        alert("Project sent successfully!");
+      }, 500);
+    } catch (err) {
+      console.error(err);
+      let msg = err.message;
+      if (msg === "Failed to fetch") msg = "Server not reachable (wrong IP?).";
+
+      alert("Error: " + msg);
+
+      progContainer.style.display = "none";
+      btnRow.style.display = "flex";
+    }
+  }
+
+  function openScratchStyleModal() {
+    const settings = getSettings();
+
+    const { backdrop, container, content, closeButton, remove } = addon.tab.createModal("Share project locally", {
+      isOpen: true,
+      useEditorClasses: true,
+    });
+
+    container.classList.add("sa-local-share-popup");
+    content.classList.add("sa-local-share-content");
+
+    const description = Object.assign(document.createElement("p"), {
+      textContent: "Send your project to another device on your local network.",
+      className: "sa-description",
+    });
+    content.appendChild(description);
+
+    const labelHost = Object.assign(document.createElement("label"), {
+      textContent: "Recipient's IP address:",
+      htmlFor: "sa-input-host",
+      className: "sa-label",
+    });
+    const inputHost = Object.assign(document.createElement("input"), {
+      type: "text",
+      placeholder: "e.g. 192.168.1.42",
+      value: settings.host,
+      id: "sa-input-host",
+      className: "sa-input sa-input-host " + addon.tab.scratchClass("prompt_variable-name-text-input"),
+    });
+    content.appendChild(labelHost);
+    content.appendChild(inputHost);
+
+    const labelPort = Object.assign(document.createElement("label"), {
+      textContent: "Port:",
+      htmlFor: "sa-input-port",
+      className: "sa-label",
+    });
+    const inputPort = Object.assign(document.createElement("input"), {
+      type: "text",
+      placeholder: "3000",
+      value: settings.port,
+      id: "sa-input-port",
+      className: "sa-input sa-input-port " + addon.tab.scratchClass("prompt_variable-name-text-input"),
+    });
+    content.appendChild(labelPort);
+    content.appendChild(inputPort);
+
+    const progressContainer = Object.assign(document.createElement("div"), {
+      className: "sa-progress-container",
+    });
+    const progressTrack = Object.assign(document.createElement("div"), {
+      className: "sa-progress-track",
+    });
+    const progressFill = Object.assign(document.createElement("div"), {
+      className: "sa-progress-fill",
+    });
+    const progressText = Object.assign(document.createElement("div"), {
+      className: "sa-progress-text",
+      textContent: "Preparation...",
+    });
+    progressTrack.appendChild(progressFill);
+    progressContainer.appendChild(progressTrack);
+    progressContainer.appendChild(progressText);
+    content.appendChild(progressContainer);
+
+    const btnRow = Object.assign(document.createElement("div"), {
+      className: addon.tab.scratchClass("prompt_button-row", { others: "sa-modal-buttons" }),
+    });
+
+    const cancelBtn = Object.assign(document.createElement("button"), {
+      textContent: "Cancel",
+    });
+    cancelBtn.addEventListener("click", remove);
+
+    const sendBtn = Object.assign(document.createElement("button"), {
+      textContent: "Send",
+      className: addon.tab.scratchClass("prompt_ok-button"),
+    });
+    sendBtn.addEventListener("click", () => startTransfer(content, remove));
+
+    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(sendBtn);
+    content.appendChild(btnRow);
+
+    backdrop.addEventListener("click", remove);
+    closeButton.addEventListener("click", remove);
+
+    inputHost.focus();
+  }
+
+  while (true) {
+    const dropdownList = await addon.tab.waitForElement("[class*='menu-bar_menu-bar-menu_'] ul", {
+      markAsSeen: true,
+      reduxCondition: (state) => state.scratchGui && state.scratchGui.menus.fileMenu,
+    });
+
+    if (dropdownList.querySelector(".sa-local-share-item")) continue;
+
+    const li = Object.assign(document.createElement("li"), {
+      className: "menu_menu-item_-vv8x menu_hoverable_ZLcfJ sa-local-share-item",
+    });
+    const labelSpan = Object.assign(document.createElement("span"), {
+      textContent: "Share locally",
+    });
+    li.appendChild(labelSpan);
+
+    li.addEventListener("click", (e) => {
+      e.stopPropagation();
+
+      const menuBar = document.querySelector("[class*='menu-bar_account-info-group']");
+      if (menuBar) {
+        menuBar.click();
+      }
+
+      openScratchStyleModal();
+    });
+
+    dropdownList.appendChild(li);
+  }
+}

--- a/addons/local-share/userscript.js
+++ b/addons/local-share/userscript.js
@@ -204,7 +204,7 @@ export default async function ({ addon, console, msg }) {
     const cancelBtn = Object.assign(document.createElement("button"), {
       textContent: "Cancel",
     });
-    cancelBtn.onclick = () => remove;
+    cancelBtn.onclick = () => remove();
 
     const sendBtn = Object.assign(document.createElement("button"), {
       textContent: "Send",
@@ -216,8 +216,8 @@ export default async function ({ addon, console, msg }) {
     btnRow.appendChild(sendBtn);
     content.appendChild(btnRow);
 
-    backdrop.onclick = () => remove;
-    closeButton.onclick = () => remove;
+    backdrop.onclick = () => remove();
+    closeButton.onclick = () => remove();
 
     inputHost.focus();
   }

--- a/addons/local-share/userstyle.css
+++ b/addons/local-share/userstyle.css
@@ -1,6 +1,3 @@
-/*User style from my Project - Fixed with proper modal styling*/
-
-/* Modal container sizing - similar to media recorder */
 .sa-local-share-popup {
   box-sizing: border-box;
   width: 520px;
@@ -12,19 +9,16 @@
   margin-right: auto;
 }
 
-/* Content padding */
 .sa-local-share-content {
   padding: 1.5rem 2.25rem;
 }
 
-/* Description text */
 .sa-description {
   margin-bottom: 1.5rem;
   font-size: 1rem;
   color: var(--editorDarkMode-text, #575e75);
 }
 
-/* Labels */
 .sa-label {
   display: block;
   font-weight: bold;
@@ -34,7 +28,6 @@
   margin-bottom: 0.5rem;
 }
 
-/* Input fields */
 .sa-input {
   width: 100%;
   padding: 0.5rem 0.6rem;
@@ -52,7 +45,6 @@
   border-color: var(--editorDarkMode-primary, #855cd6);
 }
 
-/* Progress container */
 .sa-progress-container {
   display: none;
   margin-top: 1.5rem;
@@ -81,7 +73,6 @@
   margin-top: 0.5rem;
 }
 
-/* Button row */
 .sa-modal-buttons {
   margin-top: 1.5rem;
   display: flex;
@@ -106,7 +97,6 @@
   background-color: var(--editorDarkMode-primary-transparent15, rgba(133, 92, 214, 0.15));
 }
 
-/* Menu item styling */
 .sa-local-share-item {
   border-top: 1px solid rgba(0, 0, 0, 0.08);
   margin-top: 4px;

--- a/addons/local-share/userstyle.css
+++ b/addons/local-share/userstyle.css
@@ -1,0 +1,115 @@
+/*User style from my Project - Fixed with proper modal styling*/
+
+/* Modal container sizing - similar to media recorder */
+.sa-local-share-popup {
+  box-sizing: border-box;
+  width: 520px;
+  max-height: min(700px, 80vh);
+  max-width: 85%;
+  margin-top: 12vh;
+  overflow-y: auto;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Content padding */
+.sa-local-share-content {
+  padding: 1.5rem 2.25rem;
+}
+
+/* Description text */
+.sa-description {
+  margin-bottom: 1.5rem;
+  font-size: 1rem;
+  color: var(--editorDarkMode-text, #575e75);
+}
+
+/* Labels */
+.sa-label {
+  display: block;
+  font-weight: bold;
+  font-size: 0.9rem;
+  color: var(--editorDarkMode-text, #575e75);
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Input fields */
+.sa-input {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  box-sizing: border-box;
+  border: 1px solid var(--editorDarkMode-border, #d9d9d9);
+  border-radius: 0.25rem;
+  background-color: var(--editorDarkMode-input, #ffffff);
+  color: var(--editorDarkMode-text, #575e75);
+  font-size: 0.95rem;
+  outline: none;
+  margin-bottom: 0.25rem;
+}
+
+.sa-input:focus {
+  border-color: var(--editorDarkMode-primary, #855cd6);
+}
+
+/* Progress container */
+.sa-progress-container {
+  display: none;
+  margin-top: 1.5rem;
+  width: 100%;
+}
+
+.sa-progress-track {
+  width: 100%;
+  height: 0.75rem;
+  background-color: var(--editorDarkMode-border, #d9d9d9);
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+
+.sa-progress-fill {
+  height: 100%;
+  width: 0%;
+  background-color: var(--editorDarkMode-primary, #855cd6);
+  transition: width 0.2s ease;
+}
+
+.sa-progress-text {
+  font-size: 0.875rem;
+  color: var(--editorDarkMode-text, #575e75);
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+/* Button row */
+.sa-modal-buttons {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.sa-modal-buttons button {
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.sa-modal-buttons button:first-child {
+  background: transparent;
+  border: 1px solid var(--editorDarkMode-border, #d9d9d9);
+  color: var(--editorDarkMode-text, #575e75);
+}
+
+.sa-modal-buttons button:first-child:hover {
+  background-color: var(--editorDarkMode-primary-transparent15, rgba(133, 92, 214, 0.15));
+}
+
+/* Menu item styling */
+.sa-local-share-item {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  margin-top: 4px;
+  padding-top: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
Resolves #8757

### Changes

This PR adds a small addon that lets you share Scratch projects directly from the editor.

It adds a “Local Share” button to the File menu, which opens a simple modal where you can enter the recipient’s IP address and port. The current project is then exported and sent to another device over HTTP, with a progress indicator shown during the upload.

I tried to keep the addon as general as possible so it can be used in different local network setups. I looked through existing addons and didn’t find anything with similar functionality. If there *is* overlap with another addon, I’m happy to adapt or adjust this to avoid duplication.

This is my first Scratch Addon, so I mainly followed the structure of existing addons and based the UI on the “Media Recorder” addon. I’m not fully sure if everything is done in the best possible way, but it works and follows existing patterns as closely as I could.


### Reason for changes

The original idea behind this feature was to make it easier to send projects directly from the Scratch editor to ScratchEverywhere!  
(https://github.com/ScratchEverywhere/ScratchEverywhere)

Without this, transferring projects often requires a separate app (for example FTP) or manually copying files via an SD card. This addon is mostly a convenience / nice-to-have feature that removes a few of those steps.

The feature does not necessarily have to be added, as I will also integrate it directly into the SE! editor.
(https://editor.scratchbox.dev/editor.html).  
However, it would be really nice if this functionality were also available through Scratch Addons for general use.


### Tests

Tested in Chrome and Firefox.
(In Forefox, however, you have to disable `security.mixed_content.block_active_content` for HTTP requests.)


I’m keeping this as a draft PR for now so I can get feedback on improvements, better ways to handle things, or anything I might have missed. Open to criticism and suggestions!

