### PR TITLE
download-button: resize icon and fix label alignment

### DIFF
--- a/addons/download-button/style.css
+++ b/addons/download-button/style.css
@@ -3,14 +3,13 @@
 #sa-download-button:before {
   background-image: url("./download.svg");
   display: inline-block;
-  margin-top: -2px;
   margin-right: 0.25rem;
   background-repeat: no-repeat;
   background-position: center center;
   background-size: contain;
-  width: 1.125rem;
-  height: 1.125rem;
-  vertical-align: middle;
+  width: 0.875rem;
+  height: 0.875rem;
+  vertical-align: bottom;
   content: "";
 }
 


### PR DESCRIPTION
Changes the download button's icon size to be the same as on other action buttons, which also fixes the labels not being aligned correctly.

Before (Download icon is much bigger and the label is 1px higher than the others):
<img width="582" height="57" alt="image" src="https://github.com/user-attachments/assets/52a44454-20ba-496f-9e67-4c4a8f597fe3" />

After:
<img width="575" height="52" alt="image" src="https://github.com/user-attachments/assets/7b526cc0-0c08-4115-8e32-13159fb42a60" />