### PR TITLE
stage-monitors: Increase CSS specificity

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -182,7 +182,6 @@
   "horizontal-mystuff-tabs",
   "// For editor:",
   "editor-dark-mode",
-  "stage-monitor",
   "editor-colored-context-menus",
   "hide-stage",
   "editor-stage-left",
@@ -190,5 +189,6 @@
   "fullscreen",
   "columns",
   "editor-compact",
-  "editor-theme3"
+  "editor-theme3",
+  "stage-monitor"
 ]

--- a/addons/stage-monitor/monitor-values.css
+++ b/addons/stage-monitor/monitor-values.css
@@ -1,6 +1,6 @@
-[class*="monitor_value_"],
-[class*="monitor_large-value_"],
-[class*="monitor_list-value_"] {
+body [class*="monitor_value_"],
+body [class*="monitor_large-value_"],
+body [class*="monitor_list-value_"] {
   background-color: var(--stageMonitor-monitorValueBg) !important;
   color: var(--stageMonitor-monitorValueText) !important;
 }

--- a/addons/stage-monitor/monitor-values.css
+++ b/addons/stage-monitor/monitor-values.css
@@ -1,6 +1,6 @@
-body [class*="monitor_value_"],
-body [class*="monitor_large-value_"],
-body [class*="monitor_list-value_"] {
+[class*="monitor_value_"],
+[class*="monitor_large-value_"],
+[class*="monitor_list-value_"] {
   background-color: var(--stageMonitor-monitorValueBg) !important;
   color: var(--stageMonitor-monitorValueText) !important;
 }

--- a/addons/stage-monitor/monitors.css
+++ b/addons/stage-monitor/monitors.css
@@ -19,8 +19,8 @@ body [class*="monitor_monitor-container_"],
   color: var(--stageMonitor-listHeaderText);
 }
 
-[class*="monitor_monitor-container_"],
-[class*="monitor_large-value_"] {
+body [class*="monitor_monitor-container_"],
+body [class*="monitor_large-value_"] {
   border-radius: calc(var(--stageMonitor-monitorRadius) * 1px);
 }
 


### PR DESCRIPTION
Fixes https://github.com/ScratchAddons/feedback-internal/issues/570

### Changes

Increases the specificity of some `stage-monitor` selectors.

### Reason for changes

#8850 decreased it which caused some styles to not apply.

### Tests

Tested on Helium