### PR TITLE
Do not capture Escape key when search empty

### DIFF
--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -673,8 +673,11 @@ let fuse;
       document.querySelector("#searchBox").focus();
     } else if (e.key === "Escape") {
       if (document.activeElement === document.querySelector("#searchBox")) {
-        if (vue.searchInputReal.length > 0) e.preventDefault();
-        vue.searchInputReal = "";
+        if (vue.searchInputReal.length > 0) {
+          // Escape is used to close extension popups, so we should only prevent it if there's input text to clear
+          e.preventDefault();
+          vue.searchInputReal = "";
+        }
       } else if (vue.categoryOpen && vue.smallMode) {
         vue.categoryOpen = false;
       } else {


### PR DESCRIPTION
Resolves #8864

Currently, pressing Escape clears the search box. This change allows the Escape key to close the extension's popup when the search box is already empty.

### Tests

Tested in Edge 146.