### PR TITLE
Preserve stroke styles after paint boolean operations

### DIFF
--- a/addons/paint-boolean-ops/paper-helpers.js
+++ b/addons/paint-boolean-ops/paper-helpers.js
@@ -35,13 +35,15 @@ export const cleanResult = (r) => {
 };
 
 // ── Style helpers ──────────────────────────────────────────────────────
-// Snapshots an item's fill, stroke colour, and stroke width. Boolean ops
-// in paper.js reliably lose style information, so we save before and
-// restore after every operation.
+// Snapshots an item's fill and stroke style. Boolean ops in paper.js reliably
+// lose style information, so we save before and restore after every operation.
 export const cloneStyle = (src) => ({
   fillColor: src.fillColor ? src.fillColor.clone() : null,
   strokeColor: src.strokeColor ? src.strokeColor.clone() : null,
   strokeWidth: src.strokeWidth,
+  strokeJoin: src.strokeJoin,
+  strokeCap: src.strokeCap,
+  miterLimit: src.miterLimit,
 });
 
 // Restores a previously snapshotted style onto an item.
@@ -49,6 +51,9 @@ export const applyStyle = (dst, style) => {
   dst.fillColor = style.fillColor;
   dst.strokeColor = style.strokeColor;
   dst.strokeWidth = style.strokeWidth;
+  dst.strokeJoin = style.strokeJoin;
+  dst.strokeCap = style.strokeCap;
+  dst.miterLimit = style.miterLimit;
 };
 
 // ── Path normalisation ─────────────────────────────────────────────────
@@ -227,11 +232,10 @@ export const convertTextItems = (paper) => {
   );
   let count = 0;
   for (const textItem of textItems) {
+    const style = cloneStyle(textItem);
     const path = TextToPath.convert(textItem, paper);
     if (!path) continue;
-    path.fillColor = textItem.fillColor ? textItem.fillColor.clone() : null;
-    path.strokeColor = textItem.strokeColor ? textItem.strokeColor.clone() : null;
-    path.strokeWidth = textItem.strokeWidth;
+    applyStyle(path, style);
     const idx = textItem.index;
     const layer = textItem.layer;
     textItem.selected = false;

--- a/addons/paint-boolean-ops/paper-helpers.js
+++ b/addons/paint-boolean-ops/paper-helpers.js
@@ -111,7 +111,9 @@ export const getPaintingSelected = (paper) =>
               item.segments[0].point.getDistance(item.segments[item.segments.length - 1].point) < 0.01))) ||
           item instanceof paper.CompoundPath)
     )
-    .sort((a, b) => a.index - b.index);
+    // Indices only order siblings. Paper's comparison includes their parent
+    // groups, so the backmost shape supplies the style even across groups.
+    .sort((a, b) => (a.isBelow(b) ? -1 : a.isAbove(b) ? 1 : 0));
 
 // Returns the top-level selected items on the painting layer, back-to-front.
 // Groups are treated as one unit; child paths inside a Group are excluded.


### PR DESCRIPTION
Follow-up to #8917 & the request in #8914

### Changes

Boolean operations now preserve stroke joins, caps, and miter limits when creating replacement paths. Text converted to paths uses the same shared style helper.

### Reason for changes

Combine and Expand previously restored only colours and width, causing round corners and endpoints to revert to Paper.js defaults.