### PR TITLE
editor-dark-mode: fix menu scrollbars

### DIFF
--- a/addons/columns/style.css
+++ b/addons/columns/style.css
@@ -111,12 +111,6 @@
   font-size: 0.65rem;
 }
 
-[class*="extension-button_radiate_"]::before,
-[class*="extension-button_radiate_"]::after {
-  border-radius: 0.25rem;
-  clip-path: none;
-}
-
 /* hide-flyout compatibility */
 
 [class*="gui_tabs_"] {

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -469,6 +469,8 @@ img[class*="tool-select-base_tool-select-icon_"],
   border-color: var(--editorDarkMode-primary);
 }
 [class*="input_input-form_"]:not([class*="project-title-input_title-field_"]):hover,
+[class*="react-tabs_react-tabs__tab_"]:focus-visible,
+[class*="react-tabs_react-tabs__tab_"][class*="gui_tab_"][class*="gui_is-selected_"]:focus-visible,
 [class*="toggle-buttons_button_"]:focus::before,
 [class*="stage_frame_"],
 [class*="sprite-selector-item_sprite-selector-item_"]:hover,
@@ -737,9 +739,6 @@ div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="de
   color-scheme: light;
 }
 
-[class*="react-tabs_react-tabs__tab_"]:focus {
-  outline: revert;
-}
 [class*="react-tabs_react-tabs__tab_"]:focus::after {
   display: none;
 }

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -25,14 +25,10 @@
 /* Menu bar background */
 [class*="menu-bar_menu-bar_"],
 [class*="menu_menu_"],
-[class*="menu_submenu_"] > [class*="menu_menu_"]::-webkit-scrollbar-track,
 [class*="modal_header_"],
 [class*="webgl-modal_illustration"] {
   background-color: var(--editorDarkMode-menuBar);
   color: var(--editorDarkMode-menuBar-text);
-}
-[class*="menu_submenu_"] > [class*="menu_menu_"]::-webkit-scrollbar-thumb {
-  border-color: var(--editorDarkMode-menuBar);
 }
 [class*="menu-bar_menu-bar-item_"],
 [class*="input_input-form_"][class*="project-title-input_title-field_"],
@@ -91,9 +87,11 @@
 [class*="menu-bar_menu-bar-item_"][class*="menu-bar_hoverable_"]:hover,
 [class*="menu_menu-item_"][class*="menu_active_"],
 [class*="menu_menu-item_"]:hover,
-[class*="menu_menu-item_"][class*="menu_expanded_"],
-[class*="menu_submenu_"] > [class*="menu_menu_"]::-webkit-scrollbar-thumb {
+[class*="menu_menu-item_"][class*="menu_expanded_"] {
   background-color: var(--editorDarkMode-menuBar-border);
+}
+[class*="menu_submenu_"] > [class*="menu_menu_"] {
+  scrollbar-color: var(--editorDarkMode-menuBar-border) var(--editorDarkMode-menuBar);
 }
 
 /* Active tab background */

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -736,3 +736,10 @@ div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="de
   /* The <object> gets a white background if color-scheme is dark. */
   color-scheme: light;
 }
+
+[class*="react-tabs_react-tabs__tab_"]:focus {
+  outline: revert;
+}
+[class*="react-tabs_react-tabs__tab_"]:focus::after {
+  display: none;
+}

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -454,8 +454,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="audio-trimmer_selection-background_"],
 [class*="tag-button_tag-button_"]:not([class*="tag-button_active_"]),
 [class*="action-menu_button_"],
-[class*="context-menu_menu-item_"]:hover,
-.driver-popover[class*="tooltip-face-sensing"] {
+[class*="context-menu_menu-item_"]:hover {
   background-color: var(--editorDarkMode-primary);
   color: var(--editorDarkMode-primary-text);
 }
@@ -478,15 +477,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="stage-selector_stage-selector_"]:hover,
 [class*="drag-layer_image_"],
 [class*="sound-editor_button_"]:focus::before,
-[class*="library-item_library-item_"]:hover,
-.driver-popover[class*="tooltip-face-sensing"] {
+[class*="library-item_library-item_"]:hover {
   border-color: var(--editorDarkMode-primary);
-}
-.driver-popover-arrow.driver-popover-arrow-side-right[class*="driver-popover-arrow-align-"] {
-  border-right-color: var(--editorDarkMode-primary);
-}
-.driver-popover-arrow.driver-popover-arrow-side-left.driver-popover-arrow-align-start {
-  border-left-color: var(--editorDarkMode-primary);
 }
 .sa-editor input {
   outline-color: var(--editorDarkMode-primary);
@@ -546,22 +538,6 @@ img[class*="tool-select-base_tool-select-icon_"],
 }
 [class*="action-menu_main-button_"]:hover {
   box-shadow: 0 0 0 6px var(--editorDarkMode-primary-transparent35);
-}
-[class*="extension-button_radiate_"]::before,
-[class*="extension-button_radiate_"]::after,
-[class*="library-item_radiate_"]::before,
-[class*="library-item_radiate_"]::after {
-  animation-name: sa-radiate;
-  --radiate-color: var(--editorDarkMode-primary);
-}
-@keyframes sa-radiate {
-  0% {
-    box-shadow: 0 0 0 0 var(--radiate-color); /* for browsers that don't support color-mix */
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--radiate-color) 70%, transparent);
-  }
-  100% {
-    box-shadow: 0 0 0 20px transparent;
-  }
 }
 [class*="dial_gauge-path_"] {
   fill: var(--editorDarkMode-primary-transparent35);

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -469,8 +469,6 @@ img[class*="tool-select-base_tool-select-icon_"],
   border-color: var(--editorDarkMode-primary);
 }
 [class*="input_input-form_"]:not([class*="project-title-input_title-field_"]):hover,
-[class*="react-tabs_react-tabs__tab_"]:focus-visible,
-[class*="react-tabs_react-tabs__tab_"][class*="gui_tab_"][class*="gui_is-selected_"]:focus-visible,
 [class*="toggle-buttons_button_"]:focus::before,
 [class*="stage_frame_"],
 [class*="sprite-selector-item_sprite-selector-item_"]:hover,
@@ -737,8 +735,4 @@ div[class*="delete-confirmation-prompt_body_"] /* <-- specificity */ [class*="de
 .Popover .resize-sensor {
   /* The <object> gets a white background if color-scheme is dark. */
   color-scheme: light;
-}
-
-[class*="react-tabs_react-tabs__tab_"]:focus::after {
-  display: none;
 }


### PR DESCRIPTION
### Changes

Before:
<img width="264" height="182" alt="image" src="https://github.com/user-attachments/assets/db9eb024-902e-4f37-a360-5d405ef779d6" />

After:
<img width="273" height="181" alt="image" src="https://github.com/user-attachments/assets/c8856dfa-f24e-4f88-a00a-46362734873b" />

Also removes the CSS for face sensing notifications.

### Tests

Tested on Edge and Firefox.