### PR TITLE
Fix no-sprite-confirm and confirmation positions with editor-stage-left

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -442,7 +442,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="backpack_more_"],
 [class*="sprite-selector-item_is-selected_"] [class*="sprite-selector-item_sprite-info_"],
 [class*="delete-button_delete-button-visible_"],
-[class*="delete-confirmation-prompt_body_"],
+[class*="confirmation-prompt_modal-container_"],
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header_"],
 [class*="font-dropdown_mod-menu-item_"]:hover:not(:active),
 [class*="tool-select-base_mod-tool-select_"][class*="tool-select-base_is-selected_"],
@@ -567,10 +567,17 @@ img[class*="tool-select-base_tool-select-icon_"],
   fill: var(--editorDarkMode-primary-transparent35);
   stroke: var(--editorDarkMode-primary);
 }
-[class*="delete-confirmation-prompt_body_"] [class*="confirmation-prompt_button-row_"] span {
+[class*="confirmation-prompt_modal-container_"] [class*="confirmation-prompt_button-row_"] span {
   color: var(--editorDarkMode-primary);
 }
-[class*="delete-confirmation-prompt_label_"],
+/* Set thumbnail confirmation cancel button */
+[class*="modal-with-arrow_modal-content_"][style*="width: 200px"] [class*="confirmation-prompt_cancel-button_"] {
+  background-color: var(--editorDarkMode-primary);
+  border-color: var(--editorDarkMode-input);
+}
+[class*="modal-with-arrow_modal-content_"][style*="width: 200px"] [class*="confirmation-prompt_cancel-button_"] > span {
+  color: var(--editorDarkMode-input);
+}
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header-title_"],
 [class*="prompt_button-row_"] button[class*="prompt_ok-button_"],
 [class*="record-modal_button-row_"] button[class*="record-modal_ok-button_"] {
@@ -589,8 +596,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 .sa-onion-button[data-enabled="true"] .sa-onion-image {
   filter: var(--editorDarkMode-primary-filter2);
 }
-[class*="modal-with-arrow_arrow_"][style*="width: 14px"], /* sprite confirmation prompt arrow */
-[class*="delete-confirmation-prompt_body_"] img {
+[class*="modal-with-arrow_arrow_"],
+[class*="confirmation-prompt_modal-container_"] img {
   filter: var(--editorDarkMode-primary-iconFilter);
 }
 [class*="action-menu_more-buttons-outer_"],

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -567,6 +567,9 @@ img[class*="tool-select-base_tool-select-icon_"],
   fill: var(--editorDarkMode-primary-transparent35);
   stroke: var(--editorDarkMode-primary);
 }
+[class*="delete-confirmation-prompt_body_"] [class*="confirmation-prompt_button-row_"] span {
+  color: var(--editorDarkMode-primary);
+}
 [class*="delete-confirmation-prompt_label_"],
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header-title_"],
 [class*="prompt_button-row_"] button[class*="prompt_ok-button_"],
@@ -586,7 +589,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 .sa-onion-button[data-enabled="true"] .sa-onion-image {
   filter: var(--editorDarkMode-primary-filter2);
 }
-[class*="delete-confirmation-prompt_arrow-container_"] [class*="delete-confirmation-prompt_delete-icon_"] {
+[class*="modal-with-arrow_arrow_"][style*="width: 14px"], /* sprite confirmation prompt arrow */
+[class*="delete-confirmation-prompt_body_"] img {
   filter: var(--editorDarkMode-primary-iconFilter);
 }
 [class*="action-menu_more-buttons-outer_"],

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -442,7 +442,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="backpack_more_"],
 [class*="sprite-selector-item_is-selected_"] [class*="sprite-selector-item_sprite-info_"],
 [class*="delete-button_delete-button-visible_"],
-[class*="confirmation-prompt_modal-container_"],
+[class*="delete-confirmation-prompt_body_"],
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header_"],
 [class*="font-dropdown_mod-menu-item_"]:hover:not(:active),
 [class*="tool-select-base_mod-tool-select_"][class*="tool-select-base_is-selected_"],
@@ -567,17 +567,7 @@ img[class*="tool-select-base_tool-select-icon_"],
   fill: var(--editorDarkMode-primary-transparent35);
   stroke: var(--editorDarkMode-primary);
 }
-[class*="confirmation-prompt_modal-container_"] [class*="confirmation-prompt_button-row_"] span {
-  color: var(--editorDarkMode-primary);
-}
-/* Set thumbnail confirmation cancel button */
-[class*="modal-with-arrow_modal-content_"][style*="width: 200px"] [class*="confirmation-prompt_cancel-button_"] {
-  background-color: var(--editorDarkMode-primary);
-  border-color: var(--editorDarkMode-input);
-}
-[class*="modal-with-arrow_modal-content_"][style*="width: 200px"] [class*="confirmation-prompt_cancel-button_"] > span {
-  color: var(--editorDarkMode-input);
-}
+[class*="delete-confirmation-prompt_label_"],
 [class*="stage-selector_stage-selector_"][class*="stage-selector_is-selected_"] [class*="stage-selector_header-title_"],
 [class*="prompt_button-row_"] button[class*="prompt_ok-button_"],
 [class*="record-modal_button-row_"] button[class*="record-modal_ok-button_"] {
@@ -596,8 +586,7 @@ img[class*="tool-select-base_tool-select-icon_"],
 .sa-onion-button[data-enabled="true"] .sa-onion-image {
   filter: var(--editorDarkMode-primary-filter2);
 }
-[class*="modal-with-arrow_arrow_"],
-[class*="confirmation-prompt_modal-container_"] img {
+[class*="delete-confirmation-prompt_arrow-container_"] [class*="delete-confirmation-prompt_delete-icon_"] {
   filter: var(--editorDarkMode-primary-iconFilter);
 }
 [class*="action-menu_more-buttons-outer_"],

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -65,6 +65,7 @@
 }
 
 /* Move delete button confirmation to the right side */
+/* TODO: override the props of the ModalWithArrow component instead */
 .ReactModal__Content[style*="width: 290px"] {
   /* 290px (popup width)
    + 25px (padding)
@@ -72,11 +73,11 @@
    + 25px (padding) */
   margin-left: 410px !important;
 }
-/* The arrow is outside the modal's DOM and its class is shared with the set thumbnail callout */
-[class*="modal-with-arrow_arrow_"]:not([class*="feature-callout-popover_arrow_"]) {
+[class*="modal-with-arrow_arrow_"][style*="width: 14px"] {
   /* 70px (sprite selector item width)
    + 50px (padding)
-   - 10px (arrow width) */
+   + 4px (popup borders)
+   - 14px (arrow width) */
   margin-left: 110px;
   transform: scaleX(-1);
 }

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -65,15 +65,19 @@
 }
 
 /* Move delete button confirmation to the right side */
-.ReactModal__Content[style*="width: 300px"] {
-  /* 300px (popup width)
+.ReactModal__Content[style*="width: 290px"] {
+  /* 290px (popup width)
    + 25px (padding)
    + 70px (sprite selector item width)
    + 25px (padding) */
-  margin-left: 420px !important;
+  margin-left: 410px !important;
 }
-[class*="delete-confirmation-prompt_arrow-container_"] {
-  order: -1;
+/* The arrow is outside the modal's DOM and its class is shared with the set thumbnail callout */
+[class*="modal-with-arrow_arrow_"]:not([class*="feature-callout-popover_arrow_"]) {
+  /* 70px (sprite selector item width)
+   + 50px (padding)
+   - 10px (arrow width) */
+  margin-left: 110px;
   transform: scaleX(-1);
 }
 

--- a/addons/no-sprite-confirm/hide.css
+++ b/addons/no-sprite-confirm/hide.css
@@ -1,3 +1,5 @@
+/* The arrow is outside the modal's DOM and its class is shared with the set thumbnail callout */
+[class*="modal-with-arrow_arrow_"]:not([class*="feature-callout-popover_arrow_"]),
 [class*="delete-confirmation-prompt_"] {
   visibility: hidden;
 }

--- a/addons/no-sprite-confirm/hide.css
+++ b/addons/no-sprite-confirm/hide.css
@@ -1,5 +1,5 @@
-/* The arrow is outside the modal's DOM and its class is shared with the set thumbnail callout */
-[class*="modal-with-arrow_arrow_"]:not([class*="feature-callout-popover_arrow_"]),
+/* TODO: Override the props of the ModalWithArrow component instead */
+[class*="modal-with-arrow_arrow_"][style*="width: 14px"],
 [class*="delete-confirmation-prompt_"] {
   visibility: hidden;
 }

--- a/addons/no-sprite-confirm/hide.css
+++ b/addons/no-sprite-confirm/hide.css
@@ -1,4 +1,3 @@
-/* TODO: Override the props of the ModalWithArrow component instead */
 [class*="modal-with-arrow_arrow_"][style*="width: 14px"],
 [class*="delete-confirmation-prompt_"] {
   visibility: hidden;

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,7 +1,7 @@
 export default async ({ addon, console }) => {
   document.body.addEventListener("pointerup", () => {
     setTimeout(() => {
-      const confirmButton = document.querySelector("[class*='delete-confirmation-prompt_ok-button_']");
+      const confirmButton = document.querySelector("[class*='confirmation-prompt_confirm-button_']");
       if (!addon.self.disabled && confirmButton) confirmButton.click();
     }, 0);
   });

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -2,7 +2,7 @@ export default async ({ addon, console }) => {
   document.body.addEventListener("pointerup", () => {
     setTimeout(() => {
       const confirmButton = document.querySelector(
-        "[class*='confirmation-prompt_modal-container_'] [class*='confirmation-prompt_confirm-button_']"
+        "[class*='delete-confirmation-prompt_body_'] [class*='confirmation-prompt_confirm-button_']"
       );
       if (!addon.self.disabled && confirmButton) confirmButton.click();
     }, 0);

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,7 +1,7 @@
 export default async ({ addon, console }) => {
   document.body.addEventListener("pointerup", () => {
     setTimeout(() => {
-      const confirmButton = document.querySelector("[class*='confirmation-prompt_confirm-button_']");
+      const confirmButton = document.querySelector("[class*='confirmation-prompt_modal-container_'] [class*='confirmation-prompt_confirm-button_']");
       if (!addon.self.disabled && confirmButton) confirmButton.click();
     }, 0);
   });

--- a/addons/no-sprite-confirm/userscript.js
+++ b/addons/no-sprite-confirm/userscript.js
@@ -1,7 +1,9 @@
 export default async ({ addon, console }) => {
   document.body.addEventListener("pointerup", () => {
     setTimeout(() => {
-      const confirmButton = document.querySelector("[class*='confirmation-prompt_modal-container_'] [class*='confirmation-prompt_confirm-button_']");
+      const confirmButton = document.querySelector(
+        "[class*='confirmation-prompt_modal-container_'] [class*='confirmation-prompt_confirm-button_']"
+      );
       if (!addon.self.disabled && confirmButton) confirmButton.click();
     }, 0);
   });


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/feedback-internal/issues/589
Resolves #8952
Resolves #8963

This does not fix the positioning of the thumbnail one.

----
Bugs fixed by this PR:
1. no-sprite-confirm does not delete the sprite without confirmation, instead the modal simply is hidden.
2. Display stage on left side addon, causes the delete sprite confirmation modal to be off screen.