### PR TITLE
folders: fix backpack crash

### DIFF
--- a/addons/folders/userscript.js
+++ b/addons/folders/userscript.js
@@ -320,7 +320,7 @@ export default async function ({ addon, console, msg }) {
       const Backpack = backpackInstance.constructor;
       return (
         typeof Backpack.prototype.handleDrop === "function" &&
-        typeof Backpack.prototype.componentDidUpdate === "undefined"
+        typeof Backpack.prototype.componentDidUpdate === "function"
       );
     } catch {
       return false;
@@ -1396,7 +1396,9 @@ export default async function ({ addon, console, msg }) {
       }
     };
 
+    const originalComponentDidUpdate = Backpack.prototype.componentDidUpdate;
     Backpack.prototype.componentDidUpdate = function (prevProps, prevState) {
+      originalComponentDidUpdate.call(this, prevProps, prevState);
       if (!this.state.loading && prevState.loading && !this.state.error) {
         this.sa_loadNextItem();
       }


### PR DESCRIPTION
Resolves #9083

### Changes

Fixes a crash when dragging a folder into the backpack.

The addon assumed that the backpack wouldn't have a `componentDidUpdate()` method, but Scratch added one recently.

### Tests

Tested on Edge.