### PR TITLE
Split off debugger category string

### DIFF
--- a/addon-api/content-script/blocks.js
+++ b/addon-api/content-script/blocks.js
@@ -210,7 +210,7 @@ const injectWorkspace = (ScratchBlocks) => {
       id: "sa-blocks",
       xml:
         "<category" +
-        ` name="${escapeHTML(scratchAddons.l10n.get("debugger/@name", null, "Debugger"))}"` +
+        ` name="${escapeHTML(scratchAddons.l10n.get("_general/blocks/sa-category", null, "Debugger"))}"` +
         ` ${ScratchBlocks.registry ? "toolboxitemid" : "id"}="sa-blocks"` +
         ' colour="#ff7b26"' +
         ' secondaryColour="#ff7b26"' +

--- a/addons-l10n/en/_general.json
+++ b/addons-l10n/en/_general.json
@@ -5,6 +5,7 @@
   "_general/blocks/green-flag": "flag",
   "_general/blocks/clockwise": "clockwise",
   "_general/blocks/anticlockwise": "anti-clockwise",
+  "_general/blocks/sa-category": "Debugger",
 
   "_general/restore/sprites": "Restore Sprites",
   "_general/restore/costumes": "Restore Costumes",


### PR DESCRIPTION
In preparation for #8382

Splits the debugger category label into its own `_general` string so the addon API (and userscripts) no longer rely on metadata strings. As far as I know that was the only case where it did.