### PR TITLE
Update userscript.js

### DIFF
--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -1,4 +1,4 @@
-export default async function ({ addon, console }) {
+export default async function({ addon, console }) {
   const vm = addon.tab.traps.vm;
   const runtime = vm.runtime;
 
@@ -9,10 +9,9 @@ export default async function ({ addon, console }) {
   const fastFlag = addon.self.dir + "/svg/fast-flag.svg";
   let vanillaFlag = null;
 
-  // --- 1. VMの挙動をカスタマイズ ---
   const originalStart = runtime.start;
 
-  const setFPS = (fps) => {
+  const setFPS = fps => {
     global_fps = addon.self.disabled ? 30 : fps;
 
     if (runtime._steppingInterval) {
@@ -22,36 +21,41 @@ export default async function ({ addon, console }) {
     }
   };
 
-  // 実行ループのモンキーパッチ
-  runtime.start = function () {
+  runtime.start = function() {
     if (this._steppingInterval) return;
     const interval = 1000 / global_fps;
     this.currentStepTime = interval;
-    this._steppingInterval = setInterval(() => this._step(), interval);
+    this._steppingInterval = setInterval(() => {
+      this._step();
+    }, interval);
     this.emit("RUNTIME_STARTED");
   };
 
-  const updateFlagVisuals = (button) => {
+  const updateFlagVisuals = button => {
     if (!button) return;
     if (!vanillaFlag) vanillaFlag = button.src;
     button.src = mode ? fastFlag : vanillaFlag;
 
-    if (mode) button.setAttribute("data-sa-60fps", "true");
-    else button.removeAttribute("data-sa-60fps");
+    if (mode) {
+      button.setAttribute("data-sa-60fps", "true");
+    } else {
+      button.removeAttribute("data-sa-60fps");
+    }
   };
 
   const fixMonitorThrottling = () => {
     if (monitorUpdateFixed) return;
 
-    const originalListener = vm.listeners("MONITORS_UPDATE")
-      .find((f) => f.name === "onMonitorsUpdate");
+    const originalListener = vm
+      .listeners("MONITORS_UPDATE")
+      .find(f => f.name === "onMonitorsUpdate");
 
     if (originalListener) {
       vm.removeListener("MONITORS_UPDATE", originalListener);
-      vm.on("MONITORS_UPDATE", (monitors) =>
+      vm.on("MONITORS_UPDATE", monitors =>
         addon.tab.redux.dispatch({
           type: "scratch-gui/monitors/UPDATE_MONITORS",
-          monitors,
+          monitors
         })
       );
       monitorUpdateFixed = true;
@@ -73,7 +77,6 @@ export default async function ({ addon, console }) {
       .forEach(updateFlagVisuals);
   };
 
-  // --- 2. ライフサイクル管理 ---
   addon.settings.addEventListener("change", () => {
     if (mode) setFPS(addon.settings.get("framerate"));
   });
@@ -82,15 +85,13 @@ export default async function ({ addon, console }) {
     changeMode(false);
     runtime.start = originalStart;
 
-    // イベントリスナーの重複防止
     document
       .querySelectorAll("[class*='green-flag_green-flag_']")
-      .forEach((btn) => {
+      .forEach(btn => {
         btn.replaceWith(btn.cloneNode(true));
       });
   });
 
-  // --- 3. DOM監視ループ ---
   while (true) {
     const button = await addon.tab.waitForElement(
       "[class*='green-flag_green-flag_']",
@@ -99,20 +100,21 @@ export default async function ({ addon, console }) {
         reduxEvents: [
           "scratch-gui/mode/SET_PLAYER",
           "fontsLoaded/SET_FONTS_LOADED",
-          "scratch-gui/locales/SELECT_LOCALE",
-        ],
+          "scratch-gui/locales/SELECT_LOCALE"
+        ]
       }
     );
 
     updateFlagVisuals(button);
 
-    const flagListener = (e) => {
+    const flagListener = e => {
       if (addon.self.disabled) return;
 
       const isAltClick =
         e.altKey && (e.type === "click" || e.type === "contextmenu");
       const isChromebookAlt =
-        navigator.userAgent.includes("CrOS") && e.type === "contextmenu";
+        navigator.userAgent.includes("CrOS") &&
+        e.type === "contextmenu";
 
       if (isAltClick || isChromebookAlt) {
         e.stopPropagation();
@@ -121,11 +123,14 @@ export default async function ({ addon, console }) {
       }
     };
 
-    // 重複防止のため一度クローンしてから付け直す
     const cleanButton = button.cloneNode(true);
     button.replaceWith(cleanButton);
 
-    cleanButton.addEventListener("click", flagListener, { capture: true });
-    cleanButton.addEventListener("contextmenu", flagListener, { capture: true });
+    cleanButton.addEventListener("click", flagListener, {
+      capture: true
+    });
+    cleanButton.addEventListener("contextmenu", flagListener, {
+      capture: true
+    });
   }
 }

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -14,8 +14,7 @@ export default async function ({ addon, console }) {
 
   const setFPS = (fps) => {
     global_fps = addon.self.disabled ? 30 : fps;
-    
-    // すでに動いている場合は再起動してインターバルを更新
+
     if (runtime._steppingInterval) {
       clearInterval(runtime._steppingInterval);
       runtime._steppingInterval = null;
@@ -26,11 +25,9 @@ export default async function ({ addon, console }) {
   // 実行ループのモンキーパッチ
   runtime.start = function () {
     if (this._steppingInterval) return;
-    let interval = 1000 / global_fps;
+    const interval = 1000 / global_fps;
     this.currentStepTime = interval;
-    this._steppingInterval = setInterval(() => {
-      this._step();
-    }, interval);
+    this._steppingInterval = setInterval(() => this._step(), interval);
     this.emit("RUNTIME_STARTED");
   };
 
@@ -38,13 +35,17 @@ export default async function ({ addon, console }) {
     if (!button) return;
     if (!vanillaFlag) vanillaFlag = button.src;
     button.src = mode ? fastFlag : vanillaFlag;
+
     if (mode) button.setAttribute("data-sa-60fps", "true");
     else button.removeAttribute("data-sa-60fps");
   };
 
   const fixMonitorThrottling = () => {
     if (monitorUpdateFixed) return;
-    const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name === "onMonitorsUpdate");
+
+    const originalListener = vm.listeners("MONITORS_UPDATE")
+      .find((f) => f.name === "onMonitorsUpdate");
+
     if (originalListener) {
       vm.removeListener("MONITORS_UPDATE", originalListener);
       vm.on("MONITORS_UPDATE", (monitors) =>
@@ -59,14 +60,17 @@ export default async function ({ addon, console }) {
 
   const changeMode = (newMode = !mode) => {
     mode = newMode;
+
     if (mode) {
       setFPS(addon.settings.get("framerate"));
       fixMonitorThrottling();
     } else {
       setFPS(30);
     }
-    const buttons = document.querySelectorAll("[class*='green-flag_green-flag_']");
-    buttons.forEach(updateFlagVisuals);
+
+    document
+      .querySelectorAll("[class*='green-flag_green-flag_']")
+      .forEach(updateFlagVisuals);
   };
 
   // --- 2. ライフサイクル管理 ---
@@ -76,24 +80,39 @@ export default async function ({ addon, console }) {
 
   addon.self.addEventListener("disabled", () => {
     changeMode(false);
-    // アドオン無効化時は元のstart関数に戻す
     runtime.start = originalStart;
+
+    // イベントリスナーの重複防止
+    document
+      .querySelectorAll("[class*='green-flag_green-flag_']")
+      .forEach((btn) => {
+        btn.replaceWith(btn.cloneNode(true));
+      });
   });
 
   // --- 3. DOM監視ループ ---
   while (true) {
-    const button = await addon.tab.waitForElement("[class*='green-flag_green-flag_']", {
-      markAsSeen: true,
-      reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
-    });
+    const button = await addon.tab.waitForElement(
+      "[class*='green-flag_green-flag_']",
+      {
+        markAsSeen: true,
+        reduxEvents: [
+          "scratch-gui/mode/SET_PLAYER",
+          "fontsLoaded/SET_FONTS_LOADED",
+          "scratch-gui/locales/SELECT_LOCALE",
+        ],
+      }
+    );
 
     updateFlagVisuals(button);
 
     const flagListener = (e) => {
       if (addon.self.disabled) return;
-      
-      const isAltClick = e.altKey && (e.type === "click" || e.type === "contextmenu");
-      const isChromebookAlt = navigator.userAgent.includes("CrOS") && e.type === "contextmenu";
+
+      const isAltClick =
+        e.altKey && (e.type === "click" || e.type === "contextmenu");
+      const isChromebookAlt =
+        navigator.userAgent.includes("CrOS") && e.type === "contextmenu";
 
       if (isAltClick || isChromebookAlt) {
         e.stopPropagation();
@@ -102,7 +121,11 @@ export default async function ({ addon, console }) {
       }
     };
 
-    button.addEventListener("click", flagListener, { capture: true });
-    button.addEventListener("contextmenu", flagListener, { capture: true });
+    // 重複防止のため一度クローンしてから付け直す
+    const cleanButton = button.cloneNode(true);
+    button.replaceWith(cleanButton);
+
+    cleanButton.addEventListener("click", flagListener, { capture: true });
+    cleanButton.addEventListener("contextmenu", flagListener, { capture: true });
   }
 }

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -1,84 +1,115 @@
 export default async function ({ addon, console }) {
-  // TODO: test whether e.altKey is true in chromebooks when alt+clicking.
-  // If so, no timeout needed, similar to mute-project addon.
-
-  let global_fps = 30;
   const vm = addon.tab.traps.vm;
+  const runtime = vm.runtime;
+
   let mode = false;
   let monitorUpdateFixed = false;
+  let global_fps = 30;
 
   const fastFlag = addon.self.dir + "/svg/fast-flag.svg";
   let vanillaFlag = null;
 
+  // --- 1. VMの挙動をカスタマイズ (モンキーパッチ) ---
+  const originalStart = runtime.start;
+
+  const setFPS = (fps) => {
+    // アドオン無効時は強制的に30、有効時は設定値 or 30
+    global_fps = addon.self.disabled ? 30 : fps;
+    
+    if (runtime._steppingInterval) {
+      clearInterval(runtime._steppingInterval);
+      runtime._steppingInterval = null;
+      runtime.start();
+    }
+  };
+
+  // 実行ループを書き換え
+  runtime.start = function () {
+    if (this._steppingInterval) return;
+    let interval = 1000 / global_fps;
+    this.currentStepTime = interval;
+    this._steppingInterval = setInterval(() => {
+      this._step();
+    }, interval);
+    this.emit("RUNTIME_STARTED");
+  };
+
+  // --- 2. モニターの更新制限を解除 ---
+  const fixMonitorThrottling = () => {
+    if (monitorUpdateFixed) return;
+    // Scratch標準の低速モニター更新リスナーを探して差し替える
+    const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name === "onMonitorsUpdate");
+    if (originalListener) {
+      vm.removeListener("MONITORS_UPDATE", originalListener);
+      vm.on("MONITORS_UPDATE", (monitors) =>
+        addon.tab.redux.dispatch({
+          type: "scratch-gui/monitors/UPDATE_MONITORS",
+          monitors,
+        })
+      );
+      monitorUpdateFixed = true;
+    }
+  };
+
+  // --- 3. モード切替ロジック ---
+  const updateFlagVisuals = (button) => {
+    if (!button) return;
+    if (!vanillaFlag) vanillaFlag = button.src;
+    
+    button.src = mode ? fastFlag : vanillaFlag;
+    if (mode) {
+      button.setAttribute("data-sa-60fps", "true");
+    } else {
+      button.removeAttribute("data-sa-60fps");
+    }
+  };
+
+  const changeMode = (newMode = !mode) => {
+    mode = newMode;
+    if (mode) {
+      setFPS(addon.settings.get("framerate"));
+      fixMonitorThrottling();
+    } else {
+      setFPS(30);
+    }
+    // 表示されている全ての緑の旗を更新
+    const buttons = document.querySelectorAll("[class*='green-flag_green-flag_']");
+    buttons.forEach(updateFlagVisuals);
+  };
+
+  // --- 4. イベント監視と後処理 ---
+  addon.settings.addEventListener("change", () => {
+    if (mode) setFPS(addon.settings.get("framerate"));
+  });
+
+  addon.self.addEventListener("disabled", () => {
+    changeMode(false);
+  });
+
+  // --- 5. DOMの監視 (旗が生成されるたびに実行) ---
   while (true) {
-    let button = await addon.tab.waitForElement("[class*='green-flag_green-flag_']", {
+    const button = await addon.tab.waitForElement("[class*='green-flag_green-flag_']", {
       markAsSeen: true,
       reduxEvents: ["scratch-gui/mode/SET_PLAYER", "fontsLoaded/SET_FONTS_LOADED", "scratch-gui/locales/SELECT_LOCALE"],
     });
 
-    const updateFlag = () => {
-      if (!vanillaFlag) vanillaFlag = button.src;
-      button.src = mode ? fastFlag : vanillaFlag;
-      if (mode) button.setAttribute("data-sa-60fps", "");
-      else button.removeAttribute("data-sa-60fps");
-    };
+    updateFlagVisuals(button);
 
-    const changeMode = (_mode = !mode) => {
-      mode = _mode;
-      if (mode) {
-        setFPS(addon.settings.get("framerate"));
-
-        // monitor updates are throttled by default
-        // https://github.com/scratchfoundation/scratch-gui/blob/ba76db7/src/reducers/monitors.js
-        if (!monitorUpdateFixed) {
-          const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name === "onMonitorsUpdate");
-          if (originalListener) vm.removeListener("MONITORS_UPDATE", originalListener);
-          vm.on("MONITORS_UPDATE", (monitors) =>
-            addon.tab.redux.dispatch({
-              type: "scratch-gui/monitors/UPDATE_MONITORS",
-              monitors,
-            })
-          );
-          monitorUpdateFixed = true;
-        }
-      } else setFPS(30);
-      updateFlag();
-    };
     const flagListener = (e) => {
       if (addon.self.disabled) return;
-      const isAltClick = e.type === "click" && e.altKey;
-      const isChromebookAltClick = navigator.userAgent.includes("CrOS") && e.type === "contextmenu";
-      if (isAltClick || isChromebookAltClick) {
-        e.cancelBubble = true;
+      
+      const isAltClick = e.altKey && (e.type === "click" || e.type === "contextmenu");
+      const isChromebookAlt = navigator.userAgent.includes("CrOS") && e.type === "contextmenu";
+
+      if (isAltClick || isChromebookAlt) {
+        e.stopPropagation();
         e.preventDefault();
         changeMode();
       }
     };
-    button.addEventListener("click", flagListener);
-    button.addEventListener("contextmenu", flagListener);
 
-    const setFPS = (fps) => {
-      global_fps = addon.self.disabled ? 30 : fps;
-
-      clearInterval(vm.runtime._steppingInterval);
-      vm.runtime._steppingInterval = null;
-      vm.runtime.start();
-    };
-    addon.settings.addEventListener("change", () => {
-      if (vm.runtime._steppingInterval) {
-        setFPS(addon.settings.get("framerate"));
-      }
-    });
-    addon.self.addEventListener("disabled", () => changeMode(false));
-    vm.runtime.start = function () {
-      if (this._steppingInterval) return;
-      let interval = 1000 / global_fps;
-      this.currentStepTime = interval;
-      this._steppingInterval = setInterval(() => {
-        this._step();
-      }, interval);
-      this.emit("RUNTIME_STARTED");
-    };
-    updateFlag();
+    // キャプチャフェーズでイベントを奪い取る
+    button.addEventListener("click", flagListener, { capture: true });
+    button.addEventListener("contextmenu", flagListener, { capture: true });
   }
 }

--- a/addons/60fps/userscript.js
+++ b/addons/60fps/userscript.js
@@ -9,13 +9,13 @@ export default async function ({ addon, console }) {
   const fastFlag = addon.self.dir + "/svg/fast-flag.svg";
   let vanillaFlag = null;
 
-  // --- 1. VMの挙動をカスタマイズ (モンキーパッチ) ---
+  // --- 1. VMの挙動をカスタマイズ ---
   const originalStart = runtime.start;
 
   const setFPS = (fps) => {
-    // アドオン無効時は強制的に30、有効時は設定値 or 30
     global_fps = addon.self.disabled ? 30 : fps;
     
+    // すでに動いている場合は再起動してインターバルを更新
     if (runtime._steppingInterval) {
       clearInterval(runtime._steppingInterval);
       runtime._steppingInterval = null;
@@ -23,7 +23,7 @@ export default async function ({ addon, console }) {
     }
   };
 
-  // 実行ループを書き換え
+  // 実行ループのモンキーパッチ
   runtime.start = function () {
     if (this._steppingInterval) return;
     let interval = 1000 / global_fps;
@@ -34,10 +34,16 @@ export default async function ({ addon, console }) {
     this.emit("RUNTIME_STARTED");
   };
 
-  // --- 2. モニターの更新制限を解除 ---
+  const updateFlagVisuals = (button) => {
+    if (!button) return;
+    if (!vanillaFlag) vanillaFlag = button.src;
+    button.src = mode ? fastFlag : vanillaFlag;
+    if (mode) button.setAttribute("data-sa-60fps", "true");
+    else button.removeAttribute("data-sa-60fps");
+  };
+
   const fixMonitorThrottling = () => {
     if (monitorUpdateFixed) return;
-    // Scratch標準の低速モニター更新リスナーを探して差し替える
     const originalListener = vm.listeners("MONITORS_UPDATE").find((f) => f.name === "onMonitorsUpdate");
     if (originalListener) {
       vm.removeListener("MONITORS_UPDATE", originalListener);
@@ -51,19 +57,6 @@ export default async function ({ addon, console }) {
     }
   };
 
-  // --- 3. モード切替ロジック ---
-  const updateFlagVisuals = (button) => {
-    if (!button) return;
-    if (!vanillaFlag) vanillaFlag = button.src;
-    
-    button.src = mode ? fastFlag : vanillaFlag;
-    if (mode) {
-      button.setAttribute("data-sa-60fps", "true");
-    } else {
-      button.removeAttribute("data-sa-60fps");
-    }
-  };
-
   const changeMode = (newMode = !mode) => {
     mode = newMode;
     if (mode) {
@@ -72,21 +65,22 @@ export default async function ({ addon, console }) {
     } else {
       setFPS(30);
     }
-    // 表示されている全ての緑の旗を更新
     const buttons = document.querySelectorAll("[class*='green-flag_green-flag_']");
     buttons.forEach(updateFlagVisuals);
   };
 
-  // --- 4. イベント監視と後処理 ---
+  // --- 2. ライフサイクル管理 ---
   addon.settings.addEventListener("change", () => {
     if (mode) setFPS(addon.settings.get("framerate"));
   });
 
   addon.self.addEventListener("disabled", () => {
     changeMode(false);
+    // アドオン無効化時は元のstart関数に戻す
+    runtime.start = originalStart;
   });
 
-  // --- 5. DOMの監視 (旗が生成されるたびに実行) ---
+  // --- 3. DOM監視ループ ---
   while (true) {
     const button = await addon.tab.waitForElement("[class*='green-flag_green-flag_']", {
       markAsSeen: true,
@@ -108,7 +102,6 @@ export default async function ({ addon, console }) {
       }
     };
 
-    // キャプチャフェーズでイベントを奪い取る
     button.addEventListener("click", flagListener, { capture: true });
     button.addEventListener("contextmenu", flagListener, { capture: true });
   }


### PR DESCRIPTION
## 概要
プロジェクトの実行フレームレート（FPS）を、Scratch標準の30FPSから任意の設定値に引き上げる機能を追加します。
緑の旗を **Alt + クリック** することで、通常モードと高速フレームレートモードをトグル（切り替え）できます。

## 変更内容
- **FPS制御のオーバーライド**: `vm.runtime.start` を書き換え、設定されたFPSに基づいたステップ実行（`setInterval`）を行うよう変更。
- **モニター更新の同期化**: 高速実行時に変数モニターの表示が遅れないよう、Reduxの更新スロットリングをバイパスする処理を追加。
- **Chromebook対応**: ChromeOSで `Alt + クリック` が右クリック扱いになる仕様を考慮し、`contextmenu` イベントでの切り替えをサポート。
- **UIフィードバック**: モード切り替え時に緑の旗のアイコンを変更（SVGの差し替え）し、`data-sa-60fps` 属性を付与。
- **イベント管理の最適化**: 
  - `capture: true` を使用し、Scratch本来のクリック処理が走る前にモード切替を判定。
  - `waitForElement` と `markAsSeen` を組み合わせ、動的なDOM生成に対応。