### PR TITLE
middle-click-popup: fix error on new Blockly

### DIFF
--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -209,7 +209,10 @@ export class BlockInputEnum extends BlockInput {
     this.values = [];
     for (let i = 0; i < options.length; i++) {
       if (typeof options[i][1] === "string" && BlockInputEnum.INVALID_VALUES.indexOf(options[i][1]) === -1) {
-        this.values.push({ value: options[i][1], string: options[i][0].replaceAll(String.fromCharCode(160), " ") });
+        this.values.push({
+          value: options[i][1],
+          string: String(options[i][0]).replaceAll(String.fromCharCode(160), " "),
+        });
       }
     }
     this.isRound = isRound;
@@ -413,10 +416,20 @@ export class BlockTypeInfo {
     };
 
     const addFieldInputs = (field, inputIdx, fieldIdx) => {
-      if (field instanceof Blockly.FieldDropdown) {
-        const options = field.getOptions();
-        addInput(new BlockInputEnum(options, inputIdx, fieldIdx, fieldIdx === -1));
-      } else if (field instanceof Blockly.FieldImage) {
+      let FieldColourSlider;
+      let FieldNumber;
+      let FieldVerticalSeparator;
+      if (Blockly.registry) {
+        // new Blockly
+        FieldColourSlider = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_colour_slider");
+        FieldNumber = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_number");
+        FieldVerticalSeparator = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_vertical_separator");
+      } else {
+        FieldColourSlider = Blockly.FieldColourSlider;
+        FieldNumber = Blockly.FieldNumber;
+        FieldVerticalSeparator = Blockly.FieldVerticalSeparator;
+      }
+      if (field instanceof Blockly.FieldImage) {
         switch (field.getValue().split("/").pop()) {
           case "green-flag.svg":
             parts.push(locale("/_general/blocks/green-flag"));
@@ -428,33 +441,21 @@ export class BlockTypeInfo {
             parts.push(locale("/_general/blocks/anticlockwise"));
             break;
         }
+      } else if (
+        field instanceof Blockly.FieldLabel ||
+        field instanceof FieldVerticalSeparator ||
+        (!Blockly.registry && field instanceof Blockly.FieldVariableGetter)
+      ) {
+        if (field.getText().trim().length !== 0) parts.push(field.getText());
+      } else if (field instanceof FieldColourSlider) {
+        addInput(new BlockInputColour(inputIdx, fieldIdx));
+      } else if (field instanceof FieldNumber) {
+        addInput(new BlockInputNumber(inputIdx, fieldIdx, field.getText()));
+      } else if (field instanceof Blockly.FieldDropdown) {
+        const options = field.getOptions();
+        addInput(new BlockInputEnum(options, inputIdx, fieldIdx, fieldIdx === -1));
       } else {
-        let FieldColourSlider;
-        let FieldNumber;
-        let FieldVerticalSeparator;
-        if (Blockly.registry) {
-          // new Blockly
-          FieldColourSlider = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_colour_slider");
-          FieldNumber = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_number");
-          FieldVerticalSeparator = Blockly.registry.getClass(Blockly.registry.Type.FIELD, "field_vertical_separator");
-        } else {
-          FieldColourSlider = Blockly.FieldColourSlider;
-          FieldNumber = Blockly.FieldNumber;
-          FieldVerticalSeparator = Blockly.FieldVerticalSeparator;
-        }
-        if (
-          field instanceof Blockly.FieldLabel ||
-          field instanceof FieldVerticalSeparator ||
-          (!Blockly.registry && field instanceof Blockly.FieldVariableGetter)
-        ) {
-          if (field.getText().trim().length !== 0) parts.push(field.getText());
-        } else if (field instanceof FieldColourSlider) {
-          addInput(new BlockInputColour(inputIdx, fieldIdx));
-        } else if (field instanceof FieldNumber) {
-          addInput(new BlockInputNumber(inputIdx, fieldIdx, field.getText()));
-        } else {
-          addInput(new BlockInputString(inputIdx, fieldIdx, field.getText()));
-        }
+        addInput(new BlockInputString(inputIdx, fieldIdx, field.getText()));
       }
     };
 


### PR DESCRIPTION
Resolves #8943

### Changes

Makes the middle click popup open without errors in the latest version of scratch-editor.

`FieldColourSlider` is now a subclass of `FieldDropdown`, which caused the addon to think color inputs are dropdown menus. This PR fixes that by checking for `FieldDropdown` last, after all other classes.

### Tests

Tested on Edge and Firefox.