### PR TITLE
[Developer security] Don't send account data to untrusted tabs

### DIFF
--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -174,7 +174,7 @@ async function getAddonData({ addonId, manifest, url }) {
   return { userscripts, userstyles, cssVariables: manifest.customCssVariables || [] };
 }
 
-async function getContentScriptInfo(url) {
+async function getContentScriptInfo(url, trust) {
   const data = {
     url,
     httpStatusCode: null, // Set by webRequest onResponseStarted listener
@@ -208,7 +208,20 @@ async function getContentScriptInfo(url) {
   await Promise.all(promises);
   data.globalState = scratchAddons.globalState._target;
 
-  return data;
+  if (trust) {
+    return data;
+  } else {
+    // Request came from an untrusted location, so remove sensitive account data
+    const defaultAuth = {
+      isLoggedIn: false,
+      username: null,
+      userId: null,
+      xToken: null,
+      csrfToken: null,
+      scratchLang: navigator.language,
+    };
+    return { ...data, globalState: { ...data.globalState, auth: defaultAuth } };
+  }
 }
 
 function createCsIdentity({ tabId, frameId, url }) {
@@ -217,6 +230,10 @@ function createCsIdentity({ tabId, frameId, url }) {
 }
 
 const csInfoCache = new Map();
+// The following whitelist defines the places where it is safe to pass account data into.
+// This is important for developers using SA on localhost, which may not always
+// contain trusted content.
+const trustedOrigins = ["https://scratch.mit.edu"];
 
 // Using this event to preload contentScriptInfo ASAP, since onBeforeRequest
 // obviously happens before the content script has a chance to send us a message.
@@ -226,10 +243,14 @@ chrome.webRequest.onBeforeRequest.addListener(
   async (request) => {
     setUserAsActive();
     if (!scratchAddons.localState.allReady) return;
+
+    const requestUrl = new URL(request.url);
+    const isTrustedRequest = trustedOrigins.includes(requestUrl.origin);
+
     const identity = createCsIdentity({ tabId: request.tabId, frameId: request.frameId, url: request.url });
     const loadingObj = { loading: true };
     csInfoCache.set(identity, loadingObj);
-    const info = await getContentScriptInfo(request.url);
+    const info = await getContentScriptInfo(request.url, isTrustedRequest);
     if (csInfoCache.get(identity) !== loadingObj) {
       // Another content script with same identity took our
       // place in the csInfoCache map while the promise resolved
@@ -279,11 +300,18 @@ chrome.webRequest.onResponseStarted.addListener(
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (!request.contentScriptReady) return;
+  // This URL is what userscripts and userstyles are matched against.
+  // It may be a pseudo-URL.
+  const matchUrl = request.contentScriptReady.url;
+  // For security purposes, this is the URL that the request actually came from.
+  const trustedUrl = new URL(sender.url);
+  const isTrustedRequest = trustedOrigins.includes(trustedUrl.origin);
+
   if (scratchAddons.localState.allReady) {
     const identity = createCsIdentity({
       tabId: sender.tab.id,
       frameId: sender.frameId,
-      url: request.contentScriptReady.url,
+      url: matchUrl,
     });
     const getCacheEntry = () => csInfoCache.get(identity);
     let cacheEntry = getCacheEntry();
@@ -305,7 +333,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         csInfoCache.delete(identity);
       }
     } else {
-      getContentScriptInfo(request.contentScriptReady.url).then((info) => {
+      getContentScriptInfo(matchUrl, isTrustedRequest).then((info) => {
         sendResponse(info);
       });
       return true;
@@ -315,7 +343,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     scratchAddons.localEvents.addEventListener(
       "ready",
       async () => {
-        const info = await getContentScriptInfo(request.contentScriptReady.url);
+        const info = await getContentScriptInfo(matchUrl, isTrustedRequest);
         sendResponse(info);
       },
       { once: true }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -1,6 +1,7 @@
 import changeAddonState from "./imports/change-addon-state.js";
 import { getMissingOptionalPermissions } from "./imports/util.js";
 import { setUserAsActive } from "./imports/inactivity.js";
+import { isTrustedOrigin, guestUser } from "./imports/trust-manager.js";
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.replaceTabWithUrl) chrome.tabs.update(sender.tab.id, { url: request.replaceTabWithUrl });
@@ -211,16 +212,8 @@ async function getContentScriptInfo(url, trust) {
   if (trust) {
     return data;
   } else {
-    // Request came from an untrusted location, so remove sensitive account data
-    const defaultAuth = {
-      isLoggedIn: false,
-      username: null,
-      userId: null,
-      xToken: null,
-      csrfToken: null,
-      scratchLang: navigator.language,
-    };
-    return { ...data, globalState: { ...data.globalState, auth: defaultAuth } };
+    // Request came from an untrusted location, so don't include account data
+    return { ...data, globalState: { ...data.globalState, auth: guestUser } };
   }
 }
 
@@ -230,10 +223,6 @@ function createCsIdentity({ tabId, frameId, url }) {
 }
 
 const csInfoCache = new Map();
-// The following whitelist defines the places where it is safe to pass account data into.
-// This is important for developers using SA on localhost, which may not always
-// contain trusted content.
-const trustedOrigins = ["https://scratch.mit.edu"];
 
 // Using this event to preload contentScriptInfo ASAP, since onBeforeRequest
 // obviously happens before the content script has a chance to send us a message.
@@ -244,8 +233,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     setUserAsActive();
     if (!scratchAddons.localState.allReady) return;
 
-    const requestUrl = new URL(request.url);
-    const isTrustedRequest = trustedOrigins.includes(requestUrl.origin);
+    const isTrustedRequest = isTrustedOrigin(request.url);
 
     const identity = createCsIdentity({ tabId: request.tabId, frameId: request.frameId, url: request.url });
     const loadingObj = { loading: true };
@@ -303,9 +291,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // This URL is what userscripts and userstyles are matched against.
   // It may be a pseudo-URL.
   const matchUrl = request.contentScriptReady.url;
-  // For security purposes, this is the URL that the request actually came from.
-  const trustedUrl = new URL(sender.url);
-  const isTrustedRequest = trustedOrigins.includes(trustedUrl.origin);
+  // For security purposes, sender.url is the URL which the request actually came from.
+  const isTrustedRequest = isTrustedOrigin(sender.url);
 
   if (scratchAddons.localState.allReady) {
     const identity = createCsIdentity({

--- a/background/imports/global-state.js
+++ b/background/imports/global-state.js
@@ -45,10 +45,41 @@ class StateProxy {
   }
 }
 
+// The following whitelist defines the places where it is safe to pass account data into.
+// This is important for developers using SA on localhost, which may not always
+// contain trusted content.
+const trustedOrigins = ["https://scratch.mit.edu"];
+
 function messageForAllTabs(message) {
-  chrome.tabs.query({}, (tabs) =>
-    tabs.forEach((tab) => tab.url && chrome.tabs.sendMessage(tab.id, message, () => void chrome.runtime.lastError))
-  );
+  chrome.tabs.query({}, (tabs) => {
+    tabs.forEach((tab) => {
+      if (!tab.url) return; // Skip tabs we don't have access to
+
+      const tabUrl = new URL(tab.url);
+      const isTrustedTab = trustedOrigins.includes(tabUrl.origin);
+
+      let messageToSend = message;
+      if (message.newGlobalState && !isTrustedTab) {
+        // For untrusted tabs, modify the message to remove account data
+        messageToSend = {
+          ...message,
+          newGlobalState: {
+            ...message.newGlobalState,
+            auth: {
+              isLoggedIn: false,
+              username: null,
+              userId: null,
+              xToken: null,
+              csrfToken: null,
+              scratchLang: navigator.language,
+            },
+          },
+        };
+      }
+      chrome.tabs.sendMessage(tab.id, messageToSend, () => void chrome.runtime.lastError);
+    });
+  });
+
   scratchAddons.sendToPopups(message);
 }
 

--- a/background/imports/global-state.js
+++ b/background/imports/global-state.js
@@ -3,6 +3,8 @@
 // Content scripts cannot modify global state, but they can always read from it.
 // Exception: authentication info is local state, but is stored here for historical reasons.
 
+import { isTrustedOrigin, guestUser } from "./trust-manager.js";
+
 const _globalState = {
   auth: {
     isLoggedIn: false,
@@ -45,19 +47,11 @@ class StateProxy {
   }
 }
 
-// The following whitelist defines the places where it is safe to pass account data into.
-// This is important for developers using SA on localhost, which may not always
-// contain trusted content.
-const trustedOrigins = ["https://scratch.mit.edu"];
-
 function messageForAllTabs(message) {
   chrome.tabs.query({}, (tabs) => {
     tabs.forEach((tab) => {
       if (!tab.url) return; // Skip tabs we don't have access to
-
-      const tabUrl = new URL(tab.url);
-      const isTrustedTab = trustedOrigins.includes(tabUrl.origin);
-
+      const isTrustedTab = isTrustedOrigin(tab.url);
       let messageToSend = message;
       if (message.newGlobalState && !isTrustedTab) {
         // For untrusted tabs, modify the message to remove account data
@@ -65,14 +59,7 @@ function messageForAllTabs(message) {
           ...message,
           newGlobalState: {
             ...message.newGlobalState,
-            auth: {
-              isLoggedIn: false,
-              username: null,
-              userId: null,
-              xToken: null,
-              csrfToken: null,
-              scratchLang: navigator.language,
-            },
+            auth: guestUser,
           },
         };
       }

--- a/background/imports/trust-manager.js
+++ b/background/imports/trust-manager.js
@@ -1,0 +1,20 @@
+// This module helps to ensure authentication data is passed safely.
+// The following whitelist defines the places where it is safe to pass account data into.
+// This is important for developers using SA on localhost, which may not always
+// contain trusted content.
+const trustedOrigins = ["https://scratch.mit.edu"];
+
+export function isTrustedOrigin(url) {
+  return trustedOrigins.includes(new URL(url).origin);
+}
+
+// This is the placeholder value for globalState.auth which should be the substitute
+// when sending data to a content script in an untrusted context, such as localhost.
+export const guestUser = {
+  isLoggedIn: false,
+  username: null,
+  userId: null,
+  xToken: null,
+  csrfToken: null,
+  scratchLang: navigator.language,
+};


### PR DESCRIPTION
Resolves #9054

### Changes

Previously, Scratch Addons could hand out your CSRF token and X-Token to tabs of sites outside scratch.mit.edu, including localhost, where the content script exposed them via the `window` object, potentially putting developers' Scratch accounts at risk.

Now, account info and credentials are replaced with a placeholder before the data is sent anywhere except scratch.mit.edu, preventing unauthorized webpages from seeing your account data.

This change applies to two background modules, `get-userscripts.js` and `global-state.js`.

The different data received by two tabs on different URLs is shown below:

<img width="522" height="151" alt="globalState auth on scratch" src="https://github.com/user-attachments/assets/28870baf-95b2-44a7-b811-034044cfdb32" />
<img width="504" height="155" alt="globalState auth on localhost" src="https://github.com/user-attachments/assets/96ff8e38-bd38-4acc-9fb2-afd2ba73f41b" />

The two objects would have been the same before this change.

### Reason for changes

These changes introduce a valuable security measure for developers. While Scratch accounts aren't as important as others, they can still be used for impersonation if compromised. They're still meaningful assets that deserve protection.

These fixes shouldn't affect the developer experience. Logged-out user status is already handled gracefully by the extension, so nothing will fail. Production account credentials were never meant to be used by local instances of `scratch-www` anyway.

See #9052 for more info.

### Security overview

I would rate this security issue a "moderate" due to the specific conditions an attacker would need to exploit it.

I would say a full security advisory isn't necessary for this vulnerability due to the limited impact (likely a few hundred developers who actively use recent versions of the source code) and low probability of exploitation.

For all Scratch Addons developers, I would recommend **disabling `http://localhost/*` in the Manage Extension menu** when you're not actively testing `scratch-www` locally. This prevents exploits like the one described above.

### Notes

Tested in Edge 148.

Changes inspired by a conversation with GitHub Copilot (Claude Haiku 4.5).