### PR TITLE
Improve navigation bars

### DIFF
--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -104,9 +104,8 @@ button {
   content: "";
   display: block;
   position: absolute;
-  left: 10px;
-  right: 10px;
   bottom: 0;
+  width: calc(100% - 20px);
   height: 4px;
   background-color: var(--orange);
   border-radius: 4px 4px 0 0;

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -105,7 +105,7 @@ button {
   display: block;
   position: absolute;
   bottom: 0;
-  width: calc(100% - 20px);
+  inset-inline: 10px;
   height: 4px;
   background-color: var(--orange);
   border-radius: 4px 4px 0 0;

--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -75,7 +75,7 @@
     display: block;
     width: 4px;
     border-radius: 0 4px 4px 0;
-    height: 40px;
+    height: calc(100% - 8px);
     background: var(--orange);
     position: absolute;
     left: 0;
@@ -88,9 +88,6 @@
   .category.sel::before {
     opacity: 1;
   }
-  .category.hasParent::before {
-    height: 25px;
-  }
 
   .category img {
     height: 18px;
@@ -99,5 +96,11 @@
   }
   .category span {
     margin-inline-start: 15px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .category {
+      transition-property: background-color;
+    }
   }
 </style>

--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -75,10 +75,10 @@
     display: block;
     width: 4px;
     border-radius: 0 4px 4px 0;
-    height: calc(100% - 8px);
     background: var(--orange);
     position: absolute;
     left: 0;
+    inset-block: 6px;
     opacity: 0;
   }
   [dir="rtl"] .category::before {

--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -23,7 +23,7 @@ export default async function ({ template }) {
         event.stopPropagation();
         if (this.selectedCategory === this.category.id) {
           if (this.$root.smallMode) {
-            vue.categoryOpen = false;
+            this.$root.categoryOpen = false;
           } else {
             if (this.category.parent || Date.now() - this.lastClick < 350) return;
             this.$root.selectedCategory = "all";

--- a/webpages/settings/components/category-selector.js
+++ b/webpages/settings/components/category-selector.js
@@ -21,8 +21,13 @@ export default async function ({ template }) {
     methods: {
       onClick(event) {
         event.stopPropagation();
-        if (this.selectedCategory === this.category.id && !this.category.parent && Date.now() - this.lastClick > 350) {
-          this.$root.selectedCategory = "all";
+        if (this.selectedCategory === this.category.id) {
+          if (this.$root.smallMode) {
+            vue.categoryOpen = false;
+          } else {
+            if (this.category.parent || Date.now() - this.lastClick < 350) return;
+            this.$root.selectedCategory = "all";
+          }
         } else {
           this.$root.selectedCategory = this.category.id;
         }

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -190,7 +190,7 @@ let fuse;
         this.closePickers();
         this.$els.moresettings.showModal();
         if (vue.smallMode) {
-          vue.sidebarToggle();
+          vue.categoryOpen = false;
         }
         location.hash = "";
       },

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -32,7 +32,7 @@ button {
   box-shadow: var(--large-shadow);
   user-select: none;
   position: relative;
-  z-index: 10;
+  z-index: 100;
 }
 
 h1 {

--- a/webpages/styles/components/categories.css
+++ b/webpages/styles/components/categories.css
@@ -14,10 +14,11 @@
 .categories-block.smallMode {
   box-sizing: border-box;
   position: absolute;
-  z-index: 200;
+  z-index: 20;
   height: calc(100vh - 60px);
   height: calc(100svh - 60px);
   padding-bottom: 0;
+  box-shadow: var(--large-shadow);
   transition: 0.25s;
 }
 

--- a/webpages/styles/components/categories.css
+++ b/webpages/styles/components/categories.css
@@ -23,11 +23,22 @@
 }
 
 .categories-block.smallMode.closed {
-  transform: translateX(-100%);
   visibility: hidden;
 }
-[dir="rtl"] .categories-block.smallMode.closed {
-  transform: translateX(100%);
+
+@media (prefers-reduced-motion: no-preference) {
+  .categories-block.smallMode.closed {
+    transform: translateX(-100%);
+  }
+  [dir="rtl"] .categories-block.smallMode.closed {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .categories-block.smallMode.closed {
+    opacity: 0;
+  }
 }
 
 .categories-block.closed:not(.smallMode) {


### PR DESCRIPTION
### Changes

Small changes have been made to the sidebar in the settings page and the tab bar in the popup.

- Design:
  - Clicking on a selected category in the sidebar in small mode now closes the sidebar, making navigation easier.[^1]
  - The sidebar now has a shadow in small mode and is positioned behind the navbar.
- Fixes:
  - A bug which made the sidebar open under the More Settings dialog when visiting `(...)#moresettings` has been fixed.
  - Animations are reduced if that is the user's motion preference.
- Code clarity:
  - Uses a single style rule to set the length of the orange indicators on selected categories/tabs, reducing the number of lines of code. Previously, left/right offsets were used in the popup and a separate length value was used for child categories in the settings page.

### Tests

Tested on Edge 146.

[^1]: Partially solves #9001