### PR TITLE
editor-theme3: fix incorrect originalColors after reentering editor

### DIFF
--- a/addons/editor-theme3/theme3.js
+++ b/addons/editor-theme3/theme3.js
@@ -973,7 +973,12 @@ export default async function ({ addon, console, msg }) {
     Blockly.ThemeManager.prototype.subscribeWorkspace = function (workspace) {
       oldThemeManagerSubscribeWorkspace.call(this, workspace);
       setTimeout(() => {
-        updateOriginalColors(workspace.getTheme());
+        /* We need to update originalColors if the user toggles the high contrast theme
+           while the addon is dynamically disabled. We shouldn't update them if the addon is
+           enabled because that would save the colors modified by the addon to originalColors. */
+        if (addon.self.disabled) {
+          updateOriginalColors(workspace.getTheme());
+        }
         updateColors(workspace);
       }, 0);
     };


### PR DESCRIPTION
Resolves #9036

### Changes

Fixes the `originalColors` object containing incorrect values. This fixes the following bugs that currently occur after going to the project page and back:
* Dynamically disabling the addon doesn't revert to the original colors.
* Extension blocks lose their customized color after switching sprites (#9036).

### Tests

Tested on Edge.