### PR TITLE
Settings page: fix `.main` height

### DIFF
--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -57,6 +57,7 @@ h1 {
 }
 
 .main {
+  min-height: 0;
   flex-grow: 1;
   display: flex;
   align-items: stretch;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -76,7 +76,6 @@ h1 {
   padding-top: 10px;
   scrollbar-width: thin;
   scrollbar-color: var(--gray-text) transparent;
-  flex-basis: 0;
   flex-grow: 1;
 }
 

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -76,7 +76,6 @@ h1 {
   padding-top: 10px;
   scrollbar-width: thin;
   scrollbar-color: var(--gray-text) transparent;
-  flex-grow: 1;
 }
 
 .addons-container .placeholder {


### PR DESCRIPTION
Fixes #8927

#8896 caused the sidebar to increase the height of `.main` when overflowed instead of scrolling.