### PR TITLE
Rename Blockly renderer from scratch to scratch_classic

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -323,7 +323,7 @@ export default async function ({ addon, console, msg }) {
       return hat;
     };
 
-    const ScratchRenderer = Blockly.registry.getClass(Blockly.registry.Type.RENDERER, "scratch");
+    const ScratchRenderer = Blockly.registry.getClass(Blockly.registry.Type.RENDERER, "scratch_classic");
     const oldMakeDrawer = ScratchRenderer.prototype.makeDrawer_;
     ScratchRenderer.prototype.makeDrawer_ = function (...args) {
       const drawer = oldMakeDrawer.call(this, ...args);

--- a/addons/custom-block-shape/modern-blockly.js
+++ b/addons/custom-block-shape/modern-blockly.js
@@ -4,7 +4,7 @@ export default async function ({ addon, console }) {
   const Blockly = await addon.tab.traps.getBlockly();
   if (!Blockly.registry) return;
 
-  const ScratchRenderer = Blockly.registry.getClass(Blockly.registry.Type.RENDERER, "scratch");
+  const ScratchRenderer = Blockly.registry.getClass(Blockly.registry.Type.RENDERER, "scratch_classic");
   const oldScratchRendererMakeConstants = ScratchRenderer.prototype.makeConstants_;
   ScratchRenderer.prototype.makeConstants_ = function () {
     const constants = oldScratchRendererMakeConstants.call(this);


### PR DESCRIPTION
### Changes

Renames a couple Blockly renderer class references from `scratch` to `scratch_classic` to fix those addons on new Blockly.

### Tests

Tested on Helium. I did not test with the Scratch membership and additional might need to be made for those with its variant of cat blocks enabled.