### PR TITLE
Remove new table buttons (reverted)

### DIFF
--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -47,16 +47,12 @@
           </div>
         </div>
         <div class="split-button setting-table-dropdown dropdown-parent">
-          <button
-            :disabled="!addon._enabled"
-            class="icon-button split-button-button"
-            :title="msg('addRow')"
-            @click="addTableRow()"
-          >
+          <button :disabled="!addon._enabled" class="large-button split-button-button" @click="addTableRow()">
             <img class="icon-type" src="../../images/icons/plus.svg" draggable="false" />
+            {{ msg("addRow") }}
           </button>
           <dropdown
-            button-class="icon-button split-button-dropdown"
+            button-class="large-button split-button-dropdown"
             :disabled="!addon._enabled"
             :button-title="msg('addPresetRow')"
           >

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -20,26 +20,8 @@
         <div class="setting-table-list" v-sortable>
           <div class="setting-table-row" v-for="(i, row) of addonSettings[setting.id]">
             <div class="setting-table-options">
-              <button
-                :disabled="!addon._enabled || i == 0"
-                class="icon-button"
-                :class="{'disabled': i == 0}"
-                @click="moveTableRow(i, i - 1)"
-                :title="msg('moveUp')"
-              >
-                <img class="icon-type" src="../../images/icons/move-up.svg" />
-              </button>
               <button :disabled="!addon._enabled" class="icon-button handle" tabindex="-1">
                 <img class="icon-type" src="../../images/icons/drag.svg" />
-              </button>
-              <button
-                :disabled="!addon._enabled || i == addonSettings[setting.id].length - 1"
-                class="icon-button"
-                :class="{'disabled': i == addonSettings[setting.id].length - 1}"
-                @click="moveTableRow(i, i + 1)"
-                :title="msg('moveDown')"
-              >
-                <img class="icon-type" src="../../images/icons/move-down.svg" />
               </button>
             </div>
             <div class="setting-table-row-settings">
@@ -65,12 +47,16 @@
           </div>
         </div>
         <div class="split-button setting-table-dropdown dropdown-parent">
-          <button :disabled="!addon._enabled" class="large-button split-button-button" @click="addTableRow()">
+          <button
+            :disabled="!addon._enabled"
+            class="icon-button split-button-button"
+            :title="msg('addRow')"
+            @click="addTableRow()"
+          >
             <img class="icon-type" src="../../images/icons/plus.svg" draggable="false" />
-            {{ msg("addRow") }}
           </button>
           <dropdown
-            button-class="large-button split-button-dropdown"
+            button-class="icon-button split-button-dropdown"
             :disabled="!addon._enabled"
             :button-title="msg('addPresetRow')"
           >


### PR DESCRIPTION
Removes the arrow buttons from table items, added in #8934. Other design changes are kept, leaving it to look like this:

<img width="409" height="432" alt="Redesigned setting table interface" src="https://github.com/user-attachments/assets/94a58ba8-e737-4418-a038-c97d9bb26950" />

This is temporary; the buttons can be added again in a feature update or after v1.45.1 once the new "move up" and "move down" strings are translated.

@Samq64 @mxmou What do you think of this plan?

### Follow-up

- [ ] Re-add in v1.46.0