### PR TITLE
block-duplicate: spork fixes

### DIFF
--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -47,7 +47,11 @@ export async function load(addon) {
       }
 
       const isDuplicating =
-        enableDuplication && e.altKey && !this.flyout && this.targetBlock.type !== "procedures_definition";
+        enableDuplication &&
+        e.altKey &&
+        !this.flyout &&
+        this.targetBlock.type !== "procedures_definition" &&
+        this.targetBlock.type !== "procedures_prototype";
 
       if (isDuplicating) {
         this.startWorkspace_.setResizesEnabled(false);

--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -54,8 +54,9 @@ export async function load(addon) {
         ScratchBlocks.Events.disable();
         let newBlock;
         try {
-          const xmlBlock = ScratchBlocks.Xml.blockToDom(this.targetBlock);
-          newBlock = ScratchBlocks.Xml.domToBlock(xmlBlock, this.startWorkspace_);
+          const serializedBlock = ScratchBlocks.serialization.blocks.save(this.targetBlock);
+          ScratchBlocks.scratchBlocksUtils.stripIds(serializedBlock);
+          newBlock = ScratchBlocks.serialization.blocks.appendInternal(serializedBlock, this.startWorkspace_);
           const xy = this.targetBlock.getRelativeToSurfaceXY();
           newBlock.moveBy(xy.x, xy.y);
         } catch (e) {


### PR DESCRIPTION
### Changes

Fixes two bugs in the block-duplicate addon.

#### Duplicating custom block prototypes

To reproduce:
* Try to Alt+drag a prototype out of a define block. It looks like nothing has happened, but this actually creates a duplicate of the prototype.
* Move the define block out of the way to reveal the duplicate.

#### Cursed inputs

To reproduce:
* Put a variable into a text or number input
* Duplicate the block using Alt+drag
* Delete the original block
* Switch to another sprite and back
* Remove the variable from the input

Fixed by using the `stripIds()` utility function that Scratch added for this purpose.

### Tests

Tested on Edge and Firefox.