### PR TITLE
Remove remaining references to `global` and "`cons`"

### DIFF
--- a/addons/editor-compact/userscript.js
+++ b/addons/editor-compact/userscript.js
@@ -1,6 +1,6 @@
 import { eventTarget as tooltipUpdateEventTarget } from "./force-tooltip-update.js";
 
-export default async function ({ addon, global, console }) {
+export default async function ({ addon, console }) {
   // The workspace needs to be manually resized via a window resize event
   // whenever the addon modifies or stops modifying UI elements
   resizeWorkspace();

--- a/addons/editor-random-direction-block/userscript.js
+++ b/addons/editor-random-direction-block/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, global, cons, msg }) {
+export default async function ({ addon, console, msg }) {
   const ScratchBlocks = await addon.tab.traps.getBlockly();
 
   function appendRandomOption(menuOptions) {

--- a/addons/expanded-backpack/userscript.js
+++ b/addons/expanded-backpack/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, global, console }) {
+export default async function ({ addon, console }) {
   // fix area above the backpack displaying at the wrong height when addon settings are changed
   addon.settings.addEventListener("change", heightFix);
   addon.self.addEventListener("disabled", heightFix);

--- a/addons/necropost-highlighter/userscript.js
+++ b/addons/necropost-highlighter/userscript.js
@@ -5,7 +5,7 @@
  * to read actual dates.
  */
 
-export default async function ({ addon, global, console, msg }) {
+export default async function ({ addon, console, msg }) {
   // Default is a little over a month's worth of topics. Reasonably stable through 2022.
   // There's a lot of tolerance. Half or twice as many topics filter pretty much the same.
   const TOPICS_PER_MONTH = 7500;


### PR DESCRIPTION
A few addon userscripts still have the unused `global` parameter. This PR removes it and also corrects `cons` to `console`.