### PR TITLE
Make redux.initialize() wait until Redux is ready

### DIFF
--- a/addon-api/content-script/ReduxHandler.js
+++ b/addon-api/content-script/ReduxHandler.js
@@ -13,21 +13,25 @@ export default class ReduxHandler extends Listenable {
   }
 
   /**
-   * Initialize the handler. Must be called before adding events.
+   * Initialize the handler and wait until Redux has its first real state.
+   * Existing callers do not need to await this unless they use Redux immediately.
+   * @returns {Promise<void>}
    */
   initialize() {
-    if (!__scratchAddonsRedux.target || this.initialized) return;
-    this.initialized = true;
-    __scratchAddonsRedux.target.addEventListener("statechanged", ({ detail }) => {
-      const newEvent = new CustomEvent("statechanged", {
-        detail: {
-          action: detail.action,
-          prev: detail.prev,
-          next: detail.next,
-        },
+    if (__scratchAddonsRedux.target && !this.initialized) {
+      this.initialized = true;
+      __scratchAddonsRedux.target.addEventListener("statechanged", ({ detail }) => {
+        const newEvent = new CustomEvent("statechanged", {
+          detail: {
+            action: detail.action,
+            prev: detail.prev,
+            next: detail.next,
+          },
+        });
+        this.dispatchEvent(newEvent);
       });
-      this.dispatchEvent(newEvent);
-    });
+    }
+    return __scratchAddonsRedux.ready ?? Promise.resolve();
   }
 
   /**
@@ -55,8 +59,8 @@ export default class ReduxHandler extends Listenable {
    * @param {string=|string[]=} actions - the action(s) to check for.
    * @returns {Promise} a Promise resolved when the state meets the condition.
    */
-  waitForState(condition, opts = {}) {
-    this.initialize();
+  async waitForState(condition, opts = {}) {
+    await this.initialize();
     if (!__scratchAddonsRedux.target) return Promise.reject(new Error("Redux is unavailable"));
     if (condition(__scratchAddonsRedux.state)) return Promise.resolve();
     let actions = opts.actions || null;

--- a/content-scripts/load-redux.js
+++ b/content-scripts/load-redux.js
@@ -1,5 +1,13 @@
 function injectRedux() {
-  window.__scratchAddonsRedux = {};
+  let resolveReduxReady;
+  window.__scratchAddonsRedux = {
+    // Create the event channel before Scratch creates its store so early
+    // userscripts can subscribe without missing later Redux events.
+    target: new EventTarget(),
+    ready: new Promise((resolve) => {
+      resolveReduxReady = resolve;
+    }),
+  };
 
   // ReDucks: Redux ducktyped
   // Not actual Redux, but should be compatible
@@ -35,13 +43,14 @@ function injectRedux() {
   let newerCompose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
   function compose(...args) {
     const scratchAddonsRedux = window.__scratchAddonsRedux;
-    const reduxTarget = (scratchAddonsRedux.target = new EventTarget());
+    const reduxTarget = scratchAddonsRedux.target;
     scratchAddonsRedux.state = {};
     scratchAddonsRedux.dispatch = () => {};
 
     function middleware({ getState, dispatch }) {
       scratchAddonsRedux.dispatch = dispatch;
       scratchAddonsRedux.state = getState();
+      resolveReduxReady();
       return (next) => (action) => {
         const nextReturn = next(action);
         const ev = new CustomEvent("statechanged", {


### PR DESCRIPTION
Some userscripts start before Scratch has finished setting up Redux. If they call `addon.tab.redux.initialize()` too early, it currently returns straight away and their listener is never connected.

This creates the Redux event channel earlier and lets addons wait until the first real Redux state is available:

```js
await addon.tab.redux.initialize();
```

Addons that only listen for later changes can continue calling it without `await`.

`waitForState()` now waits for Redux to be ready before checking the state.

The readiness promise exists even while Redux is still loading. If it is missing, `initialize()` now throws an error instead of carrying on as though Redux were ready.

Fixes #7933

