### PR TITLE
Popup: remove Delete button and add Report button

### DIFF
--- a/addons-l10n/en/scratch-messaging.json
+++ b/addons-l10n/en/scratch-messaging.json
@@ -2,6 +2,7 @@
   "scratch-messaging/send-error": "Error sending comment",
   "scratch-messaging/popup-title": "Scratch Addons - Messaging",
   "scratch-messaging/open-new-tab": "Open comment in new tab",
+  "scratch-messaging/report": "Report",
   "scratch-messaging/reply": "Reply",
   "scratch-messaging/posting": "Posting...",
   "scratch-messaging/post": "Post",

--- a/addons-l10n/en/scratch-messaging.json
+++ b/addons-l10n/en/scratch-messaging.json
@@ -1,12 +1,7 @@
 {
   "scratch-messaging/send-error": "Error sending comment",
-  "scratch-messaging/deleting": "Deleting comment...",
-  "scratch-messaging/delete-error": "Error deleting comment - you might not have permission to do this.",
-  "scratch-messaging/deleted": "[deleted]",
   "scratch-messaging/popup-title": "Scratch Addons - Messaging",
   "scratch-messaging/open-new-tab": "Open comment in new tab",
-  "scratch-messaging/delete": "Delete",
-  "scratch-messaging/delete-confirm": "Click to confirm deletion",
   "scratch-messaging/reply": "Reply",
   "scratch-messaging/posting": "Posting...",
   "scratch-messaging/post": "Post",

--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -842,10 +842,46 @@ const handleBanner = async () => {
   }
 };
 
-if (document.readyState !== "loading") {
+const handleReport = async () => {
+  // If the user clicked a Report button in the Messaging popup,
+  // click the corresponding Report button on the website.
+  if (!location.search.includes("sa-action=report")) return;
+
+  // Remove the URL parameter
+  const url = new URL(location);
+  url.searchParams.delete("sa-action");
+  history.replaceState(null, "", url);
+
+  // Check up to 50 times
+  for (let i = 0; i < 50; i++) {
+    const openedComment = document.querySelector(location.hash);
+    if (!openedComment) {
+      // If button not found, check in 0.25s
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    } else {
+      const reportBtn = openedComment.querySelector("[data-control='report'], .comment-report");
+
+      const isProfile = pathArr[0] === "users" && pathArr[2] === "";
+      if (isProfile) {
+        // On profile pages, wait for the page to finish scrolling
+        await new Promise((resolve) => setTimeout(resolve, 750));
+      }
+
+      reportBtn.click();
+      return;
+    }
+  }
+};
+
+const onPageLoad = () => {
   handleBanner();
+  handleReport();
+};
+
+if (document.readyState !== "loading") {
+  onPageLoad();
 } else {
-  window.addEventListener("DOMContentLoaded", handleBanner, { once: true });
+  window.addEventListener("DOMContentLoaded", onPageLoad, { once: true });
 }
 
 const isProfile = pathArr[0] === "users" && pathArr[2] === "";

--- a/popups/scratch-messaging/api.js
+++ b/popups/scratch-messaging/api.js
@@ -11,41 +11,6 @@ export class DetailedError extends Error {
   }
 }
 
-export async function deleteComment(addon, { resourceType, resourceId, commentId }) {
-  if (resourceType === "user") return deleteLegacyComment(addon, { resourceType, resourceId, commentId });
-  const resourceTypeUrl = resourceType === "project" ? "project" : "studio";
-  const xToken = await addon.auth.fetchXToken();
-  return fetch(
-    `https://api.scratch.mit.edu/proxy/comments/${resourceTypeUrl}/${resourceId}/comment/${commentId}?sareferer`,
-    {
-      headers: {
-        "content-type": "application/json",
-        "x-csrftoken": addon.auth.csrfToken,
-        "x-token": xToken,
-      },
-      method: "DELETE",
-    }
-  ).then((resp) => {
-    if (!resp.ok)
-      throw HTTPError.fromResponse(`Deleting ${resourceTypeUrl} comment ${commentId} of ${resourceId} failed`, resp);
-  });
-}
-
-const deleteLegacyComment = async (addon, { resourceType, resourceId, commentId }) => {
-  return fetch(`https://scratch.mit.edu/site-api/comments/${resourceType}/${resourceId}/del/?sareferer`, {
-    headers: {
-      "content-type": "application/json",
-      "x-csrftoken": addon.auth.csrfToken,
-      "x-requested-with": "XMLHttpRequest",
-    },
-    body: JSON.stringify({ id: String(commentId) }),
-    method: "POST",
-  }).then((resp) => {
-    if (!resp.ok)
-      throw HTTPError.fromResponse(`Deleting ${resourceType} comment ${commentId} of ${resourceId} failed`, resp);
-  });
-};
-
 export async function dismissAlert(addon, alertId) {
   return fetch("https://scratch.mit.edu/site-api/messages/messages-delete/?sareferer", {
     headers: {

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -205,11 +205,11 @@ a.message-type-title-text {
 [dir="rtl"] .popout-comment {
   transform: scaleX(-1);
 }
-.delete-btn {
+.comment a.delete-btn {
   float: right;
   opacity: 0;
   color: var(--gray-text);
-  font-size: 0.65rem;
+  font-size: 0.75rem;
   padding-top: 2px;
   user-select: none;
 }

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -213,10 +213,6 @@ a.message-type-title-text {
   padding-top: 2px;
   user-select: none;
 }
-.delete-confirm {
-  font-weight: bold;
-  color: var(--red);
-}
 .child-comment {
   margin-inline-start: 3em;
 }

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -47,13 +47,7 @@
             />
           </a>
         </span>
-        <a
-          class="delete-btn"
-          rel="noopener noreferrer"
-          target="_blank"
-          :href="reportURL"
-          >{{ messages.reportMsg }}
-        </a>
+        <a class="delete-btn" rel="noopener noreferrer" target="_blank" :href="reportURL">{{ messages.reportMsg }} </a>
         <bdo dir="ltr">
           <!-- prevents LTR comments from being messed up in RTL layout - not ideal, but consistent with Scratch -->
           <div class="comment-content" :class="{'comment-self' : thisComment.author === username}">

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -47,6 +47,13 @@
             />
           </a>
         </span>
+        <a
+          class="delete-btn"
+          rel="noopener noreferrer"
+          target="_blank"
+          :href="reportURL"
+          >{{ messages.reportMsg }}
+        </a>
         <bdo dir="ltr">
           <!-- prevents LTR comments from being messed up in RTL layout - not ideal, but consistent with Scratch -->
           <div class="comment-content" :class="{'comment-self' : thisComment.author === username}">

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -36,7 +36,7 @@
           href="https://scratch.mit.edu/users/{{ thisComment.author }}/"
           >{{ thisComment.author }}</a
         >{{ thisComment.scratchTeam ? "*" : "" }}
-        <span class="comment-time" v-show="deleteStep !== 1 && !deleted">
+        <span class="comment-time">
           · {{ commentTimeAgo }}
           <a rel="noopener noreferrer" target="_blank" :href="commentURL">
             <img
@@ -47,23 +47,11 @@
             />
           </a>
         </span>
-        <a
-          @click="deleteComment()"
-          @keydown.enter="deleteComment()"
-          tabindex="0"
-          class="delete-btn"
-          :class="{'delete-confirm': deleteStep === 1}"
-          v-show="!deleted"
-          v-if="canDeleteComment"
-          >{{ deleteStep === 0 ? messages.deleteMsg : messages.deleteConfirmMsg }}
-        </a>
         <bdo dir="ltr">
           <!-- prevents LTR comments from being messed up in RTL layout - not ideal, but consistent with Scratch -->
           <div class="comment-content" :class="{'comment-self' : thisComment.author === username}">
             <div class="comment-content-text">
-              <span v-show="deleting">{{ messages.deletingMsg }}</span>
-              <span v-show="deleted && !deleting">{{ messages.deletedMsg }}</span>
-              <dom-element-renderer :element="thisComment.content" v-show="!deleted"></dom-element-renderer>
+              <dom-element-renderer :element="thisComment.content"></dom-element-renderer>
             </div>
             <a
               class="reply-button-comment"
@@ -72,7 +60,6 @@
               @keydown.enter="replying = true"
               :class="{'replying': replying}"
               :style="{'visibility': replying ? 'hidden' : 'visible'}"
-              v-show="!deleted"
               >{{ messages.replyMsg }}</a
             >
           </div>

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -52,20 +52,13 @@ export default async ({ addon, msg, safeMsg }) => {
       return {
         replying: false,
         replyBoxValue: "",
-        deleted: false,
-        deleting: false,
-        deleteStep: 0,
         postingComment: false,
         messages: {
           openNewTabMsg: msg("open-new-tab"),
-          deleteMsg: msg("delete"),
-          deleteConfirmMsg: msg("delete-confirm"),
           replyMsg: msg("reply"),
           postingMsg: msg("posting"),
           postMsg: msg("post"),
           cancelMsg: msg("cancel"),
-          deletedMsg: msg("deleted"),
-          deletingMsg: msg("deleting"),
         },
       };
     },
@@ -157,46 +150,8 @@ export default async ({ addon, msg, safeMsg }) => {
             this.postingComment = false;
           });
       },
-      deleteComment() {
-        if (this.deleteStep === 0) {
-          setTimeout(() => (this.deleteStep = 1), 250);
-          setTimeout(() => {
-            if (this.deleteStep === 1) this.deleteStep = 0;
-          }, 5000);
-          return;
-        }
-        this.deleted = true;
-        this.deleting = true;
-        API.deleteComment(addon, {
-          resourceType: this.resourceType,
-          resourceId: this.resourceId,
-          commentId: Number(this.commentId.substring(2)),
-        })
-          .then(() => {
-            if (this.isParent) this.thisComment.children = [];
-          })
-          .catch((e) => {
-            console.error("Error while deleting a comment: ", e);
-            alert(msg("delete-error"));
-            this.deleteStep = 0;
-            this.deleted = false;
-          })
-          .finally(() => {
-            this.deleting = false;
-          });
-      },
     },
     computed: {
-      canDeleteComment() {
-        switch (this.resourceType) {
-          case "user":
-            return this.resourceId === this.username;
-          case "project":
-            return this.thisComment.projectAuthor === this.username;
-          default:
-            return true; // Studio comment deletion is complex, just assume we can
-        }
-      },
       thisComment() {
         return this.commentsObj[this.commentId];
       },

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -55,6 +55,7 @@ export default async ({ addon, msg, safeMsg }) => {
         postingComment: false,
         messages: {
           openNewTabMsg: msg("open-new-tab"),
+          reportMsg: msg("report"),
           replyMsg: msg("reply"),
           postingMsg: msg("posting"),
           postMsg: msg("post"),
@@ -184,6 +185,11 @@ export default async ({ addon, msg, safeMsg }) => {
           this.resourceId
         }/${commentPath}#comments-${this.commentId.substring(2)}`;
       },
+      reportURL() {
+        const url = new URL(this.commentURL);
+        url.searchParams.set("sa-action", "report");
+        return url.href;
+      }
     },
     watch: {
       replying(newVal) {

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -189,7 +189,7 @@ export default async ({ addon, msg, safeMsg }) => {
         const url = new URL(this.commentURL);
         url.searchParams.set("sa-action", "report");
         return url.href;
-      }
+      },
     },
     watch: {
       replying(newVal) {


### PR DESCRIPTION
Resolves #477

### Changes

- Replaces the Delete button with a Report button.
- Clicking the Report button takes you to the selected comment on Scratch and then opens the Report confirmation dialog.

### Reason for changes

- Reporting comments is a more valuable action than deleting comments.
- Not all comments can be deleted, so never showing the option to delete comments (which would expand into an even longer "click to confirm deletion" button) maintains consistency and space for other UI elements.
- The majority of comments are never deleted.
- It's easier to repurpose an existing element (lol).

### Tests

Tested with profile and project comments (no comments were reported).