### PR TITLE
Grab single block with Ctrl key -> Grab single block by default

### DIFF
--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -3,6 +3,10 @@
   "description": "Inverts the block dragging controls. Drag a single block out of the middle of a script by default and hold the Ctrl key to drag the entire stack attached below it.",
   "info": [
     {
+      "text": "To drag a single block without this addon hold Ctrl.",
+      "id": "vanilla"
+    },
+    {
       "text": "On macOS, use the Cmd key instead of the Ctrl key.",
       "id": "macContextDisabled"
     }

--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -3,7 +3,7 @@
   "description": "Flips the block dragging controls. Drag a single block out of the middle of a script by default, or hold the Ctrl key to drag the entire stack attached below it.",
   "info": [
     {
-      "text": "To drag a single block without this addon hold Ctrl.",
+      "text": "To drag a single block without this addon, hold Ctrl.",
       "id": "vanilla"
     },
     {

--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -1,6 +1,6 @@
 {
   "name": "Grab single block by default",
-  "description": "Inverts the block dragging controls. Drag a single block out of the middle of a script by default and hold the Ctrl key to drag the entire stack attached below it.",
+  "description": "Flips the block dragging controls. Drag a single block out of the middle of a script by default, or hold the Ctrl key to drag the entire stack attached below it.",
   "info": [
     {
       "text": "To drag a single block without this addon hold Ctrl.",

--- a/addons/block-cherry-picking/addon.json
+++ b/addons/block-cherry-picking/addon.json
@@ -1,6 +1,6 @@
 {
-  "name": "Grab single block with Ctrl key",
-  "description": "Adds the ability to drag a single block out of the middle of a script (instead of the entire stack attached below it) while holding the Ctrl key.",
+  "name": "Grab single block by default",
+  "description": "Inverts the block dragging controls. Drag a single block out of the middle of a script by default and hold the Ctrl key to drag the entire stack attached below it.",
   "info": [
     {
       "text": "On macOS, use the Cmd key instead of the Ctrl key.",
@@ -22,16 +22,7 @@
       "matches": ["projects"]
     }
   ],
-  "settings": [
-    {
-      "name": "Flip controls",
-      "id": "invertDrag",
-      "description": "Make grabbing blocks individually the default behavior. Hold Ctrl to drag entire stacks.",
-      "type": "boolean",
-      "default": false
-    }
-  ],
-  "tags": ["editor", "codeEditor", "featured"],
+  "tags": ["editor", "codeEditor"],
   "relatedAddons": ["block-duplicate"],
   "dynamicDisable": true,
   "dynamicEnable": true,

--- a/addons/block-cherry-picking/userscript.js
+++ b/addons/block-cherry-picking/userscript.js
@@ -2,7 +2,7 @@ import * as sharedModule from "../block-duplicate/module.js";
 
 export default async function ({ addon, console }) {
   const update = () => {
-    sharedModule.setCherryPicking(!addon.self.disabled, addon.settings.get("invertDrag"));
+    sharedModule.setCherryPicking(!addon.self.disabled);
   };
   addon.self.addEventListener("disabled", update);
   addon.self.addEventListener("reenabled", update);

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -84,37 +84,79 @@ export async function load(addon) {
       }
 
       oldUpdateIsDragging.call(this, e);
-    };
+      return;
+    }
 
-    const oldStartDrag = ScratchBlocks.dragging.BlockDragStrategy.prototype.startDrag;
-    ScratchBlocks.dragging.BlockDragStrategy.prototype.startDrag = function (e) {
-      if (this.block.isShadow()) {
-        oldStartDrag.call(this, e);
-        return;
+    const isDuplicating =
+      enableDuplication && e.altKey && !this.flyout && this.targetBlock.type !== "procedures_definition";
+
+    if (isDuplicating) {
+      this.startWorkspace_.setResizesEnabled(false);
+      ScratchBlocks.Events.disable();
+      let newBlock;
+      try {
+        const xmlBlock = ScratchBlocks.Xml.blockToDom(this.targetBlock);
+        newBlock = ScratchBlocks.Xml.domToBlock(xmlBlock, this.startWorkspace_);
+        const xy = this.targetBlock.getRelativeToSurfaceXY();
+        newBlock.moveBy(xy.x, xy.y);
+      } catch (e) {
+        console.error(e);
       }
+      ScratchBlocks.Events.enable();
+      this.startWorkspace_.setResizesEnabled(true);
 
-      if (enableDuplication) {
-        // By default, both Ctrl/Cmd and Alt can be used for cherry picking.
-        // Exclude Alt if duplication is enabled.
-        Object.defineProperty(e, "altKey", { value: false });
+      if (newBlock) {
+        if (ScratchBlocks.Events.isEnabled()) {
+          ScratchBlocks.Events.setGroup(true);
+          // setGroup(false) will be called in endDrag() (overridden below)
+          ScratchBlocks.Events.fire(new (ScratchBlocks.Events.get(ScratchBlocks.Events.BLOCK_CREATE))(newBlock));
+        }
+        const isCherryPickingInverted = invertCherryPicking && this.targetBlock.getParent();
+        if ((e.ctrlKey || e.metaKey) === !isCherryPickingInverted) {
+          // Holding both Ctrl/Cmd and Alt -> duplicate a single block
+          const nextBlock = newBlock.getNextBlock();
+          if (nextBlock) {
+            nextBlock.dispose();
+          }
+        }
+        this.targetBlock = newBlock;
+        ScratchBlocks.common.setSelected(newBlock);
+        newBlock.dragStrategy.saIsDuplicating = true;
       }
+    }
 
-      const isDuplicating = this.saIsDuplicating;
-      delete this.saIsDuplicating;
-      const isCherryPickingInverted = invertCherryPicking && (isDuplicating || this.block.getParent());
-      if (isCherryPickingInverted) {
-        const modifierKeyPressed = e.ctrlKey || e.metaKey || e.altKey;
-        Object.defineProperty(e, "ctrlKey", { value: !modifierKeyPressed });
-        Object.defineProperty(e, "metaKey", { value: !modifierKeyPressed });
-        if (!enableDuplication) Object.defineProperty(e, "altKey", { value: !modifierKeyPressed });
-      }
+    oldUpdateIsDragging.call(this, e);
+  };
 
+  const oldStartDrag = ScratchBlocks.dragging.BlockDragStrategy.prototype.startDrag;
+  ScratchBlocks.dragging.BlockDragStrategy.prototype.startDrag = function (e) {
+    if (this.block.isShadow()) {
       oldStartDrag.call(this, e);
-    };
+      return;
+    }
 
-    const oldEndDrag = ScratchBlocks.dragging.BlockDragStrategy.prototype.endDrag;
-    ScratchBlocks.dragging.BlockDragStrategy.prototype.endDrag = function (e) {
-      oldEndDrag.call(this, e);
-      ScratchBlocks.Events.setGroup(false);
-    };
+    if (enableDuplication) {
+      // By default, both Ctrl/Cmd and Alt can be used for cherry picking.
+      // Exclude Alt if duplication is enabled.
+      Object.defineProperty(e, "altKey", { value: false });
+    }
+
+    const isDuplicating = this.saIsDuplicating;
+    delete this.saIsDuplicating;
+    const isCherryPickingInverted = invertCherryPicking && (isDuplicating || this.block.getParent());
+    if (isCherryPickingInverted) {
+      const modifierKeyPressed = e.ctrlKey || e.metaKey || e.altKey;
+      Object.defineProperty(e, "ctrlKey", { value: !modifierKeyPressed });
+      Object.defineProperty(e, "metaKey", { value: !modifierKeyPressed });
+      if (!enableDuplication) Object.defineProperty(e, "altKey", { value: !modifierKeyPressed });
+    }
+
+    oldStartDrag.call(this, e);
+  };
+
+  const oldEndDrag = ScratchBlocks.dragging.BlockDragStrategy.prototype.endDrag;
+  ScratchBlocks.dragging.BlockDragStrategy.prototype.endDrag = function (e) {
+    oldEndDrag.call(this, e);
+    ScratchBlocks.Events.setGroup(false);
+  };
 }

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -88,15 +88,21 @@ export async function load(addon) {
     }
 
     const isDuplicating =
-      enableDuplication && e.altKey && !this.flyout && this.targetBlock.type !== "procedures_definition";
+      enableDuplication &&
+      e.altKey &&
+      !this.flyout &&
+      this.targetBlock.type !== "procedures_definition" &&
+      this.targetBlock.type !== "procedures_prototype";
 
     if (isDuplicating) {
       this.startWorkspace_.setResizesEnabled(false);
       ScratchBlocks.Events.disable();
       let newBlock;
       try {
-        const xmlBlock = ScratchBlocks.Xml.blockToDom(this.targetBlock);
-        newBlock = ScratchBlocks.Xml.domToBlock(xmlBlock, this.startWorkspace_);
+        let serializedBlock = ScratchBlocks.serialization.blocks.save(this.targetBlock);
+        const stripIdsResult = ScratchBlocks.scratchBlocksUtils.stripIds(serializedBlock);
+        if (stripIdsResult) serializedBlock = stripIdsResult;
+        newBlock = ScratchBlocks.serialization.blocks.appendInternal(serializedBlock, this.startWorkspace_);
         const xy = this.targetBlock.getRelativeToSurfaceXY();
         newBlock.moveBy(xy.x, xy.y);
       } catch (e) {

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -32,57 +32,9 @@ export async function load(addon) {
 
   const ScratchBlocks = await addon.tab.traps.getBlockly();
 
-    const oldUpdateIsDragging = ScratchBlocks.Gesture.prototype.updateIsDragging;
-    ScratchBlocks.Gesture.prototype.updateIsDragging = function (e) {
-      if (!this.targetBlock) {
-        oldUpdateIsDragging.call(this, e);
-        return;
-      }
-
-      const isDuplicating =
-        enableDuplication &&
-        e.altKey &&
-        !this.flyout &&
-        this.targetBlock.type !== "procedures_definition" &&
-        this.targetBlock.type !== "procedures_prototype";
-
-      if (isDuplicating) {
-        this.startWorkspace_.setResizesEnabled(false);
-        ScratchBlocks.Events.disable();
-        let newBlock;
-        try {
-          let serializedBlock = ScratchBlocks.serialization.blocks.save(this.targetBlock);
-          const stripIdsResult = ScratchBlocks.scratchBlocksUtils.stripIds(serializedBlock);
-          if (stripIdsResult) serializedBlock = stripIdsResult;
-          newBlock = ScratchBlocks.serialization.blocks.appendInternal(serializedBlock, this.startWorkspace_);
-          const xy = this.targetBlock.getRelativeToSurfaceXY();
-          newBlock.moveBy(xy.x, xy.y);
-        } catch (e) {
-          console.error(e);
-        }
-        ScratchBlocks.Events.enable();
-        this.startWorkspace_.setResizesEnabled(true);
-
-        if (newBlock) {
-          if (ScratchBlocks.Events.isEnabled()) {
-            ScratchBlocks.Events.setGroup(true);
-            // setGroup(false) will be called in endDrag() (overridden below)
-            ScratchBlocks.Events.fire(new (ScratchBlocks.Events.get(ScratchBlocks.Events.BLOCK_CREATE))(newBlock));
-          }
-          const isCherryPickingInverted = invertCherryPicking && this.targetBlock.getParent();
-          if ((e.ctrlKey || e.metaKey) === !isCherryPickingInverted) {
-            // Holding both Ctrl/Cmd and Alt -> duplicate a single block
-            const nextBlock = newBlock.getNextBlock();
-            if (nextBlock) {
-              nextBlock.dispose();
-            }
-          }
-          this.targetBlock = newBlock;
-          ScratchBlocks.common.setSelected(newBlock);
-          newBlock.dragStrategy.saIsDuplicating = true;
-        }
-      }
-
+  const oldUpdateIsDragging = ScratchBlocks.Gesture.prototype.updateIsDragging;
+  ScratchBlocks.Gesture.prototype.updateIsDragging = function (e) {
+    if (!this.targetBlock) {
       oldUpdateIsDragging.call(this, e);
       return;
     }

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -1,10 +1,6 @@
-let enableCherryPicking = false;
 let invertCherryPicking = false;
-export function setCherryPicking(newEnabled, newInverted) {
-  enableCherryPicking = newEnabled;
-  // If cherry picking is disabled, also disable invert. Duplicating blocks can still cause
-  // this setting to be used.
-  invertCherryPicking = newEnabled && newInverted;
+export function setCherryPicking(newInverted) {
+  invertCherryPicking = newInverted;
 }
 
 let enableDuplication = false;
@@ -35,9 +31,6 @@ export async function load(addon) {
   loaded = true;
 
   const ScratchBlocks = await addon.tab.traps.getBlockly();
-
-  if (ScratchBlocks.registry) {
-    // new Blockly: only implement duplication (cherry picking is a vanilla feature)
 
     const oldUpdateIsDragging = ScratchBlocks.Gesture.prototype.updateIsDragging;
     ScratchBlocks.Gesture.prototype.updateIsDragging = function (e) {
@@ -124,73 +117,4 @@ export async function load(addon) {
       oldEndDrag.call(this, e);
       ScratchBlocks.Events.setGroup(false);
     };
-
-    return;
-  }
-
-  // https://github.com/scratchfoundation/scratch-blocks/blob/912b8cc728bea8fd91af85078c64fcdbfe21c87a/core/gesture.js#L454
-  const originalStartDraggingBlock = ScratchBlocks.Gesture.prototype.startDraggingBlock_;
-  ScratchBlocks.Gesture.prototype.startDraggingBlock_ = function (...args) {
-    let block = this.targetBlock_;
-
-    // Scratch uses fake mouse events to implement right click > duplicate
-    const isRightClickDuplicate = !(this.mostRecentEvent_ instanceof MouseEvent);
-
-    const isDuplicating =
-      enableDuplication &&
-      altPressed &&
-      !isRightClickDuplicate &&
-      !this.flyout_ &&
-      !this.shouldDuplicateOnDrag_ &&
-      this.targetBlock_.type !== "procedures_definition";
-
-    const isCherryPickingInverted = invertCherryPicking && !isRightClickDuplicate && block.getParent();
-    const canCherryPick = enableCherryPicking || isDuplicating;
-    const isCherryPicking = canCherryPick && ctrlOrMetaPressed === !isCherryPickingInverted && !block.isShadow();
-
-    if (isDuplicating || isCherryPicking) {
-      if (!ScratchBlocks.Events.getGroup()) {
-        // Scratch will disable grouping on its own later.
-        ScratchBlocks.Events.setGroup(true);
-      }
-    }
-
-    if (isDuplicating) {
-      // Based on https://github.com/scratchfoundation/scratch-blocks/blob/feda366947432b9d82a4f212f43ff6d4ab6f252f/core/scratch_blocks_utils.js#L171
-      // Setting this.shouldDuplicateOnDrag_ = true does NOT work because it doesn't call changeObscuredShadowIds
-      this.startWorkspace_.setResizesEnabled(false);
-      ScratchBlocks.Events.disable();
-      let newBlock;
-      try {
-        const xmlBlock = ScratchBlocks.Xml.blockToDom(block);
-        newBlock = ScratchBlocks.Xml.domToBlock(xmlBlock, this.startWorkspace_);
-        ScratchBlocks.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
-        const xy = block.getRelativeToSurfaceXY();
-        newBlock.moveBy(xy.x, xy.y);
-      } catch (e) {
-        console.error(e);
-      }
-      ScratchBlocks.Events.enable();
-
-      if (newBlock) {
-        block = newBlock;
-        this.targetBlock_ = newBlock;
-        if (ScratchBlocks.Events.isEnabled()) {
-          ScratchBlocks.Events.fire(new ScratchBlocks.Events.BlockCreate(newBlock));
-        }
-      }
-    }
-
-    if (isCherryPicking) {
-      if (isRightClickDuplicate || isDuplicating) {
-        const nextBlock = block.getNextBlock();
-        if (nextBlock) {
-          nextBlock.dispose();
-        }
-      }
-      block.unplug(true);
-    }
-
-    return originalStartDraggingBlock.call(this, ...args);
-  };
 }

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -203,7 +203,7 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
         }
       }
 
-      // Needs to be outside of manifest.settings condition
+      // Needs to be outside of the manifest.settings condition
       if (addonId === "block-cherry-picking" && settings.invertDrag !== undefined) {
         // Transition v1.45.2 to v1.46.0
         addonsEnabled[addonId] = settings.invertDrag;

--- a/background/get-addon-settings.js
+++ b/background/get-addon-settings.js
@@ -203,6 +203,14 @@ chrome.storage.sync.get([...ADDON_SETTINGS_KEYS, "addonsEnabled"], (storageItems
         }
       }
 
+      // Needs to be outside of manifest.settings condition
+      if (addonId === "block-cherry-picking" && settings.invertDrag !== undefined) {
+        // Transition v1.45.2 to v1.46.0
+        addonsEnabled[addonId] = settings.invertDrag;
+        delete settings.invertDrag;
+        madeAnyChanges = madeChangesToAddon = true;
+      }
+
       if (manifest.settings) {
         for (const option of manifest.settings) {
           if (settings[option.id] === undefined) {


### PR DESCRIPTION
### Changes

`block-cherry-picking` now only flips the controls and the name and description have been updated to reflect that.

### Reason for changes

Cherry picking is now included in the default editor.

### Tests

Tested on Helium.