### PR TITLE
onion-skinning: defense-in-depth against SVGs that contain executable code

### DIFF
--- a/addons/onion-skinning/userscript.js
+++ b/addons/onion-skinning/userscript.js
@@ -310,6 +310,23 @@ export default async function ({ addon, console, msg }) {
       if (svgAttrs && svgAttrs[0].indexOf("xmlns=") === -1) {
         asset = asset.replace("<svg ", '<svg xmlns="http://www.w3.org/2000/svg" ');
       }
+
+      // After the above, we apply sanitization. Reference:
+      // https://github.com/scratchfoundation/scratch-paint/commit/cc837ae481a3be5be379665ef3bd107a71aac670
+      //
+      // This is a rough approximation of:
+      // https://github.com/scratchfoundation/scratch-editor/blob/develop/packages/scratch-svg-renderer/src/sanitize-svg.js#L176
+      //
+      // We don't have a good way to access that function directly, but isomorphic-dompurify exports the
+      // DOMPurify on Window which we can access. This is the same DOMPurify used by Scratch internally,
+      // so we get all the hooks Scratch has configured. The only important part of that function is
+      // calling DOMPurify, which we can easily copy the right arguments for.
+      asset = window.DOMPurify.sanitize(asset, {
+        USE_PROFILES: { svg: true },
+        FORBID_TAGS: ["a", "audio", "canvas", "video"],
+        ADD_DATA_URI_TAGS: ["image"],
+      });
+
       const parser = new DOMParser();
       const svgDom = parser.parseFromString(asset, "text/xml");
       const viewBox = svgDom.documentElement.attributes.viewBox


### PR DESCRIPTION
### Changes

onion-skinning now runs the SVG through the same DOMPurify that scratch-svg-renderer uses internally

### Reason for changes

Background: https://muffin.ink/blog/scratch-vulnerability-disclosure/

Scratch fixed it through a few ways. Direct SVG file uploads have sanitized for a while, and now the asset server does a remotely acceptable job filtering out code in SVGs. They also [put some code in scratch-paint to sanitize before passing into paper.js](https://github.com/scratchfoundation/scratch-paint/commit/cc837ae481a3be5be379665ef3bd107a71aac670). Notably, the underlying paper.js vulnerability is still there (no iframe sandbox). This code is written in such a way that onion-skinning does not get to use it automatically and I don't think there's an easy way to take advantage of it. Thankfully isomorphic-dompurify exports DOMPurify on window and the actual sanitize function is [really just calling DOMPurify with a simple set of config options](https://github.com/scratchfoundation/scratch-editor/blob/develop/packages/scratch-svg-renderer/src/sanitize-svg.js#L176) so we can recreate it easily.

At this point, it shouldn't be possible for someone to get a malicious SVG into the VM at all in practice. But, if someone were able to, the onion skinning addon would allow executing it. This is an extra layer of defense to avoid executing that code.

It would be really nice if Scratch just implemented the iframe sandbox in their paper.js fork. It would actually be possible for us to patch that in ourselves but decided that's probably a bad approach.

### Testing

I tested it with directly inserting the malicious SVG from the blog post into the VM (via JS console) and confirmed that the code no longer executes in a Chromium browser.