### PR TITLE
color-inputs: code editor support

### DIFF
--- a/addons/color-inputs/addon.json
+++ b/addons/color-inputs/addon.json
@@ -1,13 +1,21 @@
 {
   "name": "Number inputs in color picker",
-  "description": "Lets you set an exact value (0-100) for each slider in the costume editor color picker by typing in a number.",
+  "description": "Lets you set an exact value (0-100) for each slider in the color picker by typing in a number.",
   "credits": [
     {
       "name": "TheColaber",
       "link": "https://scratch.mit.edu/users/TheColaber/"
+    },
+    {
+      "name": "Maximouse",
+      "link": "https://scratch.mit.edu/users/Maximouse/"
     }
   ],
   "versionAdded": "1.25.0",
+  "latestUpdate": {
+    "version": "1.46.0",
+    "temporaryNotice": "Now works with blocks such as \"touching color\" and \"set pen color\"."
+  },
   "tags": ["editor", "costumeEditor", "featured"],
   "userscripts": [
     {

--- a/addons/color-inputs/addon.json
+++ b/addons/color-inputs/addon.json
@@ -32,5 +32,7 @@
       "url": "style.css",
       "matches": ["projects"]
     }
-  ]
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true
 }

--- a/addons/color-inputs/addon.json
+++ b/addons/color-inputs/addon.json
@@ -11,7 +11,17 @@
   "tags": ["editor", "costumeEditor", "featured"],
   "userscripts": [
     {
-      "url": "userscript.js",
+      "url": "code-editor.js",
+      "matches": ["projects"]
+    },
+    {
+      "url": "paint-editor.js",
+      "matches": ["projects"]
+    }
+  ],
+  "userstyles": [
+    {
+      "url": "style.css",
       "matches": ["projects"]
     }
   ]

--- a/addons/color-inputs/code-editor.js
+++ b/addons/color-inputs/code-editor.js
@@ -1,0 +1,42 @@
+export default async function ({ addon, console }) {
+  const Blockly = await addon.tab.traps.getBlockly();
+
+  const oldCreateLabelDom = Blockly.FieldColourSlider.prototype.createLabelDom_;
+  Blockly.FieldColourSlider.prototype.createLabelDom_ = function (...args) {
+    const [header, readout] = oldCreateLabelDom.call(this, ...args);
+    header.classList.add("sa-color-inputs-row-header");
+    readout.remove();
+    const input = document.createElement("input");
+    input.type = "number";
+    input.min = 0;
+    input.max = 100;
+    input.className = addon.tab.scratchClass("input_input-form", "input_input-small", "input_input-small-range", {
+      others: "sa-color-input",
+    });
+    Object.defineProperty(input, "textContent", {
+      set(newValue) {
+        input.value = newValue;
+      },
+    });
+    header.appendChild(input);
+    return [header, input];
+  }
+
+  const getInputListener = (field, channel) => {
+    const sliderListener = field.sliderCallbackFactory_(channel);
+    return (e) => {
+      let oldValue = e.target.value;
+      e.target.value *= { hue: 360 / 100, saturation: 1 / 100, brightness: 255 / 100 }[channel];
+      sliderListener(e);
+      e.target.value = oldValue;
+    }
+  };
+
+  const oldShowEditor = Blockly.FieldColourSlider.prototype.showEditor_;
+  Blockly.FieldColourSlider.prototype.showEditor_ = function (...args) {
+    oldShowEditor.call(this);
+    this.hueReadout_.addEventListener("input", getInputListener(this, "hue"));
+    this.saturationReadout_.addEventListener("input", getInputListener(this, "saturation"));
+    this.brightnessReadout_.addEventListener("input", getInputListener(this, "brightness"));
+  }
+}

--- a/addons/color-inputs/code-editor.js
+++ b/addons/color-inputs/code-editor.js
@@ -1,11 +1,12 @@
 export default async function ({ addon, console }) {
   const Blockly = await addon.tab.traps.getBlockly();
 
+  const roundValue = (val) => Math.round(val * 10) / 10;
+
   const oldCreateLabelDom = Blockly.FieldColourSlider.prototype.createLabelDom_;
   Blockly.FieldColourSlider.prototype.createLabelDom_ = function (...args) {
     const [header, readout] = oldCreateLabelDom.call(this, ...args);
     header.classList.add("sa-color-inputs-row-header");
-    readout.remove();
     const input = document.createElement("input");
     input.type = "number";
     input.min = 0;
@@ -13,13 +14,10 @@ export default async function ({ addon, console }) {
     input.className = addon.tab.scratchClass("input_input-form", "input_input-small", "input_input-small-range", {
       others: "sa-color-input",
     });
-    Object.defineProperty(input, "textContent", {
-      set(newValue) {
-        input.value = newValue;
-      },
-    });
+    addon.tab.displayNoneWhileDisabled(input);
     header.appendChild(input);
-    return [header, input];
+    readout.saInput = input;
+    return [header, readout];
   }
 
   const getInputListener = (field, channel) => {
@@ -35,8 +33,26 @@ export default async function ({ addon, console }) {
   const oldShowEditor = Blockly.FieldColourSlider.prototype.showEditor_;
   Blockly.FieldColourSlider.prototype.showEditor_ = function (...args) {
     oldShowEditor.call(this, ...args);
-    this.hueReadout_.addEventListener("input", getInputListener(this, "hue"));
-    this.saturationReadout_.addEventListener("input", getInputListener(this, "saturation"));
-    this.brightnessReadout_.addEventListener("input", getInputListener(this, "brightness"));
+     if (
+      !this.hueReadout_?.saInput ||
+      !this.saturationReadout_?.saInput ||
+      !this.brightnessReadout_?.saInput
+    ) return;
+    this.hueReadout_.saInput.addEventListener("input", getInputListener(this, "hue"));
+    this.saturationReadout_.saInput.addEventListener("input", getInputListener(this, "saturation"));
+    this.brightnessReadout_.saInput.addEventListener("input", getInputListener(this, "brightness"));
+  }
+
+  const oldUpdateDom = Blockly.FieldColourSlider.prototype.updateDom_;
+  Blockly.FieldColourSlider.prototype.updateDom_ = function (...args) {
+    oldUpdateDom.call(this, ...args);
+    if (
+      !this.hueReadout_?.saInput ||
+      !this.saturationReadout_?.saInput ||
+      !this.brightnessReadout_?.saInput
+    ) return;
+    this.hueReadout_.saInput.value = roundValue((100 * this.hue_) / 360);
+    this.saturationReadout_.saInput.value = roundValue(100 * this.saturation_);
+    this.brightnessReadout_.saInput.value = roundValue((100 * this.brightness_) / 255);
   }
 }

--- a/addons/color-inputs/code-editor.js
+++ b/addons/color-inputs/code-editor.js
@@ -34,7 +34,7 @@ export default async function ({ addon, console }) {
 
   const oldShowEditor = Blockly.FieldColourSlider.prototype.showEditor_;
   Blockly.FieldColourSlider.prototype.showEditor_ = function (...args) {
-    oldShowEditor.call(this);
+    oldShowEditor.call(this, ...args);
     this.hueReadout_.addEventListener("input", getInputListener(this, "hue"));
     this.saturationReadout_.addEventListener("input", getInputListener(this, "saturation"));
     this.brightnessReadout_.addEventListener("input", getInputListener(this, "brightness"));

--- a/addons/color-inputs/code-editor.js
+++ b/addons/color-inputs/code-editor.js
@@ -18,7 +18,7 @@ export default async function ({ addon, console }) {
     header.appendChild(input);
     readout.saInput = input;
     return [header, readout];
-  }
+  };
 
   const getInputListener = (field, channel) => {
     const sliderListener = field.sliderCallbackFactory_(channel);
@@ -27,32 +27,24 @@ export default async function ({ addon, console }) {
       e.target.value *= { hue: 360 / 100, saturation: 1 / 100, brightness: 255 / 100 }[channel];
       sliderListener(e);
       e.target.value = oldValue;
-    }
+    };
   };
 
   const oldShowEditor = Blockly.FieldColourSlider.prototype.showEditor_;
   Blockly.FieldColourSlider.prototype.showEditor_ = function (...args) {
     oldShowEditor.call(this, ...args);
-     if (
-      !this.hueReadout_?.saInput ||
-      !this.saturationReadout_?.saInput ||
-      !this.brightnessReadout_?.saInput
-    ) return;
+    if (!this.hueReadout_?.saInput || !this.saturationReadout_?.saInput || !this.brightnessReadout_?.saInput) return;
     this.hueReadout_.saInput.addEventListener("input", getInputListener(this, "hue"));
     this.saturationReadout_.saInput.addEventListener("input", getInputListener(this, "saturation"));
     this.brightnessReadout_.saInput.addEventListener("input", getInputListener(this, "brightness"));
-  }
+  };
 
   const oldUpdateDom = Blockly.FieldColourSlider.prototype.updateDom_;
   Blockly.FieldColourSlider.prototype.updateDom_ = function (...args) {
     oldUpdateDom.call(this, ...args);
-    if (
-      !this.hueReadout_?.saInput ||
-      !this.saturationReadout_?.saInput ||
-      !this.brightnessReadout_?.saInput
-    ) return;
+    if (!this.hueReadout_?.saInput || !this.saturationReadout_?.saInput || !this.brightnessReadout_?.saInput) return;
     this.hueReadout_.saInput.value = roundValue((100 * this.hue_) / 360);
     this.saturationReadout_.saInput.value = roundValue(100 * this.saturation_);
     this.brightnessReadout_.saInput.value = roundValue((100 * this.brightness_) / 255);
-  }
+  };
 }

--- a/addons/color-inputs/paint-editor.js
+++ b/addons/color-inputs/paint-editor.js
@@ -43,6 +43,7 @@ export default async function ({ addon, msg, console }) {
           pickerContainer.handleColorChange();
         });
       });
+      addon.tab.displayNoneWhileDisabled(input);
       header.append(input);
     });
   }

--- a/addons/color-inputs/paint-editor.js
+++ b/addons/color-inputs/paint-editor.js
@@ -20,18 +20,15 @@ export default async function ({ addon, msg, console }) {
     const color = ["hue", "saturation", "brightness"];
     color.forEach((c, i) => {
       const header = headers[i];
-      // TODO: move these styles into a userstyle and use header.classList.add
-      header.style.display = "flex";
-      header.style.alignItems = "center";
-      header.style.justifyContent = "space-between";
-      header.querySelector("[class*='color-picker_label-readout']").style.display = "none";
+      header.classList.add("sa-color-inputs-row-header");
       const input = document.createElement("input");
       input.type = "number";
       input.value = Math.round(pickerComponent.props[c] * 10) / 10;
       input.min = 0;
       input.max = 100;
-      input.className = addon.tab.scratchClass("input_input-form", "input_input-small", "input_input-small-range");
-      input.style.height = "1.5rem";
+      input.className = addon.tab.scratchClass("input_input-form", "input_input-small", "input_input-small-range", {
+        others: "sa-color-input",
+      });
       const _setState = pickerContainer.setState.bind(pickerContainer);
       pickerContainer.setState = function (state, callback) {
         const [type, val] = Object.entries(state)[0];

--- a/addons/color-inputs/paint-editor.js
+++ b/addons/color-inputs/paint-editor.js
@@ -31,9 +31,10 @@ export default async function ({ addon, msg, console }) {
       });
       const _setState = pickerContainer.setState.bind(pickerContainer);
       pickerContainer.setState = function (state, callback) {
-        const [type, val] = Object.entries(state)[0];
-        if (type === c) {
-          input.value = Math.round(val * 10) / 10;
+        for (const [type, val] of Object.entries(state)) {
+          if (type === c) {
+            input.value = Math.round(val * 10) / 10;
+          }
         }
         _setState(state, callback);
       };

--- a/addons/color-inputs/style.css
+++ b/addons/color-inputs/style.css
@@ -4,7 +4,7 @@
   align-items: center;
 }
 
-.sa-color-inputs-row-header [class*='color-picker_label-readout'],
+.sa-color-inputs-row-header [class*="color-picker_label-readout"],
 .sa-color-inputs-row-header .scratchColourPickerReadout {
   display: none;
 }

--- a/addons/color-inputs/style.css
+++ b/addons/color-inputs/style.css
@@ -4,7 +4,8 @@
   align-items: center;
 }
 
-.sa-color-inputs-row-header [class*='color-picker_label-readout'] {
+.sa-color-inputs-row-header [class*='color-picker_label-readout'],
+.sa-color-inputs-row-header .scratchColourPickerReadout {
   display: none;
 }
 

--- a/addons/color-inputs/style.css
+++ b/addons/color-inputs/style.css
@@ -1,0 +1,13 @@
+.sa-color-inputs-row-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sa-color-inputs-row-header [class*='color-picker_label-readout'] {
+  display: none;
+}
+
+.sa-color-input {
+  height: 1.5rem;
+}


### PR DESCRIPTION
Resolves #4534
Resolves #5765

### Changes

* The addon now works in the code editor.
* All three inputs are now updated when clicking on one of the gradient colors or picking a color using the eyedropper. They still don't update when swapping gradient colors, but that's a Scratch bug - the sliders don't update either.
* Adds dynamic enable/disable.

### Tests

Tested on Edge and Firefox.