### PR TITLE
live-featured-project: always show auto-play setting

### DIFF
--- a/addons/live-featured-project/addon.json
+++ b/addons/live-featured-project/addon.json
@@ -70,10 +70,7 @@
       "id": "autoPlay",
       "name": "Auto-play projects",
       "type": "boolean",
-      "default": false,
-      "if": {
-        "settings": { "alternativePlayer": ["turbowarp", "forkphorus"] }
-      }
+      "default": false
     },
     {
       "id": "enableTWAddons",


### PR DESCRIPTION
The live featured project addon's autoplay setting works with all players, but it was marked as "for alternative players" in #753 and latter hidden completely if the player was set to Scratch. This PR makes it always visible, which has always been the intended behavior.