### PR TITLE
fix: fix dark mode styles for confirmation prompts

### DIFF
--- a/addons/editor-dark-mode/experimental_editor.css
+++ b/addons/editor-dark-mode/experimental_editor.css
@@ -184,7 +184,6 @@
   color: var(--editorDarkMode-accent-text);
   color-scheme: var(--editorDarkMode-accent-colorScheme);
 }
-[class*="confirmation-prompt_confirm-button_"],
 [class*="confirmation-prompt_cancel-button_"][class*="delete-confirmation-prompt_button-row-button_"] {
   background-color: var(--editorDarkMode-accent);
 }
@@ -459,7 +458,8 @@ img[class*="tool-select-base_tool-select-icon_"],
 [class*="audio-trimmer_selection-background_"],
 [class*="tag-button_tag-button_"]:not([class*="tag-button_active_"]),
 [class*="action-menu_button_"],
-[class*="context-menu_menu-item_"]:hover {
+[class*="context-menu_menu-item_"]:hover,
+[class*="confirmation-prompt_confirm-button_"] {
   background-color: var(--editorDarkMode-primary);
   color: var(--editorDarkMode-primary-text);
 }


### PR DESCRIPTION
Resolves https://github.com/ScratchAddons/ScratchAddons/issues/9171

### Changes

Moves a class selector to the bottom.

### Reason for changes

Fixes an issue where the yes button is dark.