### PR TITLE
Fix unused variables disappearing

### DIFF
--- a/libraries/common/cs/update-all-blocks.js
+++ b/libraries/common/cs/update-all-blocks.js
@@ -16,18 +16,13 @@ export async function updateAllBlocks(
 
   if (workspace) {
     if (updateMainWorkspace) {
-      let clearWorkspaceAndLoadFromXml;
       const xml = blockly.Xml.workspaceToDom(workspace);
-      if (blockly.registry) {
-        // new Blockly: use Scratch's modified implementation instead of the one from Blockly
-        clearWorkspaceAndLoadFromXml = blockly.clearWorkspaceAndLoadFromXml;
-        if (!xml.querySelector("variables")) {
-          xml.appendChild(blockly.utils.xml.createElement("variables"));
-        }
-      } else {
-        clearWorkspaceAndLoadFromXml = blockly.Xml.clearWorkspaceAndLoadFromXml;
+      if (xml.querySelector("variables")) {
+        xml.querySelector("variables").remove();
       }
-      clearWorkspaceAndLoadFromXml(xml, workspace);
+      // Add all variables, including unused ones, to the XML document
+      xml.appendChild(blockly.Xml.variablesToDom(workspace.getVariableMap().getAllVariables()));
+      blockly.clearWorkspaceAndLoadFromXml(xml, workspace);
     }
     const toolbox = workspace.getToolbox();
     const flyout = workspace.getFlyout();

--- a/libraries/common/cs/update-all-blocks.js
+++ b/libraries/common/cs/update-all-blocks.js
@@ -21,7 +21,18 @@ export async function updateAllBlocks(
         xml.querySelector("variables").remove();
       }
       // Add all variables, including unused ones, to the XML document
-      xml.appendChild(blockly.Xml.variablesToDom(workspace.getVariableMap().getAllVariables()));
+      const variables = blockly.utils.xml.createElement("variables");
+      const globalVariables = Object.values(tab.traps.vm.runtime.getTargetForStage().variables);
+      const localVariables = tab.traps.vm.editingTarget.isStage
+        ? []
+        : Object.values(tab.traps.vm.editingTarget.variables);
+      for (const variable of globalVariables) {
+        variables.appendChild(blockly.utils.xml.textToDom(variable.toXML()));
+      }
+      for (const variable of localVariables) {
+        variables.appendChild(blockly.utils.xml.textToDom(variable.toXML(true)));
+      }
+      xml.appendChild(variables);
       blockly.clearWorkspaceAndLoadFromXml(xml, workspace);
     }
     const toolbox = workspace.getToolbox();


### PR DESCRIPTION
Resolves #8962
Resolves #8979

### Changes

New Blockly's `workspaceToDom()` method removes unused variables for some reason. This PR fixes it by replacing the `<variables>` element generated by `workspaceToDom()` with one containing all variables.

### Tests

Tested on Edge and Firefox. Verified that no variables are removed when enabling or disabling Custom block shape or Square block inputs.