### PR TITLE
Fix shadows in More Settings modal

### DIFF
--- a/webpages/settings/components/modal.html
+++ b/webpages/settings/components/modal.html
@@ -35,6 +35,7 @@
   }
 
   .modal-header {
+    margin-bottom: 10px;
     display: flex;
     justify-content: space-between;
   }

--- a/webpages/styles/components/modal.css
+++ b/webpages/styles/components/modal.css
@@ -7,7 +7,8 @@
   color: var(--gray-text);
 }
 .settings-block {
-  margin-top: 20px;
+  margin: 0 -20px;
+  padding: 10px 20px; /* prevents shadows from being cut off */
   overflow-y: auto;
 }
 .more-settings .filter-selector {


### PR DESCRIPTION
Resolves #8907

### Changes

Changes margin and padding values to make shadows render correctly without changing the layout. This also moves the scrollbar (if there's one) to the edge of the modal, which I think looks better.

### Tests

Tested by increasing the opacity of shadows to make them more visible.