### PR TITLE
Join flow fixes

### DIFF
--- a/addons/dark-www/banners/darker.css
+++ b/addons/dark-www/banners/darker.css
@@ -99,13 +99,8 @@
 .sa-annual-report-2020 .reach-scratch-jr {
   background-color: #1c465a;
 }
-#force-account-rename,
 .financials-section,
 .sa-annual-report-2020 .directors-message,
 .sa-annual-report-2021 .founders-message {
   background-color: #16171d;
-}
-.join-flow-outer-content /* username change */ {
-  background-clip: padding-box;
-  border-color: rgba(255, 255, 255, 0.25);
 }

--- a/addons/dark-www/banners/desaturated.css
+++ b/addons/dark-www/banners/desaturated.css
@@ -105,13 +105,8 @@
 .compose-comment .compose-error-row .compose-error-tip {
   background-color: #a37629;
 }
-#force-account-rename,
 .financials-section,
 .sa-annual-report-2020 .directors-message,
 .sa-annual-report-2021 .founders-message {
   background-color: #16171d;
-}
-.join-flow-outer-content /* username change */ {
-  background-clip: padding-box;
-  border-color: rgba(255, 255, 255, 0.25);
 }

--- a/addons/dark-www/experimental_scratchwww.css
+++ b/addons/dark-www/experimental_scratchwww.css
@@ -160,7 +160,6 @@ body {
 :root:not(.sa-editor) [class*="stage-header_stage-button_"],
 .studio-adder-section .studio-adder-row input,
 .avatar-item img,
-.join-flow-outer-content /* username change */,
 .conf2019-panel-flag,
 .plan .faq .short,
 .conf2017-panel-flag,
@@ -416,7 +415,6 @@ p.callout,
 .transfer-host-modal .transfer-outcome,
 .filter-container,
 .tab-choice-selected-sa,
-#bad-username-splash .admin-message /* username change */,
 .sa-annual-report-2020 .initiatives-section .year-in-review,
 .initiatives-section .initiatives-subsection-content .map,
 .sa-annual-report-2021 .leadership-section .leadership-scratch-team .avatar-item img,
@@ -429,7 +427,6 @@ p.callout,
 .empty h4,
 .thumbnail-column .thumbnail .thumbnail-info .thumbnail-title .thumbnail-creator a,
 .studio-page #view,
-#bad-username-splash .admin-message .admin-message-date /* username change */,
 .milestones-section h2 {
   color: var(--darkWww-blue-text);
 }

--- a/background/get-userscripts.js
+++ b/background/get-userscripts.js
@@ -347,7 +347,7 @@ const WELL_KNOWN_PATTERNS = {
   // scratch-www routes, not including project pages
   // Matches /projects (an error page) but not /projects/<id>
   scratchWWWNoProject:
-    /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps?)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher|projects|cookies|accounts\/bad-username)\/?)?$/,
+    /^\/(?:(?:about|annual-report(?:\/\d+)?|camp|conference\/20(?:1[79]|[2-9]\d|18(?:\/(?:[^\/]+\/details|expect|plan|schedule))?)|contact-us|code-of-ethics|credits|developers|DMCA|download(?:\/(?:scratch2|scratch-link))?|educators(?:\/(?:faq|register|waiting))?|explore\/(?:project|studio)s\/\w+(?:\/\w+)?|community_guidelines|faq|ideas|join|messages|parents|privacy_policy(?:\/apps?)?|research|scratch_1\.4|search\/(?:project|studio)s|starter-projects|classes\/(?:complete_registration|[^\/]+\/register\/[^\/]+)|signup\/[^\/]+|terms_of_use|wedo(?:-legacy)?|ev3|microbit|vernier|boost|studios\/\d*(?:\/(?:projects|comments|curators|activity))?|components|become-a-scratcher|projects|cookies)\/?)?$/,
 };
 
 const WELL_KNOWN_MATCHERS = {


### PR DESCRIPTION
The bad username page [was "temporarily" removed in 2023](https://github.com/scratchfoundation/scratch-www/commit/d121de84e9a02884ae161db7dcd5bcffc58611e5). This PR deletes it from the `scratchWWWNoProject` match pattern and removes the CSS for it, which also fixes the join flow not having rounded corners - it looks like this in v1.45.2:

<img width="603" height="185" alt="image" src="https://github.com/user-attachments/assets/ee48762e-278c-4550-890b-2b10e04a7ba8" /><br />

After this change:

<img width="601" height="182" alt="image" src="https://github.com/user-attachments/assets/30c4c389-1cee-4a6e-bf81-4ed580f4fd2c" />