### PR TITLE
middle-click-popup: more spork fixes

### DIFF
--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -275,13 +275,10 @@ export class BlockInstance {
    * @returns {*} A 'workspace form' block.
    */
   createWorkspaceForm() {
-    if (this.typeInfo.id === "control_stop") {
-      this.typeInfo.domForm
-        .querySelector("mutation")
-        .setAttribute("hasnext", "" + (this.inputs[0].value === "other scripts in sprite"));
-    }
-
-    const block = this.typeInfo.Blockly.Xml.domToBlock(this.typeInfo.domForm, this.typeInfo.workspace);
+    const block = this.typeInfo.Blockly.serialization.blocks.append(
+      this.typeInfo.serializedForm,
+      this.typeInfo.workspace
+    );
     for (let i = 0; i < this.typeInfo.inputs.length; i++) {
       const inputValue = this.inputs[i];
       if (inputValue !== null) this.typeInfo.inputs[i].setValue(block, inputValue);
@@ -377,19 +374,11 @@ export class BlockTypeInfo {
    * @returns {BlockTypeInfo[]}
    */
   static getBlocks(Blockly, vm, workspace, locale) {
-    const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
+    const flyout = workspace.getFlyout();
+    const flyoutWorkspace = flyout?.getWorkspace();
     if (!flyoutWorkspace) return [];
 
     const blocks = [];
-
-    const flyoutDom = Blockly.Xml.workspaceToDom(flyoutWorkspace);
-    const flyoutDomBlockMap = {};
-    for (const blockDom of flyoutDom.children) {
-      if (blockDom.tagName.toUpperCase() === "BLOCK") {
-        let id = blockDom.getAttribute("id");
-        flyoutDomBlockMap[id] = blockDom;
-      }
-    }
     for (const workspaceBlock of flyoutWorkspace.getTopBlocks()) {
       blocks.push(
         ...BlockTypeInfo._createBlocks(
@@ -398,7 +387,7 @@ export class BlockTypeInfo {
           Blockly,
           locale,
           workspaceBlock,
-          flyoutDomBlockMap[workspaceBlock.id]
+          flyout.serializeBlock(workspaceBlock)
         )
       );
     }
@@ -406,7 +395,7 @@ export class BlockTypeInfo {
     return blocks;
   }
 
-  static _createBlocks(workspace, vm, Blockly, locale, workspaceForm, domForm) {
+  static _createBlocks(workspace, vm, Blockly, locale, workspaceForm, serializedForm) {
     let parts = [];
     let inputs = [];
 
@@ -546,7 +535,7 @@ export class BlockTypeInfo {
         ofParts[baseVarPartIdx] = ofInputs[baseVarInputIdx];
         ofParts[baseTargetPartIdx] = ofInputs[baseTargetInputIdx];
 
-        blocks.push(new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, domForm, ofParts, ofInputs));
+        blocks.push(new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, ofParts, ofInputs));
       }
 
       return blocks;
@@ -567,19 +556,19 @@ export class BlockTypeInfo {
       newBlockParts[parts.indexOf(oldInput)] = newInput;
 
       return [
-        new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, domForm, parts, inputs, BlockShape.End),
-        new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, domForm, newBlockParts, [newInput], BlockShape.Stack),
+        new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, parts, inputs, BlockShape.End),
+        new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, newBlockParts, [newInput], BlockShape.Stack),
       ];
     } else {
-      return [new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, domForm, parts, inputs)];
+      return [new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, parts, inputs)];
     }
   }
 
-  constructor(workspace, Blockly, vm, workspaceForm, domForm, parts, inputs, shape) {
+  constructor(workspace, Blockly, vm, workspaceForm, serializedForm, parts, inputs, shape) {
     /** @type {string} */
     this.id = workspaceForm.type;
     this.workspaceForm = workspaceForm;
-    this.domForm = domForm;
+    this.serializedForm = serializedForm;
     /** @type {BlockShape} */
     this.shape = shape ?? BlockShape.getBlockShape(this.workspaceForm);
     /** @type {BlockCategory} */

--- a/addons/middle-click-popup/BlockTypeInfo.js
+++ b/addons/middle-click-popup/BlockTypeInfo.js
@@ -557,7 +557,16 @@ export class BlockTypeInfo {
 
       return [
         new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, parts, inputs, BlockShape.End),
-        new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, newBlockParts, [newInput], BlockShape.Stack),
+        new BlockTypeInfo(
+          workspace,
+          Blockly,
+          vm,
+          workspaceForm,
+          serializedForm,
+          newBlockParts,
+          [newInput],
+          BlockShape.Stack
+        ),
       ];
     } else {
       return [new BlockTypeInfo(workspace, Blockly, vm, workspaceForm, serializedForm, parts, inputs)];

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -392,11 +392,6 @@ export default async function ({ addon, msg, console }) {
     Blockly.Events.disable();
     try {
       newBlock = selectedPreview.block.createWorkspaceForm();
-      if (!Blockly.registry) {
-        // New Blockly doesn't currently change shadow IDs when copying blocks,
-        // so the addon only does this on old Blockly.
-        Blockly.scratchBlocksUtils.changeObscuredShadowIds(newBlock);
-      }
 
       var svgRootNew = newBlock.getSvgRoot();
       if (!svgRootNew) {

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -230,8 +230,15 @@ export default async function ({ addon, msg, console }) {
         updateSelection(resultIdx);
         allowMenuClose = !e.shiftKey;
         selectBlock(e);
-        allowMenuClose = true;
-        if (e.shiftKey) popupInput.focus();
+        if (e.shiftKey) {
+          // Keep the popup focused when Shift+dragging
+          // Blockly wants to focus the dragged block when starting or ending drag
+          popupInput.focus();
+          document.addEventListener("pointerup", () => {
+            allowMenuClose = true;
+            popupInput.focus();
+          }, { once: true });
+        }
       };
 
       const svgBackground = popupPreviewBlocks.appendChild(

--- a/addons/middle-click-popup/userscript.js
+++ b/addons/middle-click-popup/userscript.js
@@ -234,10 +234,14 @@ export default async function ({ addon, msg, console }) {
           // Keep the popup focused when Shift+dragging
           // Blockly wants to focus the dragged block when starting or ending drag
           popupInput.focus();
-          document.addEventListener("pointerup", () => {
-            allowMenuClose = true;
-            popupInput.focus();
-          }, { once: true });
+          document.addEventListener(
+            "pointerup",
+            () => {
+              allowMenuClose = true;
+              popupInput.focus();
+            },
+            { once: true }
+          );
         }
       };
 


### PR DESCRIPTION
Resolves #8991

### Changes

* Fixes cursed inputs by using Scratch's `serializeBlock()` method, which creates a representation of the block that doesn't include shadow IDs, forcing new ones to be generated when the block is added to a workspace.
* Fixes the popup closing when Shift+dragging blocks out of it. The Shift modifier is meant to keep the popup open so that multiple blocks can be dragged out without having to type the query each time.

### Tests

Tested on Edge and Firefox.