### PR TITLE
Improve addon topbar spacing in small windows

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -359,14 +359,8 @@
     .clickable-area {
       padding-inline-start: 6px;
     }
-    .addon-icon {
-      margin-inline-end: 6px;
-    }
     .addon-name-and-tags {
       padding: 6px 0;
-    }
-    .addon-name {
-      margin-inline-start: 8px;
     }
 
     .addon-settings {

--- a/webpages/settings/components/addon-group-header.html
+++ b/webpages/settings/components/addon-group-header.html
@@ -34,9 +34,5 @@
     .addon-group {
       padding-inline: 6px;
     }
-
-    .addon-group > img {
-      margin-inline-end: 5px;
-    }
   }
 </style>

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -263,6 +263,10 @@ body.iframe #search-not-found {
   .addons-container {
     padding: 10px 0;
   }
+
+  .arrow-button {
+    margin-inline-end: 6px;
+  }
 }
 
 /* Popup */


### PR DESCRIPTION
Updates how addon list icons are spaced in the popup to look nicer and save more space. Just see for yourself:

<img width="804" height="600" alt="Side by side popups" src="https://github.com/user-attachments/assets/658fb77b-b228-4a25-ac96-e14d053dd220" />
