### PR TITLE
Fix debugger block preview and heatmap for new Blockly

### DIFF
--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -323,6 +323,11 @@
   border-radius: 3px;
 }
 
+/* Keep Blockly's selected-path overlay from painting over heatmapped blocks. */
+.sa-debugger-heatmap > .blocklyPathSelected {
+  fill: none !important;
+}
+
 .sa-timing-timer {
   position: absolute;
   top: 0px;

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -13,11 +13,13 @@ function recursiveFillBlock(block, fill = null) {
     else style.fill = fill;
   };
   setFill(block.pathObject.svgPath.style);
+  // Mark heatmapped blocks so CSS can keep Blockly's selected overlay unfilled.
+  block.getSvgRoot().classList.toggle("sa-debugger-heatmap", !isReset);
 
   // Set text color for blocks with heatmap applied
   const textElements = block
     .getSvgRoot()
-    .querySelectorAll(":scope > :not(.blocklyDraggable):not([data-shapes='stack']) > text, :scope > text");
+    .querySelectorAll(":scope > :not(.blocklyDraggable) > text, :scope > text");
 
   if (!isReset) {
     // Heatmap is being applied - force white text

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -15,9 +15,9 @@ function recursiveFillBlock(block, fill = null) {
   setFill(block.pathObject.svgPath.style);
 
   // Set text color for blocks with heatmap applied
-  const textElements = block.getSvgRoot().querySelectorAll(
-    ":scope > :not(.blocklyDraggable):not([data-shapes='stack']) > text, :scope > text"
-  );
+  const textElements = block
+    .getSvgRoot()
+    .querySelectorAll(":scope > :not(.blocklyDraggable):not([data-shapes='stack']) > text, :scope > text");
 
   if (!isReset) {
     // Heatmap is being applied - force white text

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -7,15 +7,19 @@ function valueToHeatmapColor(value, min = 0, max = 1) {
 }
 
 function recursiveFillBlock(block, fill = null) {
-  const fillColor = fill === null ? block.colour_ : fill;
-  block.svgPath_.style.fill = fillColor;
+  const isReset = fill === null;
+  const setFill = (style) => {
+    if (isReset) style.removeProperty("fill");
+    else style.fill = fill;
+  };
+  setFill(block.pathObject.svgPath.style);
 
   // Set text color for blocks with heatmap applied
-  const textElements = block.svgGroup_.querySelectorAll(
+  const textElements = block.getSvgRoot().querySelectorAll(
     ":scope > :not(.blocklyDraggable):not([data-shapes='stack']) > text, :scope > text"
   );
 
-  if (fill !== null) {
+  if (!isReset) {
     // Heatmap is being applied - force white text
     textElements.forEach((textEl) => {
       textEl.style.setProperty("fill", "white", "important");
@@ -37,9 +41,13 @@ function recursiveFillBlock(block, fill = null) {
 
   block.inputList.forEach((input) => {
     input.fieldRow.forEach((field) => {
-      if (field.box_) field.box_.style.fill = fill;
+      if (field.box_) setFill(field.box_.style);
     });
   });
+
+  if (isReset) {
+    block.applyColour();
+  }
 }
 
 class HeatmapManager {
@@ -70,7 +78,7 @@ class HeatmapManager {
     // Reset all previously colored blocks, not just current timer blocks
     const workspace = this.getWorkspace();
     this.coloredBlocks.forEach((blockId) => {
-      const block = workspace.blockDB_[blockId];
+      const block = workspace.getBlockById(blockId);
       if (block) {
         recursiveFillBlock(block);
       }
@@ -90,7 +98,7 @@ class HeatmapManager {
         return this.config.showLineByLine ? isLineByLineTimer : !isLineByLineTimer;
       })
       .forEach((timer) => {
-        const block = workspace.blockDB_[timer.blockId];
+        const block = workspace.getBlockById(timer.blockId);
         if (block) fillFn(block, timer);
       });
   }
@@ -157,7 +165,7 @@ class HeatmapManager {
     const max = Math.max(...timerPercentTimes) * heatmapMax;
 
     filteredTimers.forEach((timer) => {
-      const block = workspace.blockDB_[timer.blockId];
+      const block = workspace.getBlockById(timer.blockId);
       if (block) {
         recursiveFillBlock(block, valueToHeatmapColor(timer.totalTime / totalTimerTime, min, max));
         this.coloredBlocks.add(timer.blockId);

--- a/addons/debugger/timing/HeatmapManager.js
+++ b/addons/debugger/timing/HeatmapManager.js
@@ -17,9 +17,7 @@ function recursiveFillBlock(block, fill = null) {
   block.getSvgRoot().classList.toggle("sa-debugger-heatmap", !isReset);
 
   // Set text color for blocks with heatmap applied
-  const textElements = block
-    .getSvgRoot()
-    .querySelectorAll(":scope > :not(.blocklyDraggable) > text, :scope > text");
+  const textElements = block.getSvgRoot().querySelectorAll(":scope > :not(.blocklyDraggable) > text, :scope > text");
 
   if (!isReset) {
     // Heatmap is being applied - force white text

--- a/addons/debugger/userscript.js
+++ b/addons/debugger/userscript.js
@@ -423,6 +423,20 @@ export default async function ({ addon, console, msg }) {
     return parts.join(" ");
   };
 
+  const getScratchBlockCategory = (jsonData) => {
+    if (jsonData.extensions?.includes("scratch_extension")) {
+      return "pen";
+    }
+
+    const colorExtension = jsonData.extensions?.find((extension) => extension.startsWith("colours_"));
+    return colorExtension
+      ? {
+          colours_event: "events",
+          colours_data_lists: "list",
+        }[colorExtension] || colorExtension.replace("colours_", "")
+      : null;
+  };
+
   const createBlockPreview = (targetId, blockId) => {
     const target = vm.runtime.getTargetById(targetId);
     if (!target) {
@@ -499,8 +513,7 @@ export default async function ({ addon, console, msg }) {
       if (!text) {
         return null;
       }
-      // jsonData.extensions is not guaranteed to exist
-      category = jsonData.extensions?.includes("scratch_extension") ? "pen" : jsonData.category;
+      category = getScratchBlockCategory(jsonData);
       const isStatement =
         (jsonData.extensions &&
           (jsonData.extensions.includes("shape_statement") ||


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? If there aren't any, please submit one first unless this is a hotfix or minor string update. -->

Resolves #8955

### Changes                                                                                                                                                                                
                                                                                                                                                                                             
  Updated the debugger for the new Blockly renderer in two places:                                                                                                                           
                                                                                                                                                                                             
  - Fixed block previews in the profiler/timing table by deriving preview categories from Scratch block extensions such as colours_control, instead of relying on the removed                
    jsonData.category field.                                                                                                                                                                 
  - Fixed debugger heatmap rendering on new Blockly by replacing old internal block lookups with workspace.getBlockById(...), using current block renderer APIs, and restoring block/input   
    styling correctly when heatmap is disabled or cleared.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/3c589df0-3299-40e9-8eac-5cc0f050d190" />
                                                                                                                            
                                                                                                                                                                                             
  ### Reason for changes                                                                                                                                                                     

  Scratch’s move away from scratch-blocks broke debugger assumptions in both preview rendering and heatmap coloring. The profiler preview path was still expecting old block JSON category   
  metadata, and the heatmap path was still reaching into old Blockly internals and renderer fields. These changes align the debugger with the current Scratch/Blockly behavior so previews   
  and heatmap work again.                                                                                                                                                                    
                                                                                                                                                                                             
  ### Tests                                                                                                                                                                                  
                                                                                                                                                                                             
  Tested manually in the editor with the debugger timing tab on https://scratch.mit.edu/projects/1030987979:                                                                                                                                
                                                                                                                                                                                             
  - Verified profiler block previews render again for line-by-line timing rows.                                                                                                              
  - Verified heatmap can be enabled without throwing errors.                                                                                                                                 
  - Verified heatmap can be disabled and cleared without leaving text input fields stuck in the wrong visual state.