### PR TITLE
swap-local-global: allow conversion between local and global across multiple sprites

### DIFF
--- a/addons/swap-local-global/userscript.js
+++ b/addons/swap-local-global/userscript.js
@@ -66,6 +66,18 @@ export default async function ({ addon, msg, console }) {
     }
   };
 
+  // Rewrites all block field references from oldId to newId in a target's blocks.
+  const remapVariableReferencesInTarget = (target, oldId, newId, newName) => {
+    for (const block of Object.values(target.blocks._blocks)) {
+      for (const field of Object.values(block.fields)) {
+        if (field.id === oldId) {
+          field.id = newId;
+          field.value = newName;
+        }
+      }
+    }
+  };
+
   const syncBlockVariableNameWithActualVariableName = (workspace, id) => {
     const variable = workspace.getVariableMap().getVariableById(id);
     for (const block of workspace.getAllBlocks()) {
@@ -193,35 +205,23 @@ export default async function ({ addon, msg, console }) {
           alert(msg("cant-convert-stage"));
           return;
         }
-        // Variables used by unfocused sprites cannot be made local
-        // That includes cases where the variable is used by multiple sprites and where it's only used by an unfocused sprite
-        const targets = getTargetsThatUseVariable(id);
-        if (!targets.every((i) => i === editingTarget)) {
-          if (targets.length > 1) {
-            alert(
-              msg("cant-convert-to-local", {
-                sprites: targets.map(getTargetName).join(", "),
-              })
-            );
-          } else {
-            alert(
-              msg("cant-convert-used-elsewhere", {
-                sprite: getTargetName(targets[0]),
-              })
-            );
-          }
-          return;
+        // Give each other sprite that uses this variable its own local copy so their blocks keep working.
+        const globalVarValue = vm.runtime.getTargetForStage().variables[id].value;
+        for (const target of getTargetsThatUseVariable(id)) {
+          if (target === editingTarget) continue;
+          const newId = crypto.randomUUID();
+          target.createVariable(newId, name, type);
+          target.variables[newId].value = globalVarValue;
+          remapVariableReferencesInTarget(target, id, newId, name);
         }
       } else {
-        // Global variables must not conflict with any local variables
-        const targets = getTargetsWithLocalVariableNamed(name, type).filter((target) => target !== editingTarget);
-        if (targets.length > 0) {
-          alert(
-            msg("cant-convert-conflict", {
-              sprites: targets.map(getTargetName).join(", "),
-            })
-          );
-          return;
+        // Merge other sprites' same-named locals into this global: remap their blocks to the new global
+        // ID, then delete the now-redundant local.
+        for (const target of getTargetsWithLocalVariableNamed(name, type)) {
+          if (target === editingTarget) continue;
+          const conflictVar = target.lookupVariableByNameAndType(name, type, true);
+          remapVariableReferencesInTarget(target, conflictVar.id, id, name);
+          target.deleteVariable(conflictVar.id);
         }
       }
     }


### PR DESCRIPTION
### Overview

The **swap-local-global** addon now allows converting a variable between local and global even when it is used by multiple sprites. Previously this was blocked with an error message.

### Changes

**Global → Local:** When converting a global variable to local on the current sprite, any *other* sprite that also uses that variable now automatically gets its own independent local copy with the same name and current value. All of those sprites' block references are remapped to their new local ID so nothing breaks.

**Local → Global:** When converting a local variable to global, any other sprite that happens to have a same-named local variable is automatically merged into the new global — its blocks are remapped to point at the global ID and its now-redundant local is deleted.

A small shared helper `remapVariableReferencesInTarget` was added to walk a target's block fields and update any field whose ID matches the old variable, used by both conversion paths.

### Reason for changes

The previous behaviour blocked very common real-world cases. A game's `score` or `lives` variable is often shared between a player sprite and the stage. A student clicking "make local" on such a variable was met with an unhelpful error rather than a useful outcome. The new behaviour does what users intuitively expect: each sprite gets its own copy (or they all share the one global), with no manual cleanup needed.

### Tests

Tested in Chrome:
- Global → local on a variable used by 3 sprites: each sprite received an independent local copy; all scripts continued to work correctly
- Local → global where 2 other sprites had a same-named local: both were merged into the global; block references updated correctly in all sprites
- Single-sprite conversions (the original behaviour) are unchanged