### PR TITLE
Fix paint editor color picker z-index

### DIFF
--- a/addons/2d-color-picker/style.css
+++ b/addons/2d-color-picker/style.css
@@ -1,3 +1,7 @@
+.Popover {
+  z-index: 492; /* above menu bar */
+}
+
 .sa-2dcolor-picker {
   width: 150px;
   height: 150px;

--- a/addons/color-picker/style.css
+++ b/addons/color-picker/style.css
@@ -1,3 +1,7 @@
+.Popover {
+  z-index: 492; /* above menu bar */
+}
+
 .sa-color-picker {
   display: flex;
 }

--- a/addons/editor-stage-left/stageleft.css
+++ b/addons/editor-stage-left/stageleft.css
@@ -84,7 +84,7 @@
 
 .Popover {
   /* See hide-flyout */
-  z-index: 51;
+  z-index: 492;
 }
 
 /* hide-stage compatibility */

--- a/addons/hide-flyout/style.css
+++ b/addons/hide-flyout/style.css
@@ -115,9 +115,13 @@
   padding: 0;
 }
 
-/* https://github.com/ScratchAddons/ScratchAddons/issues/4896 */
 .Popover {
-  /* Above stage wrapper and target pane */
+  /* Must be above stage wrapper and target pane:
+     https://github.com/ScratchAddons/ScratchAddons/issues/4896
+
+     Putting it above the menu bar also fixes color pickers
+     appearing behind other elements when they're too tall:
+     https://github.com/ScratchAddons/ScratchAddons/issues/5986 */
   /* See editor-stage-left */
-  z-index: 51;
+  z-index: 492;
 }

--- a/addons/opacity-slider/style.css
+++ b/addons/opacity-slider/style.css
@@ -1,3 +1,7 @@
+.Popover {
+  z-index: 492; /* above menu bar */
+}
+
 .sa-opacity-slider {
   /* overflow: hidden; */
   background-image: linear-gradient(45deg, #eaf0f8 25%, transparent 25%, transparent 75%, #eaf0f8 75%),


### PR DESCRIPTION
Resolves #5986

### Changes

The color picker in the costume editor automatically adjusts its position if there isn't enough vertical space for it, but because its z-index is too low, this may cause other elements to appear in front of it.

This PR adds a CSS rule that increases the z-index to all addons that make the color picker taller.

<img width="363" height="433" alt="image" src="https://github.com/user-attachments/assets/1d6f28e4-cc5a-458d-8467-8ee297edc6c5" />

### Tests

Tested on Edge.