### PR TITLE
Merge sidebar buttons and add darkened background overlay

### DIFF
--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -228,7 +228,7 @@
       </div>
 
       <!-- This is the main menu, where the searchbar and the addon items are located -->
-      <div class="addons-block">
+      <div class="addons-block" :class="{darken: smallMode && categoryOpen}">
         <div class="addons-block-header">
           <div v-if="!isIframe" class="category-header-title" v-cloak>
             <button

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -232,10 +232,9 @@
         <div class="addons-block-header">
           <div v-if="!isIframe" class="category-header-title" v-cloak>
             <button
-              id="sidebar-toggle"
               class="arrow-button"
               :title="msg('toggleSidebar')"
-              @click="sidebarToggle()"
+              @click="categoryOpen = !categoryOpen"
               v-cloak
             >
               <img src="../../images/icons/menu.svg" draggable="false" />

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -177,17 +177,6 @@
   </head>
   <body v-cloak :class="{light: theme}">
     <div class="navbar">
-      <button
-        id="sidebar-toggle"
-        class="header-button"
-        :class="{sidebarToggleOpen: categoryOpen === true}"
-        :title="msg('toggleSidebar')"
-        @click="sidebarToggle()"
-        v-cloak
-        v-show="smallMode"
-      >
-        <img src="../../images/icons/menu.svg" draggable="false" />
-      </button>
       <img src="../../images/icon-transparent.svg" class="logo" alt="Logo" draggable="false" />
       <h1 v-cloak>{{ msg("settings") }}</h1>
       <button
@@ -232,28 +221,26 @@
           <img src="../../images/icons/comment.svg" draggable="false" />
           <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
         </a>
-        <button v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
+        <button v-cloak class="category" style="margin-top: 12px" @click="openMoreSettings()">
           <img src="../../images/icons/wrench.svg" draggable="false" />
           <span>{{ msg("moreSettings") }}</span>
         </button>
       </div>
-      <button
-        v-show="!isIframe && smallMode === false"
-        class="categories-shrink"
-        @click="sidebarToggle()"
-        :title="msg('toggleSidebar')"
-      >
-        <img
-          src="../../images/icons/left-arrow.svg"
-          :class="{flipped: categoryOpen === (direction() === 'rtl')}"
-          draggable="false"
-        />
-      </button>
 
       <!-- This is the main menu, where the searchbar and the addon items are located -->
       <div class="addons-block">
         <div class="addons-block-header">
           <div v-if="!isIframe" class="category-header-title" v-cloak>
+            <button
+              id="sidebar-toggle"
+              class="arrow-button"
+              :title="msg('toggleSidebar')"
+              @click="sidebarToggle()"
+              v-cloak
+            >
+              <img src="../../images/icons/menu.svg" draggable="false" />
+            </button>
+
             <div v-if="relatedAddonsOpen" class="related-addons-header">
               <button class="arrow-button" :title="msg('back')" @click="backRelatedAddon()">
                 <img src="../../images/icons/left-arrow.svg" draggable="false" />

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -231,12 +231,7 @@
       <div class="addons-block" :class="{darken: smallMode && categoryOpen}">
         <div class="addons-block-header">
           <div v-if="!isIframe" class="category-header-title" v-cloak>
-            <button
-              class="arrow-button"
-              :title="msg('toggleSidebar')"
-              @click="categoryOpen = !categoryOpen"
-              v-cloak
-            >
+            <button class="arrow-button" :title="msg('toggleSidebar')" @click="categoryOpen = !categoryOpen" v-cloak>
               <img src="../../images/icons/menu.svg" draggable="false" />
             </button>
 

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -190,7 +190,7 @@ let fuse;
         this.closePickers();
         this.$els.moresettings.showModal();
         if (vue.smallMode) {
-          vue.sidebarToggle();
+          this.categoryOpen = false;
         }
         location.hash = "";
       },
@@ -228,9 +228,6 @@ let fuse;
           // 2s (animation length) + 1ms
           setTimeout(() => addonElem.classList.remove("addon-blink"), 2001);
         }, 0);
-      },
-      sidebarToggle: function () {
-        this.categoryOpen = !this.categoryOpen;
       },
       msg(message, ...params) {
         return chrome.i18n.getMessage(message, ...params);
@@ -356,9 +353,8 @@ let fuse;
     },
     events: {
       closesidebar(event) {
-        if (event?.target?.closest("#sidebar-toggle")) return;
         if (this.categoryOpen && this.smallMode) {
-          this.sidebarToggle();
+          this.categoryOpen = false;
         }
       },
     },

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -70,6 +70,24 @@ h1 {
   flex-direction: column;
 }
 
+.addons-block {
+  position: relative;
+}
+
+.addons-block::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s;
+}
+
+.addons-block.darken::after {
+  opacity: 1;
+}
+
 .addons-container {
   overflow-y: auto;
   padding: 20px;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -86,6 +86,7 @@ h1 {
 
 .addons-block.darken::after {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .addons-container {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -214,7 +214,6 @@ h1 {
 .header-button:focus-visible {
   outline: 2px solid var(--white-text);
 }
-.sidebarToggleOpen,
 .header-button:hover {
   background: var(--header-hover-darken);
 }
@@ -298,8 +297,7 @@ body.iframe .search-box input {
     margin-inline-start: 42px;
   }
 
-  body[v-cloak] .categories-block,
-  body[v-cloak] .categories-shrink {
+  body[v-cloak] .categories-block {
     display: none;
   }
 }

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -76,17 +76,15 @@ h1 {
 
 .addons-block::after {
   content: "";
-  position: fixed;
+  position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  opacity: 0;
+  z-index: 199; /* Just beflow .categories-block.smallMode */
   pointer-events: none;
-  transition: opacity 0.25s;
+  transition: background-color 0.25s;
 }
 
 .addons-block.darken::after {
-  opacity: 1;
-  pointer-events: auto;
+  background-color: var(--modal-overlay);
 }
 
 .addons-container {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -123,11 +123,13 @@ h1 {
   border-bottom: 1px solid var(--control-border);
   display: flex;
   align-items: center;
-  padding: 10px 40px;
+  padding: 10px 30px;
   user-select: none;
 }
 
 .category-header-title {
+  display: flex;
+  align-items: center;
   flex-grow: 1;
   font-size: 16px;
   font-weight: 500;
@@ -271,25 +273,6 @@ body.iframe .navbar {
 body.iframe .search-box input {
   flex-grow: 1;
   flex-basis: 0;
-}
-
-.categories-shrink {
-  text-align: right;
-  bottom: 0;
-  position: fixed;
-  padding: 0;
-  margin: 5px;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  user-select: none;
-}
-.categories-shrink img {
-  vertical-align: middle;
-  filter: var(--content-icon-filter);
-}
-.flipped {
-  transform: scaleX(-1);
 }
 
 /* Hide categories and prevent logo from jumping while loading in the popup and small mode */

--- a/webpages/styles/components/categories.css
+++ b/webpages/styles/components/categories.css
@@ -8,7 +8,7 @@
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--gray-text) transparent;
-  padding: 20px 0;
+  padding-top: 20px;
 }
 
 .categories-block.smallMode {
@@ -17,7 +17,6 @@
   z-index: 200;
   height: calc(100vh - 60px);
   height: calc(100svh - 60px);
-  padding-bottom: 0;
   transition: 0.25s;
 }
 


### PR DESCRIPTION
Resolves #8937

### Changes

Combined both sidebar buttons into a single one next the the category name and darkens the background when the sidebar is open in small mode.

### Reason for changes

It's more consistent and the darkening makes it much clearer how to close the sidebar when no button is visible.

### Tests

Tested on Helium.

Right after opening more settings in small mode there are two overlays until the sidebar transition finishes.