### PR TITLE
Split sidebar content into two flexboxes

### DIFF
--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -8,7 +8,6 @@
     v-if="!category.hidden"
     v-show="shouldShow"
     transition="expand"
-    :style="{ marginBottom: category.marginBottom ? '12px' : 0 }"
     @click="onClick($event)"
   >
     <img :src="'../../images/icons/' + category.icon + '.svg'" draggable="false" />

--- a/webpages/settings/data/categories.js
+++ b/webpages/settings/data/categories.js
@@ -88,7 +88,6 @@ export default [
     id: "popup",
     icon: "popup",
     name: chrome.i18n.getMessage("popupFeatures"),
-    marginBottom: true,
   },
   {
     id: "easterEgg",

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -205,37 +205,39 @@
         v-show="!isIframe"
         :class="{closed: categoryOpen === false, smallMode: smallMode === true}"
       >
-        <category-selector v-for="category of categories" :category="category"></category-selector>
-
-        <a
-          v-cloak
-          class="category"
-          style="margin-top: auto"
-          href="https://scratchaddons.com/credits/"
-          :href="sidebarUrls.contributors"
-          target="_blank"
-        >
-          <img src="../../images/icons/users.svg" draggable="false" />
-          <span>{{ msg("credits") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
-        </a>
-        <a v-cloak class="category" href="https://scratchaddons.com/translate" target="_blank">
-          <img src="../../images/icons/translate.svg" draggable="false" />
-          <span>{{ msg("translate") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
-        </a>
-        <a
-          v-cloak
-          class="category"
-          href="https://scratchaddons.com/feedback/"
-          :href="sidebarUrls.feedback"
-          target="_blank"
-        >
-          <img src="../../images/icons/comment.svg" draggable="false" />
-          <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
-        </a>
-        <button v-cloak class="category" style="margin-top: 12px; margin-bottom: 14px" @click="openMoreSettings()">
-          <img src="../../images/icons/wrench.svg" draggable="false" />
-          <span>{{ msg("moreSettings") }}</span>
-        </button>
+        <div>
+          <category-selector v-for="category of categories" :category="category"></category-selector>
+        </div>
+        <div>
+          <a
+            v-cloak
+            class="category"
+            href="https://scratchaddons.com/credits/"
+            :href="sidebarUrls.contributors"
+            target="_blank"
+          >
+            <img src="../../images/icons/users.svg" draggable="false" />
+            <span>{{ msg("credits") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
+          </a>
+          <a v-cloak class="category" href="https://scratchaddons.com/translate" target="_blank">
+            <img src="../../images/icons/translate.svg" draggable="false" />
+            <span>{{ msg("translate") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
+          </a>
+          <a
+            v-cloak
+            class="category"
+            href="https://scratchaddons.com/feedback/"
+            :href="sidebarUrls.feedback"
+            target="_blank"
+          >
+            <img src="../../images/icons/comment.svg" draggable="false" />
+            <span>{{ msg("feedback") }} <img src="../../images/icons/popout.svg" draggable="false" /></span>
+          </a>
+          <button v-cloak class="category" style="margin-top: 12px" @click="openMoreSettings()">
+            <img src="../../images/icons/wrench.svg" draggable="false" />
+            <span>{{ msg("moreSettings") }}</span>
+          </button>
+        </div>
       </div>
       <button
         v-show="!isIframe && smallMode === false"

--- a/webpages/styles/components/categories.css
+++ b/webpages/styles/components/categories.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   flex-shrink: 0;
   flex-grow: 0;
+  gap: 12px;
+  justify-content: space-between;
   background: var(--navigation-background);
   min-width: 300px;
   overflow-y: auto;
@@ -11,21 +13,24 @@
   padding: 20px 0;
 }
 
+.categories-block > div {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
 .categories-block.smallMode {
   box-sizing: border-box;
   position: absolute;
   z-index: 20;
   height: calc(100vh - 60px);
   height: calc(100svh - 60px);
-  padding-bottom: 0;
   box-shadow: var(--large-shadow);
   transition: 0.25s;
 }
-
 .categories-block.smallMode.closed {
   visibility: hidden;
 }
-
 @media (prefers-reduced-motion: no-preference) {
   .categories-block.smallMode.closed {
     transform: translateX(-100%);
@@ -34,13 +39,14 @@
     transform: translateX(100%);
   }
 }
-
 @media (prefers-reduced-motion: reduce) {
   .categories-block.smallMode.closed {
     opacity: 0;
   }
 }
-
+.categories-block:not(.smallMode) {
+  padding-bottom: 34px; /* Space for the collapse button */
+}
 .categories-block.closed:not(.smallMode) {
   display: none;
 }


### PR DESCRIPTION
As shown in the side-by-side comparison image below, the flex container consisting of the category has been split in two. Padding and margin overrides that were previously set on individual items have been moved or changed to row gaps.

<img width="663" height="854" alt="Sidebar layout comparison" src="https://github.com/user-attachments/assets/f6c78614-1937-466e-aec2-37abe0ee4432" />

The visual layout and the design of the sidebar remain the same*—it's just simpler for developers to modify, which will make accessibility features and layout changes easier to implement in the future. For example, the 12px space between addon categories and external links is no longer the margin of any particular addon category, so the [`marginBottom` flag](https://github.com/ScratchAddons/ScratchAddons/blob/ee6157c11597db7c732e120841becf5cce96eed4/webpages/settings/data/categories.js#L91) is no longer needed. This would've helped with changes like:
- #8924
- #9008

<sub>*The 14-px space below the More Settings button in small mode have been transferred to the parent element and increased to 20px to match the padding on the top of the sidebar.</sub>

Tested on Edge 149.