### PR TITLE
Use ESLint 9.x

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -28,6 +28,6 @@ jobs:
 
       - name: Run ESLint
         run: |
-          npm i globals@^17.3.0 @eslint/js@^9.39.2 @eslint/eslintrc
+          npm i globals@^17.3.0 eslint@^9.39.2 @eslint/js@^9.39.2 @eslint/eslintrc
           npx eslint . --config eslint.config.mjs
 


### PR DESCRIPTION
### Resolves

> @Samq64 • https://github.com/ScratchAddons/ScratchAddons/pull/8836#issuecomment-3886815452
>
> It might be a good idea to pin the ESLint version to 10.x and update it on our own schedule.

### Changes

Uses `globals` version `^17.3.0` and `@eslint/js` version `^9.39.2`.

### Reason for changes

Major ESLint updates may have breaking changes. ESLint 10 added new rule recommendations which caused some checks to fail.

### Related

#8836 is ready for when we update to ESLint 10.