### PR TITLE
hide-flyout: fix palette closing while editing input

### DIFF
--- a/addons/hide-flyout/userscript.js
+++ b/addons/hide-flyout/userscript.js
@@ -229,8 +229,8 @@ export default async function ({ addon, console, msg }) {
         return oldShowContextMenu.call(this, ...args);
       };
 
-      const oldShowInlineEditor = Blockly.FieldTextInput.prototype.showInlineEditor_;
-      Blockly.FieldTextInput.prototype.showInlineEditor_ = function (...args) {
+      const oldShowInlineEditor = Blockly.FieldTextInput.prototype.showInlineEditor;
+      Blockly.FieldTextInput.prototype.showInlineEditor = function (...args) {
         widgetDivOwner = this;
         return oldShowInlineEditor.call(this, ...args);
       };


### PR DESCRIPTION
Resolves #9115

### Changes

Fixes the block palette closing while a block input inside the palette was focused. The bug started happening again because Blockly removed an underscore from a function name.

### Tests

Tested on Edge.