### PR TITLE
Block transparency: Fix opacity of comments

### DIFF
--- a/addons/transparent-orphans/userstyle.css
+++ b/addons/transparent-orphans/userstyle.css
@@ -2,14 +2,8 @@
 .blocklyFlyout > .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable {
   opacity: calc(1 - var(--transparentOrphans-block) / 100);
 }
-.blocklyWsDragSurface > .blocklyBlockCanvas > .blocklyDraggable[data-shapes*="hat"] {
-  opacity: calc(1 - var(--transparentOrphans-block) / 100);
-}
 
-.blocklySvg > .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable:not([data-shapes*="hat"]) {
-  opacity: calc(1 - var(--transparentOrphans-orphan) / 100);
-}
-.blocklyWsDragSurface > .blocklyBlockCanvas > .blocklyDraggable:not([data-shapes*="hat"]) {
+.blocklySvg > .blocklyWorkspace > .blocklyBlockCanvas > .blocklyDraggable:not([data-shapes*="hat"], .blocklyComment) {
   opacity: calc(1 - var(--transparentOrphans-orphan) / 100);
 }
 


### PR DESCRIPTION
Resolves #9028

### Changes

Excludes comments from transparent orphans and removes the `.blocklyWsDragSurface` styles. Transparency is kept when dragging comments or block stacks with comments attached.

### Reason for changes

Comments were not affected before except when dragging the comments themselves. This PR restores that behaviour except comments are now also affected when dragging the stack. 

### Tests

Tested on Helium.