### PR TITLE
feat(forum-copy-code): support copying scratchblocks code

### DIFF
--- a/addons-l10n/en/forum-copy-code.json
+++ b/addons-l10n/en/forum-copy-code.json
@@ -1,4 +1,4 @@
 {
   "forum-copy-code/copy-code": "Copy Code",
-  "forum-copy-code/copy-scratchblocks": "Copy Scratchblocks Code"
+  "forum-copy-code/copy-scratchblocks": "Copy Scratchblocks"
 }

--- a/addons-l10n/en/forum-copy-code.json
+++ b/addons-l10n/en/forum-copy-code.json
@@ -1,3 +1,4 @@
 {
-  "forum-copy-code/copy-code": "Copy Code"
+  "forum-copy-code/copy-code": "Copy Code",
+  "forum-copy-code/copy-scratchblocks": "Copy Scratchblocks Code"
 }

--- a/addons/forum-copy-code/addon.json
+++ b/addons/forum-copy-code/addon.json
@@ -1,10 +1,14 @@
 {
   "name": "Copy code button on forums",
-  "description": "Adds a \"copy code\" button above code boxes in forum posts that copies the contents into the clipboard.",
+  "description": "Adds a \"copy code\" button above code boxes and scratchblocks in forum posts that copies the contents into the clipboard.",
   "credits": [
     {
       "name": "CST1229",
       "link": "https://github.com/CST1229/"
+    },
+    {
+      "name": "LuYifei2011",
+      "link": "https://github.com/LuYifei2011/"
     }
   ],
   "userscripts": [

--- a/addons/forum-copy-code/userscript.js
+++ b/addons/forum-copy-code/userscript.js
@@ -1,6 +1,6 @@
 export default async function ({ addon, console, msg }) {
   while (true) {
-    const codeBlock = await addon.tab.waitForElement("div.code", {
+    const codeBlock = await addon.tab.waitForElement("div.code, pre.blocks", {
       markAsSeen: true,
     }); //For every code block
 
@@ -13,7 +13,10 @@ export default async function ({ addon, console, msg }) {
     copyCodeButton.textContent = msg("copy-code"); //The text
     copyCodeButton.onclick = function () {
       //Code to copy the code
-      const codeBlockText = this.parentNode.nextSibling.children[0].textContent; //Get the code
+      const block = this.parentNode.nextSibling;
+      const codeBlockText = block.matches("pre.blocks")
+        ? block.dataset.original //Get the code from data-original for scratchblocks
+        : block.children[0].textContent; //Get the code from text content for div.code
       navigator.clipboard.writeText(codeBlockText);
     };
 

--- a/addons/forum-copy-code/userscript.js
+++ b/addons/forum-copy-code/userscript.js
@@ -4,17 +4,19 @@ export default async function ({ addon, console, msg }) {
       markAsSeen: true,
     }); //For every code block
 
+    const isScratchblocks = codeBlock.matches("pre.blocks");
+
     const copyCode = document.createElement("div"); //Div used to store the text
     copyCode.className = "sa-copyCodeDiv"; //Class
     addon.tab.displayNoneWhileDisabled(copyCode); //Dynamic disable
 
     const copyCodeButton = document.createElement("span"); //The actual button
     copyCodeButton.className = "sa-copyCodeButton"; //Class
-    copyCodeButton.textContent = msg("copy-code"); //The text
+    copyCodeButton.textContent = isScratchblocks ? msg("copy-scratchblocks") : msg("copy-code"); //The text
     copyCodeButton.onclick = function () {
       //Code to copy the code
       const block = this.parentNode.nextSibling;
-      const codeBlockText = block.matches("pre.blocks")
+      const codeBlockText = isScratchblocks
         ? block.dataset.original //Get the code from data-original for scratchblocks
         : block.children[0].textContent; //Get the code from text content for div.code
       navigator.clipboard.writeText(codeBlockText);

--- a/addons/forum-copy-code/userstyle.css
+++ b/addons/forum-copy-code/userstyle.css
@@ -1,6 +1,7 @@
 .sa-copyCodeDiv {
   text-align: right;
   height: 0px;
+  /* To make the button appear on top of the scratchblocks, or else it will not be able to be clicked */
   position: relative;
   z-index: 1;
 }

--- a/addons/forum-copy-code/userstyle.css
+++ b/addons/forum-copy-code/userstyle.css
@@ -1,6 +1,8 @@
 .sa-copyCodeDiv {
   text-align: right;
   height: 0px;
+  position: relative;
+  z-index: 1;
 }
 .sa-copyCodeButton {
   opacity: 0.75;


### PR DESCRIPTION
Resolves #8944

### Changes

<img width="2843" height="1550" alt="image" src="https://github.com/user-attachments/assets/4325825c-526a-4464-818d-6fc59bffe903" />

### Reason for changes

Easier to copy scratchblocks code from forum posts.

### Tests

On Chrome 147.
