### PR TITLE
Add more menu items with `editor-random-direction-block`

### DIFF
--- a/addons-l10n/en/editor-random-direction-block.json
+++ b/addons-l10n/en/editor-random-direction-block.json
@@ -1,0 +1,4 @@
+{
+  "editor-random-direction-block/next-costume": "next costume",
+  "editor-random-direction-block/previous-costume": "previous costume"
+}

--- a/addons/editor-extra-keys/addon.json
+++ b/addons/editor-extra-keys/addon.json
@@ -37,6 +37,7 @@
       "matches": ["projects"]
     }
   ],
+  "relatedAddons": ["editor-random-direction-block"],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "versionAdded": "1.20.0"

--- a/addons/editor-random-direction-block/addon.json
+++ b/addons/editor-random-direction-block/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Point towards random direction block",
-  "description": "Adds a \"random direction\" option to the \"point towards ()\" block that makes the sprite point in a random direction. This will work for everyone using the project.",
+  "name": "Extended block menus",
+  "description": "Adds more menu options to some block dropdowns. These will work for everyone using the project.",
   "userscripts": [
     {
       "url": "userscript.js",
@@ -8,10 +8,48 @@
     }
   ],
   "versionAdded": "1.35.0",
-  "tags": ["editor", "codeEditor"],
+  "latestUpdate": {
+    "version": "1.46.0",
+    "newSettings": ["sameSprite", "nextCostume", "previousCostume"]
+  },
+  "info": [
+    {
+      "id": "nameChange",
+      "text": "This used to be the \"Point towards random direction block\" addon."
+    }
+  ],
+  "tags": ["editor", "codeEditor", "featured"],
+  "relatedAddons": ["editor-extra-keys"],
   "enabledByDefault": false,
   "dynamicEnable": true,
   "dynamicDisable": true,
+  "settings": [
+    {
+      "name": "Current sprite",
+      "id": "sameSprite",
+      "type": "boolean",
+      "description": "Allows you to select the current sprite in sprite menus, useful to refer to the parent sprite of a clone.",
+      "default": true
+    },
+    {
+      "name": "(Point towards) random direction",
+      "id": "randomDirection",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "(Switch to) next costume",
+      "id": "nextCostume",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "name": "(Switch to) previous costume",
+      "id": "previousCostume",
+      "type": "boolean",
+      "default": true
+    }
+  ],
   "credits": [
     {
       "name": "Tacodiva",
@@ -23,6 +61,14 @@
     },
     {
       "name": "emir4169"
+    },
+    {
+      "name": "d016",
+      "link": "https://scratch.mit.edu/users/d016/"
+    },
+    {
+      "name": "DNin01",
+      "link": "https://github.com/DNin01"
     }
   ]
 }

--- a/addons/editor-random-direction-block/userscript.js
+++ b/addons/editor-random-direction-block/userscript.js
@@ -1,27 +1,68 @@
-export default async function ({ addon, global, cons, msg }) {
+export default async function ({ addon, console, msg }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
+  const runtime = await addon.tab.traps.vm.runtime;
 
-  function appendRandomOption(menuOptions) {
-    if (!addon.self.disabled) {
-      if (!menuOptions.find((option) => option[1] === "_random_"))
-        menuOptions.push([ScratchBlocks.Msg.MOTION_POINTTOWARDS_RANDOM, "_random_"]);
+  function extendPointTowardsMenu(menuOptions) {
+    if (!addon.self.disabled && addon.settings.get("randomDirection")) {
+      if (!menuOptions.find((option) => option[1] === "_random_")) {
+        menuOptions.splice(1, 0, [ScratchBlocks.Msg.MOTION_POINTTOWARDS_RANDOM, "_random_"]);
+      }
+    }
+    return menuOptions;
+  }
+  function extendSwitchCostumeMenu(menuOptions) {
+    if (addon.self.disabled) return menuOptions;
+    if (addon.settings.get("nextCostume")) {
+      if (!menuOptions.find((option) => option[1] === "next costume")) {
+        menuOptions.push(["next costume", "next costume"]);
+      }
+    }
+    if (addon.settings.get("previousCostume")) {
+      if (!menuOptions.find((option) => option[1] === "previous costume")) {
+        menuOptions.push(["previous costume", "previous costume"]);
+      }
+    }
+    return menuOptions;
+  }
+  function extendSpriteMenu(menuOptions) {
+    if (!addon.self.disabled && addon.settings.get("sameSprite")) {
+      const currentSprite = runtime.getEditingTarget();
+      if (!currentSprite || currentSprite.isStage) return menuOptions;
+      const spriteName = currentSprite.getName();
+      if (!menuOptions.find((option) => option[1] === spriteName)) {
+        const insertIndex = menuOptions.findIndex((option) => option[1] === "_mouse_") + 1;
+        menuOptions.splice(insertIndex, 0, [spriteName, spriteName]);
+      }
     }
     return menuOptions;
   }
 
-  const block = ScratchBlocks.Blocks["motion_pointtowards_menu"];
-  const originalInit = block.init;
-  block.init = function (...args) {
-    const originalJsonInit = this.jsonInit;
-    this.jsonInit = function (obj) {
-      const originalOptionsMenu = obj.args0[0].options;
-      obj.args0[0].options = function (...args) {
-        return appendRandomOption(originalOptionsMenu.call(this, ...args));
+  let modifiedBlocks = [];
+  function setBlock(opcode, func) {
+    modifiedBlocks.push(opcode);
+    const block = ScratchBlocks.Blocks[opcode];
+    const originalInit = block.init;
+    block.init = function (...args) {
+      const originalJsonInit = this.jsonInit;
+      this.jsonInit = function (obj) {
+        const originalOptionsMenu = obj.args0[0].options;
+        obj.args0[0].options = function (...args) {
+          return func(originalOptionsMenu.call(this, ...args));
+        };
+        return originalJsonInit.call(this, obj);
       };
-      return originalJsonInit.call(this, obj);
+      originalInit.call(this, ...args);
     };
-    return originalInit.call(this, ...args);
-  };
+  }
+  setBlock("motion_pointtowards_menu", extendSpriteMenu);
+  setBlock("motion_pointtowards_menu", extendPointTowardsMenu);
+  setBlock("looks_costume", extendSwitchCostumeMenu);
+  setBlock("motion_goto_menu", extendSpriteMenu);
+  setBlock("motion_glideto_menu", extendSpriteMenu);
+  setBlock("control_create_clone_of_menu", extendSpriteMenu);
+  setBlock("sensing_touchingobjectmenu", extendSpriteMenu);
+  setBlock("sensing_distancetomenu", extendSpriteMenu);
+  setBlock("sensing_of_object_menu", extendSpriteMenu);
 
   const updateExistingBlocks = () => {
     const workspace = addon.tab.traps.getWorkspace();
@@ -29,22 +70,31 @@ export default async function ({ addon, global, cons, msg }) {
     if (workspace && flyout) {
       const allBlocks = [...workspace.getAllBlocks(), ...flyout.getWorkspace().getAllBlocks()];
       for (const block of allBlocks) {
-        if (block.type !== "motion_pointtowards_menu") {
-          continue;
-        }
+        if (!modifiedBlocks.includes(block.type)) continue;
         const input = block.inputList[0];
-        if (!input) {
-          continue;
-        }
+        if (!input) continue;
         const field = input.fieldRow.find((i) => i && typeof i.menuGenerator_ === "function");
-        if (!field) {
-          continue;
-        }
-        const originalMenuGenerator = field.menuGenerator_;
+        if (!field) continue;
 
-        field.menuGenerator_ = function (...args) {
-          return appendRandomOption(originalMenuGenerator.call(this, ...args));
-        };
+        const originalMenuGenerator = field.menuGenerator_;
+        switch (block.type) {
+          case "motion_pointtowards_menu": {
+            field.menuGenerator_ = function (...args) {
+              return extendPointTowardsMenu(originalMenuGenerator.call(this, ...args));
+            };
+            break;
+          }
+          case "looks_costume": {
+            field.menuGenerator_ = function (...args) {
+              return extendSwitchCostumeMenu(originalMenuGenerator.call(this, ...args));
+            };
+          }
+          default: {
+            field.menuGenerator_ = function (...args) {
+              return extendSpriteMenu(originalMenuGenerator.call(this, ...args));
+            };
+          }
+        }
       }
     }
   };

--- a/addons/editor-random-direction-block/userscript.js
+++ b/addons/editor-random-direction-block/userscript.js
@@ -14,12 +14,12 @@ export default async function ({ addon, console, msg }) {
     if (addon.self.disabled) return menuOptions;
     if (addon.settings.get("nextCostume")) {
       if (!menuOptions.find((option) => option[1] === "next costume")) {
-        menuOptions.push(["next costume", "next costume"]);
+        menuOptions.push([msg("next-costume"), "next costume"]);
       }
     }
     if (addon.settings.get("previousCostume")) {
       if (!menuOptions.find((option) => option[1] === "previous costume")) {
-        menuOptions.push(["previous costume", "previous costume"]);
+        menuOptions.push([msg("previous-costume"), "previous costume"]);
       }
     }
     return menuOptions;
@@ -88,6 +88,7 @@ export default async function ({ addon, console, msg }) {
             field.menuGenerator_ = function (...args) {
               return extendSwitchCostumeMenu(originalMenuGenerator.call(this, ...args));
             };
+            break;
           }
           default: {
             field.menuGenerator_ = function (...args) {


### PR DESCRIPTION
Resolves #6761
Resolves #8778
Supersedes #8865

### Changes

You can now add "next costume" and "previous costume" items to the "switch costume to" block menu and select the current sprite in sprite menus using the `editor-random-direction-block` addon.

### Reason for changes

- Scratch does not let you select the current editing target in sprite menus, which makes it harder to use the parent sprite of a clone as a reference.
- Selecting "previous costume" can be faster than setting up the blocks to decrement the costume number by 1.

### Notes

Tested in Edge 145.

Minimum release version: 1.46.0

Credits:
- Based on the work done by @e016 in #8865.