### PR TITLE
CSS changes related to Set Thumbnail update

### DIFF
--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -207,7 +207,7 @@ body {
 .financials-section .financials-button,
 .donate-section .donate-button,
 .initiatives-section .initiatives-subsection-content .bubble.inverted,
-.share-modal .change-thumbnail-button {
+.share-modal .cancel-button {
   background-color: var(--darkWww-box);
 }
 .ReactModal__Content[style*="background: rgb(255, 255, 255)"] {

--- a/addons/debugger/style.css
+++ b/addons/debugger/style.css
@@ -1,13 +1,5 @@
 @import url("../editor-theme3/compatibility.css");
 
-[dir="ltr"] .sa-debugger-container {
-  margin-right: 0.2rem;
-}
-
-[dir="rtl"] .sa-debugger-container {
-  margin-left: 0.2rem;
-}
-
 .sa-small-stage [class*="gui_body-wrapper_"]:not(.sa-stage-hidden) .sa-debugger-container {
   display: none !important;
 }

--- a/addons/editor-buttons-reverse-order/userstyle.css
+++ b/addons/editor-buttons-reverse-order/userstyle.css
@@ -6,18 +6,14 @@
   flex-direction: row-reverse;
 }
 
-[dir="ltr"] [class*="stage-header_stage-size-toggle-group"],
-[dir="ltr"] .sa-debugger-container,
-[dir="ltr"] .sa-gamepad-container {
+.sa-fullscreen [dir="ltr"] .sa-gamepad-container {
   margin-right: 0;
-  margin-left: 0.2rem;
+  margin-left: 0.25rem;
 }
 
-[dir="rtl"] [class*="stage-header_stage-size-toggle-group"],
-[dir="rtl"] .sa-debugger-container,
-[dir="rtl"] .sa-gamepad-container {
+.sa-fullscreen [dir="rtl"] .sa-gamepad-container {
   margin-left: 0;
-  margin-right: 0.2rem;
+  margin-right: 0.25rem;
 }
 
 [class*="green-flag_green-flag-button_"] {

--- a/addons/editor-dark-mode/addon.json
+++ b/addons/editor-dark-mode/addon.json
@@ -741,6 +741,17 @@
       }
     },
     {
+      "name": "accent-info",
+      "value": {
+        "type": "alphaBlend",
+        "opaqueSource": {
+          "type": "settingValue",
+          "settingId": "accent"
+        },
+        "transparentSource": "#4d97ff26"
+      }
+    },
+    {
       "name": "accent-success",
       "value": {
         "type": "alphaBlend",

--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -262,6 +262,9 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="sound-editor_round-button_"] {
   border-color: var(--editorDarkMode-accent-transparent75);
 }
+[class*="alert_alert_"][class*="alert_info-blue_"] {
+  background-color: var(--editorDarkMode-accent-info);
+}
 [class*="alert_alert_"][class*="alert_success_"] {
   background-color: var(--editorDarkMode-accent-success);
   box-shadow: 0 0 0 2px var(--editorDarkMode-accent-success);

--- a/addons/gamepad/style.css
+++ b/addons/gamepad/style.css
@@ -1,11 +1,8 @@
-[dir="ltr"] .sa-gamepad-container {
-  margin-right: 0.2rem;
+.sa-fullscreen [dir="ltr"] .sa-gamepad-container {
+  margin-right: 0.25rem;
 }
-[dir="rtl"] .sa-gamepad-container {
-  margin-left: 0.2rem;
-}
-[class*="stage-header_rightSection_"] > .sa-gamepad-container {
-  margin: 0;
+.sa-fullscreen [dir="rtl"] .sa-gamepad-container {
+  margin-left: 0.25rem;
 }
 
 .sa-gamepad-popup-outer {


### PR DESCRIPTION
### Changes

* Added CSS for the "Setting thumbnail..." alert
   <img width="279" height="89" alt="image" src="https://github.com/user-attachments/assets/1916d7a4-eff6-47e3-bf06-70a70911389a" />
* Updated share modal CSS to fix the Cancel button being white in dark mode
   <img width="809" height="183" alt="image" src="https://github.com/user-attachments/assets/fc04ea19-c5c6-4e88-86c0-aa4e51915316" />
* Updated margins so that buttons in the stage header are evenly spaced
   <img width="329" height="65" alt="image" src="https://github.com/user-attachments/assets/d514a227-808a-482f-bc9b-14d4d7b4b541" />

### Tests

Tested on Edge.