### PR TITLE
editor-searchable-dropdown: fix space key handling

### DIFF
--- a/addons/editor-searchable-dropdowns/userscript.js
+++ b/addons/editor-searchable-dropdowns/userscript.js
@@ -330,6 +330,9 @@ export default async function ({ addon, console, msg }) {
         }
       }
       // If there is no top value, do nothing and leave the dropdown open
+    } else if (event.key === " ") {
+      // Typing space in search bar shouldn't select an item.
+      event.stopPropagation();
     } else if (event.key === "Escape") {
       Blockly.DropDownDiv.hide();
     } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {


### PR DESCRIPTION
Resolves #8988

### Changes

Makes it possible to type a space into the dropdown search bar.

### Tests

Tested on Edge and Firefox.