### PR TITLE
Add landmarks to sidebar and main settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -149,8 +149,8 @@
   "close": {
     "message": "Close"
   },
-  "filters": {
-    "message": "Addon filters"
+  "categoryFilter": {
+    "message": "Addon category filter"
   },
   "resetToDefault": {
     "message": "Reset to default settings"
@@ -265,6 +265,9 @@
   },
   "search": {
     "message": "Search"
+  },
+  "addonsSearch": {
+    "message": "Addons Search"
   },
   "permissionsTitle": {
     "message": "Permissions - Scratch Addons"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -149,8 +149,8 @@
   "close": {
     "message": "Close"
   },
-  "filter": {
-    "message": "Filter:"
+  "filters": {
+    "message": "Addon filters"
   },
   "resetToDefault": {
     "message": "Reset to default settings"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -143,6 +143,9 @@
   "moreSettings": {
     "message": "More Settings"
   },
+  "sidebar": {
+    "message": "Sidebar"
+  },
   "toggleSidebar": {
     "message": "Toggle sidebar"
   },

--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -8,7 +8,6 @@
     v-if="!category.hidden"
     v-show="shouldShow"
     transition="expand"
-    :style="{ marginBottom: category.marginBottom ? '12px' : 0 }"
     @click="onClick($event)"
   >
     <img :src="'../../images/icons/' + category.icon + '.svg'" draggable="false" />

--- a/webpages/settings/data/categories.js
+++ b/webpages/settings/data/categories.js
@@ -88,7 +88,6 @@ export default [
     id: "popup",
     icon: "popup",
     name: chrome.i18n.getMessage("popupFeatures"),
-    marginBottom: true,
   },
   {
     id: "easterEgg",

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -205,37 +205,39 @@
         v-show="!isIframe"
         :class="{closed: categoryOpen === false, smallMode: smallMode === true}"
       >
-        <category-selector v-for="category of categories" :category="category"></category-selector>
-
-        <a
-          v-cloak
-          class="category"
-          style="margin-top: auto"
-          href="https://scratchaddons.com/credits/"
-          :href="sidebarUrls.contributors"
-          target="_blank"
-        >
-          <img src="../../images/icons/users.svg" draggable="false" />
-          <span>{{ msg("credits") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
-        </a>
-        <a v-cloak class="category" href="https://scratchaddons.com/translate" target="_blank">
-          <img src="../../images/icons/translate.svg" draggable="false" />
-          <span>{{ msg("translate") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
-        </a>
-        <a
-          v-cloak
-          class="category"
-          href="https://scratchaddons.com/feedback/"
-          :href="sidebarUrls.feedback"
-          target="_blank"
-        >
-          <img src="../../images/icons/comment.svg" draggable="false" />
-          <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
-        </a>
-        <button v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
-          <img src="../../images/icons/wrench.svg" draggable="false" />
-          <span>{{ msg("moreSettings") }}</span>
-        </button>
+        <div class="categories-container">
+          <category-selector v-for="category of categories" :category="category"></category-selector>
+        </div>
+        <div class="categories-container" style="margin-top: auto;">
+          <a
+            v-cloak
+            class="category"
+            href="https://scratchaddons.com/credits/"
+            :href="sidebarUrls.contributors"
+            target="_blank"
+          >
+            <img src="../../images/icons/users.svg" draggable="false" />
+            <span>{{ msg("credits") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
+          </a>
+          <a v-cloak class="category" href="https://scratchaddons.com/translate" target="_blank">
+            <img src="../../images/icons/translate.svg" draggable="false" />
+            <span>{{ msg("translate") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
+          </a>
+          <a
+            v-cloak
+            class="category"
+            href="https://scratchaddons.com/feedback/"
+            :href="sidebarUrls.feedback"
+            target="_blank"
+          >
+            <img src="../../images/icons/comment.svg" draggable="false" />
+            <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
+          </a>
+          <button v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
+            <img src="../../images/icons/wrench.svg" draggable="false" />
+            <span>{{ msg("moreSettings") }}</span>
+          </button>
+        </div>
       </div>
       <button
         v-show="!isIframe && smallMode === false"

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -208,7 +208,7 @@
         <div class="categories-container">
           <category-selector v-for="category of categories" :category="category"></category-selector>
         </div>
-        <div class="categories-container" style="margin-top: auto;">
+        <div class="categories-container" style="margin-top: auto">
           <a
             v-cloak
             class="category"

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -176,7 +176,7 @@
     <script src="index.js" type="module"></script>
   </head>
   <body v-cloak :class="{light: theme}">
-    <div class="navbar">
+    <header class="navbar">
       <button
         id="sidebar-toggle"
         class="header-button"
@@ -197,7 +197,7 @@
       >
         <img v-cloak class="theme-switch" :src="themePath" draggable="false" />
       </button>
-    </div>
+    </header>
     <div class="main">
       <div
         class="categories-block"
@@ -205,10 +205,10 @@
         v-show="!isIframe"
         :class="{closed: categoryOpen === false, smallMode: smallMode === true}"
       >
-        <div class="categories-container">
+        <aside :aria-label="msg('filters')" class="categories-container">
           <category-selector v-for="category of categories" :category="category"></category-selector>
-        </div>
-        <div class="categories-container" style="margin-top: auto">
+        </aside>
+        <nav class="categories-container" style="margin-top: auto">
           <a
             v-cloak
             class="category"
@@ -237,7 +237,7 @@
             <img src="../../images/icons/wrench.svg" draggable="false" />
             <span>{{ msg("moreSettings") }}</span>
           </button>
-        </div>
+        </nav>
       </div>
       <button
         v-show="!isIframe && smallMode === false"
@@ -253,7 +253,7 @@
       </button>
 
       <!-- This is the main menu, where the searchbar and the addon items are located -->
-      <div class="addons-block">
+      <main class="addons-block">
         <div class="addons-block-header">
           <div v-if="!isIframe" class="category-header-title" v-cloak>
             <div v-if="relatedAddonsOpen" class="related-addons-header">
@@ -264,7 +264,7 @@
             </div>
             <span v-else>{{ selectedCategoryName }}</span>
           </div>
-          <div v-cloak class="search-box" v-if="!relatedAddonsOpen" :class="{smallMode: smallMode === true}">
+          <search v-cloak class="search-box" v-if="!relatedAddonsOpen" :class="{smallMode: smallMode === true}">
             <input type="text" id="searchBox" :placeholder="searchMsg" v-model="searchInputReal" autofocus />
             <button disabled v-show="searchInput === ''">
               <img src="../../images/icons/search.svg" class="search-icon" />
@@ -272,7 +272,7 @@
             <button v-else @click="clearAndFocusSearch()">
               <img src="../../images/icons/x.svg" class="search-icon" />
             </button>
-          </div>
+          </search>
         </div>
 
         <div class="addons-container" :class="{placeholder: !loaded}" v-cloak>
@@ -311,7 +311,7 @@
             </div>
           </template>
         </div>
-      </div>
+      </main>
     </div>
     <modal
       class="more-settings"

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -233,7 +233,7 @@
             <img src="../../images/icons/comment.svg" draggable="false" />
             <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
           </a>
-          <button v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
+          <button v-cloak class="category" style="margin-top: 12px; margin-bottom: 2px" @click="openMoreSettings()">
             <img src="../../images/icons/wrench.svg" draggable="false" />
             <span>{{ msg("moreSettings") }}</span>
           </button>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -204,6 +204,7 @@
         v-click-outside="closesidebar"
         v-show="!isIframe"
         :class="{closed: categoryOpen === false, smallMode: smallMode === true}"
+        :aria-label="msg('sidebar')"
       >
         <aside :aria-label="msg('categoryFilter')" class="categories-container">
           <category-selector v-for="category of categories" :category="category"></category-selector>

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -205,7 +205,7 @@
         v-show="!isIframe"
         :class="{closed: categoryOpen === false, smallMode: smallMode === true}"
       >
-        <aside :aria-label="msg('filters')" class="categories-container">
+        <aside :aria-label="msg('categoryFilter')" class="categories-container">
           <category-selector v-for="category of categories" :category="category"></category-selector>
         </aside>
         <nav class="categories-container" style="margin-top: auto">
@@ -264,7 +264,13 @@
             </div>
             <span v-else>{{ selectedCategoryName }}</span>
           </div>
-          <search v-cloak class="search-box" v-if="!relatedAddonsOpen" :class="{smallMode: smallMode === true}">
+          <search
+            v-cloak
+            class="search-box"
+            :aria-label="msg('addonsSearch')"
+            v-if="!relatedAddonsOpen"
+            :class="{smallMode: smallMode === true}"
+          >
             <input type="text" id="searchBox" :placeholder="searchMsg" v-model="searchInputReal" autofocus />
             <button disabled v-show="searchInput === ''">
               <img src="../../images/icons/search.svg" class="search-icon" />

--- a/webpages/styles/components/categories.css
+++ b/webpages/styles/components/categories.css
@@ -36,4 +36,5 @@
 .categories-container {
   display: flex;
   flex-direction: column;
+  margin-bottom: 12px;
 }

--- a/webpages/styles/components/categories.css
+++ b/webpages/styles/components/categories.css
@@ -32,3 +32,8 @@
 .categories-block.closed:not(.smallMode) {
   display: none;
 }
+
+.categories-container {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
This pull request adds landmarks to the Scratch Addons settings page, helping screen reader users navigate and understand the general layout of the settings page (many screen readers allow users to jump between landmarks and other important elements for faster navigation).

<img width="687" height="353" alt="Image showing landmark layout of settings page" src="https://github.com/user-attachments/assets/1f4edef1-88c5-4530-b244-df90a1aa9601" />

### How I made this

First, I split up the settings page sidebar into sections. Previously, the sidebar was a flat list containing every addon category and other element on one level, but now each type of item lives inside a different parent element. There are two of these on the sidebar, one for the addon categories and one for the other items like More Settings and Send Feedback.

This also allowed me to transfer the margin of 12px below the last addon category list item to the parent `div`, making those components more flexible to develop.

After that, it was easy to convert the two new sidebar sections to landmark elements: `<aside>` for the addon category list (which is labeled "Addon filters") and `<nav>` for the rest, and to put both of them in a group called "Sidebar". The addon category list is `<aside>` because it is complementary to the main content, the addon settings.

I also added the landmark elements `<header>`, `<main>`, and `<search>`.

### Testing

For testing, activate a screen reader and ensure that the landmarks are announced properly when navigated to (e.g., `<main>` should be read as something like "main landmark").

I used Windows Narrator with Microsoft Edge.