### PR TITLE
Fix forum-search addon by using ScratchPost API instead of ScratchDB

### DIFF
--- a/addons-l10n/en/forum-search.json
+++ b/addons-l10n/en/forum-search.json
@@ -1,6 +1,6 @@
 {
-  "forum-search/loading": "Loading...",
-  "forum-search/error": "Error loading from ScratchDB!",
+  "forum-search/loading": "Loading more results...",
+  "forum-search/error": "Error loading from ScratchPost!",
   "forum-search/none": "Your search returned no results",
   "forum-search/username": "Username:",
   "forum-search/posts-here": "User Posts Here",
@@ -8,6 +8,7 @@
   "forum-search/last-edited-by": "Last edited by {username} ({datetime})",
   "forum-search/placeholder": "Search posts",
   "forum-search/relevance": "relevance",
+  "forum-search/popularity": "popularity",
   "forum-search/newest": "newest",
   "forum-search/oldest": "oldest",
   "forum-search/filter-placeholder": {

--- a/addons-l10n/en/forum-search.json
+++ b/addons-l10n/en/forum-search.json
@@ -1,5 +1,5 @@
 {
-  "forum-search/loading": "Loading more results...",
+  "forum-search/loading": "Loading...",
   "forum-search/error": "Error loading from ScratchPost!",
   "forum-search/none": "Your search returned no results",
   "forum-search/username": "Username:",

--- a/addons/forum-search/addon.json
+++ b/addons/forum-search/addon.json
@@ -9,6 +9,10 @@
       "name": "Hans5958"
     },
     {
+      "name": "redspacecat",
+      "link": "https://scratch.mit.edu/users/redspacecat"
+    },
+    {
       "name": "-gr",
       "link": "https://scratch.mit.edu/users/-gr"
     }

--- a/addons/forum-search/addon.json
+++ b/addons/forum-search/addon.json
@@ -1,12 +1,16 @@
 {
   "name": "Forum search",
-  "description": "Adds a post search bar to the forums. Uses ScratchDB for information.",
+  "description": "Adds a post search bar to the forums. Posts fetched from ScratchPost.",
   "credits": [
     {
       "name": "DatOneLefty"
     },
     {
       "name": "Hans5958"
+    },
+    {
+      "name": "-gr",
+      "link": "https://scratch.mit.edu/users/-gr"
     }
   ],
   "dynamicEnable": true,

--- a/addons/forum-search/userscript.js
+++ b/addons/forum-search/userscript.js
@@ -83,8 +83,13 @@ function parseFilterParams(filter) {
   const topicMatch = filter.match(/topic\.id\s*=\s*(\d+)/i);
   if (topicMatch) params.topic = topicMatch[1];
 
-  const categoryMatch = filter.match(/topic\.category\s*=\s*"([^"]+)"/i);
-  if (categoryMatch) params.category = categoryMatch[1];
+  const categoryMatch = filter.match(/topic\.category\s*=\s*(?:"([^"]+)"|(\d+))/i);
+  if (categoryMatch) {
+    const categoryValue = Number.parseInt(categoryMatch[1] ?? categoryMatch[2], 10);
+    if (!Number.isNaN(categoryValue)) {
+      params.category = categoryValue;
+    }
+  }
 
   const postMatch = filter.match(/post\.id\s*=\s*(\d+)/i);
   if (postMatch) params.post = postMatch[1];
@@ -113,13 +118,13 @@ function appendSearch(box, query, filter, page, term, msg) {
   }
 
   const filterParams = parseFilterParams(filter);
-  const categoryParam = filterParams.category || "all";
+  const categoryParam = Number.isInteger(filterParams.category) ? filterParams.category : 0;
   delete filterParams.category;
 
   const searchParams = new URLSearchParams({
     q: query,
     mode,
-    category: categoryParam,
+    category: String(categoryParam),
     limit: String(limit),
     offset: String(offset),
     detail: "3",

--- a/addons/forum-search/userscript.js
+++ b/addons/forum-search/userscript.js
@@ -92,28 +92,6 @@ function parseFilterParams(filter) {
   return params;
 }
 
-/* Beginning of function below, but the old ScratchDB code just for reference.
-
-function appendSearch(box, query, filter, page, term, msg) {
-  if (!hasMoreResults && page > 0) return 0;
-  isCurrentlyProcessing = true;
-  let loading = document.createTextNode(msg("loading"));
-  currentPage = page;
-  box.appendChild(loading);
-  window
-    .fetch(
-      `https://scratchdb.lefty.one/search/indexes/forum_posts/search?attributesToSearchOn=content&hitsPerPage=50&q=${encodeURIComponent(
-        query
-      )}&filter=${encodeURIComponent(filter)}&page=${page + 1}${
-        term === "newest" ? "&sort=id:desc" : term === "oldest" ? "&sort=id:asc" : ""
-      }`,
-      {
-        headers: {
-          // Note: the following token is well-known and public.
-          authorization: "Bearer 3396f61ef5b02abf801096be5f0b0ee620de304dd92fc6045aeb99539cd0bec4",
-        },
-      }
-    )*/
 function appendSearch(box, query, filter, page, term, msg) {
   if (!hasMoreResults && page > 0) {
     return 0;


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #8847

### Changes

- Updated `forum-search` addon to use [ScratchPost](https://scratchpost.quuq.dev) API instead of now defunct ScratchDB.
- Added 'popularity' sort mode to forum search dropdown to align with mode & sort options in the ScratchPost API 

### Reason for changes

The `forum-search` addon has been broken for a long time because ScratchDB hasn't worked in a long time. @redspacecat made a new forum indexer called ScratchPost and that can be used to search for forum posts. ScratchPost is the recommended method for searching for forum posts in the [Guide to Finding Duplicates](https://scratch.mit.edu/discuss/topic/867706/) on the Scratch Forums, and [approved of by Scratch Team member Paddle2See](https://scratch.mit.edu/discuss/post/8993955/).

### Tests

Tested and working on Chromium 145.0.7632.75 and Firefox 148.0b15.
