### PR TITLE
Add Ctrl/Cmd key support to editor-number-arrow-keys

### DIFF
--- a/addons/editor-number-arrow-keys/addon.json
+++ b/addons/editor-number-arrow-keys/addon.json
@@ -127,7 +127,44 @@
       "max": 8,
       "if": { "settings": { "useCustom": true } }
     },
+    {
+      "name": "Change on Ctrl+Key (Cmd on Mac)",
+      "id": "ctrl",
+      "type": "select",
+      "default": "hundredth",
+      "potentialValues": [
+        {
+          "id": "none",
+          "name": "None"
+        },
+        {
+          "id": "hundredth",
+          "name": "0.01"
+        },
+        {
+          "id": "tenth",
+          "name": "0.1"
+        },
+        {
+          "id": "one",
+          "name": "1"
+        },
+        {
+          "id": "ten",
+          "name": "10"
+        }
+      ],
+      "if": { "settings": { "useCustom": false } }
+    },
 
+    {
+      "name": "Change on Ctrl+Key (Cmd on Mac)",
+      "id": "ctrlCustom",
+      "type": "untranslated",
+      "default": "0.01",
+      "max": 8,
+      "if": { "settings": { "useCustom": true } }
+    },
     {
       "name": "Use custom values",
       "id": "useCustom",
@@ -142,6 +179,10 @@
     },
     {
       "name": "World_Languages"
+    },
+    {
+      "name": "kalyzu",
+      "link": "https://github.com/kalyzu"
     }
   ],
   "dynamicDisable": true,

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -1,6 +1,6 @@
 export default async function ({ addon }) {
-  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-             || navigator.userAgent.toLowerCase().includes('mac');
+  const isMac =
+    navigator.platform.toUpperCase().indexOf("MAC") >= 0 || navigator.userAgent.toLowerCase().includes("mac");
   const settings = {
     none: 0,
     hundredth: 0.01,

--- a/addons/editor-number-arrow-keys/userscript.js
+++ b/addons/editor-number-arrow-keys/userscript.js
@@ -1,4 +1,6 @@
 export default async function ({ addon }) {
+  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+             || navigator.userAgent.toLowerCase().includes('mac');
   const settings = {
     none: 0,
     hundredth: 0.01,
@@ -118,13 +120,18 @@ export default async function ({ addon }) {
     // If this is a number input, it will prevent the default browser behavior when pressing up/down in a
     // number input (increase or decrease by 1). If we didn't prevent, the user would be increasing twice.
 
+    // Assign ctrlModifier based on platform
+    const ctrlModifier = isMac ? e.metaKey : e.ctrlKey;
+
     let changeBy = e.key === "ArrowUp" ? 1 : -1;
     if (addon.settings.get("useCustom")) {
-      let settingValue = e.shiftKey
-        ? addon.settings.get("shiftCustom")
-        : e.altKey
-          ? addon.settings.get("altCustom")
-          : addon.settings.get("regularCustom");
+      let settingValue = ctrlModifier
+        ? addon.settings.get("ctrlCustom")
+        : e.shiftKey
+          ? addon.settings.get("shiftCustom")
+          : e.altKey
+            ? addon.settings.get("altCustom")
+            : addon.settings.get("regularCustom");
       if (settingValue === "") settingValue = 0;
       let valueAsFloat = parseFloat(settingValue);
       if (valueAsFloat < 0) valueAsFloat *= -1; // If user typed a negative number, we make it positive
@@ -137,11 +144,13 @@ export default async function ({ addon }) {
         return;
       }
     } else {
-      changeBy *= e.shiftKey
-        ? settings[addon.settings.get("shift")]
-        : e.altKey
-          ? settings[addon.settings.get("alt")]
-          : settings[addon.settings.get("regular")];
+      changeBy *= ctrlModifier
+        ? settings[addon.settings.get("ctrl")]
+        : e.shiftKey
+          ? settings[addon.settings.get("shift")]
+          : e.altKey
+            ? settings[addon.settings.get("alt")]
+            : settings[addon.settings.get("regular")];
     }
 
     const decimalCount = Math.max(amountOfDecimals(e.target.value), amountOfDecimals(changeBy.toString()));


### PR DESCRIPTION
**Resolves**: No prior issues; I decided not to be redundant. This minimal change can be disputed here.

### Changes

Allows for another option for arrow key incrementation, the Ctrl key.
Logic has been implemented to use `e.metaKey` if the platform is MacOS.

### Reason for changes

I have found that I need arrow key incrementation for 10, 1, 0.1, _and_ 0.01 at the same time, so I (the lvl 0 experience dev) took it upon myself to add it, not just open an issue.

### Tests
All platforms worked exceptionally well with no bugs to mention.

Linux (Arch)
 * [x] Chromium
 * [x] Firefox

(Fix was extremely minimal, cross-platform testing was skipped)
