### PR TITLE
custom-zoom: add expanded workspace scrolling option

### DIFF
--- a/addons/custom-zoom/addon.json
+++ b/addons/custom-zoom/addon.json
@@ -6,6 +6,10 @@
     {
       "name": "ErrorGamer2000",
       "link": "https://scratch.mit.edu/users/ErrorGamer2000/"
+    },
+    {
+      "name": "griffpatch",
+      "link": "https://scratch.mit.edu/users/griffpatch/"
     }
   ],
   "versionAdded": "1.13.0",
@@ -23,6 +27,13 @@
     }
   ],
   "settings": [
+    {
+      "name": "Extended scrolling limit for code area",
+      "id": "expandWorkspace",
+      "type": "boolean",
+      "default": true,
+      "description": "Add extra scrollable space around your blocks so you can scroll further in all directions"
+    },
     {
       "name": "Maximum Zoom (100-500%)",
       "id": "maxZoom",

--- a/addons/custom-zoom/userscript.js
+++ b/addons/custom-zoom/userscript.js
@@ -1,3 +1,4 @@
+/** @param {AddonContext} param0 */
 export default async function ({ addon, console }) {
   const Blockly = await addon.tab.traps.getBlockly();
 
@@ -51,26 +52,33 @@ export default async function ({ addon, console }) {
 
         // Override with our expanded version
         workspace.getMetrics = function () {
-          // Get the original metrics
           const originalMetrics = originalGetMetrics.call(this);
+          // Scroll limits are in workspace coordinates, independent of toolbox screen position.
+          // Expand by half a viewport on each side — matches vertical which also uses viewHeight/2 per side.
+          const extraLeft = originalMetrics.viewWidth / 2;
+          const extraRight = originalMetrics.viewWidth / 2;
+          const totalExtraWidth = extraLeft + extraRight + (originalMetrics.toolboxWidth || 0);
+          const extraHeight = originalMetrics.viewHeight;
 
-          // Add half a screen width and height to each side of the content area
-          const screenWidth = window.innerWidth;
-          const screenHeight = window.innerHeight;
-          const extraWidth = screenWidth; // Half screen on each side = full screen total
-          const extraHeight = screenHeight; // Half screen on each side = full screen total
-
-          // Expand the content area - this is what defines the scrollable boundaries
-          return {
-            ...originalMetrics,
-            // Expand content dimensions
-            contentWidth: originalMetrics.contentWidth + extraWidth,
-            contentHeight: originalMetrics.contentHeight + extraHeight,
-            // Shift content position to center the original content in the expanded area
-            contentLeft: originalMetrics.contentLeft - extraWidth / 2,
-            contentTop: originalMetrics.contentTop - extraHeight / 2,
-            // Keep all other properties (view, toolbox, etc.) unchanged
-          };
+          if (Blockly.registry) {
+            // New Blockly: scrollable area is defined by scrollWidth/scrollHeight/scrollLeft/scrollTop
+            return {
+              ...originalMetrics,
+              scrollWidth: originalMetrics.scrollWidth + totalExtraWidth,
+              scrollHeight: originalMetrics.scrollHeight + extraHeight,
+              scrollLeft: originalMetrics.scrollLeft - extraLeft,
+              scrollTop: originalMetrics.scrollTop - extraHeight / 2,
+            };
+          } else {
+            // Old Blockly: scrollable area is defined by contentWidth/contentHeight/contentLeft/contentTop
+            return {
+              ...originalMetrics,
+              contentWidth: originalMetrics.contentWidth + totalExtraWidth,
+              contentHeight: originalMetrics.contentHeight + extraHeight,
+              contentLeft: originalMetrics.contentLeft - extraLeft,
+              contentTop: originalMetrics.contentTop - extraHeight / 2,
+            };
+          }
         };
 
         // Force Blockly to recalculate and redraw scrollbars with new metrics

--- a/addons/custom-zoom/userscript.js
+++ b/addons/custom-zoom/userscript.js
@@ -30,6 +30,8 @@ export default async function ({ addon, console }) {
     getElementAtPoint(e).dispatchEvent(new WheelEvent("wheel", e));
   });
 
+  let originalGetMetrics = null; // Store the original getMetrics function
+
   function update() {
     if (addon.tab.editorMode !== "editor") return;
 
@@ -39,6 +41,58 @@ export default async function ({ addon, console }) {
     zoomOptions.minScale = addon.settings.get("minZoom") / 100;
     zoomOptions.startScale = addon.settings.get("startZoom") / 100;
     zoomOptions.scaleSpeed = 1 + 0.2 * (addon.settings.get("zoomSpeed") / 100);
+
+    if (addon.settings.get("expandWorkspace")) {
+      // Override getMetrics to return expanded scrollable area
+      // Only override once to avoid multiple overrides
+      if (!originalGetMetrics && workspace.getMetrics) {
+        // Backup the original method
+        originalGetMetrics = workspace.getMetrics;
+
+        // Override with our expanded version
+        workspace.getMetrics = function () {
+          // Get the original metrics
+          const originalMetrics = originalGetMetrics.call(this);
+
+          // Add half a screen width and height to each side of the content area
+          const screenWidth = window.innerWidth;
+          const screenHeight = window.innerHeight;
+          const extraWidth = screenWidth; // Half screen on each side = full screen total
+          const extraHeight = screenHeight; // Half screen on each side = full screen total
+
+          // Expand the content area - this is what defines the scrollable boundaries
+          return {
+            ...originalMetrics,
+            // Expand content dimensions
+            contentWidth: originalMetrics.contentWidth + extraWidth,
+            contentHeight: originalMetrics.contentHeight + extraHeight,
+            // Shift content position to center the original content in the expanded area
+            contentLeft: originalMetrics.contentLeft - extraWidth / 2,
+            contentTop: originalMetrics.contentTop - extraHeight / 2,
+            // Keep all other properties (view, toolbox, etc.) unchanged
+          };
+        };
+
+        // Force Blockly to recalculate and redraw scrollbars with new metrics
+        workspace.resizeContents();
+        if (workspace.scrollbar) {
+          workspace.scrollbar.resize();
+        }
+        // Also trigger a resize event to update everything
+        workspace.resize();
+      }
+    } else if (originalGetMetrics) {
+      // Restore original getMetrics if we had overridden it before
+      workspace.getMetrics = originalGetMetrics;
+      originalGetMetrics = null;
+
+      // Force refresh when restoring original metrics too
+      workspace.resizeContents();
+      if (workspace.scrollbar) {
+        workspace.scrollbar.resize();
+      }
+      workspace.resize();
+    }
 
     const autohide = addon.settings.get("autohide");
     const blocklySvg = document.querySelector(".blocklySvg");
@@ -54,7 +108,8 @@ export default async function ({ addon, console }) {
   }
 
   if (!addon.self.enabledLate) {
-    addon.tab.traps.getWorkspace().scale = addon.settings.get("startZoom") / 100;
+    const workspace = addon.tab.traps.getWorkspace();
+    workspace.scale = addon.settings.get("startZoom") / 100;
   }
 
   addon.settings.addEventListener("change", update);


### PR DESCRIPTION
### Changes

Adds a new **"Extended scrolling limit for code area"** setting (boolean, enabled by default) to the Customizable code area zoom addon.

When enabled, overrides Blockly's `workspace.getMetrics()` to expand the scrollable content boundary by one screen-width on each side horizontally and one screen-height on each side vertically. The override is applied once and restored cleanly if the setting is toggled off. Scrollbars are refreshed after each change.

Also:
- Refactors the `enabledLate` path to store the workspace in a variable rather than calling `getWorkspace()` twice
- Adds griffpatch to credits

### Reason for changes

By default, Scratch's code area prevents scrolling beyond the bounding box of your blocks. This makes it difficult to place new blocks in empty space far from existing ones, or to work near the edges of a large project. The extended scrolling setting adds a comfortable margin of empty space in all four directions so you can freely scroll and position blocks without hitting an invisible wall.

### Tests

Tested in Chrome. Verified:
- Extra scroll space is available in all four directions when the setting is enabled
- The setting can be toggled off at runtime and the original scroll boundaries are restored
- Existing zoom controls (min/max/speed/start/autohide) are unaffected