### PR TITLE
Fix gamepad icon contrast with both dark-www and scratch3to2

### DIFF
--- a/addons/scratch3to2/project.css
+++ b/addons/scratch3to2/project.css
@@ -274,9 +274,6 @@
 :root:not(.sa-editor) [class*="stage-header_stage-button_"]:active {
   background-color: transparent;
 }
-:root:not(.sa-editor) [class*="stage-header_stage-button-icon_"] {
-  filter: none;
-}
 :root:not(.sa-editor) [class*="stage-header_stage-button-icon_"]:not(.sa-gamepad-container *) {
   display: none;
 }


### PR DESCRIPTION
Removes the gamepad icon filter override which was originally added in #8501 before `scratch3to2` gained dark mode support for the stage header in #8849.