### PR TITLE
scratch-messaging: fix posting comments that contain no a-z characters

### DIFF
--- a/content-scripts/cs.js
+++ b/content-scripts/cs.js
@@ -859,12 +859,7 @@ if (isProfile || isStudio || isProject || isForums) {
       .filter((char, i, charArr) => (i === 0 ? true : charArr[i - 1] !== char))
       .join("");
   const shouldCaptureComment = (value) => {
-    const limitedValue = removeReiteratedChars(
-      value
-        .toLowerCase()
-        .match(/[a-z]+/g)
-        .join("")
-    );
+    const limitedValue = removeReiteratedChars((value.toLowerCase().match(/[a-z]+/g) || []).join(""));
     return limitedValue.includes("scratchadon");
   };
   const extensionPolicyLink = document.createElement("a");

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -78,9 +78,7 @@ export default async ({ addon, msg, safeMsg }) => {
             .join("");
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js
-          const limitedValue = removeReiteratedChars(
-            (value.toLowerCase().match(/[a-z]+/g) || []).join("")
-          );
+          const limitedValue = removeReiteratedChars((value.toLowerCase().match(/[a-z]+/g) || []).join(""));
           return limitedValue.includes("scratchadon");
         };
         if (shouldCaptureComment(this.replyBoxValue)) {

--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -79,10 +79,7 @@ export default async ({ addon, msg, safeMsg }) => {
         const shouldCaptureComment = (value) => {
           // From content-scripts/cs.js
           const limitedValue = removeReiteratedChars(
-            value
-              .toLowerCase()
-              .match(/[a-z]+/g)
-              .join("")
+            (value.toLowerCase().match(/[a-z]+/g) || []).join("")
           );
           return limitedValue.includes("scratchadon");
         };


### PR DESCRIPTION

### Changes

There is no longer an uncaught error if the thing being posted fails to match `/[a-z]+/g`. For example, if the post is written in Japanese.

FYI: I had a claude read all the feedback-internals and find "quick wins". This was one of those. Manually tested.

### Reason for changes

Resolves https://github.com/ScratchAddons/feedback-internal/issues/280


### Tests

<img width="431" height="159" alt="image" src="https://github.com/user-attachments/assets/3eefe857-0cf8-4540-849c-00d885d3ea50" />

the warning still works:

<img width="821" height="301" alt="image" src="https://github.com/user-attachments/assets/d048f676-ff7d-4910-a2da-3549488b41bd" />
<img width="506" height="434" alt="image" src="https://github.com/user-attachments/assets/29c4dcf5-6437-4b9a-814d-ab47909b8b9e" />
