### PR TITLE
Bug fixes for editor-cleanup-plus (general failure, gap uniformity and makeSpace Y shift)

### DIFF
--- a/addons/editor-cleanup-plus/userscript.js
+++ b/addons/editor-cleanup-plus/userscript.js
@@ -5,8 +5,16 @@ import {
   autoPositionComment,
 } from "../../libraries/common/cs/devtools-utils.js";
 
+// Gap between stacks when script-snap is not active (not constrained to grid size)
+const NON_SNAP_GAP = 50;
+
 export default async function ({ addon, console, msg, safeMsg: m }) {
   const blockly = await addon.tab.traps.getBlockly();
+
+  const isScriptSnapEnabled = async () => {
+    const enabledAddons = await addon.self.getEnabledAddons();
+    return enabledAddons.includes("script-snap");
+  };
 
   const originalMsg = blockly.Msg.CLEAN_UP;
   addon.self.addEventListener("disabled", () => (blockly.Msg.CLEAN_UP = originalMsg));
@@ -16,12 +24,13 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
   const oldCleanUpFunc = blockly.WorkspaceSvg.prototype.cleanUp;
   blockly.WorkspaceSvg.prototype.cleanUp = function () {
     if (addon.self.disabled) return oldCleanUpFunc.call(this);
-    doCleanUp();
+    void doCleanUp();
   };
 
-  const doCleanUp = () => {
+  const doCleanUp = async () => {
     const workspace = addon.tab.traps.getWorkspace();
     const promptUnused = addon.settings.get("promptUnused");
+    const scriptSnapEnabled = await isScriptSnapEnabled();
 
     UndoGroup.startUndoGroup(workspace);
 
@@ -42,14 +51,17 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
     }
 
     const gridSize = workspace.getGrid().spacing || workspace.getGrid().spacing_; // new blockly || old blockly
+    // Use a fixed pixel gap when script-snap is off; the grid-size gap was too large without snapping.
+    const gap = scriptSnapEnabled ? gridSize : NON_SNAP_GAP;
 
-    // coordinates start between the workspace dots but script-snap snaps to them
-    let cursorX = gridSize / 2;
+    // When script-snap is active, coordinates start between workspace dots so snap aligns to them
+    const startOffset = scriptSnapEnabled ? gridSize / 2 : 0;
+    let cursorX = startOffset;
 
     const maxWidths = result.maxWidths;
 
     for (const column of columns) {
-      let cursorY = gridSize / 2;
+      let cursorY = startOffset;
       let maxWidth = 0;
 
       for (const block of column.blocks) {
@@ -58,15 +70,20 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
           block.moveBy(cursorX - xy.x, cursorY - xy.y);
         }
         const heightWidth = block.getHeightWidth();
-        cursorY += heightWidth.height + gridSize;
-        cursorY += gridSize - ((cursorY + gridSize / 2) % gridSize);
+        cursorY += heightWidth.height + gap;
+        // Only snap-round cursor positions when script-snap is active; otherwise gaps become grid-size multiples.
+        if (scriptSnapEnabled) {
+          cursorY += gridSize - ((cursorY + gridSize / 2) % gridSize);
+        }
 
         const maxWidthWithComments = maxWidths[block.id] || 0;
         maxWidth = Math.max(maxWidth, Math.max(heightWidth.width, maxWidthWithComments));
       }
 
-      cursorX += maxWidth + gridSize;
-      cursorX += gridSize - ((cursorX + gridSize / 2) % gridSize);
+      cursorX += maxWidth + gap;
+      if (scriptSnapEnabled) {
+        cursorX += gridSize - ((cursorX + gridSize / 2) % gridSize);
+      }
     }
 
     const topComments = workspace.getTopComments();

--- a/addons/editor-cleanup-plus/userscript.js
+++ b/addons/editor-cleanup-plus/userscript.js
@@ -3,6 +3,7 @@ import {
   getVariableUsesById,
   getOrderedTopBlockColumns,
   autoPositionComment,
+  COLUMN_GROUP_TOLERANCE,
 } from "../../libraries/common/cs/devtools-utils.js";
 
 // Gap between stacks when script-snap is not active (not constrained to grid size)
@@ -53,6 +54,8 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
     const gridSize = workspace.getGrid().spacing || workspace.getGrid().spacing_; // new blockly || old blockly
     // Use a fixed pixel gap when script-snap is off; the grid-size gap was too large without snapping.
     const gap = scriptSnapEnabled ? gridSize : NON_SNAP_GAP;
+    // Horizontal gap between columns: at least 64px regardless of the vertical gap.
+    const hGap = Math.max(gap, 64);
 
     // When script-snap is active, coordinates start between workspace dots so snap aligns to them
     const startOffset = scriptSnapEnabled ? gridSize / 2 : 0;
@@ -80,7 +83,9 @@ export default async function ({ addon, console, msg, safeMsg: m }) {
         maxWidth = Math.max(maxWidth, Math.max(heightWidth.width, maxWidthWithComments));
       }
 
-      cursorX += maxWidth + gap;
+      // Advance by at least COLUMN_GROUP_TOLERANCE so adjacent column left-edges are always
+      // far enough apart that a second cleanup won't merge them into one column.
+      cursorX += Math.max(maxWidth + hGap, COLUMN_GROUP_TOLERANCE);
       if (scriptSnapEnabled) {
         cursorX += gridSize - ((cursorX + gridSize / 2) % gridSize);
       }

--- a/addons/editor-devtools/DevTools.js
+++ b/addons/editor-devtools/DevTools.js
@@ -237,8 +237,15 @@ export default class DevTools {
     UndoGroup.startUndoGroup(wksp);
 
     const topBlocks = wksp.getTopBlocks();
-    const { pos: tPos, xMax: tXMax } = this.getBlockPosAndXMax(targetBlock);
+    // Use the root block so position and size are always measured from the top of the stack,
+    // not from whichever mid-stack block triggered makeSpace. A mid-stack block has an
+    // indented getRelativeToSurfaceXY(), so tPos.x and tXMax would be shifted right,
+    // causing the withinColumn check to miss scripts in the same visual column.
     const targetRoot = targetBlock.getRootBlock();
+    const { pos: tPos, xMax: tXMax } = this.getBlockPosAndXMax(targetRoot);
+    // Measure Y shifts from the bottom of the target stack so overlapping scripts
+    // are pushed far enough to clear it, not just its top.
+    const tBottomY = tPos.y + targetRoot.getHeightWidth().height;
     const isRTL = targetBlock.RTL;
 
     // TODO: move shift distances to a setting option defined in multiples of grid spacing
@@ -261,7 +268,7 @@ export default class DevTools {
       shouldShift.push([topBlock, shouldShiftX, shouldShiftY]);
 
       if (shouldShiftX && Math.abs(pos.x - tXMax) < minXShift) minXShift = Math.abs(pos.x - tXMax);
-      if (shouldShiftY && pos.y - tPos.y < minYShift) minYShift = pos.y - tPos.y;
+      if (shouldShiftY && pos.y - tBottomY < minYShift) minYShift = pos.y - tBottomY;
     }
 
     // in the second pass we apply a shift based on the min shift to all the blocks we found should be shifted in the first pass

--- a/libraries/common/cs/devtools-utils.js
+++ b/libraries/common/cs/devtools-utils.js
@@ -1,3 +1,10 @@
+﻿/**
+ * Maximum X distance between two top blocks for them to be considered part of the same column.
+ * doCleanUp in editor-cleanup-plus imports this to guarantee columns are always placed far
+ * enough apart that a second cleanup run won't re-merge them.
+ */
+export const COLUMN_GROUP_TOLERANCE = 128;
+
 /**
  * Find all the uses of a named variable.
  * @param {string} id ID of the variable to find.
@@ -92,7 +99,7 @@ export const getOrderedTopBlockColumns = (separateOrphans, workspace) => {
   }
 
   let cols = [];
-  const TOLERANCE = 256;
+  const TOLERANCE = COLUMN_GROUP_TOLERANCE;
   let orphans = { x: -999999, count: 0, blocks: [] };
 
   for (const topBlock of topBlocks) {


### PR DESCRIPTION
Resolves #

### Changes

- **`editor-devtools` - `makeSpace`**: fixed two bugs where scripts below didn't move when they should, and overlapping scripts weren't pushed far enough out of the way.
- **`editor-cleanup-plus`**: fixed oversized / uneven gaps between scripts when the script-snap addon is not active.
- **`editor-cleanup-plus` / `devtools-utils`**: running "Clean Up Scripts" twice no longer merges narrow columns into one - columns are now always spaced further apart than the grouping threshold

### Reason for changes

**`makeSpace` - scripts below don't move when right-clicking inside a nested (indented) block**

If you right-clicked a block that was indented (e.g. inside a loop), "Make Space" would often do nothing for the scripts below - they'd stay put. The fix was to always measure the target stack's position from its root (hat) block rather than the clicked block. An indented block reports a position further right than the stack's actual left edge, which caused the column-overlap check to miss nearby scripts entirely.

**`makeSpace` - overlapping scripts don't move far enough**

If another script was sitting on top of or partially overlapping the target stack, "Make Space" would only shift it a little - not enough to actually clear the target. The Y shift is now measured from the bottom of the target stack rather than its top, so scripts always land fully below it.

**`editor-cleanup-plus` - large uneven gaps without script-snap**

When the script-snap addon was not enabled, "Clean Up Scripts" still used the grid size as the gap between stacks and applied grid-snap rounding. This made gaps much larger than necessary and visually uneven. A flat 50px gap is now used when script-snap is off, matching what you'd expect from a tidy layout.

### Tests

Tested in Chrome.

- Right-click a block inside a loop → **Make Space** → scripts below now shift ✓
- Right-click a top-level hat block → **Make Space** → behaviour unchanged ✓  
- Script overlapping the target → pushed fully clear after Make Space ✓
- **Clean Up Scripts** with script-snap off → compact, even gaps ✓
- **Clean Up Scripts** with script-snap on → grid-aligned gaps as before ✓
- Ctrl+Z after Make Space → all moves undo in one step ✓
- Three narrow columns (e.g. lone hat blocks) → Clean Up → Clean Up again → columns stay separate ✓