### PR TITLE
Fix stage header when `dark-www` and `scratch3to2` are active simultaneously

### DIFF
--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -186,7 +186,10 @@
 }
 :root:not(.sa-editor) [class*="stage-header_stage-header-wrapper_"],
 :root:not(.sa-editor) [class*="stage-header_stage-header-wrapper-overlay_"] /* embeds */ {
-  background-image: linear-gradient(var(--darkWww-page, white), color-mix(in srgb, var(--darkWww-page, white), black 10%));
+  background-image: linear-gradient(
+    var(--darkWww-page, white),
+    color-mix(in srgb, var(--darkWww-page, white), black 10%)
+  );
   border: 1px solid var(--darkWww-border-15, #d0d1d2);
   border-bottom: none;
   border-radius: 8px 8px 0 0;
@@ -332,7 +335,7 @@
   background-color: transparent;
 }
 :root:not(.sa-editor) [class*="stage_stage_"] {
-  border-color: #d0d1d2;
+  border-color: var(--darkWww-border-15, #d0d1d2);
   border-radius: 0;
 }
 @media (max-width: 767px) {
@@ -343,7 +346,7 @@
   }
 }
 :root:not(.sa-editor) [class*="stage-wrapper_full-screen_"] [class*="stage_stage_"] /* embeds */ {
-  border: 1px solid #d0d1d2;
+  border: 1px solid var(--darkWww-border-15, #d0d1d2);
 }
 :root:not(.sa-editor) [class*="stage_green-flag-overlay-wrapper_"] {
   top: 1px;


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves https://discord.com/channels/806602307750985799/1469856099590213683

### Changes

<!-- Please describe the changes you've made. Add any screenshots or videos here if applicable. -->

Updated the `scratch3to2` addon's userstyle to apply the page background and border colors from `dark-www` on the stage header, if the latter is enabled. If `dark-www` is enabled, the gradient uses the colors from "Page background" and a darker variant.

### `dark-www` disabled

<img width="616" height="262" alt="image" src="https://github.com/user-attachments/assets/8194ddc7-dc34-4af1-b5b3-5ee39debdb00" />

### `dark-www` enabled

<img width="621" height="245" alt="image" src="https://github.com/user-attachments/assets/a4ad8471-67bd-42dc-891a-a5ebacfca8e9" />

### Reason for changes

<!-- Why should these changes be made? -->

This change ensures that colors are consistent when both `dark-www` and `scratch3to2` are enabled.

### Tests

<!-- Please test your changes in at least one browser and add any known issues or other testing notes here. Bigger changes should be tested on both Chrome and Firefox. -->

Tested on Microsoft Edge 145.0.3800.65.
