### PR TITLE
hide-stage: fix button not appearing

### DIFF
--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -87,7 +87,7 @@
 .sa-stage-hidden [class*="stage-header_stage-size-row_"] {
   right: auto;
   left: 0.5rem;
-  width: calc(240px + 0.125rem);
+  width: calc(480px + 0.125rem);
   justify-content: flex-end;
 }
 
@@ -97,7 +97,7 @@
 }
 
 .sa-stage-hidden [class*="gui_tab-list_"] {
-  padding-inline-start: calc(240px + 1.125rem);
+  padding-inline-start: calc(480px + 1.125rem);
 }
 
 /* search-sprites compatibility */

--- a/addons/hide-stage/style.css
+++ b/addons/hide-stage/style.css
@@ -20,7 +20,7 @@
 }
 
 /* [class*="gui_flex-wrapper_"] is for specificity over hide-flyout */
-.sa-stage-hidden [class*="gui_flex-wrapper_"] [class*="gui_stage-and-target-wrapper_"],
+[class*="gui_flex-wrapper_"].sa-stage-hidden [class*="gui_stage-and-target-wrapper_"],
 .sa-stage-hidden [class*="stage-wrapper_stage-wrapper_"]:not([class*="stage-wrapper_full-screen_"]),
 .sa-stage-hidden [class*="gui_target-wrapper_"] {
   padding: 0;

--- a/addons/hide-stage/userscript.js
+++ b/addons/hide-stage/userscript.js
@@ -55,14 +55,14 @@ export default async function ({ addon, console, msg }) {
   });
   addon.self.addEventListener("reenabled", () => {
     const stageControls = document.querySelector(
-      "[class*='stage-header_stage-size-toggle-group_'] > [class*='toggle-buttons_row_']"
+      "[class*='stage-header_stage-size-row_'] > [class*='toggle-buttons_row_']"
     );
     if (stageControls) stageControls.insertBefore(hideStageButton, smallStageButton);
   });
 
   while (true) {
     const stageControls = await addon.tab.waitForElement(
-      "[class*='stage-header_stage-size-toggle-group_'] > [class*='toggle-buttons_row_']",
+      "[class*='stage-header_stage-size-row_'] > [class*='toggle-buttons_row_']",
       {
         markAsSeen: true,
         reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,


### PR DESCRIPTION
Resolves #8970

### Changes

Fixes issues caused by the Set Thumbnail update:
* the hide stage button didn't appear;
* after hiding the stage, some empty space remained;
* if editor-stage-left was enabled, there wasn't enough space for all the buttons when the stage was hidden.

### Tests

Tested on Edge and Firefox.