### PR TITLE
Revise warning message in disable-auto-save addon

### DIFF
--- a/addons/disable-auto-save/addon.json
+++ b/addons/disable-auto-save/addon.json
@@ -4,7 +4,7 @@
   "info": [
     {
       "type": "warning",
-      "text": "This will disable all types of project autosaving. Make sure to manually save your changes frequently to avoid losing them.",
+      "text": "This will prevent projects from saving automatically; manually save your changes whenever possible to avoid data loss.",
       "id": "manuallysave"
     }
   ],

--- a/addons/disable-auto-save/addon.json
+++ b/addons/disable-auto-save/addon.json
@@ -4,7 +4,7 @@
   "info": [
     {
       "type": "warning",
-      "text": "This will prevent projects from saving automatically; manually save your changes whenever possible to avoid data loss.",
+      "text": "Manually save your changes whenever possible to prevent data loss.",
       "id": "manuallysave"
     }
   ],


### PR DESCRIPTION
For a while, "Disable auto-save" has displayed this justifiable warning message:

> <img width="816" height="46" alt="This will disable all types of project autosaving. Make sure to manually save your changes frequently to avoid losing them." src="https://github.com/user-attachments/assets/bad4335f-15e2-4bb4-9dec-a102721b6012" />

This proposes a revised warning message for the addon:

> This will prevent projects from saving automatically; manually save your changes whenever possible to avoid data loss.

This revised message was inspired by potential guilt felt from ignoring the original warning for real reasons. In Scratch, autosaves usually happen at 10-minute intervals, so disabling the feature would imply that you want to edit without saving for longer. While that's already not ideal for avoiding data loss, saving changes directly to a shared project does publish them immediately (which is one of the main reasons people have asked for the option to disable autosaving). Also, autosaves overwrite anything you've modified or deleted, so if you want to revert them, you'll need to have a backup.

The original warning message may be stronger, but the cost is that users could feel criticized for avoiding saving very often, despite Scratch Addons still providing the option and being all about customizing to suit your needs. "Make sure to manually save your changes frequently" is just a little overly commanding for a recommendation, considering the point of the addon is to not be forced to have such frequent saves.

The new warning message points out the risks while trusting users to make informed decisions. It was written with an understanding that users know that saving is important but could have reasons not to save at an ideal frequency. Some of its phrase changes include:
- "Frequently" has been changed to "whenever possible," which is meant to be interpreted based on what I said earlier. That might be, "when I've finished drawing and am ready to release my changes."
- "All types" has been omitted because Scratch only auto-saves on a single timer currently.

Both messages have advantages. In my opinion, the original message might be enough of a helpful push for someone to not lose work the hard way while the revised message is less likely to be off-putting. Ultimately, I think both wordings do a good job at concisely indicating the risks, but I think the updated warning message is a better fit for our extension.

What do you think, and why do you prefer having or not having autosaves in Scratch (or any other program)?