### PR TITLE
Popup & settings page: partial support for forced colors mode (high contrast)

### DIFF
--- a/popups/cloud-games/popup.css
+++ b/popups/cloud-games/popup.css
@@ -117,3 +117,9 @@ body {
   background: var(--blue);
   border-color: var(--blue-variant);
 }
+
+@media (forced-colors: active) {
+  .loading-progress {
+    background-color: CanvasText;
+  }
+}

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -27,6 +27,9 @@ button {
     background-color: ButtonFace;
     outline: 1px solid ButtonBorder;
   }
+  .btn-dropdown:focus {
+    outline: revert;
+  }
 }
 
 .reverted {

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -22,6 +22,12 @@ button {
 .message-type-title:hover .btn-dropdown {
   background: var(--hover-highlight);
 }
+@media (forced-colors: active) {
+  .btn-dropdown {
+    background-color: ButtonFace;
+    outline: 1px solid ButtonBorder;
+  }
+}
 
 .reverted {
   transform: rotate(180deg);

--- a/popups/scratch-messaging/popup.css
+++ b/popups/scratch-messaging/popup.css
@@ -190,6 +190,12 @@ button > .small-icon {
   /*font-weight: 200;*/
   opacity: 0.5;
 }
+@media (forced-colors: active) {
+  .comment-time {
+    opacity: 1;
+    color: GrayText;
+  }
+}
 .popout-comment {
   cursor: pointer;
   height: 12px;
@@ -213,6 +219,12 @@ button > .small-icon {
   font-weight: bold;
   color: var(--red);
 }
+@media (forced-colors: active) {
+  .delete-btn,
+  .delete-confirm {
+    color: LinkText;
+  }
+}
 .child-comment {
   margin-inline-start: 3em;
 }
@@ -229,6 +241,11 @@ button > .small-icon {
   color: var(--blue-text);
   font-weight: 500;
   user-select: none;
+}
+@media (forced-colors: active) {
+  .reply-button-comment {
+    color: LinkText;
+  }
 }
 .comment:is(:hover, :focus-within) .reply-button-comment,
 .comment:is(:hover, :focus-within) .delete-btn {

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -171,6 +171,12 @@ iframe {
     opacity: 1;
   }
 
+  .header-button {
+    background-color: ButtonFace;
+    outline: 1px solid ButtonBorder;
+    outline-offset: -1px;
+  }
+
   .popup-name {
     background-color: ButtonFace;
     color: ButtonText;

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -172,6 +172,8 @@ iframe {
   }
 
   .popup-name {
+    background-color: ButtonFace;
+    color: ButtonText;
     transition: none;
   }
   .popup-name.sel {

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -176,6 +176,9 @@ iframe {
     outline: 1px solid ButtonBorder;
     outline-offset: -1px;
   }
+  .header-button:focus {
+    outline: revert;
+  }
 
   .popup-name {
     background-color: ButtonFace;

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -165,3 +165,21 @@ iframe {
   font-size: 14px;
   user-select: text;
 }
+
+@media (forced-colors: active) {
+  #version {
+    opacity: 1;
+  }
+
+  .popup-name {
+    transition: none;
+  }
+  .popup-name.sel {
+    background-color: Highlight;
+    color: HighlightText;
+    forced-color-adjust: preserve-parent-color;
+  }
+  .popup-name.sel::before {
+    background-color: HighlightText;
+  }
+}

--- a/webpages/settings/components/addon-body.html
+++ b/webpages/settings/components/addon-body.html
@@ -399,4 +399,10 @@
       margin-inline-end: 0;
     }
   }
+
+  @media (forced-colors: active) {
+    .addon-description {
+      color: GrayText;
+    }
+  }
 </style>

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -328,4 +328,14 @@
       flex-shrink: 0;
     }
   }
+
+  @media (forced-colors: active) {
+    .setting-dropdown .color-preview {
+      forced-color-adjust: none;
+    }
+
+    .setting-dropdown .color-preview span {
+      border-color: CanvasText;
+    }
+  }
 </style>

--- a/webpages/settings/components/addon-setting.html
+++ b/webpages/settings/components/addon-setting.html
@@ -330,6 +330,10 @@
   }
 
   @media (forced-colors: active) {
+    .setting-input:focus-visible {
+      outline: revert;
+    }
+
     .setting-dropdown .color-preview {
       forced-color-adjust: none;
     }

--- a/webpages/settings/components/category-selector.html
+++ b/webpages/settings/components/category-selector.html
@@ -102,4 +102,19 @@
       transition-property: background-color;
     }
   }
+
+  @media (forced-colors: active) {
+    .category {
+      transition-property: padding, height;
+    }
+
+    .category.sel {
+      background-color: Highlight;
+      color: HighlightText;
+      forced-color-adjust: preserve-parent-color;
+    }
+    .category::before {
+      background-color: HighlightText;
+    }
+  }
 </style>

--- a/webpages/settings/components/modal.html
+++ b/webpages/settings/components/modal.html
@@ -81,6 +81,7 @@
 
     .close {
       background-color: ButtonFace;
+      outline: 1px solid ButtonBorder;
     }
   }
 </style>

--- a/webpages/settings/components/modal.html
+++ b/webpages/settings/components/modal.html
@@ -84,5 +84,9 @@
       background-color: ButtonFace;
       outline: 1px solid ButtonBorder;
     }
+
+    .close:focus {
+      outline: revert;
+    }
   }
 </style>

--- a/webpages/settings/components/modal.html
+++ b/webpages/settings/components/modal.html
@@ -54,6 +54,7 @@
     margin-left: auto;
     background-color: transparent;
     border: none;
+    line-height: 0;
     cursor: pointer;
   }
 
@@ -70,6 +71,16 @@
       max-height: 100%;
       box-sizing: border-box;
       border-radius: 0;
+    }
+  }
+
+  @media (forced-colors: active) {
+    .modal {
+      outline: 1px solid;
+    }
+
+    .close {
+      background-color: ButtonFace;
     }
   }
 </style>

--- a/webpages/settings/components/modal.html
+++ b/webpages/settings/components/modal.html
@@ -47,6 +47,7 @@
   .modal-header.zero-height {
     height: 0;
     margin-bottom: 0;
+    align-items: flex-start;
   }
 
   .close {

--- a/webpages/settings/components/previews/compact-messages.html
+++ b/webpages/settings/components/previews/compact-messages.html
@@ -63,6 +63,7 @@
     background-color: #4d97ff;
     border-radius: 10px;
     opacity: 0.25;
+    forced-color-adjust: none;
   }
 
   .compact-messages-text-placeholder {
@@ -94,6 +95,7 @@
     background-color: #4d97ff;
     border-radius: 3px;
     opacity: 0.25;
+    forced-color-adjust: none;
   }
 
   .compact-messages-comment-bubble {
@@ -141,5 +143,15 @@
     left: auto;
     right: -12px;
     border-radius: 0 0 12px 0;
+  }
+
+  @media (forced-colors: active) {
+    .compact-messages-text-placeholder {
+      background-color: CanvasText;
+    }
+
+    .compact-messages-comment-bubble::after {
+      border-color: Canvas;
+    }
   }
 </style>

--- a/webpages/settings/components/previews/dark-www.html
+++ b/webpages/settings/components/previews/dark-www.html
@@ -146,6 +146,7 @@
     background-color: var(--page);
     border: 1px solid var(--control-border);
     border-radius: 4px;
+    forced-color-adjust: none;
   }
   .wdm-inner {
     padding-inline: 22px;

--- a/webpages/settings/components/previews/editor-dark-mode.html
+++ b/webpages/settings/components/previews/editor-dark-mode.html
@@ -629,6 +629,7 @@
     border: 1px solid var(--control-border);
     border-radius: 4px;
     transition: box-shadow 0.2s ease;
+    forced-color-adjust: none;
   }
   .edm-preview * {
     transition:

--- a/webpages/settings/components/previews/palette.html
+++ b/webpages/settings/components/previews/palette.html
@@ -44,4 +44,14 @@
   [dir="rtl"] .preset-palette > span:last-child {
     border-radius: 4px 0 0 4px;
   }
+
+  @media (forced-colors: active) {
+    .preset-palette {
+      forced-color-adjust: none;
+    }
+
+    .preset-palette > span {
+      border-color: CanvasText;
+    }
+  }
 </style>

--- a/webpages/settings/components/previews/stage-monitor-preset.html
+++ b/webpages/settings/components/previews/stage-monitor-preset.html
@@ -24,6 +24,7 @@
     border-radius: 4px;
     color: var(--monitor-label);
     user-select: none;
+    forced-color-adjust: none;
   }
 
   .monitor-preset-label {

--- a/webpages/settings/components/previews/stage-monitor.html
+++ b/webpages/settings/components/previews/stage-monitor.html
@@ -73,6 +73,7 @@
     border: 1px solid var(--control-border);
     border-radius: 4px;
     user-select: none;
+    forced-color-adjust: none;
   }
 
   .monitor-preview * {

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -364,7 +364,9 @@ button.setting-input.color {
 }
 
 @media (forced-colors: active) {
-  .header-button {
+  .header-button,
+  .categories-shrink,
+  .arrow-button {
     background-color: ButtonFace;
     outline: 1px solid ButtonBorder;
     outline-offset: -1px;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -1,5 +1,7 @@
 html {
   background: var(--content-background);
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-text) transparent;
 }
 
 body {
@@ -228,26 +230,6 @@ body.iframe #search-not-found {
   text-align: center;
 }
 
-/*scrollbar*/
-
-/* width */
-::-webkit-scrollbar {
-  width: 7px;
-  height: 7px;
-}
-
-/* hide track */
-::-webkit-scrollbar-track,
-::-webkit-scrollbar-corner {
-  background: none;
-}
-
-/* Handle */
-::-webkit-scrollbar-thumb {
-  background: var(--gray-text);
-  border-radius: 4px;
-}
-
 /* Small screens & popup */
 @media (max-width: 700px) {
   .addons-block-header {
@@ -379,4 +361,20 @@ button.setting-input.color {
   align-items: center;
   justify-content: center;
   user-select: none;
+}
+
+@media (forced-colors: active) {
+  .header-button {
+    background-color: ButtonFace;
+    outline: 1px solid ButtonBorder;
+    outline-offset: -1px;
+  }
+
+  .color-container {
+    forced-color-adjust: none;
+  }
+
+  .color-container .setting-input.color {
+    border-color: ButtonBorder;
+  }
 }

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -371,6 +371,11 @@ button.setting-input.color {
     outline: 1px solid ButtonBorder;
     outline-offset: -1px;
   }
+  .header-button:focus,
+  .categories-shrink:focus,
+  .arrow-button:focus {
+    outline: revert;
+  }
 
   .addons-block-header {
     border-color: Canvas;

--- a/webpages/settings/style.css
+++ b/webpages/settings/style.css
@@ -372,6 +372,10 @@ button.setting-input.color {
     outline-offset: -1px;
   }
 
+  .addons-block-header {
+    border-color: Canvas;
+  }
+
   .color-container {
     forced-color-adjust: none;
   }

--- a/webpages/styles/components/badges.css
+++ b/webpages/styles/components/badges.css
@@ -79,3 +79,10 @@
 .filer-option.sel.lightblue {
   background: #1394bf;
 }
+
+@media (forced-colors: active) {
+  .badge {
+    outline: 1px solid;
+    outline-offset: -1px;
+  }
+}

--- a/webpages/styles/components/buttons.css
+++ b/webpages/styles/components/buttons.css
@@ -93,4 +93,9 @@
     outline: 1px solid ButtonBorder;
     outline-offset: -1px;
   }
+
+  .large-button:focus-visible,
+  .icon-button:focus-visible {
+    outline: revert;
+  }
 }

--- a/webpages/styles/components/buttons.css
+++ b/webpages/styles/components/buttons.css
@@ -86,3 +86,11 @@
 [dir="rtl"] .split-button-dropdown {
   border-radius: 4px 0 0 4px;
 }
+
+@media (forced-colors: active) {
+  .icon-button {
+    background-color: ButtonFace;
+    outline: 1px solid ButtonBorder;
+    outline-offset: -1px;
+  }
+}

--- a/webpages/styles/components/filter.css
+++ b/webpages/styles/components/filter.css
@@ -65,3 +65,22 @@
     text-align: center;
   }
 }
+
+@media (forced-colors: active) {
+  .filter-options {
+    border-color: ButtonBorder;
+  }
+
+  .filter-option {
+    background-color: ButtonFace;
+    border-color: ButtonBorder;
+    color: ButtonText;
+    transition: none;
+  }
+
+  .filter-options input:checked + label {
+    background-color: Highlight;
+    color: HighlightText;
+    forced-color-adjust: preserve-parent-color;
+  }
+}

--- a/webpages/styles/components/filter.css
+++ b/webpages/styles/components/filter.css
@@ -83,4 +83,9 @@
     color: HighlightText;
     forced-color-adjust: preserve-parent-color;
   }
+
+  .filter-options input:focus-visible + label {
+    outline-color: HighlightText;
+    outline-offset: -3px;
+  }
 }

--- a/webpages/styles/components/filter.css
+++ b/webpages/styles/components/filter.css
@@ -38,6 +38,9 @@
 .filter-option:hover {
   background: var(--button-hover-background);
 }
+.filter-options input:focus-visible {
+  outline: none;
+}
 .filter-options input:focus-visible + label {
   outline: 2px solid var(--content-text);
 }

--- a/webpages/styles/components/modal.css
+++ b/webpages/styles/components/modal.css
@@ -103,3 +103,8 @@
     align-items: center;
   }
 }
+@media (forced-colors: active) {
+  .step-number {
+    outline: 1px solid CanvasText;
+  }
+}

--- a/webpages/styles/components/search.css
+++ b/webpages/styles/components/search.css
@@ -63,4 +63,9 @@ body:not(.iframe) .search-box:focus-within {
     background-color: ButtonFace;
     outline: 1px solid ButtonBorder;
   }
+
+  .search-box input:focus-visible,
+  .search-box > button:focus-visible {
+    outline: revert;
+  }
 }

--- a/webpages/styles/components/search.css
+++ b/webpages/styles/components/search.css
@@ -57,3 +57,10 @@ body:not(.iframe) .search-box:focus-within {
 .search-box > button:focus-visible > img {
   filter: none;
 }
+
+@media (forced-colors: active) {
+  .search-box > button {
+    background-color: ButtonFace;
+    outline: 1px solid ButtonBorder;
+  }
+}

--- a/webpages/styles/components/switch.css
+++ b/webpages/styles/components/switch.css
@@ -47,3 +47,25 @@
 [dir="rtl"] .switch:checked::before {
   left: 4px;
 }
+
+@media (forced-colors: active) {
+  .switch {
+    background-color: ButtonFace;
+    border-color: ButtonBorder;
+    transition: none;
+  }
+
+  .switch::before {
+    background-color: ButtonText;
+    transition-property: left;
+  }
+
+  .switch:checked,
+  .switch.blue:checked {
+    background-color: SelectedItem;
+  }
+
+  .switch:checked::before {
+    background-color: SelectedItemText;
+  }
+}

--- a/webpages/styles/components/switch.css
+++ b/webpages/styles/components/switch.css
@@ -68,4 +68,8 @@
   .switch:checked::before {
     background-color: SelectedItemText;
   }
+
+  .switch:focus-visible {
+    outline-offset: 3px;
+  }
 }

--- a/webpages/styles/components/tooltips.css
+++ b/webpages/styles/components/tooltips.css
@@ -90,3 +90,13 @@
   border-inline-end-color: transparent;
   border-top-color: var(--tooltip-background);
 }
+
+@media (forced-colors: active) {
+  .tooltiptext {
+    outline: 1px solid;
+  }
+
+  .tooltip .tooltiptext::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Changes

Fixes some issues in the extension UI that made it difficult to use when the forced colors mode was enabled. Side-by-side comparison on Edge:

| | 1.45.2 | This PR |
| --- | --- | --- |
| Switch (on) | <img width="77" height="47" alt="image" src="https://github.com/user-attachments/assets/87bec54e-869b-4fce-8f96-032d2d4e9cb0" /> | <img width="65" height="40" alt="image" src="https://github.com/user-attachments/assets/89eca119-c8cc-4234-8ca5-7e1f06b1f636" /> |
| Switch (off) | <img width="77" height="47" alt="image" src="https://github.com/user-attachments/assets/87bec54e-869b-4fce-8f96-032d2d4e9cb0" /> | <img width="70" height="47" alt="image" src="https://github.com/user-attachments/assets/73252b43-9e43-4ef7-914e-c8ea80635e22" /> |
| Category selector | <img width="267" height="127" alt="image" src="https://github.com/user-attachments/assets/3466c250-8305-402a-914f-fa1c67772a3a" /> | <img width="280" height="131" alt="image" src="https://github.com/user-attachments/assets/315f7b6e-6181-4931-8180-1e70f9ede941" /> |
| Color picker | <img width="318" height="357" alt="image" src="https://github.com/user-attachments/assets/218d198e-50c5-4d9e-9d7e-80b157f63363" /> | <img width="315" height="361" alt="image" src="https://github.com/user-attachments/assets/3fc1d170-06b8-4af6-90a5-53ee57e87df4" /> |

The full settings page looks like this:

<img width="1915" height="923" alt="image" src="https://github.com/user-attachments/assets/2525b023-d383-4b92-a118-800b0a2ce0f2" /><br />

And with a light color scheme (the default one on Firefox):

<img width="1917" height="910" alt="image" src="https://github.com/user-attachments/assets/12ee7d72-6b15-4035-b32d-c8355fbd5cd9" /><br />

### Known issue

A remaining issue is that icons don't have the right color (they might even be invisible, as seen in the screenshot above). This could be solved by using an icon font, as suggested in #1220, or inline SVGs, as suggested in #4989.

### Testing

There are several ways to turn on forced colors when testing these changes:
* System-wide setting on Windows: several preset color schemes are available in Windows settings → Accessibility → Contrast themes. It's also possible to choose custom colors.
* Developer setting on Chromium browsers: enable the forced-colors media feature on the Rendering tab in devtools.
* Browser setting on Firefox: Settings → Accessibility → Website contrast. A custom color scheme can be set.