### PR TITLE
block-duplicate: use return value of stripIds

### DIFF
--- a/addons/block-duplicate/module.js
+++ b/addons/block-duplicate/module.js
@@ -58,8 +58,9 @@ export async function load(addon) {
         ScratchBlocks.Events.disable();
         let newBlock;
         try {
-          const serializedBlock = ScratchBlocks.serialization.blocks.save(this.targetBlock);
-          ScratchBlocks.scratchBlocksUtils.stripIds(serializedBlock);
+          let serializedBlock = ScratchBlocks.serialization.blocks.save(this.targetBlock);
+          const stripIdsResult = ScratchBlocks.scratchBlocksUtils.stripIds(serializedBlock);
+          if (stripIdsResult) serializedBlock = stripIdsResult;
           newBlock = ScratchBlocks.serialization.blocks.appendInternal(serializedBlock, this.startWorkspace_);
           const xy = this.targetBlock.getRelativeToSurfaceXY();
           newBlock.moveBy(xy.x, xy.y);


### PR DESCRIPTION
### Changes

There's an open PR in scratch-blocks that changes `stripIds()` to create a new object instead of mutating the argument, which will break the cursed inputs fix introduced in #8997. This PR updates the code that calls `stripIds()` to use the returned value if there's one.

### Tests

Verified that the cursed inputs bug is still fixed on scratch.mit.edu and on the [fix/stripIds-mutation](https://github.com/scratchfoundation/scratch-blocks/tree/fix/stripIds-mutation) branch of scratch-blocks.