### PR TITLE
editor-theme3: fix scroll in long inputs

### DIFF
--- a/addons/editor-theme3/black_text.css
+++ b/addons/editor-theme3/black_text.css
@@ -8,8 +8,8 @@
 .scratch-renderer.default-theme .blocklyEditableField > text {
   fill: var(--editorTheme3-inputColor-blackText);
 }
-.sa-theme3-editable-label .blocklyHtmlInput {
-  /* Labels in custom block editor */
+.blocklyHtmlInput,
+.scratch-renderer.default-theme .blocklyHtmlInput {
   color: var(--editorTheme3-inputColor-blackText);
 }
 

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -21,6 +21,12 @@
      In the new Blockly version, they currently look like normal text inputs. */
   fill: var(--editorTheme3-inputColor);
 }
+.blocklyShadow.textField.blocklyEditing,
+.blocklyInputField.blocklyEditing {
+  /* Hide text input fields while editing so that only the HTML input is visible.
+     This is needed for transparent inputs. */
+  visibility: hidden;
+}
 
 /* Override Scratch's high contrast theme */
 .blocklyDropDownDiv .goog-menuitem {

--- a/addons/editor-theme3/theme3.css
+++ b/addons/editor-theme3/theme3.css
@@ -9,16 +9,12 @@
 }
 .blocklyHtmlInput,
 .scratch-renderer.default-theme .blocklyHtmlInput {
-  /* Hide the HTML input so that only the SVG part is visible.
-     This is needed for transparent inputs. */
-  background-color: transparent;
-  color: transparent;
-  caret-color: var(--editorTheme3-inputColor-text);
+  background-color: var(--editorTheme3-inputColor);
+  color: var(--editorTheme3-inputColor-text);
 }
 .sa-theme3-editable-label .blocklyHtmlInput {
   /* Labels in custom block editor (focused state) */
   background-color: var(--editorTheme3-inputColor-editableLabel);
-  color: var(--editorTheme3-inputColor-text);
 }
 .scratch-renderer.default-theme .blocklyEditableField > rect:not(.blocklyDropdownRect) {
   /* Labels in custom block editor.


### PR DESCRIPTION
Resolves #9007

### Changes

Fixes not being able to scroll left and right using arrow keys when editing a long string in a text input.

editor-theme3 used to hide the editable HTML part of block inputs so that only the SVG elements behind it were visible - before spork, this was the simplest way to make transparent inputs work. New Blockly is easier to style with CSS, so I was able to change it to keep the HTML input visible, making long inputs behave as intended.

### Tests

Tested on Edge and Firefox.
* It's now possible to move left and right when editing long inputs.
* Focused inputs are still rendered correctly when the input color is transparent.