### PR TITLE
Fix profile comments start in new line (`scratchr2`)

### DIFF
--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -58,11 +58,12 @@
 #comments .comment img.avatar {
   margin-right: 8px;
 }
-#comments .comment .avatar-wrapper {
-  margin-right: 0;
+#comments .comment .avatar-badge-wrapper {
+  margin-right: 8px;
 }
 #comments .comment .avatar-wrapper:not(.avatar-badge-wrapper) {
   float: none;
+  margin-right: 0;
 }
 #comments .comments .info,
 #comments .comments li ul li .comment .info {


### PR DESCRIPTION
Resolves #8815

### Changes

Undoes the new Scratch CSS that appear to be causing the problem.

### Tests

Tested in Chrome