### PR TITLE
cat-blocks & editor-theme3: fix duplicated menu items

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -541,7 +541,7 @@ export default async function ({ addon, console, msg }) {
 
   while (true) {
     const themeSubmenu = await addon.tab.waitForElement(
-      "[class*=menu-bar_menu-bar-menu_] > ul > li:nth-child(2):not(:last-child) > ul > ul",
+      "[class*=menu-bar_menu-bar-menu_] > ul > li:nth-child(2):not(:last-child) [class*=menu_menu_]",
       {
         markAsSeen: true,
         reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,

--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -1030,7 +1030,7 @@ export default async function ({ addon, console, msg }) {
 
   while (true) {
     const colorModeSubmenu = await addon.tab.waitForElement(
-      "[class*=menu-bar_menu-bar-menu_] > ul > li:last-child > ul > ul",
+      "[class*=menu-bar_menu-bar-menu_] > ul > li:last-child [class*=menu_menu_]",
       {
         markAsSeen: true,
         reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,


### PR DESCRIPTION
Updates some selectors to fix menu items appearing twice (https://github.com/ScratchAddons/ScratchAddons/pull/8742#issuecomment-4013938960).