### PR TITLE
zebra-striping: fix for `procedures_prototype`

### DIFF
--- a/addons/zebra-striping/userscript.js
+++ b/addons/zebra-striping/userscript.js
@@ -28,26 +28,28 @@ export default async function ({ addon, msg, console }) {
         stripeState.set(block, isStriped);
 
         const elements = [];
-        if (block.pathObject) {
-          // new Blockly
-          elements.push(block.pathObject.svgPath);
-          if (block.pathObject.svgPathSelected) {
-            elements.push(block.pathObject.svgPathSelected);
+        if (block.type !== "procedures_prototype") {
+          if (block.pathObject) {
+            // new Blockly
+            elements.push(block.pathObject.svgPath);
+            if (block.pathObject.svgPathSelected) {
+              elements.push(block.pathObject.svgPathSelected);
+            }
+            for (const outlinePath of block.pathObject.outlines.values()) {
+              elements.push(outlinePath);
+            }
+          } else {
+            elements.push(block.svgPath_);
           }
-          for (const outlinePath of block.pathObject.outlines.values()) {
-            elements.push(outlinePath);
-          }
-        } else {
-          elements.push(block.svgPath_);
-        }
-        for (const input of block.inputList) {
-          if (input.outlinePath) {
-            // old Blockly
-            elements.push(input.outlinePath);
-          }
-          for (const field of input.fieldRow) {
-            if (field.fieldGroup_) {
-              elements.push(field.fieldGroup_);
+          for (const input of block.inputList) {
+            if (input.outlinePath) {
+              // old Blockly
+              elements.push(input.outlinePath);
+            }
+            for (const field of input.fieldRow) {
+              if (field.fieldGroup_) {
+                elements.push(field.fieldGroup_);
+              }
             }
           }
         }


### PR DESCRIPTION
Resolves #9021

### Changes

Fixes an issue with the `procedures_prototype` block, as it was affected by zebra coloring, which would lead to very white or muddy colors inside the "define" hat.

### Reason for changes

1. It worked just fine in old blockly
2. white/muddy colors do not fit with the "define" block

### Examples

Before:

<img width="572" height="294" alt="image" src="https://github.com/user-attachments/assets/c761b6d0-9faa-4c7c-b5be-a2db7a943a6d" />
<img width="565" height="305" alt="image" src="https://github.com/user-attachments/assets/79b54f90-c151-455a-9e69-1a2732ef3259" />
(high contrast often gives very white blocks)

After:

<img width="398" height="226" alt="image" src="https://github.com/user-attachments/assets/1de9766d-9380-4976-b24c-f39c7af0861d" />

<img width="624" height="333" alt="image" src="https://github.com/user-attachments/assets/9efc1fde-7273-4e40-bcc4-b6f86adac2eb" />



### Tests

I have only tested on Chrome