### PR TITLE
Settings page - Load addons lazily

### DIFF
--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -1,6 +1,6 @@
 <template>
   <div class="addon-body" v-show="shouldShow" :id="'addon-' + addon._addonId">
-    <div class="addon-topbar">
+    <div class="addon-topbar" v-if="everWithinView">
       <div class="clickable-area" @click="expanded = !expanded">
         <button class="arrow-button" :title="msg(expanded ? 'collapse' : 'expand')">
           <img src="../../images/icons/expand.svg" :class="{'reverted': expanded}" draggable="false" />
@@ -28,7 +28,7 @@
         <input type="checkbox" class="switch" v-model="addon._enabled" @click="toggleAddonRequest" />
       </div>
     </div>
-    <div class="addon-settings" v-if="everExpanded" v-show="expanded">
+    <div class="addon-settings" v-if="everWithinView && everExpanded" v-show="expanded">
       <div class="addon-description-full">{{ addon.description }}</div>
       <div class="addon-message addon-update" v-if="showUpdateNotice">
         <addon-tag tag="new"></addon-tag>
@@ -217,6 +217,7 @@
     padding-inline-start: 10px;
   }
   .addon-body {
+    min-height: 54px;
     margin: 10px;
     background: var(--content-background);
     border: 1px solid var(--content-border);
@@ -360,6 +361,9 @@
     .addon-topbar {
       min-height: 44px;
       padding-inline-end: 6px;
+    }
+    .addon-body {
+      min-height: 46px;
     }
     .clickable-area {
       padding-inline-start: 6px;

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -6,16 +6,15 @@
           <img src="../../images/icons/expand.svg" :class="{'reverted': expanded}" draggable="false" />
         </button>
         <img :src="addonIconSrc" :title="addonIconAlt" class="icon-type addon-icon" draggable="false" />
-        <!-- prettier-ignore -->
         <div class="addon-name-and-tags" v-if="isPlaceholder">
           <div class="addon-name tooltip"><span></span></div>
         </div>
+        <!-- prettier-ignore -->
         <div class="addon-name-and-tags" v-else>
           <div class="addon-name tooltip">
             <span>{{ addon.name }}</span>
             <span v-if="devMode" class="tooltiptext tooltiptexttop">{{ addon._addonId }}</span>
-          </div>
-          <!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
+          </div><!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
         </div>
       </div>
       <template v-if="everWithinView">

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -222,7 +222,6 @@
     padding-inline-start: 10px;
   }
   .addon-body {
-    min-height: 54px;
     margin: 10px;
     background: var(--content-background);
     border: 1px solid var(--content-border);
@@ -366,9 +365,6 @@
     .addon-topbar {
       min-height: 44px;
       padding-inline-end: 6px;
-    }
-    .addon-body {
-      min-height: 46px;
     }
     .clickable-area {
       padding-inline-start: 6px;

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -1,32 +1,37 @@
 <template>
   <div class="addon-body" v-show="shouldShow" :id="'addon-' + addon._addonId">
-    <div class="addon-topbar" v-if="everWithinView">
+    <div class="addon-topbar">
       <div class="clickable-area" @click="expanded = !expanded">
         <button class="arrow-button" :title="msg(expanded ? 'collapse' : 'expand')">
           <img src="../../images/icons/expand.svg" :class="{'reverted': expanded}" draggable="false" />
         </button>
         <img :src="addonIconSrc" :title="addonIconAlt" class="icon-type addon-icon" draggable="false" />
         <!-- prettier-ignore -->
-        <div class="addon-name-and-tags">
+        <div class="addon-name-and-tags" v-if="isPlaceholder">
+          <div class="addon-name tooltip"><span></span></div>
+        </div>
+        <div class="addon-name-and-tags" v-else>
           <div class="addon-name tooltip">
             <span>{{ addon.name }}</span>
             <span v-if="devMode" class="tooltiptext tooltiptexttop">{{ addon._addonId }}</span>
           </div><!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
         </div>
       </div>
-      <div class="addon-description" v-show="!expanded" dir="auto">{{ addon.description }}</div>
-      <div class="addon-check">
-        <div v-show="expanded && addon._enabled" v-if="addon.settings" class="split-button dropdown-parent">
-          <button class="icon-button split-button-button" title="{{ msg('resetToDefault') }}" @click="loadDefaults">
-            <img src="../../images/icons/undo.svg" class="icon-type" draggable="false" />
-          </button>
-          <dropdown button-class="icon-button split-button-dropdown" :button-title="msg('importExport')">
-            <li role="menuitem" tabindex="0" @click="exportPreset">{{ msg('export') }}</li>
-            <li role="menuitem" tabindex="0" @click="importPreset">{{ msg('import') }}</li>
-          </dropdown>
+      <template v-if="everWithinView">
+        <div class="addon-description" v-show="!expanded" dir="auto">{{ addon.description }}</div>
+        <div class="addon-check">
+          <div v-show="expanded && addon._enabled" v-if="addon.settings" class="split-button dropdown-parent">
+            <button class="icon-button split-button-button" title="{{ msg('resetToDefault') }}" @click="loadDefaults">
+              <img src="../../images/icons/undo.svg" class="icon-type" draggable="false" />
+            </button>
+            <dropdown button-class="icon-button split-button-dropdown" :button-title="msg('importExport')">
+              <li role="menuitem" tabindex="0" @click="exportPreset">{{ msg('export') }}</li>
+              <li role="menuitem" tabindex="0" @click="importPreset">{{ msg('import') }}</li>
+            </dropdown>
+          </div>
+          <input type="checkbox" class="switch" v-model="addon._enabled" @click="toggleAddonRequest" />
         </div>
-        <input type="checkbox" class="switch" v-model="addon._enabled" @click="toggleAddonRequest" />
-      </div>
+      </template>
     </div>
     <div class="addon-settings" v-if="everWithinView && everExpanded" v-show="expanded">
       <div class="addon-description-full">{{ addon.description }}</div>

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -14,7 +14,8 @@
           <div class="addon-name tooltip">
             <span>{{ addon.name }}</span>
             <span v-if="devMode" class="tooltiptext tooltiptexttop">{{ addon._addonId }}</span>
-          </div><!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
+          </div>
+          <!-- no space --><addon-tag v-for="tag of addon.tags" :tag="tag"></addon-tag>
         </div>
       </div>
       <template v-if="everWithinView">

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -10,6 +10,7 @@ export default async function ({ template }) {
         isIframe: isIframe,
         expanded: this.getDefaultExpanded(),
         everExpanded: this.getDefaultExpanded(),
+        everWithinView: this.addon.name === "", // Always render placeholders immediately
         hoveredSettingId: null,
         highlightedSettingId: null,
       };
@@ -54,6 +55,12 @@ export default async function ({ template }) {
       },
     },
     methods: {
+      onIntersectionChange(entries, observer) {
+        if (entries.some((e) => e.isIntersecting)) {
+          this.everWithinView = true;
+          observer.disconnect();
+        }
+      },
       getDefaultExpanded() {
         return isIframe ? false : this.groupId === "enabled";
       },
@@ -218,6 +225,18 @@ export default async function ({ template }) {
       };
       window.addEventListener("hashchange", onHashChange, { capture: false });
       setTimeout(onHashChange, 0);
+
+      if (!this.everWithinView) {
+        this._intersectionObserver = new IntersectionObserver(this.onIntersectionChange, {
+          root: document.querySelector(".addons-container"),
+          threshold: 0,
+          rootMargin: "50px",
+        });
+        this._intersectionObserver.observe(this.$el);
+      }
+    },
+    beforeDestroy() {
+      this._intersectionObserver?.disconnect();
     },
   });
   Vue.component("addon-body", AddonBody);

--- a/webpages/settings/components/addon-body.js
+++ b/webpages/settings/components/addon-body.js
@@ -16,6 +16,9 @@ export default async function ({ template }) {
       };
     },
     computed: {
+      isPlaceholder() {
+        return this.addon.name === "" || !this.everWithinView;
+      },
       shouldShow() {
         return this.visible && (this.$root.searchInput === "" ? this.groupExpanded : true);
       },

--- a/webpages/settings/components/addon-group-header.html
+++ b/webpages/settings/components/addon-group-header.html
@@ -1,9 +1,9 @@
 <template>
-  <div class="addon-group" v-show="shouldShow" @click="toggle" :class="{  'margin-above': marginAbove }">
+  <div class="addon-group" v-show="shouldShow" @click="toggle" :class="{ 'margin-above': marginAbove }">
     <button class="arrow-button" :title="msg(group.expanded ? 'collapse' : 'expand')">
       <img src="../../images/icons/expand.svg" :class="{ 'reverted': group.expanded }" draggable="false" />
     </button>
-    {{ group.name }} ({{ shownCount }})
+    {{ label }}
   </div>
 </template>
 

--- a/webpages/settings/components/addon-group-header.js
+++ b/webpages/settings/components/addon-group-header.js
@@ -15,7 +15,7 @@ export default async function ({ template }) {
       },
       label() {
         return this.group.name + (this.$root.loaded ? ` (${this.shownCount})` : "");
-      }
+      },
     },
     methods: {
       toggle() {

--- a/webpages/settings/components/addon-group-header.js
+++ b/webpages/settings/components/addon-group-header.js
@@ -13,6 +13,9 @@ export default async function ({ template }) {
       manifestsById() {
         return this.$root.manifestsById;
       },
+      label() {
+        return this.group.name + (this.$root.loaded ? ` (${this.shownCount})` : "");
+      }
     },
     methods: {
       toggle() {

--- a/webpages/settings/data/addon-groups.js
+++ b/webpages/settings/data/addon-groups.js
@@ -17,16 +17,6 @@ export default [
     fullscreenShow: false,
   },
   {
-    // Needed to create addonListObjs items for non-enabled addons
-    id: "_iframeSearch",
-    name: "",
-    addonIds: [],
-    expanded: true,
-    iframeShow: true,
-    fullscreenShow: false,
-  },
-
-  {
     id: "featuredNew",
     name: chrome.i18n.getMessage("featuredNew"),
     addonIds: [],
@@ -91,5 +81,14 @@ export default [
     expanded: false,
     iframeShow: false,
     fullscreenShow: true,
+  },
+  {
+    // Needed to create addonListObjs items for non-enabled addons
+    id: "_iframeSearch",
+    name: "",
+    addonIds: [],
+    expanded: true,
+    iframeShow: true,
+    fullscreenShow: false,
   },
 ];

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -403,6 +403,7 @@ let fuse;
         duplicate: false,
       };
 
+      // Display placeholders while the addon list is loading
       setTimeout(() => {
         if (!this.loaded) {
           this.addonListObjs = Array(EXAMPLE_LIST_SIZE)
@@ -624,6 +625,7 @@ let fuse;
     for (const group of vue.addonGroups) {
       for (let groupIndex = 0; groupIndex < group.addonIds.length; groupIndex++) {
         const addonId = group.addonIds[groupIndex];
+        // Find and reuse a placeholder object if one exists (see exampleAddonListItem)
         const cachedObj = vue.addonListObjs.find((o) => o.manifest._addonId === "example");
         const obj = cachedObj || {};
         // Some addons might be twice in the list, such as in "new" and "enabled"
@@ -644,13 +646,13 @@ let fuse;
         if (!cachedObj) vue.addonListObjs.push(obj);
         naturalIndex++;
 
-        // After replacing all cached objects, pause until the first items render
+        // After reusing all placeholder objects, pause until the first items render
         if (naturalIndex === EXAMPLE_LIST_SIZE) {
           await new Promise((resolve) => setTimeout(resolve, 0));
         }
       }
     }
-    // Remove unused remaining cached objects. Can only happen in iframe mode
+    // Remove leftover placeholder slots. Can only happen in iframe mode
     vue.addonListObjs = vue.addonListObjs.filter((o) => o.manifest._addonId !== "example");
 
     vue.loaded = true;

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -13,6 +13,7 @@ import { isFirefox } from "../../libraries/common/cs/detect-browser.js";
 
 const MORE_SETTINGS_HASH = "#moresettings";
 const ADDON_HASH_PREFIX = "#addon-";
+const EXAMPLE_LIST_SIZE = 15; // Determines the number of placeholders to show on the skeleton loader
 
 let isIframe = false;
 if (window.parent !== window) {
@@ -404,7 +405,7 @@ let fuse;
 
       setTimeout(() => {
         if (!this.loaded) {
-          this.addonListObjs = Array(25)
+          this.addonListObjs = Array(EXAMPLE_LIST_SIZE)
             .fill("")
             .map(() => JSON.parse(JSON.stringify(exampleAddonListItem)));
         }
@@ -621,7 +622,8 @@ let fuse;
 
     let naturalIndex = 0; // Index when not searching
     for (const group of vue.addonGroups) {
-      group.addonIds.forEach((addonId, groupIndex) => {
+      for (let groupIndex = 0; groupIndex < group.addonIds.length; groupIndex++) {
+        const addonId = group.addonIds[groupIndex];
         const cachedObj = vue.addonListObjs.find((o) => o.manifest._addonId === "example");
         const obj = cachedObj || {};
         // Some addons might be twice in the list, such as in "new" and "enabled"
@@ -639,7 +641,12 @@ let fuse;
         // exampleAddonListItem object on the vue.ready method, so that it's reactive!
         if (!cachedObj) vue.addonListObjs.push(obj);
         naturalIndex++;
-      });
+
+        // After replacing all cached objects, pause until the first items render
+        if (naturalIndex === EXAMPLE_LIST_SIZE) {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      }
     }
     // Remove unused remaining cached objects. Can only happen in iframe mode
     vue.addonListObjs = vue.addonListObjs.filter((o) => o.manifest._addonId !== "example");

--- a/webpages/settings/index.js
+++ b/webpages/settings/index.js
@@ -633,7 +633,9 @@ let fuse;
         obj.group = group;
         obj.matchesSearch = false; // Later set to true by vue.addonList if needed
         const shouldHideAsEasterEgg = obj.manifest._categories[0] === "easterEgg" && obj.manifest._enabled === false;
-        obj.matchesCategory = !shouldHideAsEasterEgg;
+        obj.matchesCategory =
+          !shouldHideAsEasterEgg &&
+          (vue.selectedCategory === "all" || obj.manifest._categories.includes(vue.selectedCategory));
         obj.naturalIndex = naturalIndex;
         obj.headerAbove = groupIndex === 0;
         obj.footerBelow = groupIndex === group.addonIds.length - 1;


### PR DESCRIPTION
Finally. Should help with #2531, something @WorldLanguages knows is pretty annoying.

https://github.com/user-attachments/assets/dc41d646-29ac-4a5e-aebf-6795e525bf5a

### Description

This pull request changes two things which significantly contributed to the **perceived** loading time of the list of addon settings:
1. Rendering every item in the list, including those offscreen, wasted time. Now, all contents of addon list items and loaded lazily, which means they render only after they are scrolled into view, using IntersectionObserver.
2. Populating the entire list in one pass also adds a delay. Now, a set number of items near the top of the page are rendered and the rest of the list continues to render after the screen refreshes, allowing the first page of content to be presented quicker.

Now the addon settings UI responds much faster after loading the page or returning to the main categories after opening a Related Addons list. I challenge you to go back to how it was before after testing this out!

Here are the most notable side effects caused by each change:
1. Addons may briefly appear blank before they render. You might see this if you scroll quickly or search, but it's a small trade-off for improved response time.
2. Numbers may appear dynamically and the scroll track may shift as items load.

Some code comments have also been clarified.

### Notes

Tested on Edge 148.

Some changes to `addon-body.js` were based on carefully reviewed code generated by Claude Haiku 4.5 via GitHub Copilot.