### PR TITLE
color-picker: set color when clicking outside

### DIFF
--- a/addons/color-picker/paint-editor.js
+++ b/addons/color-picker/paint-editor.js
@@ -39,7 +39,7 @@ export default async ({ addon, console, msg }) => {
         addon.tab.redux.dispatch({
           type: "scratch-paint/eye-dropper/DEACTIVATE_COLOR_PICKER",
         });
-      }, 50);
+      }, 0);
     };
     addon.tab.redux.addEventListener("statechanged", onEyeDropperOpened);
     element.children[1].children[0].click();


### PR DESCRIPTION
Resolves #5993

### Changes

Fixes the color not updating when clicking outside the hex color input after editing it.

To update the color, the addon activates the eyedropper, then deactivates it after a timeout. But if the update was the result of a click, the click event would deactivate the eyedropper before the addon could do it. Reducing the timeout from 50ms to a single tick fixes the bug.

### Tests

Tested on Edge and Firefox.