### PR TITLE
Webpages: Simpler "nolink" selector

### DIFF
--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -85,10 +85,6 @@ body {
   box-shadow: var(--content-shadow);
 }
 
-.title a {
-  color: var(--content-text);
-}
-
 .title-placeholder {
   display: inline-block;
   vertical-align: middle;

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -128,9 +128,6 @@ button > .small-icon {
     margin-inline-start: 10px;
   }
 }
-a.message-type-title-text {
-  color: var(--content-text);
-}
 .float-right {
   margin-inline-start: 6px;
   white-space: nowrap;
@@ -179,15 +176,15 @@ a.message-type-title-text {
   /* For multi-line comments */
   white-space: break-spaces;
 }
-.comment-author {
+a.comment-author {
   font-weight: 500;
   color: var(--dark-red-text);
 }
-.comment-me .comment-author {
+.comment-me a.comment-author {
   font-weight: 700;
   color: var(--green-text);
 }
-.unread .comment-author {
+.unread a.comment-author {
   font-weight: 700;
 }
 .comment-time {

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -45,7 +45,6 @@ button {
 
 .message-type-title {
   font-size: 14px;
-  color: var(--content-text);
   padding: 6px;
   padding-inline-end: 9px;
   cursor: default;
@@ -176,15 +175,15 @@ button > .small-icon {
   /* For multi-line comments */
   white-space: break-spaces;
 }
-a.comment-author {
+.comment-author {
   font-weight: 500;
   color: var(--dark-red-text);
 }
-.comment-me a.comment-author {
+.comment-me .comment-author {
   font-weight: 700;
   color: var(--green-text);
 }
-.unread a.comment-author {
+.unread .comment-author {
   font-weight: 700;
 }
 .comment-time {

--- a/popups/scratch-messaging/popup.html
+++ b/popups/scratch-messaging/popup.html
@@ -30,7 +30,7 @@
         :class="{'child-comment': !isParent, 'unread': unread, 'comment-me' : thisComment.author === username}"
       >
         <a
-          class="comment-author nolink"
+          class="comment-author"
           rel="noopener noreferrer"
           target="_blank"
           href="https://scratch.mit.edu/users/{{ thisComment.author }}/"

--- a/webpages/styles/components/popup.css
+++ b/webpages/styles/components/popup.css
@@ -38,10 +38,10 @@ a {
   cursor: pointer;
   text-decoration: none;
 }
-a[href] {
+[href] {
   color: var(--blue-text);
 }
-a.nolink {
+.nolink {
   color: var(--content-text);
 }
 a:hover {

--- a/webpages/styles/components/popup.css
+++ b/webpages/styles/components/popup.css
@@ -38,8 +38,11 @@ a {
   cursor: pointer;
   text-decoration: none;
 }
-a[href]:not(.nolink) {
+a[href] {
   color: var(--blue-text);
+}
+a.nolink {
+  color: var(--content-text);
 }
 a:hover {
   text-decoration: underline;


### PR DESCRIPTION
The selector below has a specificity of `0, 2, 1`.
```css
a[href]:not(.nolink)
```

So I replaced its rule with [less specific ones](https://github.com/DNin01/ScratchAddons/blob/b30521d5e781197b7d98c1604a9a451e6160784a/webpages/styles/components/popup.css#L37-L46) (and removed style rules that were unnecessary after this). The new selectors are:
```css
[href]
.nolink
```

This shouldn't have altered any visual elements, but it makes it easier for custom colors to be applied to links with CSS.

---

Related: #8824