### PR TITLE
Fix cat ears on profiles

### DIFF
--- a/addons/better-featured-project/userstyle.css
+++ b/addons/better-featured-project/userstyle.css
@@ -37,7 +37,7 @@
 #profile-data .box-head .profile-details .group {
   border-right-color: white;
 }
-#profile-data .box-head .portrait img {
+#profile-data .box-head .portrait img:not(.avatar-badge) {
   border: none;
 }
 #profile-data .box-head .buttons {

--- a/addons/scratchr2/profile.css
+++ b/addons/scratchr2/profile.css
@@ -89,12 +89,18 @@
   text-shadow: none;
 }
 .box .box-head .portrait {
-  height: 64px;
   margin-right: 6px;
+  line-height: 0;
 }
+.box .box-head .portrait .avatar-wrapper,
 .box .box-head .portrait img {
   width: 64px;
   height: 64px;
+}
+.box .box-head .portrait .avatar-badge-wrapper {
+  height: 88px;
+}
+.box .box-head .portrait img:not(.avatar-badge) {
   background-color: var(--darkWww-page, #fcfcfc);
   border-radius: 5px;
   border: none;


### PR DESCRIPTION
Resolves #9100

### Changes

Makes cat ears displayed correctly in the profile page header when enabling "Scratch 2.0 → 3.0", "Profile page banner", or both.

<img width="392" height="107" alt="image" src="https://github.com/user-attachments/assets/95bf079f-632d-452e-96f7-40be642e1cb4" />

<img width="461" height="102" alt="image" src="https://github.com/user-attachments/assets/549efcab-a2b6-4b39-a47f-36810a0dab93" />

### Tests

Tested on Edge and Firefox.