### PR TITLE
editor-cleanup-plus: remove notice

### DIFF
--- a/addons/editor-cleanup-plus/addon.json
+++ b/addons/editor-cleanup-plus/addon.json
@@ -10,12 +10,6 @@
       "link": "https://scratch.mit.edu/users/Chrome_Cat/"
     }
   ],
-  "info": [
-    {
-      "text": "This addon was previously part of the \"developer tools\" addon but has moved here.",
-      "id": "developer-tools"
-    }
-  ],
   "settings": [
     {
       "name": "Find unused variables",


### PR DESCRIPTION
The addon has been separate from devtools for almost a year.