### PR TITLE
player-thumb: less strict selectors

### DIFF
--- a/addons/player-thumb/userscript.js
+++ b/addons/player-thumb/userscript.js
@@ -7,9 +7,9 @@ export default async function ({ addon, console }) {
     `url(https://uploads.scratch.mit.edu/get_image/project/${projectId}_480x360.png)`
   );
 
-  const stageWrapper = await addon.tab.waitForElement('div[class*="stage-wrapper_stage-wrapper_"]');
+  const stageWrapper = await addon.tab.waitForElement('[class*="stage-wrapper_stage-wrapper_"]');
   addon.tab.redux.initialize();
-  const controls = stageWrapper.querySelector('div[class^="controls_controls-container_"]');
+  const controls = stageWrapper.querySelector('[class*="controls_controls-container_"]');
   // Ensure the project has not already loaded when disabling the controls
   if (addon.tab.redux.state?.scratchGui?.projectState?.loadingState === "SHOWING_WITH_ID") return;
   controls.classList.add("sa-controls-disabled");


### PR DESCRIPTION
### Changes

Fixes `player-thumb` by simplifying a couple of its selectors. Only the first one needed to be changed, the second one is for consistency. There are likely still other addons with broken selectors but I haven't found any more yet.

### Tests

Tested on Helium
