### PR TITLE
find-bar: change placeholder when switching tabs

### DIFF
--- a/addons-l10n/en/find-bar.json
+++ b/addons-l10n/en/find-bar.json
@@ -1,5 +1,7 @@
 {
   "find-bar/find-placeholder": "Find (Ctrl+F)",
+  "find-bar/costume-placeholder": "Find costume (Ctrl+F)",
+  "find-bar/sound-placeholder": "Find sound (Ctrl+F)",
   "find-bar/complex-broadcast": "(expression)",
   "find-bar/var-local": {
     "string": "var {name}",

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -66,11 +66,9 @@ export default async function ({ addon, msg, console }) {
       const visible = tab === 0 || tab === 1 || tab === 2;
       this.findBarOuter.hidden = !visible;
       if (visible) {
-        this.findInput.placeholder = [
-          msg("find-placeholder"),
-          msg("costume-placeholder"),
-          msg("sound-placeholder"),
-        ][tab];
+        this.findInput.placeholder = [msg("find-placeholder"), msg("costume-placeholder"), msg("sound-placeholder")][
+          tab
+        ];
       }
     }
 

--- a/addons/find-bar/userscript.js
+++ b/addons/find-bar/userscript.js
@@ -43,7 +43,6 @@ export default async function ({ addon, msg, console }) {
       // for <label>
       this.findInput.id = "sa-find-input";
       this.findInput.type = "search";
-      this.findInput.placeholder = msg("find-placeholder");
       this.findInput.autocomplete = "off";
 
       this.dropdownOut.appendChild(this.dropdown.createDom());
@@ -66,6 +65,13 @@ export default async function ({ addon, msg, console }) {
       const tab = addon.tab.redux.state.scratchGui.editorTab.activeTabIndex;
       const visible = tab === 0 || tab === 1 || tab === 2;
       this.findBarOuter.hidden = !visible;
+      if (visible) {
+        this.findInput.placeholder = [
+          msg("find-placeholder"),
+          msg("costume-placeholder"),
+          msg("sound-placeholder"),
+        ][tab];
+      }
     }
 
     inputChange() {


### PR DESCRIPTION
### Reason for changes

From feedback:

> Can yall add these: costume search and ignore saving block (when it wont let me save my project)

We already have costume search in the find bar addon, but it's possible that people don't realize that - since the addon is enabled by default, they might not ever read its description. In addition, the placement next to the tab bar and not inside the active tab doesn't make it obvious that the find bar's function changes depending on which tab is selected. I remember initially thinking that it was only for searching code.

### Changes

Changes the input placeholder to "Find", "Find costume", or "Find sound", depending on which tab is selected. This should make it clear that the find bar can be used to find costumes and sounds.

### Tests

Tested on Edge.