### PR TITLE
Document licenses for icon sets (settings page)

### DIFF
--- a/libraries/README.md
+++ b/libraries/README.md
@@ -16,3 +16,11 @@ Third-party libraries included are:
 - [Roboto](https://fonts.google.com/specimen/Roboto) (Apache-2.0)
 
 Note that these libraries are either from official release websites or from unpkg (which distributes the content uploaded to NPM as-is).
+
+Included third-party icons may come from the following sets:
+- [Ant Design Icons](https://ant.design/components/icon) (MIT)
+- [Bootstrap Icons](https://icons.getbootstrap.com/) (MIT)
+- [Google Material Icons](https://fonts.google.com/icons) (Apache-2.0)
+- [HeroIcons](https://heroicons.com/) (Apache-2.0)
+- [Material Design Icons](https://pictogrammers.com/library/mdi/) (MIT)
+- [Unicons](https://iconscout.com/unicons) (Apache-2.0)

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -22,5 +22,5 @@ Included third-party icons may come from the following sets:
 - [Bootstrap Icons](https://icons.getbootstrap.com/) (MIT)
 - [Google Material Icons](https://fonts.google.com/icons) (Apache-2.0)
 - [HeroIcons](https://heroicons.com/) (MIT)
-- [Material Design Icons](https://pictogrammers.com/library/mdi/) (Apache-2.0)
+- [Pictogrammers Material Design Icons](https://pictogrammers.com/library/mdi/) (Apache-2.0)
 - [Unicons](https://iconscout.com/unicons) (Apache-2.0)

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -21,6 +21,6 @@ Included third-party icons may come from the following sets:
 - [Ant Design Icons](https://ant.design/components/icon) (MIT)
 - [Bootstrap Icons](https://icons.getbootstrap.com/) (MIT)
 - [Google Material Icons](https://fonts.google.com/icons) (Apache-2.0)
-- [HeroIcons](https://heroicons.com/) (Apache-2.0)
-- [Material Design Icons](https://pictogrammers.com/library/mdi/) (MIT)
+- [HeroIcons](https://heroicons.com/) (MIT)
+- [Material Design Icons](https://pictogrammers.com/library/mdi/) (Apache-2.0)
 - [Unicons](https://iconscout.com/unicons) (Apache-2.0)

--- a/libraries/license-info.json
+++ b/libraries/license-info.json
@@ -90,5 +90,28 @@
   },
   "blockly": {
     "license": "Apache-2.0"
+  },
+  "ant-design-icons": {
+    "year": "2018-present",
+    "fullname": "Ant UED, https://xtech.antfin.com/",
+    "license": "MIT"
+  },
+  "bootstrap-icons": {
+    "year": "2019-2024",
+    "fullname": "The Bootstrap Authors",
+    "license": "MIT"
+  },
+  "google-material-icons": {
+    "license": "Apache-2.0"
+  },
+  "heroicons": {
+    "fullname": "Tailwind Labs, Inc.",
+    "license": "MIT"
+  },
+  "material-design-icons": {
+    "license": "Apache-2.0"
+  },
+  "unicons": {
+    "license": "Apache-2.0"
   }
 }

--- a/libraries/license-info.json
+++ b/libraries/license-info.json
@@ -108,7 +108,7 @@
     "fullname": "Tailwind Labs, Inc.",
     "license": "MIT"
   },
-  "material-design-icons": {
+  "pictogrammers-mdi": {
     "license": "Apache-2.0"
   },
   "unicons": {

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -430,7 +430,7 @@
         </p>
         <p>
           <a
-            href="./licenses.html?libraries=icu-message-formatter,vue,color-picker-web-component,comlink,Sora,fuse,idb,sortable,Roboto"
+            href="./licenses.html?libraries=icu-message-formatter,vue,color-picker-web-component,comlink,Sora,fuse,idb,sortable,Roboto,ant-design-icons,bootstrap-icons,google-material-icons,heroicons,material-design-icons,unicons"
             target="_blank"
             >{{ msg("libraryCredits") }}</a
           >

--- a/webpages/settings/index.html
+++ b/webpages/settings/index.html
@@ -430,7 +430,7 @@
         </p>
         <p>
           <a
-            href="./licenses.html?libraries=icu-message-formatter,vue,color-picker-web-component,comlink,Sora,fuse,idb,sortable,Roboto,ant-design-icons,bootstrap-icons,google-material-icons,heroicons,material-design-icons,unicons"
+            href="./licenses.html?libraries=icu-message-formatter,vue,color-picker-web-component,comlink,Sora,fuse,idb,sortable,Roboto,ant-design-icons,bootstrap-icons,google-material-icons,heroicons,pictogrammers-mdi,unicons"
             target="_blank"
             >{{ msg("libraryCredits") }}</a
           >


### PR DESCRIPTION
It seems like a good idea to mention where we get our icons from. The Licenses page should now show their "library" names, licenses, and copyright information.