### PR TITLE
custom-block-text: fix input text size

### DIFF
--- a/addons/cat-blocks/userscript.js
+++ b/addons/cat-blocks/userscript.js
@@ -460,19 +460,7 @@ export default async function ({ addon, console, msg }) {
       await setTheme(scratchTheme);
     }
 
-    if (Blockly.registry) {
-      // new Blockly
-      const workspace = addon.tab.traps.getWorkspace();
-      workspace.renderer.refreshDom(workspace.getSvgGroup(), workspace.getTheme(), workspace.getInjectionDiv());
-
-      const flyout = workspace.getFlyout();
-      if (flyout) {
-        const flyoutWorkspace = flyout.getWorkspace();
-        flyoutWorkspace.renderer.refreshDom(flyoutWorkspace.getSvgGroup(), flyoutWorkspace.getTheme(), null);
-      }
-    }
-
-    updateAllBlocks(addon.tab);
+    updateAllBlocks(addon.tab, { updateRenderer: true });
   };
 
   update();

--- a/addons/custom-block-shape/modern-blockly.js
+++ b/addons/custom-block-shape/modern-blockly.js
@@ -167,20 +167,11 @@ export default async function ({ addon, console }) {
     return new Blockly.utils.Size(-8 * multiplier, 0);
   };
 
-  const updateRendererAndBlocks = () => {
-    const workspace = addon.tab.traps.getWorkspace();
-    workspace.renderer.refreshDom(workspace.getSvgGroup(), workspace.getTheme(), workspace.getInjectionDiv());
-
-    const flyout = workspace.getFlyout();
-    if (flyout) {
-      const flyoutWorkspace = flyout.getWorkspace();
-      flyoutWorkspace.renderer.refreshDom(flyoutWorkspace.getSvgGroup(), flyoutWorkspace.getTheme(), null);
-    }
-
-    updateAllBlocks(addon.tab);
+  const update = () => {
+    updateAllBlocks(addon.tab, { updateRenderer: true });
   };
-  addon.settings.addEventListener("change", () => updateRendererAndBlocks());
-  addon.self.addEventListener("disabled", () => updateRendererAndBlocks());
-  addon.self.addEventListener("reenabled", () => updateRendererAndBlocks());
-  updateRendererAndBlocks();
+  addon.settings.addEventListener("change", () => update());
+  addon.self.addEventListener("disabled", () => update());
+  addon.self.addEventListener("reenabled", () => update());
+  update();
 }

--- a/addons/custom-block-text/userscript.js
+++ b/addons/custom-block-text/userscript.js
@@ -21,8 +21,7 @@ export default async function ({ addon, console }) {
   // Be careful with specificity because we're adding this userstyle manually
   // to the <head> without checking if other styles are above or below.
   fontSizeCss.textContent = `
-    .blocklyText,
-    .blocklyHtmlInput {
+    .blocklyText {
       font-size: calc(var(--customBlockText-sizeSetting) * 0.12pt) !important;
     }
     .blocklyFlyoutLabelText {
@@ -65,6 +64,16 @@ export default async function ({ addon, console }) {
   textShadowCss.disabled = true;
   document.head.appendChild(textShadowCss);
 
+  const ScratchRenderer = blocklyInstance.registry.getClass(blocklyInstance.registry.Type.RENDERER, "scratch_classic");
+  const oldScratchRendererMakeConstants = ScratchRenderer.prototype.makeConstants_;
+  ScratchRenderer.prototype.makeConstants_ = function () {
+    const constants = oldScratchRendererMakeConstants.call(this);
+    if (!addon.self.disabled) {
+      constants.FIELD_TEXT_FONTSIZE = 0.12 * currentTextSize;
+    }
+    return constants;
+  };
+
   const updateBlockly = () => {
     if (!blocklyInstance.registry) {
       // old Blockly
@@ -72,6 +81,15 @@ export default async function ({ addon, console }) {
     }
     // If font size has changed, middle click popup needs to clear its cache too
     clearTextWidthCache();
+
+    const workspace = addon.tab.traps.getWorkspace();
+    workspace.renderer.refreshDom(workspace.getSvgGroup(), workspace.getTheme(), workspace.getInjectionDiv());
+
+    const flyout = workspace.getFlyout();
+    if (flyout) {
+      const flyoutWorkspace = flyout.getWorkspace();
+      flyoutWorkspace.renderer.refreshDom(flyoutWorkspace.getSvgGroup(), flyoutWorkspace.getTheme(), null);
+    }
 
     updateAllBlocks(addon.tab);
   };

--- a/addons/custom-block-text/userscript.js
+++ b/addons/custom-block-text/userscript.js
@@ -82,16 +82,7 @@ export default async function ({ addon, console }) {
     // If font size has changed, middle click popup needs to clear its cache too
     clearTextWidthCache();
 
-    const workspace = addon.tab.traps.getWorkspace();
-    workspace.renderer.refreshDom(workspace.getSvgGroup(), workspace.getTheme(), workspace.getInjectionDiv());
-
-    const flyout = workspace.getFlyout();
-    if (flyout) {
-      const flyoutWorkspace = flyout.getWorkspace();
-      flyoutWorkspace.renderer.refreshDom(flyoutWorkspace.getSvgGroup(), flyoutWorkspace.getTheme(), null);
-    }
-
-    updateAllBlocks(addon.tab);
+    updateAllBlocks(addon.tab, { updateRenderer: true });
   };
 
   const setFontSize = (wantedSize) => {

--- a/addons/editor-square-inputs/userscript.js
+++ b/addons/editor-square-inputs/userscript.js
@@ -113,21 +113,12 @@ export default async function ({ addon }) {
     };
   }
 
-  const updateRendererAndBlocks = () => {
-    const workspace = addon.tab.traps.getWorkspace();
-    workspace.renderer.refreshDom(workspace.getSvgGroup(), workspace.getTheme(), workspace.getInjectionDiv());
-
-    const flyout = workspace.getFlyout();
-    if (flyout) {
-      const flyoutWorkspace = flyout.getWorkspace();
-      flyoutWorkspace.renderer.refreshDom(flyoutWorkspace.getSvgGroup(), flyoutWorkspace.getTheme(), null);
-    }
-
-    updateAllBlocks(addon.tab);
+  const update = () => {
+    updateAllBlocks(addon.tab, { updateRenderer: true });
   };
 
-  addon.self.addEventListener("disabled", () => updateRendererAndBlocks());
-  addon.self.addEventListener("reenabled", () => updateRendererAndBlocks());
-  addon.settings.addEventListener("change", () => updateRendererAndBlocks());
-  updateRendererAndBlocks();
+  addon.self.addEventListener("disabled", () => update());
+  addon.self.addEventListener("reenabled", () => update());
+  addon.settings.addEventListener("change", () => update());
+  update();
 }

--- a/libraries/common/cs/update-all-blocks.js
+++ b/libraries/common/cs/update-all-blocks.js
@@ -3,13 +3,15 @@ const updateAllBlocksEvents = new EventTarget();
 
 export async function updateAllBlocks(
   tab,
-  { updateMainWorkspace = true, updateFlyout = true, updateCategories = false } = {}
+  { updateMainWorkspace = true, updateFlyout = true, updateCategories = false, updateRenderer = false } = {}
 ) {
   // Don't try to update if project hasn't loaded
   if (!tab.traps.vm.editingTarget) return;
 
   const blockly = await tab.traps.getBlockly();
   const workspace = tab.traps.getWorkspace();
+  const toolbox = workspace.getToolbox();
+  const flyout = workspace.getFlyout();
 
   // Calling Events.disable() will:
   // - prevent changes to the workspace from being added to the undo stack;
@@ -18,6 +20,13 @@ export async function updateAllBlocks(
   blockly.Events.disable();
 
   if (workspace) {
+    if (updateRenderer) {
+      workspace.renderer.refreshDom(workspace.getSvgGroup(), workspace.getTheme(), workspace.getInjectionDiv());
+      if (flyout) {
+        const flyoutWorkspace = flyout.getWorkspace();
+        flyoutWorkspace.renderer.refreshDom(flyoutWorkspace.getSvgGroup(), flyoutWorkspace.getTheme(), null);
+      }
+    }
     if (updateMainWorkspace) {
       const xml = blockly.Xml.workspaceToDom(workspace);
       if (xml.querySelector("variables")) {
@@ -38,8 +47,6 @@ export async function updateAllBlocks(
       xml.appendChild(variables);
       blockly.clearWorkspaceAndLoadFromXml(xml, workspace);
     }
-    const toolbox = workspace.getToolbox();
-    const flyout = workspace.getFlyout();
     if (toolbox && flyout && (updateFlyout || updateCategories)) {
       if (updateFlyout) {
         if (blockly.registry) {


### PR DESCRIPTION
Resolves #9010

### Changes

Fixes the incorrect font size of focused block inputs. Also moves some code that's now used by four different addons to the `updateAllBlocks` module.

### Tests

Tested on Edge with different values of the text size setting and different workspace zoom levels.