### PR TITLE
Update links to Blockly source code

### DIFF
--- a/addons/columns/userscript.js
+++ b/addons/columns/userscript.js
@@ -15,7 +15,7 @@ export default async function ({ addon, msg, console }) {
   ];
 
   // https://github.com/scratchfoundation/scratch-blocks/blob/893c7e7ad5bfb416eaed75d9a1c93bdce84e36ab/core/toolbox.js#L235
-  // https://github.com/google/blockly/blob/60b7ee1/core/toolbox/toolbox.ts#L683
+  // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/toolbox/toolbox.ts#L694
   const _ToolboxPosition = Blockly.Toolbox.prototype.position;
   Blockly.Toolbox.prototype.position = function () {
     _ToolboxPosition.call(this);
@@ -31,7 +31,7 @@ export default async function ({ addon, msg, console }) {
   };
 
   // https://github.com/scratchfoundation/scratch-blocks/blob/893c7e7ad5bfb416eaed75d9a1c93bdce84e36ab/core/flyout_vertical.js#L314
-  // https://github.com/google/blockly/blob/60b7ee1/core/flyout_vertical.ts#L125
+  // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/flyout_vertical.ts#L125
   const _VerticalFlyoutPosition = Blockly.VerticalFlyout.prototype.position;
   Blockly.VerticalFlyout.prototype.position = function () {
     _VerticalFlyoutPosition.call(this);
@@ -132,7 +132,7 @@ export default async function ({ addon, msg, console }) {
   if (Blockly.registry) {
     // new Blockly
 
-    // https://github.com/google/blockly/blob/60b7ee1/core/toolbox/toolbox.ts#L185
+    // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/toolbox/toolbox.ts#L185
     const _ToolboxCreateDom = Blockly.Toolbox.prototype.createDom_;
     Blockly.Toolbox.prototype.createDom_ = function (...args) {
       const container = _ToolboxCreateDom.call(this, ...args);
@@ -158,7 +158,7 @@ export default async function ({ addon, msg, console }) {
       return container;
     };
 
-    // https://github.com/google/blockly/blob/60b7ee1/core/toolbox/toolbox.ts#L380
+    // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/toolbox/toolbox.ts#L391
     const _ToolboxRenderContents = Blockly.Toolbox.prototype.renderContents_;
     Blockly.Toolbox.prototype.renderContents_ = function (toolboxDef) {
       /* Separate extensions from core categories */
@@ -178,14 +178,14 @@ export default async function ({ addon, msg, console }) {
       this.contentsDiv_ = originalTable;
     };
 
-    // https://github.com/google/blockly/blob/60b7ee1/core/toolbox/toolbox.ts#L895
+    // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/toolbox/toolbox.ts#L906
     const _ToolboxSelectItem = Blockly.Toolbox.prototype.selectItem_;
     Blockly.Toolbox.prototype.selectItem_ = function (oldItem, newItem) {
       _ToolboxSelectItem.call(this, oldItem, newItem);
       Blockly.utils.aria.setState(this.secondTable, Blockly.utils.aria.State.ACTIVEDESCENDANT, newItem.getId());
     };
 
-    // https://github.com/google/blockly/blob/60b7ee1/core/toolbox/toolbox.ts#L878
+    // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/toolbox/toolbox.ts#L889
     const _ToolboxDeselectItem = Blockly.Toolbox.prototype.deselectItem_;
     Blockly.Toolbox.prototype.deselectItem_ = function (item) {
       _ToolboxDeselectItem.call(this, item);
@@ -244,7 +244,7 @@ export default async function ({ addon, msg, console }) {
   }
 
   // https://github.com/scratchfoundation/scratch-blocks/blob/d374085e42a84d8aaf10f1ef3fb6ec6e9f1b7cf4/core/scrollbar.js#L700
-  // https://github.com/google/blockly/blob/60b7ee1/core/scrollbar.ts#L711
+  // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/scrollbar.ts#L711
   const _ScrollbarOnMouseDownBarName = Blockly.registry ? "onMouseDownBar" : "onMouseDownBar_";
   const _ScrollbarOnMouseDownBar = Blockly.Scrollbar.prototype[_ScrollbarOnMouseDownBarName];
   Blockly.Scrollbar.prototype[_ScrollbarOnMouseDownBarName] = function (e) {

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -429,7 +429,7 @@ export default class DevTools {
       target.dispatchEvent(new KeyboardEvent("keydown", { keyCode: 67, ctrlKey: true }));
       if (next || blockOnly === 2) {
         // wait until the event has been fired
-        // see https://github.com/google/blockly/blob/fa4fce5/core/events/utils.ts#L113-L115
+        // see https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/events/utils.ts#L112-L114
         requestAnimationFrame(() => {
           setTimeout(() => {
             if (!blockly.registry && next) {

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -174,8 +174,8 @@ export default async function ({ addon, msg, console }) {
       // Call preventDefault() to make sure that the event only goes to scratch-blocks or scratch-paint.
       // Blockly.onKeyDown_:
       // https://github.com/scratchfoundation/scratch-blocks/blob/1421093/core/blockly.js#L185
-      // onKeyDown() in Blockly.inject module:
-      // https://github.com/google/blockly/blob/089179b/core/inject.ts#L294
+      // globalShortcutHandler() in Blockly:
+      // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/common.ts#L322
       // KeyboardShortcutsHOC.handleKeyPress:
       // https://github.com/scratchfoundation/scratch-paint/blob/8119055/src/hocs/keyboard-shortcuts-hoc.jsx#L29
       let isTargetInput;

--- a/addons/fix-editor-comments/userscript.js
+++ b/addons/fix-editor-comments/userscript.js
@@ -49,7 +49,7 @@ export default async function ({ addon, console }) {
    */
   if (Blockly.registry) {
     // new Blockly
-    // https://github.com/google/blockly/blob/e6e57dd/core/dragging/dragger.ts#L99
+    // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/dragging/dragger.ts#L104
     const originalOnDragEnd = Blockly.dragging.Dragger.prototype.onDragEnd;
     Blockly.dragging.Dragger.prototype.onDragEnd = function (...args) {
       if (!addon.self.disabled && addon.settings.get("straighten") && this.draggable.dropAnchor) {

--- a/addons/swap-local-global/addon.json
+++ b/addons/swap-local-global/addon.json
@@ -23,5 +23,5 @@
   "dynamicEnable": true,
   "dynamicDisable": true,
   "enabledByDefault": false,
-  "libraries": ["scratch-blocks"]
+  "libraries": ["blockly"]
 }

--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -51,7 +51,7 @@ export default async function ({ addon, msg, console }) {
     }
     if (ScratchBlocks.registry) {
       // new Blockly: can't use deleteVariable() because it also deletes references
-      // https://github.com/google/blockly/blob/fa4fce5/core/variable_map.ts#L288-L294
+      // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/variable_map.ts#L322-L330
       const variableMap = workspace.getVariableMap().variableMap;
       const variablesOfType = variableMap.get(variable.getType());
       if (variablesOfType && variablesOfType.has(variable.getId())) {
@@ -109,7 +109,7 @@ export default async function ({ addon, msg, console }) {
     if (ScratchBlocks.registry) {
       // new Blockly: we can't call fireNow() because it isn't exported,
       // but we can wait until the events have been fired
-      // see https://github.com/google/blockly/blob/fa4fce5/core/events/utils.ts#L113-L115
+      // see https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/events/utils.ts#L112-L114
       return new Promise((resolve) => {
         requestAnimationFrame(() => {
           setTimeout(resolve, 0);

--- a/libraries/common/cs/UndoGroup.js
+++ b/libraries/common/cs/UndoGroup.js
@@ -29,7 +29,7 @@ export default class UndoGroup {
     // Events (responsible for undoStack updates) are delayed with a setTimeout(f, 0)
     // https://github.com/scratchfoundation/scratch-blocks/blob/f159a1779e5391b502d374fb2fdd0cb5ca43d6a2/core/events.js#L182
     // New Blockly uses a setTimeout inside requestAnimationFrame
-    // https://github.com/google/blockly/blob/fa4fce5/core/events/utils.ts#L113-L115
+    // https://github.com/RaspberryPiFoundation/blockly/blob/39c4b58/packages/blockly/core/events/utils.ts#L112-L114
     requestAnimationFrame(() => {
       setTimeout(() => {
         const group = generateUID();

--- a/libraries/license-info.json
+++ b/libraries/license-info.json
@@ -87,5 +87,8 @@
   },
   "scratch-flash": {
     "license": "GPL-2.0"
+  },
+  "blockly": {
+    "license": "Apache-2.0"
   }
 }


### PR DESCRIPTION
Updates links to point to the Blockly repo's new location. Also changes `scratch-blocks` to `blockly` in the `libraries` field of an addon that uses code from Blockly.