### PR TITLE
Align student deactivation banner in scratch3to2

### DIFF
--- a/addons/scratch3to2/main.css
+++ b/addons/scratch3to2/main.css
@@ -472,6 +472,11 @@ a:hover {
   background-color: transparent;
 }
 
+/* Student deactivation banner */
+.student-deactivation-banner {
+  top: 35px;
+}
+
 /* Footer */
 #footer {
   height: 220px;


### PR DESCRIPTION
### Changes

Before:
<img width="480" height="167" alt="image" src="https://github.com/user-attachments/assets/7a6c6425-ab38-4404-80ae-93ce1f5f50aa" />
After:
<img width="487" height="146" alt="image" src="https://github.com/user-attachments/assets/f4e998d4-45bb-4806-b6e2-827b7c1015f8" />


### Reason for changes
Bugfix

### Tests

Tested in Chrome