### PR TITLE
Add reset button to more settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -367,6 +367,9 @@
   "viewSettings": {
     "message": "View settings file"
   },
+  "resetSettings": {
+    "message": "Reset settings"
+  },
   "fileNotSelected": {
     "message": "Please select a settings file."
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -368,7 +368,7 @@
     "message": "View settings file"
   },
   "resetSettings": {
-    "message": "Reset settings"
+    "message": "Reset all settings"
   },
   "fileNotSelected": {
     "message": "Please select a settings file."

--- a/libraries/common/reset-settings.js
+++ b/libraries/common/reset-settings.js
@@ -1,0 +1,47 @@
+export default function resetSettings() {
+  const res = confirm(
+    "Are you sure you want to CLEAR ALL SETTINGS? If you haven't exported your settings first, click Cancel."
+  );
+  if (!res) return;
+  const res2 = prompt("Type 123 to confirm. You will lose all your Scratch Addons settings.");
+  if (res2 !== "123") {
+    alert("Settings were NOT reset.");
+    return;
+  }
+
+  try {
+    chrome.storage.local.clear();
+  } catch (err) {
+    console.error(err);
+  }
+  try {
+    chrome.storage.sync.clear();
+  } catch (err) {
+    console.error(err);
+  }
+  try {
+    localStorage.clear();
+  } catch (err) {
+    console.error(err);
+  }
+  try {
+    // We should try to list all IndexedDB databases here so that
+    // we can actually clear them all in Firefox.
+    const IDB_DATABASES = ["notifier", "messaging"];
+
+    (async () => {
+      const dbs = window.indexedDB.databases ? await window.indexedDB.databases() : null;
+      const dbNames = !dbs ? IDB_DATABASES : dbs.map((db) => db.name);
+      dbNames.forEach((name) => {
+        window.indexedDB.deleteDatabase(name);
+      });
+    })();
+  } catch (err) {
+    console.error(err);
+  }
+
+  setTimeout(() => {
+    alert("All settings were reset. The extension will reload.");
+    chrome.runtime.reload();
+  }, 1500);
+}

--- a/webpages/error/reset-settings.js
+++ b/webpages/error/reset-settings.js
@@ -1,48 +1,5 @@
+import resetSettings from "../../libraries/common/reset-settings.js";
 document.querySelector("#reset-settings-btn").onclick = () => {
   // TODO: if (!window.exportedSettings) after error page gets an "export settings" button.
-  const res = confirm(
-    "Are you sure you want to CLEAR ALL SETTINGS? If you haven't exported your settings first, click Cancel."
-  );
-  if (!res) return;
-  const res2 = prompt("Type 123 to confirm. You will lose all your Scratch Addons settings.");
-  if (res2 !== "123") {
-    alert("Settings were NOT reset.");
-    return;
-  }
-
-  try {
-    chrome.storage.local.clear();
-  } catch (err) {
-    console.error(err);
-  }
-  try {
-    chrome.storage.sync.clear();
-  } catch (err) {
-    console.error(err);
-  }
-  try {
-    localStorage.clear();
-  } catch (err) {
-    console.error(err);
-  }
-  try {
-    // We should try to list all IndexedDB databases here so that
-    // we can actually clear them all in Firefox.
-    const IDB_DATABASES = ["notifier", "messaging"];
-
-    (async () => {
-      const dbs = window.indexedDB.databases ? await window.indexedDB.databases() : null;
-      const dbNames = !dbs ? IDB_DATABASES : dbs.map((db) => db.name);
-      dbNames.forEach((name) => {
-        window.indexedDB.deleteDatabase(name);
-      });
-    })();
-  } catch (err) {
-    console.error(err);
-  }
-
-  setTimeout(() => {
-    alert("All settings were reset. The extension will reload.");
-    chrome.runtime.reload();
-  }, 1500);
+  resetSettings();
 };

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -377,6 +377,9 @@
               <div class="export-actions-group">
                 <button class="large-button" @click="viewSettings()">{{ msg("viewSettings") }}</button>
               </div>
+              <div class="export-actions-group">
+                <button class="large-button danger" @click="resetSettings()">{{ msg("resetSettings") }}</button>
+              </div>
             </div>
           </div>
         </div>

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -8,6 +8,7 @@ import categories from "./data/categories.js";
 import exampleManifest from "./data/example-manifest.js";
 import fuseOptions from "./data/fuse-options.js";
 import globalTheme from "../../libraries/common/global-theme.js";
+import resetSettings from "../../libraries/common/reset-settings.js";
 import { deserializeSettings, serializeSettings } from "./settings-utils.js";
 import { isFirefox } from "../../libraries/common/cs/detect-browser.js";
 
@@ -186,6 +187,7 @@ let fuse;
     },
 
     methods: {
+      resetSettings,
       openMoreSettings: function () {
         this.closePickers();
         this.$els.moresettings.showModal();

--- a/webpages/styles/components/buttons.css
+++ b/webpages/styles/components/buttons.css
@@ -27,3 +27,10 @@
 .large-button > * {
   vertical-align: middle;
 }
+
+.large-button.danger:hover,
+.large-button.danger:focus {
+  color: var(--white-text);
+  background-color: var(--warning-background);
+  border-color: var(--warning-border);
+}


### PR DESCRIPTION
Resolves #4754

### Changes

Adds a "Reset settings" button that becomes red on hover to the more settings modal. It uses the existing logic from the error page which now lives in its own module.

<img width="811" height="141" alt="image" src="https://github.com/user-attachments/assets/556c6fac-0dd2-4618-abeb-6abfbae92cbd" />

### Reason for changes

Some users have requested it and it is also useful during development.

### Tests

Tested both the new button and error page link with a Chromium-based browser.