### PR TITLE
Added addon cloud-to-turbowarp.

### DIFF
--- a/addons-l10n/en/cloud-games.json
+++ b/addons-l10n/en/cloud-games.json
@@ -14,5 +14,6 @@
   "cloud-games/add-studio": "Add this studio",
   "cloud-games/add-studio-desc": "Click to add the studio from the current tab to the list.",
   "cloud-games/added": "Added!",
-  "cloud-games/fetch-error": "Could not load cloud data for this project:"
+  "cloud-games/fetch-error": "Could not load cloud data for this project:",
+  "cloud-games/turbo-warp-banner": "Games data is from Scratch servers (Cloud variables → TurboWarp is active)"
 }

--- a/addons/addons.json
+++ b/addons/addons.json
@@ -17,6 +17,7 @@
   "search-profile",
   "better-emojis",
   "cloud-games",
+  "cloud-to-turbowarp",
   "studio-tools",
   "last-edit-tooltip",
   "semicolon",

--- a/addons/cloud-to-turbowarp/addon.json
+++ b/addons/cloud-to-turbowarp/addon.json
@@ -19,25 +19,12 @@
       "link": "https://scratch.mit.edu/users/Ash-Luigi/"
     }
   ],
-  "settings": [
-    {
-      "name": "Redirect to TurboWarp cloud servers",
-      "id": "enable",
-      "type": "boolean",
-      "default": false
-    }
-  ],
   "dynamicEnable": true,
   "dynamicDisable": true,
   "userscripts": [
     {
       "url": "userscript.js",
-      "matches": ["https://scratch.mit.edu/*"],
-      "if": {
-        "settings": {
-          "enable": true
-        }
-      }
+      "matches": ["https://scratch.mit.edu/*"]
     }
   ],
   "versionAdded": "1.40.0",

--- a/addons/cloud-to-turbowarp/addon.json
+++ b/addons/cloud-to-turbowarp/addon.json
@@ -1,0 +1,46 @@
+{
+  "name": "Cloud variables → TurboWarp",
+  "description": "Redirects cloud variable connections from Scratch's servers to TurboWarp's cloud servers. This allows projects with cloud variables to use TurboWarp's faster and more reliable cloud infrastructure.",
+  "info": [
+    {
+      "type": "notice",
+      "text": "This redirects your cloud variable WebSocket connections to TurboWarp's servers. TurboWarp has separate cloud data, so values will not match Scratch's cloud variables.",
+      "id": "separateCloudData"
+    },
+    {
+      "type": "info",
+      "text": "TurboWarp's cloud servers support the same protocol as Scratch but are faster and have higher rate limits. Your Scratch username is sent to TurboWarp for identification.",
+      "id": "turboWarpInfo"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Ash-Luigi",
+      "link": "https://scratch.mit.edu/users/Ash-Luigi/"
+    }
+  ],
+  "settings": [
+    {
+      "name": "Redirect to TurboWarp cloud servers",
+      "id": "enable",
+      "type": "boolean",
+      "default": false
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["https://scratch.mit.edu/*"],
+      "if": {
+        "settings": {
+          "enable": true
+        }
+      }
+    }
+  ],
+  "versionAdded": "1.40.0",
+  "tags": ["community", "projectPage"],
+  "enabledByDefault": false
+}

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -4,6 +4,9 @@ export default async function ({ addon, console }) {
   const RealWebSocket = window.WebSocket;
 
   function PatchedWebSocket(url, protocols) {
+    if (!(this instanceof PatchedWebSocket)) {
+      return protocols !== undefined ? new RealWebSocket(url, protocols) : new RealWebSocket(url);
+    }
     try {
       const parsed = new URL(url);
       if (parsed.hostname === SCRATCH_CLOUD_HOST) {
@@ -14,14 +17,21 @@ export default async function ({ addon, console }) {
     } catch (e) {
       // Invalid URL, pass through unchanged
     }
-    if (protocols !== undefined) {
-      return new RealWebSocket(url, protocols);
-    }
-    return new RealWebSocket(url);
+    return protocols !== undefined ? new RealWebSocket(url, protocols) : new RealWebSocket(url);
   }
 
   PatchedWebSocket.prototype = RealWebSocket.prototype;
   PatchedWebSocket.prototype.constructor = PatchedWebSocket;
+  Object.defineProperty(PatchedWebSocket, "name", { value: "WebSocket" });
+
+  for (const key of Object.getOwnPropertyNames(RealWebSocket)) {
+    if (key !== "prototype" && key !== "length" && key !== "name") {
+      try {
+        PatchedWebSocket[key] = RealWebSocket[key];
+      } catch (e) {}
+    }
+  }
+
   window.WebSocket = PatchedWebSocket;
 
   addon.self.addEventListener("disabled", () => {

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -1,4 +1,5 @@
 export default async function ({ addon, console }) {
+  window.alert("Cloud-to-TurboWarp: userscript is running!");
   const SCRATCH_CLOUD_HOST = "clouddata.scratch.mit.edu";
   const TURBOWARP_CLOUD_HOST = "clouddata.turbowarp.org";
   const RealWebSocket = window.WebSocket;

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -3,26 +3,25 @@ export default async function ({ addon, console }) {
   const TURBOWARP_CLOUD_HOST = "clouddata.turbowarp.org";
   const RealWebSocket = window.WebSocket;
 
-  class PatchedWebSocket extends RealWebSocket {
-    constructor(url, protocols) {
-      try {
-        const parsed = new URL(url);
-        if (parsed.hostname === SCRATCH_CLOUD_HOST) {
-          parsed.hostname = TURBOWARP_CLOUD_HOST;
-          console.log(`Redirecting cloud connection: ${url} → ${parsed.href}`);
-          url = parsed.href;
-        }
-      } catch (e) {
-        // Invalid URL, pass through unchanged
+  function PatchedWebSocket(url, protocols) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === SCRATCH_CLOUD_HOST) {
+        parsed.hostname = TURBOWARP_CLOUD_HOST;
+        console.log(`Redirecting cloud connection: ${url} → ${parsed.href}`);
+        url = parsed.href;
       }
-      if (protocols !== undefined) {
-        super(url, protocols);
-      } else {
-        super(url);
-      }
+    } catch (e) {
+      // Invalid URL, pass through unchanged
     }
+    if (protocols !== undefined) {
+      return new RealWebSocket(url, protocols);
+    }
+    return new RealWebSocket(url);
   }
 
+  PatchedWebSocket.prototype = RealWebSocket.prototype;
+  PatchedWebSocket.prototype.constructor = PatchedWebSocket;
   window.WebSocket = PatchedWebSocket;
 
   addon.self.addEventListener("disabled", () => {

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -3,27 +3,25 @@ export default async function ({ addon, console }) {
   const TURBOWARP_CLOUD_HOST = "clouddata.turbowarp.org";
   const RealWebSocket = window.WebSocket;
 
+  console.log("Cloud-to-TurboWarp addon loaded. Patching WebSocket...");
+
   function PatchedWebSocket(url, protocols) {
-    if (!(this instanceof PatchedWebSocket)) {
-      return protocols !== undefined ? new RealWebSocket(url, protocols) : new RealWebSocket(url);
-    }
+    const originalUrl = url;
     try {
       const parsed = new URL(url);
       if (parsed.hostname === SCRATCH_CLOUD_HOST) {
         parsed.hostname = TURBOWARP_CLOUD_HOST;
-        console.log(`Redirecting cloud connection: ${url} → ${parsed.href}`);
         url = parsed.href;
+        console.log(`Redirecting cloud connection: ${originalUrl} → ${url}`);
       }
     } catch (e) {
       // Invalid URL, pass through unchanged
     }
-    return protocols !== undefined ? new RealWebSocket(url, protocols) : new RealWebSocket(url);
+    const ws = protocols !== undefined ? new RealWebSocket(url, protocols) : new RealWebSocket(url);
+    return ws;
   }
 
   PatchedWebSocket.prototype = RealWebSocket.prototype;
-  PatchedWebSocket.prototype.constructor = PatchedWebSocket;
-  Object.defineProperty(PatchedWebSocket, "name", { value: "WebSocket" });
-
   for (const key of Object.getOwnPropertyNames(RealWebSocket)) {
     if (key !== "prototype" && key !== "length" && key !== "name") {
       try {
@@ -33,11 +31,14 @@ export default async function ({ addon, console }) {
   }
 
   window.WebSocket = PatchedWebSocket;
+  console.log("WebSocket patched. OPEN=" + window.WebSocket.OPEN);
 
   addon.self.addEventListener("disabled", () => {
     window.WebSocket = RealWebSocket;
+    console.log("WebSocket restored to original.");
   });
   addon.self.addEventListener("reenabled", () => {
     window.WebSocket = PatchedWebSocket;
+    console.log("WebSocket re-patched.");
   });
 }

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -3,42 +3,33 @@ export default async function ({ addon, console }) {
   const TURBOWARP_CLOUD_HOST = "clouddata.turbowarp.org";
   const RealWebSocket = window.WebSocket;
 
-  console.log("Cloud-to-TurboWarp addon loaded. Patching WebSocket...");
-
   function PatchedWebSocket(url, protocols) {
-    const originalUrl = url;
     try {
       const parsed = new URL(url);
       if (parsed.hostname === SCRATCH_CLOUD_HOST) {
         parsed.hostname = TURBOWARP_CLOUD_HOST;
+        console.log("Redirected:", url, "→", parsed.href);
         url = parsed.href;
-        console.log(`Redirecting cloud connection: ${originalUrl} → ${url}`);
       }
-    } catch (e) {
-      // Invalid URL, pass through unchanged
-    }
-    const ws = protocols !== undefined ? new RealWebSocket(url, protocols) : new RealWebSocket(url);
-    return ws;
+    } catch (e) {}
+    return protocols !== undefined
+      ? new RealWebSocket(url, protocols)
+      : new RealWebSocket(url);
   }
 
   PatchedWebSocket.prototype = RealWebSocket.prototype;
   for (const key of Object.getOwnPropertyNames(RealWebSocket)) {
     if (key !== "prototype" && key !== "length" && key !== "name") {
-      try {
-        PatchedWebSocket[key] = RealWebSocket[key];
-      } catch (e) {}
+      try { PatchedWebSocket[key] = RealWebSocket[key]; } catch (e) {}
     }
   }
 
   window.WebSocket = PatchedWebSocket;
-  console.log("WebSocket patched. OPEN=" + window.WebSocket.OPEN);
 
   addon.self.addEventListener("disabled", () => {
     window.WebSocket = RealWebSocket;
-    console.log("WebSocket restored to original.");
   });
   addon.self.addEventListener("reenabled", () => {
     window.WebSocket = PatchedWebSocket;
-    console.log("WebSocket re-patched.");
   });
 }

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -1,0 +1,34 @@
+export default async function ({ addon, console }) {
+  const SCRATCH_CLOUD_HOST = "clouddata.scratch.mit.edu";
+  const TURBOWARP_CLOUD_HOST = "clouddata.turbowarp.org";
+  const RealWebSocket = window.WebSocket;
+
+  class PatchedWebSocket extends RealWebSocket {
+    constructor(url, protocols) {
+      try {
+        const parsed = new URL(url);
+        if (parsed.hostname === SCRATCH_CLOUD_HOST) {
+          parsed.hostname = TURBOWARP_CLOUD_HOST;
+          console.log(`Redirecting cloud connection: ${url} → ${parsed.href}`);
+          url = parsed.href;
+        }
+      } catch (e) {
+        // Invalid URL, pass through unchanged
+      }
+      if (protocols !== undefined) {
+        super(url, protocols);
+      } else {
+        super(url);
+      }
+    }
+  }
+
+  window.WebSocket = PatchedWebSocket;
+
+  addon.self.addEventListener("disabled", () => {
+    window.WebSocket = RealWebSocket;
+  });
+  addon.self.addEventListener("reenabled", () => {
+    window.WebSocket = PatchedWebSocket;
+  });
+}

--- a/addons/cloud-to-turbowarp/userscript.js
+++ b/addons/cloud-to-turbowarp/userscript.js
@@ -1,5 +1,4 @@
 export default async function ({ addon, console }) {
-  window.alert("Cloud-to-TurboWarp: userscript is running!");
   const SCRATCH_CLOUD_HOST = "clouddata.scratch.mit.edu";
   const TURBOWARP_CLOUD_HOST = "clouddata.turbowarp.org";
   const RealWebSocket = window.WebSocket;

--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -2,6 +2,16 @@ body {
   padding-bottom: 1px; /* show margin below last game */
 }
 
+.turbo-warp-banner {
+  background-color: #3ddc84;
+  color: #1a1a1a;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 10px;
+  user-select: none;
+}
+
 .fade-transition {
   transition: opacity 0.2s ease;
 }

--- a/popups/cloud-games/popup.html
+++ b/popups/cloud-games/popup.html
@@ -18,6 +18,9 @@
   </head>
 
   <body>
+    <div v-cloak class="turbo-warp-banner" v-if="turboWarpEnabled">
+      {{ messages.turboWarpBanner }}
+    </div>
     <div
       v-cloak
       class="loading"

--- a/popups/cloud-games/popup.js
+++ b/popups/cloud-games/popup.js
@@ -69,11 +69,15 @@ export default async ({ addon, msg, safeMsg }) => {
     .map(({ url }) => url)
     .map(extractUrl);
 
+  const enabledAddons = await addon.self.getEnabledAddons();
+  const turboWarpEnabled = enabledAddons.includes("cloud-to-turbowarp");
+
   window.vue = new Vue({
     el: "body",
     data: {
       projects: [],
       projectsVisible: false,
+      turboWarpEnabled,
       messages: {
         loadingMsg: msg("loading"),
         noUsersMsg: msg("no-users"),
@@ -83,6 +87,7 @@ export default async ({ addon, msg, safeMsg }) => {
         addStudioDescription: msg("add-studio-desc"),
         added: msg("added"),
         changeDisplay2: msg("change-display-2"),
+        turboWarpBanner: msg("turbo-warp-banner"),
       },
       projectsChecked: 0,
       error: null,

--- a/popups/cloud-games/popup.js
+++ b/popups/cloud-games/popup.js
@@ -68,6 +68,7 @@ export default async ({ addon, msg, safeMsg }) => {
     .get("displayedGames")
     .map(({ url }) => url)
     .map(extractUrl);
+
   window.vue = new Vue({
     el: "body",
     data: {


### PR DESCRIPTION
This PR adds a addon called cloud-to-turbowarp.
When enabled, online multiplayer projects will link to turbowarp servers instead!


### Reason for changes

This addon allows people who prefer turbowarp's fast, generally more reliable servers to use in the scratch GUI! Also adds banner to games tab when enabled as servers still are scratch on games tab since turbowarp does not store logs.

### Tests

Tested on Edge (based off chromium and edge extension support chrome so will also work on chrome)
Firefox didn't work...but that's a ScratchAddon or testing bug because the addon didn't load at all (it said it did but the background process died after a bit and nothing popped changed).