### PR TITLE
scratchr2: fix text shadows

### DIFF
--- a/addons/scratchr2/forums.css
+++ b/addons/scratchr2/forums.css
@@ -260,6 +260,7 @@ body > #pagewrapper {
   overflow: visible;
   background-color: var(--darkWww-gray, #f2f2f2);
   color: var(--darkWww-gray-text, #575e75);
+  text-shadow: none;
   box-shadow: 1px 0 var(--darkWww-box-border, #d9d9d9);
 }
 .djangobb .blockpost dl {

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -86,6 +86,7 @@
   width: 293px;
   padding: 0;
   color: var(--darkWww-page-text, #575e75);
+  text-shadow: none;
 }
 .box .box-head .portrait {
   height: 64px;
@@ -255,6 +256,7 @@
   margin-top: 10px;
   background-color: var(--darkWww-input, #fafafa);
   color: var(--darkWww-input-text, #575e75);
+  text-shadow: none;
 }
 .profile-box-footer-module textarea::placeholder {
   color: var(--darkWww-input-transparentText, rgba(87, 94, 117, 0.6));

--- a/addons/scratchr2/scratchr2.css
+++ b/addons/scratchr2/scratchr2.css
@@ -215,6 +215,7 @@ select:focus {
   background-color: var(--darkWww-gray, #f2f2f2);
   border-color: var(--darkWww-box-border, #d9d9d9);
   box-shadow: none;
+  text-shadow: none;
 }
 .box .box-content,
 .box .box-content .inner {

--- a/addons/scratchr2/scratchr2_comments.css
+++ b/addons/scratchr2/scratchr2_comments.css
@@ -113,6 +113,7 @@
 #comments .highlighted {
   background: var(--darkWww-blue-20, rgba(77, 151, 255, 0.1));
   color: var(--darkWww-box-text, #575e75);
+  text-shadow: none;
   box-shadow: 0 0 0 8px var(--darkWww-blue-20, rgba(77, 151, 255, 0.1));
   border-radius: 8px;
 }


### PR DESCRIPTION
### Changes

Someone reported the issue on Scratch:

> The brighter the gray background in website customizable colors the more likely the words are gonna be bold in page titles in 2.0 styled pages even with Scratch 2.0 -> 3.0 on.

This happened when 2.0 → 3.0 was enabled and the gray background setting in website dark mode was set to white or another very light color. The "bold words" were caused by white text being drawn with a white text shadow:

<img width="427" height="72" alt="image" src="https://github.com/user-attachments/assets/13a153c6-ec9c-4e2a-9f7e-7893aa4c614b" />

### Tests

Tested on Edge.